### PR TITLE
feat(accounting-web): public marketing/landing + signup (SEO, cs/sk) [PAP-312]

### DIFF
--- a/frontend/apps/accounting-web/messages/cs.json
+++ b/frontend/apps/accounting-web/messages/cs.json
@@ -1,0 +1,182 @@
+{
+  "_meta": {
+    "status": "PLACEHOLDER copy — provisional. Final marketing copy to be supplied by CMO (PAP-312). The key structure is the contract; swap the strings, keep the keys.",
+    "brandNote": "Brand name is injected from i18n/config.ts BRAND_NAME (placeholder 'Fakto') — do not hard-code it here."
+  },
+  "nav": {
+    "features": "Funkce",
+    "pricing": "Ceník",
+    "login": "Přihlásit se",
+    "signup": "Vyzkoušet zdarma",
+    "skipToContent": "Přeskočit na obsah",
+    "openMenu": "Otevřít menu"
+  },
+  "hero": {
+    "badge": "Fakturace a účetnictví pro živnostníky a malé firmy",
+    "title": "Fakturujte za pár vteřin. Mějte přehled o penězích.",
+    "subtitle": "Vystavujte faktury, evidujte kontakty a párujte platby z banky — vše na jednom místě, v češtině a slovenštině. Bez papírování, bez stresu.",
+    "ctaPrimary": "Začít zdarma",
+    "ctaSecondary": "Prohlédnout funkce",
+    "trust": "Bez platební karty · Nastavení do 2 minut · Zrušíte kdykoli"
+  },
+  "features": {
+    "title": "Vše, co potřebujete k fakturaci",
+    "subtitle": "Od první faktury po sesouhlasení s bankou — nástroje, které vám ušetří čas každý týden.",
+    "items": [
+      {
+        "title": "Faktury na pár kliknutí",
+        "body": "Vystavte a odešlete profesionální fakturu ve formátu PDF za méně než minutu. Položky, DPH (CZ i SK) a splatnost hlídá za vás."
+      },
+      {
+        "title": "Adresář kontaktů",
+        "body": "Evidujte odběratele i dodavatele na jednom místě. Při fakturaci se údaje doplní samy."
+      },
+      {
+        "title": "Párování plateb",
+        "body": "Nahrajte bankovní výpis a my k němu napárujeme faktury. Hned víte, kdo zaplatil a kdo dluží."
+      },
+      {
+        "title": "Přehled nezaplacených",
+        "body": "Dashboard ukáže, kolik vám dluží zákazníci a které faktury jsou po splatnosti."
+      },
+      {
+        "title": "Export dat",
+        "body": "Stáhněte si faktury a přehledy v CSV pro účetní nebo pro vlastní evidenci."
+      },
+      {
+        "title": "Bezpečně a v souladu",
+        "body": "Vaše data jsou oddělená od ostatních firem a šifrovaná. Připraveno na e-fakturaci podle EN 16931."
+      }
+    ]
+  },
+  "steps": {
+    "title": "Začněte ve třech krocích",
+    "items": [
+      {
+        "title": "Založte si účet",
+        "body": "Zaregistrujte se e-mailem. Žádná instalace, žádná platební karta."
+      },
+      {
+        "title": "Vystavte fakturu",
+        "body": "Vyplňte odběratele a položky. My spočítáme DPH a vygenerujeme PDF."
+      },
+      {
+        "title": "Sledujte platby",
+        "body": "Nahrajte výpis z banky a uvidíte, co je zaplaceno a co po splatnosti."
+      }
+    ]
+  },
+  "pricing": {
+    "title": "Jednoduchý ceník",
+    "subtitle": "Začněte zdarma. Plaťte, až když porostete. Ceny jsou orientační — finální ceník dodá obchodní tým.",
+    "perMonth": "/ měsíc",
+    "mostPopular": "Nejoblíbenější",
+    "plans": [
+      {
+        "name": "Start",
+        "price": "0 €",
+        "tagline": "Pro začínající živnostníky",
+        "features": ["Až 5 faktur měsíčně", "Adresář kontaktů", "Export do CSV"],
+        "cta": "Začít zdarma"
+      },
+      {
+        "name": "Standard",
+        "price": "9 €",
+        "tagline": "Pro rostoucí podnikání",
+        "features": [
+          "Neomezené faktury",
+          "Párování plateb z banky",
+          "Přehled nezaplacených",
+          "Prioritní podpora"
+        ],
+        "cta": "Vyzkoušet 14 dní zdarma"
+      },
+      {
+        "name": "Tým",
+        "price": "19 €",
+        "tagline": "Pro firmy a účetní",
+        "features": [
+          "Vše ze Standardu",
+          "Více uživatelů",
+          "Exporty pro účetní",
+          "Pokročilá oprávnění"
+        ],
+        "cta": "Kontaktovat nás"
+      }
+    ],
+    "note": "Ceny jsou bez DPH a slouží jako ukázka. Konečný ceník bude potvrzen před spuštěním."
+  },
+  "cta": {
+    "title": "Vyzkoušejte to ještě dnes",
+    "subtitle": "Vystavte první fakturu za pár minut. Zdarma a bez závazků.",
+    "button": "Začít zdarma"
+  },
+  "footer": {
+    "tagline": "Fakturace a účetnictví, které vám rozumí.",
+    "productHeading": "Produkt",
+    "companyHeading": "Společnost",
+    "legalHeading": "Právní",
+    "links": {
+      "features": "Funkce",
+      "pricing": "Ceník",
+      "signup": "Registrace",
+      "login": "Přihlášení",
+      "about": "O nás",
+      "contact": "Kontakt",
+      "terms": "Obchodní podmínky",
+      "privacy": "Ochrana soukromí"
+    },
+    "rights": "Všechna práva vyhrazena.",
+    "placeholderNote": "Produkt ve vývoji — název a doména jsou prozatím dočasné."
+  },
+  "signup": {
+    "title": "Vytvořte si účet",
+    "subtitle": "Začněte fakturovat zdarma. Stačí pár údajů.",
+    "fields": {
+      "companyLabel": "Název firmy nebo jméno",
+      "companyPlaceholder": "Např. Jan Novák – IČO 12345678",
+      "nameLabel": "Vaše jméno",
+      "namePlaceholder": "Jan Novák",
+      "emailLabel": "E-mail",
+      "emailPlaceholder": "vas@email.cz",
+      "passwordLabel": "Heslo",
+      "passwordPlaceholder": "Alespoň 8 znaků",
+      "countryLabel": "Země",
+      "countryCz": "Česko",
+      "countrySk": "Slovensko"
+    },
+    "consent": "Registrací souhlasíte s obchodními podmínkami a zpracováním osobních údajů.",
+    "submit": "Vytvořit účet zdarma",
+    "haveAccount": "Už máte účet?",
+    "login": "Přihlaste se",
+    "validation": {
+      "companyRequired": "Vyplňte název firmy nebo jméno.",
+      "emailRequired": "Vyplňte e-mail.",
+      "emailInvalid": "Zadejte platný e-mail.",
+      "passwordShort": "Heslo musí mít alespoň 8 znaků."
+    },
+    "comingSoon": "Registrace bude brzy spuštěna. Děkujeme za zájem — vaše údaje zatím neukládáme.",
+    "benefitsTitle": "Proč začít hned",
+    "benefits": [
+      "Nastavení do 2 minut",
+      "Bez platební karty",
+      "Čeština i slovenština",
+      "Zrušíte kdykoli"
+    ]
+  },
+  "metadata": {
+    "home": {
+      "title": "Fakturace a účetnictví pro živnostníky a malé firmy",
+      "description": "Vystavujte faktury, evidujte kontakty a párujte platby z banky. Jednoduché online fakturování v češtině a slovenštině. Začněte zdarma."
+    },
+    "signup": {
+      "title": "Registrace zdarma",
+      "description": "Vytvořte si účet a vystavte první fakturu za pár minut. Bez platební karty, zrušíte kdykoli."
+    }
+  },
+  "localeSwitcher": {
+    "label": "Jazyk",
+    "cs": "Čeština",
+    "sk": "Slovenčina"
+  }
+}

--- a/frontend/apps/accounting-web/messages/cs.json
+++ b/frontend/apps/accounting-web/messages/cs.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "status": "PLACEHOLDER copy — provisional. Final marketing copy to be supplied by CMO (PAP-312). The key structure is the contract; swap the strings, keep the keys.",
+    "status": "CMO-FINAL marketing copy (PAP-312) — reviewed and signed off by CMO for cs/sk message-market fit and honest framing. Two values remain board decisions, NOT copy edits: (1) brand name, injected from i18n/config.ts BRAND_NAME (placeholder 'Fakto'); (2) pricing.plans[].price amounts + the free/Standard/Team tier split — illustrative pending board pricing decision (PAP-303 open decision). Key structure is the contract; swap strings, keep keys.",
     "brandNote": "Brand name is injected from i18n/config.ts BRAND_NAME (placeholder 'Fakto') — do not hard-code it here."
   },
   "nav": {
@@ -13,7 +13,7 @@
   },
   "hero": {
     "badge": "Fakturace a účetnictví pro živnostníky a malé firmy",
-    "title": "Fakturujte za pár vteřin. Mějte přehled o penězích.",
+    "title": "Vystavte fakturu za pár minut. Mějte přehled o penězích.",
     "subtitle": "Vystavujte faktury, evidujte kontakty a párujte platby z banky — vše na jednom místě, v češtině a slovenštině. Bez papírování, bez stresu.",
     "ctaPrimary": "Začít zdarma",
     "ctaSecondary": "Prohlédnout funkce",

--- a/frontend/apps/accounting-web/messages/sk.json
+++ b/frontend/apps/accounting-web/messages/sk.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "status": "PLACEHOLDER copy — provisional. Final marketing copy to be supplied by CMO (PAP-312). The key structure is the contract; swap the strings, keep the keys.",
+    "status": "CMO-FINAL marketing copy (PAP-312) — reviewed and signed off by CMO for sk/cs message-market fit and honest framing. Two values remain board decisions, NOT copy edits: (1) brand name, injected from i18n/config.ts BRAND_NAME (placeholder 'Fakto'); (2) pricing.plans[].price amounts + the free/Standard/Team tier split — illustrative pending board pricing decision (PAP-303 open decision). Key structure is the contract; swap strings, keep keys.",
     "brandNote": "Brand name is injected from i18n/config.ts BRAND_NAME (placeholder 'Fakto') — do not hard-code it here."
   },
   "nav": {
@@ -13,7 +13,7 @@
   },
   "hero": {
     "badge": "Fakturácia a účtovníctvo pre živnostníkov a malé firmy",
-    "title": "Fakturujte za pár sekúnd. Majte prehľad o peniazoch.",
+    "title": "Vystavte faktúru za pár minút. Majte prehľad o peniazoch.",
     "subtitle": "Vystavujte faktúry, evidujte kontakty a párujte platby z banky — všetko na jednom mieste, v slovenčine a češtine. Bez papierovania, bez stresu.",
     "ctaPrimary": "Začať zadarmo",
     "ctaSecondary": "Pozrieť funkcie",

--- a/frontend/apps/accounting-web/messages/sk.json
+++ b/frontend/apps/accounting-web/messages/sk.json
@@ -1,0 +1,182 @@
+{
+  "_meta": {
+    "status": "PLACEHOLDER copy — provisional. Final marketing copy to be supplied by CMO (PAP-312). The key structure is the contract; swap the strings, keep the keys.",
+    "brandNote": "Brand name is injected from i18n/config.ts BRAND_NAME (placeholder 'Fakto') — do not hard-code it here."
+  },
+  "nav": {
+    "features": "Funkcie",
+    "pricing": "Cenník",
+    "login": "Prihlásiť sa",
+    "signup": "Vyskúšať zadarmo",
+    "skipToContent": "Preskočiť na obsah",
+    "openMenu": "Otvoriť menu"
+  },
+  "hero": {
+    "badge": "Fakturácia a účtovníctvo pre živnostníkov a malé firmy",
+    "title": "Fakturujte za pár sekúnd. Majte prehľad o peniazoch.",
+    "subtitle": "Vystavujte faktúry, evidujte kontakty a párujte platby z banky — všetko na jednom mieste, v slovenčine a češtine. Bez papierovania, bez stresu.",
+    "ctaPrimary": "Začať zadarmo",
+    "ctaSecondary": "Pozrieť funkcie",
+    "trust": "Bez platobnej karty · Nastavenie do 2 minút · Zrušíte kedykoľvek"
+  },
+  "features": {
+    "title": "Všetko, čo potrebujete na fakturáciu",
+    "subtitle": "Od prvej faktúry po spárovanie s bankou — nástroje, ktoré vám ušetria čas každý týždeň.",
+    "items": [
+      {
+        "title": "Faktúry na pár klikov",
+        "body": "Vystavte a odošlite profesionálnu faktúru v PDF za menej než minútu. Položky, DPH (SK aj CZ) a splatnosť ustráži za vás."
+      },
+      {
+        "title": "Adresár kontaktov",
+        "body": "Evidujte odberateľov aj dodávateľov na jednom mieste. Pri fakturácii sa údaje doplnia samy."
+      },
+      {
+        "title": "Párovanie platieb",
+        "body": "Nahrajte bankový výpis a my k nemu napárujeme faktúry. Hneď viete, kto zaplatil a kto dlhuje."
+      },
+      {
+        "title": "Prehľad nezaplatených",
+        "body": "Dashboard ukáže, koľko vám dlhujú zákazníci a ktoré faktúry sú po splatnosti."
+      },
+      {
+        "title": "Export dát",
+        "body": "Stiahnite si faktúry a prehľady v CSV pre účtovníka alebo pre vlastnú evidenciu."
+      },
+      {
+        "title": "Bezpečne a v súlade",
+        "body": "Vaše dáta sú oddelené od ostatných firiem a šifrované. Pripravené na e-fakturáciu podľa EN 16931."
+      }
+    ]
+  },
+  "steps": {
+    "title": "Začnite v troch krokoch",
+    "items": [
+      {
+        "title": "Založte si účet",
+        "body": "Zaregistrujte sa e-mailom. Žiadna inštalácia, žiadna platobná karta."
+      },
+      {
+        "title": "Vystavte faktúru",
+        "body": "Vyplňte odberateľa a položky. My vypočítame DPH a vygenerujeme PDF."
+      },
+      {
+        "title": "Sledujte platby",
+        "body": "Nahrajte výpis z banky a uvidíte, čo je zaplatené a čo po splatnosti."
+      }
+    ]
+  },
+  "pricing": {
+    "title": "Jednoduchý cenník",
+    "subtitle": "Začnite zadarmo. Plaťte, až keď porastiete. Ceny sú orientačné — finálny cenník dodá obchodný tím.",
+    "perMonth": "/ mesiac",
+    "mostPopular": "Najobľúbenejšie",
+    "plans": [
+      {
+        "name": "Štart",
+        "price": "0 €",
+        "tagline": "Pre začínajúcich živnostníkov",
+        "features": ["Až 5 faktúr mesačne", "Adresár kontaktov", "Export do CSV"],
+        "cta": "Začať zadarmo"
+      },
+      {
+        "name": "Štandard",
+        "price": "9 €",
+        "tagline": "Pre rastúce podnikanie",
+        "features": [
+          "Neobmedzené faktúry",
+          "Párovanie platieb z banky",
+          "Prehľad nezaplatených",
+          "Prioritná podpora"
+        ],
+        "cta": "Vyskúšať 14 dní zadarmo"
+      },
+      {
+        "name": "Tím",
+        "price": "19 €",
+        "tagline": "Pre firmy a účtovníkov",
+        "features": [
+          "Všetko zo Štandardu",
+          "Viac používateľov",
+          "Exporty pre účtovníka",
+          "Pokročilé oprávnenia"
+        ],
+        "cta": "Kontaktovať nás"
+      }
+    ],
+    "note": "Ceny sú bez DPH a slúžia ako ukážka. Konečný cenník bude potvrdený pred spustením."
+  },
+  "cta": {
+    "title": "Vyskúšajte to ešte dnes",
+    "subtitle": "Vystavte prvú faktúru za pár minút. Zadarmo a bez záväzkov.",
+    "button": "Začať zadarmo"
+  },
+  "footer": {
+    "tagline": "Fakturácia a účtovníctvo, ktoré vám rozumie.",
+    "productHeading": "Produkt",
+    "companyHeading": "Spoločnosť",
+    "legalHeading": "Právne",
+    "links": {
+      "features": "Funkcie",
+      "pricing": "Cenník",
+      "signup": "Registrácia",
+      "login": "Prihlásenie",
+      "about": "O nás",
+      "contact": "Kontakt",
+      "terms": "Obchodné podmienky",
+      "privacy": "Ochrana súkromia"
+    },
+    "rights": "Všetky práva vyhradené.",
+    "placeholderNote": "Produkt vo vývoji — názov a doména sú zatiaľ dočasné."
+  },
+  "signup": {
+    "title": "Vytvorte si účet",
+    "subtitle": "Začnite fakturovať zadarmo. Stačí pár údajov.",
+    "fields": {
+      "companyLabel": "Názov firmy alebo meno",
+      "companyPlaceholder": "Napr. Ján Novák – IČO 12345678",
+      "nameLabel": "Vaše meno",
+      "namePlaceholder": "Ján Novák",
+      "emailLabel": "E-mail",
+      "emailPlaceholder": "vas@email.sk",
+      "passwordLabel": "Heslo",
+      "passwordPlaceholder": "Aspoň 8 znakov",
+      "countryLabel": "Krajina",
+      "countryCz": "Česko",
+      "countrySk": "Slovensko"
+    },
+    "consent": "Registráciou súhlasíte s obchodnými podmienkami a spracovaním osobných údajov.",
+    "submit": "Vytvoriť účet zadarmo",
+    "haveAccount": "Už máte účet?",
+    "login": "Prihláste sa",
+    "validation": {
+      "companyRequired": "Vyplňte názov firmy alebo meno.",
+      "emailRequired": "Vyplňte e-mail.",
+      "emailInvalid": "Zadajte platný e-mail.",
+      "passwordShort": "Heslo musí mať aspoň 8 znakov."
+    },
+    "comingSoon": "Registrácia bude čoskoro spustená. Ďakujeme za záujem — vaše údaje zatiaľ neukladáme.",
+    "benefitsTitle": "Prečo začať hneď",
+    "benefits": [
+      "Nastavenie do 2 minút",
+      "Bez platobnej karty",
+      "Slovenčina aj čeština",
+      "Zrušíte kedykoľvek"
+    ]
+  },
+  "metadata": {
+    "home": {
+      "title": "Fakturácia a účtovníctvo pre živnostníkov a malé firmy",
+      "description": "Vystavujte faktúry, evidujte kontakty a párujte platby z banky. Jednoduchá online fakturácia v slovenčine a češtine. Začnite zadarmo."
+    },
+    "signup": {
+      "title": "Registrácia zadarmo",
+      "description": "Vytvorte si účet a vystavte prvú faktúru za pár minút. Bez platobnej karty, zrušíte kedykoľvek."
+    }
+  },
+  "localeSwitcher": {
+    "label": "Jazyk",
+    "cs": "Čeština",
+    "sk": "Slovenčina"
+  }
+}

--- a/frontend/apps/accounting-web/next-env.d.ts
+++ b/frontend/apps/accounting-web/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/apps/accounting-web/next.config.js
+++ b/frontend/apps/accounting-web/next.config.js
@@ -1,0 +1,55 @@
+const createNextIntlPlugin = require('next-intl/plugin');
+
+const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
+
+const isDev = process.env.NODE_ENV !== 'production';
+
+// Public site origin — placeholder until the board finalises the product
+// name + domain (PAP-303 open decision #1). Worktree/staging deploys override
+// via NEXT_PUBLIC_SITE_URL; the deploy-wiring task (#10 / PAP deploy issue)
+// owns the real subdomain + DNS.
+const apiOrigin = process.env.NEXT_PUBLIC_API_URL;
+
+// Conservative CSP for a public marketing/signup surface. Mirrors the
+// reality-web posture but trimmed: this app has no maps/3rd-party embeds yet.
+// `connect-src` allows the configured api-server origin so the (future)
+// signup POST can reach it once the accounting-api-client (#2) is wired.
+const connectSrc = ["'self'", apiOrigin].filter(Boolean).join(' ');
+
+const csp = [
+  "default-src 'self'",
+  // next/font self-hosts; styled by CSS Modules + ui-kit tokens (no inline <style> from us,
+  // but Next injects a small inline bootstrap so 'unsafe-inline' for style is required).
+  "style-src 'self' 'unsafe-inline'",
+  // Next.js runtime + RSC payload hydration needs 'unsafe-inline'; in dev it also needs eval.
+  isDev ? "script-src 'self' 'unsafe-inline' 'unsafe-eval'" : "script-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "font-src 'self' data:",
+  `connect-src ${connectSrc}`,
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ');
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // Standalone output for the reality-web Docker pattern (deploy wiring = #10).
+  output: 'standalone',
+  reactStrictMode: true,
+  transpilePackages: ['@ppt/ui-kit', '@ppt/shared', '@ppt/dev-panel'],
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'Content-Security-Policy', value: csp },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = withNextIntl(nextConfig);

--- a/frontend/apps/accounting-web/package.json
+++ b/frontend/apps/accounting-web/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@ppt/accounting-web",
+  "private": true,
+  "description": "Accounting Portal Web Application (Next.js SSR) — public marketing/landing + signup",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@ppt/shared": "workspace:*",
+    "@ppt/ui-kit": "workspace:*",
+    "@tanstack/react-query": "^5.101.0",
+    "next": "^16.2.7",
+    "next-intl": "^4.13.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@ppt/dev-panel": "workspace:*",
+    "@ppt/vite-plugin-worktree": "workspace:*",
+    "@types/node": "^25.0.5",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.3.0"
+  },
+  "version": "0.1.0"
+}

--- a/frontend/apps/accounting-web/src/app/[locale]/layout.tsx
+++ b/frontend/apps/accounting-web/src/app/[locale]/layout.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import { notFound } from 'next/navigation';
+import { NextIntlClientProvider } from 'next-intl';
+import { getMessages, getTranslations, setRequestLocale } from 'next-intl/server';
+import { BRAND_NAME, type Locale, locales } from '@/i18n/config';
+
+const inter = Inter({
+  subsets: ['latin', 'latin-ext'],
+  display: 'swap',
+  variable: '--ppt-font-inter',
+  weight: ['400', '500', '600', '700', '800'],
+});
+
+// Placeholder public origin (PAP-303 open decision #1). Staging/worktree
+// deploys override via NEXT_PUBLIC_SITE_URL.
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://eko.dev.rlt.sk').replace(/\/+$/, '');
+
+export function generateStaticParams() {
+  return locales.map((locale) => ({ locale }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'metadata.home' });
+
+  const title = `${BRAND_NAME} — ${t('title')}`;
+  const description = t('description');
+
+  return {
+    metadataBase: new URL(SITE_URL),
+    title: {
+      default: title,
+      template: `%s · ${BRAND_NAME}`,
+    },
+    description,
+    applicationName: BRAND_NAME,
+    alternates: {
+      canonical: locale === 'cs' ? '/' : `/${locale}`,
+      languages: Object.fromEntries(locales.map((lc) => [lc, lc === 'cs' ? '/' : `/${lc}`])),
+    },
+    openGraph: {
+      type: 'website',
+      siteName: BRAND_NAME,
+      title,
+      description,
+      locale,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+    },
+    robots: { index: true, follow: true },
+  };
+}
+
+const SOFTWARE_LD = (siteUrl: string) =>
+  JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: BRAND_NAME,
+    applicationCategory: 'BusinessApplication',
+    operatingSystem: 'Web',
+    url: siteUrl,
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+    areaServed: ['CZ', 'SK'],
+  });
+
+type Props = {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+};
+
+export default async function LocaleLayout({ children, params }: Props) {
+  const { locale } = await params;
+
+  if (!locales.includes(locale as Locale)) {
+    notFound();
+  }
+
+  // Enable static rendering for this locale.
+  setRequestLocale(locale);
+  const messages = await getMessages();
+
+  return (
+    <html lang={locale} className={inter.variable}>
+      <body>
+        <script
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD, no user input
+          dangerouslySetInnerHTML={{ __html: SOFTWARE_LD(SITE_URL) }}
+        />
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          {children}
+        </NextIntlClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/frontend/apps/accounting-web/src/app/[locale]/not-found.tsx
+++ b/frontend/apps/accounting-web/src/app/[locale]/not-found.tsx
@@ -1,0 +1,31 @@
+import { BRAND_NAME } from '@/i18n/config';
+import { Link } from '@/i18n/routing';
+
+export default function NotFound() {
+  return (
+    <main
+      style={{
+        minHeight: '70vh',
+        display: 'grid',
+        placeItems: 'center',
+        textAlign: 'center',
+        padding: 'var(--ppt-space-8)',
+      }}
+    >
+      <div>
+        <p
+          style={{
+            fontSize: '3rem',
+            fontWeight: 'var(--ppt-font-weight-bold)',
+            color: 'var(--ppt-color-primary)',
+          }}
+        >
+          404
+        </p>
+        <Link href="/" className="btn btn-md btn-primary" style={{ marginTop: '1rem' }}>
+          ← {BRAND_NAME}
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/frontend/apps/accounting-web/src/app/[locale]/page.tsx
+++ b/frontend/apps/accounting-web/src/app/[locale]/page.tsx
@@ -1,0 +1,38 @@
+import { useTranslations } from 'next-intl';
+import { setRequestLocale } from 'next-intl/server';
+import { CtaBanner } from '@/components/marketing/CtaBanner';
+import { FeatureGrid } from '@/components/marketing/FeatureGrid';
+import { Hero } from '@/components/marketing/Hero';
+import { PricingTeaser } from '@/components/marketing/PricingTeaser';
+import { SiteFooter } from '@/components/marketing/SiteFooter';
+import { SiteHeader } from '@/components/marketing/SiteHeader';
+import { Steps } from '@/components/marketing/Steps';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function LandingPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <LandingContent />;
+}
+
+function LandingContent() {
+  const t = useTranslations('nav');
+  return (
+    <>
+      <a className="skip-link" href="#main">
+        {t('skipToContent')}
+      </a>
+      <SiteHeader />
+      <main id="main">
+        <Hero />
+        <FeatureGrid />
+        <Steps />
+        <PricingTeaser />
+        <CtaBanner />
+      </main>
+      <SiteFooter />
+    </>
+  );
+}

--- a/frontend/apps/accounting-web/src/app/[locale]/signup/page.tsx
+++ b/frontend/apps/accounting-web/src/app/[locale]/signup/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from 'next';
+import { useTranslations } from 'next-intl';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { CheckIcon } from '@/components/marketing/Icons';
+import { SiteHeader } from '@/components/marketing/SiteHeader';
+import { SignupForm } from '@/components/signup/SignupForm';
+import { BRAND_NAME } from '@/i18n/config';
+import { Link } from '@/i18n/routing';
+import styles from '@/styles/signup.module.css';
+
+type Props = { params: Promise<{ locale: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: 'metadata.signup' });
+  return {
+    title: t('title'),
+    description: t('description'),
+    alternates: { canonical: locale === 'cs' ? '/signup' : `/${locale}/signup` },
+  };
+}
+
+export default async function SignupPage({ params }: Props) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+  return <SignupContent />;
+}
+
+function SignupContent() {
+  const t = useTranslations('signup');
+  return (
+    <>
+      <SiteHeader />
+      <div className={styles.wrap}>
+        <section className={styles.formCol}>
+          <div className={styles.formInner}>
+            <h1 className={styles.title}>{t('title')}</h1>
+            <p className={styles.subtitle}>{t('subtitle')}</p>
+            <SignupForm />
+            <p className={styles.altAuth}>
+              {t('haveAccount')}{' '}
+              <Link href="/signup" className={styles.altAuthLink}>
+                {t('login')}
+              </Link>
+            </p>
+          </div>
+        </section>
+
+        <aside className={styles.asideCol} aria-hidden="true">
+          <div className={styles.asideBrand}>{BRAND_NAME}</div>
+          <h2 className={styles.asideHeading}>{t('benefitsTitle')}</h2>
+          <ul className={styles.benefitList}>
+            {[0, 1, 2, 3].map((i) => (
+              <li key={i} className={styles.benefit}>
+                <span className={styles.benefitCheck}>
+                  <CheckIcon />
+                </span>
+                {t(`benefits.${i}`)}
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </div>
+    </>
+  );
+}

--- a/frontend/apps/accounting-web/src/app/globals.css
+++ b/frontend/apps/accounting-web/src/app/globals.css
@@ -1,0 +1,143 @@
+/* Global styles for the Accounting Portal public surface.
+   All visual values come from the @ppt/ui-kit design tokens — no one-off
+   colors/spacings here. */
+@import "@ppt/ui-kit/tokens.css";
+
+:root {
+  --ppt-font-family:
+    var(--ppt-font-inter, "Inter"), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--ppt-font-family);
+  background-color: var(--ppt-neutral-0);
+  color: var(--ppt-fg-secondary, #374151);
+  line-height: var(--ppt-line-height-normal);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* Honour reduced-motion: turn off smooth scroll + transitions for users who ask. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  * {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Shared page container — content-driven max width from the token. */
+.container {
+  width: 100%;
+  max-width: var(--ppt-content-max, 1280px);
+  margin: 0 auto;
+  padding-inline: var(--ppt-space-6);
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding-inline: var(--ppt-space-4);
+  }
+}
+
+/* Visually-hidden utility for skip-link + a11y labels. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Button-style links (CTAs are <a>, not <button>, so they render in RSC
+   and remain crawlable). Mirrors the ui-kit Button token vocabulary. */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ppt-space-2);
+  font-family: inherit;
+  font-weight: var(--ppt-font-weight-semibold);
+  border-radius: var(--ppt-radius-md);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+  white-space: nowrap;
+}
+.btn:focus-visible {
+  outline: 2px solid var(--ppt-color-primary);
+  outline-offset: 2px;
+}
+.btn-md {
+  font-size: var(--ppt-font-size-sm);
+  padding: var(--ppt-space-2) var(--ppt-space-4);
+}
+.btn-lg {
+  font-size: var(--ppt-font-size-base);
+  padding: var(--ppt-space-3) var(--ppt-space-6);
+}
+.btn-primary {
+  background: var(--ppt-color-primary);
+  color: #fff;
+}
+.btn-primary:hover {
+  background: var(--ppt-color-primary-hover);
+}
+.btn-secondary {
+  background: var(--ppt-neutral-0);
+  color: var(--ppt-neutral-800, #1f2937);
+  border-color: var(--ppt-neutral-300);
+}
+.btn-secondary:hover {
+  border-color: var(--ppt-neutral-400);
+  background: var(--ppt-neutral-50);
+}
+.btn-white {
+  background: #fff;
+  color: var(--ppt-color-primary-dark);
+}
+.btn-white:hover {
+  background: var(--ppt-brand-50);
+}
+
+/* Skip link becomes visible on focus (keyboard users). */
+.skip-link {
+  position: absolute;
+  left: var(--ppt-space-4);
+  top: -3rem;
+  z-index: 100;
+  background: var(--ppt-color-primary);
+  color: #fff;
+  padding: var(--ppt-space-2) var(--ppt-space-4);
+  border-radius: var(--ppt-radius-md);
+  transition: top 0.15s ease;
+}
+.skip-link:focus {
+  top: var(--ppt-space-4);
+}

--- a/frontend/apps/accounting-web/src/app/icon.svg
+++ b/frontend/apps/accounting-web/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="7" fill="#2563eb"/>
+  <path d="M11 9h10M11 9v14M11 16h7" fill="none" stroke="#fff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/apps/accounting-web/src/app/layout.tsx
+++ b/frontend/apps/accounting-web/src/app/layout.tsx
@@ -1,0 +1,8 @@
+import './globals.css';
+
+// Root layout is intentionally a pass-through: the real <html>/<body> and all
+// locale-aware metadata live in [locale]/layout.tsx so next-intl can resolve
+// the request locale. (Same split as reality-web.)
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/accounting-web/src/app/manifest.ts
+++ b/frontend/apps/accounting-web/src/app/manifest.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+import { BRAND_NAME } from '@/i18n/config';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: BRAND_NAME,
+    short_name: BRAND_NAME,
+    description: 'Fakturace a účetnictví pro živnostníky a malé firmy.',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#ffffff',
+    theme_color: '#2563eb',
+    icons: [{ src: '/icon.svg', sizes: 'any', type: 'image/svg+xml' }],
+  };
+}

--- a/frontend/apps/accounting-web/src/app/robots.ts
+++ b/frontend/apps/accounting-web/src/app/robots.ts
@@ -1,0 +1,23 @@
+import type { MetadataRoute } from 'next';
+
+function siteUrl(): string {
+  return (process.env.NEXT_PUBLIC_SITE_URL || 'https://eko.dev.rlt.sk').replace(/\/+$/, '');
+}
+
+export default function robots(): MetadataRoute.Robots {
+  const base = siteUrl();
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        // The signup form is public/indexable; the authenticated app shell
+        // (added by PAP-303 #3) will live under /app and is disallowed here
+        // pre-emptively so it never leaks into the index.
+        disallow: ['/app/', '/sk/app/', '/api/', '/_next/'],
+      },
+    ],
+    sitemap: `${base}/sitemap.xml`,
+    host: base,
+  };
+}

--- a/frontend/apps/accounting-web/src/app/sitemap.ts
+++ b/frontend/apps/accounting-web/src/app/sitemap.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next';
+import { locales } from '@/i18n/config';
+
+function siteUrl(): string {
+  return (process.env.NEXT_PUBLIC_SITE_URL || 'https://eko.dev.rlt.sk').replace(/\/+$/, '');
+}
+
+// Public, indexable paths. `as-needed` prefixing: cs (default) serves the
+// bare path, sk serves `/sk/...`.
+const PUBLIC_PATHS = ['', '/signup'] as const;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = siteUrl();
+  // Static build timestamp — Date() is unavailable in some build sandboxes and
+  // a per-request value would defeat ISR caching anyway.
+  const lastModified = '2026-06-23';
+
+  return PUBLIC_PATHS.flatMap((path) =>
+    locales.map((locale) => {
+      const prefix = locale === 'cs' ? '' : `/${locale}`;
+      return {
+        url: `${base}${prefix}${path}`,
+        lastModified,
+        changeFrequency: path === '' ? ('weekly' as const) : ('monthly' as const),
+        priority: path === '' ? 1 : 0.8,
+        alternates: {
+          languages: Object.fromEntries(
+            locales.map((alt) => [alt, `${base}${alt === 'cs' ? '' : `/${alt}`}${path}`])
+          ),
+        },
+      };
+    })
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/CtaBanner.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/CtaBanner.tsx
@@ -1,0 +1,21 @@
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/routing';
+import styles from '@/styles/marketing.module.css';
+
+export function CtaBanner() {
+  const t = useTranslations('cta');
+
+  return (
+    <section className={styles.ctaBand}>
+      <div className={`container ${styles.ctaInner}`}>
+        <h2 className={styles.ctaTitle}>{t('title')}</h2>
+        <p className={styles.ctaSubtitle}>{t('subtitle')}</p>
+        <div className={styles.ctaActions}>
+          <Link href="/signup" className="btn btn-lg btn-white">
+            {t('button')}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/FeatureGrid.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/FeatureGrid.tsx
@@ -1,0 +1,42 @@
+import { useTranslations } from 'next-intl';
+import styles from '@/styles/marketing.module.css';
+import {
+  ContactsIcon,
+  DashboardIcon,
+  ExportIcon,
+  InvoiceIcon,
+  MatchIcon,
+  ShieldIcon,
+} from './Icons';
+
+const ICONS = [InvoiceIcon, ContactsIcon, MatchIcon, DashboardIcon, ExportIcon, ShieldIcon];
+
+export function FeatureGrid() {
+  const t = useTranslations('features');
+  // Six feature slots, keyed by index into the messages array.
+  const items = [0, 1, 2, 3, 4, 5];
+
+  return (
+    <section id="features" className={`container ${styles.section}`}>
+      <div className={styles.sectionHead}>
+        <h2 className={styles.sectionTitle}>{t('title')}</h2>
+        <p className={styles.sectionSubtitle}>{t('subtitle')}</p>
+      </div>
+
+      <div className={styles.featureGrid}>
+        {items.map((i) => {
+          const Icon = ICONS[i];
+          return (
+            <article key={i} className={styles.featureCard}>
+              <span className={styles.featureIcon}>
+                <Icon />
+              </span>
+              <h3 className={styles.featureTitle}>{t(`items.${i}.title`)}</h3>
+              <p className={styles.featureBody}>{t(`items.${i}.body`)}</p>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/Hero.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/Hero.tsx
@@ -1,0 +1,57 @@
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/routing';
+import styles from '@/styles/marketing.module.css';
+
+export function Hero() {
+  const t = useTranslations('hero');
+
+  return (
+    <section className={styles.hero}>
+      <div className={`container ${styles.heroInner}`}>
+        <div>
+          <span className={styles.heroBadge}>{t('badge')}</span>
+          <h1 className={styles.heroTitle}>{t('title')}</h1>
+          <p className={styles.heroSubtitle}>{t('subtitle')}</p>
+          <div className={styles.heroActions}>
+            <Link href="/signup" className="btn btn-lg btn-primary">
+              {t('ctaPrimary')}
+            </Link>
+            <a href="#features" className="btn btn-lg btn-secondary">
+              {t('ctaSecondary')}
+            </a>
+          </div>
+          <p className={styles.heroTrust}>{t('trust')}</p>
+        </div>
+
+        {/* Decorative invoice mock — token-built, no image asset. */}
+        <div className={styles.heroVisual} aria-hidden="true">
+          <div className={styles.invoiceCard}>
+            <div className={styles.invoiceTop}>
+              <div>
+                <div className={styles.invoiceLabel}>Faktúra</div>
+                <div className={styles.invoiceNo}>2026-0042</div>
+              </div>
+              <span className={styles.invoicePaid}>Zaplatené</span>
+            </div>
+            <div className={styles.invoiceRow}>
+              <span>Konzultácia (8 h)</span>
+              <span>480,00 €</span>
+            </div>
+            <div className={styles.invoiceRow}>
+              <span>Návrh & vývoj</span>
+              <span>1 200,00 €</span>
+            </div>
+            <div className={styles.invoiceRow}>
+              <span>DPH 21 %</span>
+              <span>352,80 €</span>
+            </div>
+            <div className={styles.invoiceTotal}>
+              <span>Spolu</span>
+              <span>2 032,80 €</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/Icons.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/Icons.tsx
@@ -1,0 +1,70 @@
+/**
+ * Minimal inline SVG icon set (no runtime icon dependency). Decorative by
+ * default — `aria-hidden` so screen readers skip them; the adjacent text
+ * carries the meaning.
+ */
+import type { SVGProps } from 'react';
+
+const base = (props: SVGProps<SVGSVGElement>) => ({
+  width: 24,
+  height: 24,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 2,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true,
+  ...props,
+});
+
+export const InvoiceIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg {...base(p)}>
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <path d="M14 2v6h6" />
+    <path d="M8 13h8M8 17h6" />
+  </svg>
+);
+
+export const ContactsIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg {...base(p)}>
+    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
+
+export const MatchIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg {...base(p)}>
+    <path d="M16 3h5v5M21 3l-7 7M8 21H3v-5M3 21l7-7" />
+  </svg>
+);
+
+export const DashboardIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg {...base(p)}>
+    <rect x="3" y="3" width="7" height="9" rx="1" />
+    <rect x="14" y="3" width="7" height="5" rx="1" />
+    <rect x="14" y="12" width="7" height="9" rx="1" />
+    <rect x="3" y="16" width="7" height="5" rx="1" />
+  </svg>
+);
+
+export const ExportIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg {...base(p)}>
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <path d="M7 10l5 5 5-5M12 15V3" />
+  </svg>
+);
+
+export const ShieldIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg {...base(p)}>
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+    <path d="M9 12l2 2 4-4" />
+  </svg>
+);
+
+export const CheckIcon = (p: SVGProps<SVGSVGElement>) => (
+  <svg {...base(p)} width={18} height={18}>
+    <path d="M20 6L9 17l-5-5" />
+  </svg>
+);

--- a/frontend/apps/accounting-web/src/components/marketing/LocaleSwitcher.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/LocaleSwitcher.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useLocale } from 'next-intl';
+import { locales } from '@/i18n/config';
+import { Link, usePathname } from '@/i18n/routing';
+import styles from '@/styles/marketing.module.css';
+
+/**
+ * cs/sk locale toggle. Keeps the current pathname and swaps only the locale
+ * prefix (next-intl Link handles the `as-needed` prefixing).
+ */
+export function LocaleSwitcher() {
+  const active = useLocale();
+  const pathname = usePathname();
+
+  return (
+    <div className={styles.localeSwitch} role="group" aria-label="Language">
+      {locales.map((lc) => (
+        <Link
+          key={lc}
+          href={pathname}
+          locale={lc}
+          className={`${styles.localeOption} ${lc === active ? styles.localeOptionActive : ''}`}
+          aria-current={lc === active ? 'true' : undefined}
+        >
+          {lc.toUpperCase()}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/PricingTeaser.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/PricingTeaser.tsx
@@ -1,0 +1,57 @@
+import { useTranslations } from 'next-intl';
+import { Link } from '@/i18n/routing';
+import styles from '@/styles/marketing.module.css';
+import { CheckIcon } from './Icons';
+
+export function PricingTeaser() {
+  const t = useTranslations('pricing');
+  const plans = [0, 1, 2];
+  // Feature-count per plan mirrors the messages arrays (Start 3, Standard 4, Team 4).
+  const featureCounts = [3, 4, 4];
+
+  return (
+    <section id="pricing" className={`container ${styles.section}`}>
+      <div className={styles.sectionHead}>
+        <h2 className={styles.sectionTitle}>{t('title')}</h2>
+        <p className={styles.sectionSubtitle}>{t('subtitle')}</p>
+      </div>
+
+      <div className={styles.pricingGrid}>
+        {plans.map((p) => {
+          const featured = p === 1;
+          const features = Array.from({ length: featureCounts[p] }, (_, k) => k);
+          return (
+            <div
+              key={p}
+              className={`${styles.priceCard} ${featured ? styles.priceCardFeatured : ''}`}
+            >
+              {featured && <span className={styles.priceTag}>{t('mostPopular')}</span>}
+              <div className={styles.priceName}>{t(`plans.${p}.name`)}</div>
+              <div className={styles.priceTagline}>{t(`plans.${p}.tagline`)}</div>
+              <div className={styles.priceAmount}>
+                <span className={styles.priceValue}>{t(`plans.${p}.price`)}</span>
+                <span className={styles.pricePeriod}>{t('perMonth')}</span>
+              </div>
+              <ul className={styles.priceFeatures}>
+                {features.map((f) => (
+                  <li key={f} className={styles.priceFeature}>
+                    <CheckIcon className={styles.priceCheck} />
+                    {t(`plans.${p}.features.${f}`)}
+                  </li>
+                ))}
+              </ul>
+              <Link
+                href="/signup"
+                className={`btn btn-md ${featured ? 'btn-primary' : 'btn-secondary'}`}
+              >
+                {t(`plans.${p}.cta`)}
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+
+      <p className={styles.priceNote}>{t('note')}</p>
+    </section>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/SiteFooter.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/SiteFooter.tsx
@@ -1,0 +1,79 @@
+import { useTranslations } from 'next-intl';
+import { BRAND_NAME } from '@/i18n/config';
+import { Link } from '@/i18n/routing';
+import styles from '@/styles/marketing.module.css';
+import { LocaleSwitcher } from './LocaleSwitcher';
+
+export function SiteFooter() {
+  const t = useTranslations('footer');
+  const year = 2026; // Static build year — avoids Date() in RSC render path.
+
+  return (
+    <footer className={styles.footer}>
+      <div className="container">
+        <div className={styles.footerGrid}>
+          <div>
+            <div className={styles.footerBrand}>
+              <span className={styles.brandMark} aria-hidden="true">
+                {BRAND_NAME.charAt(0)}
+              </span>
+              {BRAND_NAME}
+            </div>
+            <p className={styles.footerTagline}>{t('tagline')}</p>
+          </div>
+
+          <div>
+            <div className={styles.footerHeading}>{t('productHeading')}</div>
+            <ul className={styles.footerLinks}>
+              <li>
+                <a className={styles.footerLink} href="#features">
+                  {t('links.features')}
+                </a>
+              </li>
+              <li>
+                <a className={styles.footerLink} href="#pricing">
+                  {t('links.pricing')}
+                </a>
+              </li>
+              <li>
+                <Link className={styles.footerLink} href="/signup">
+                  {t('links.signup')}
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <div className={styles.footerHeading}>{t('companyHeading')}</div>
+            <ul className={styles.footerLinks}>
+              <li>
+                <Link className={styles.footerLink} href="/signup">
+                  {t('links.login')}
+                </Link>
+              </li>
+            </ul>
+          </div>
+
+          <div>
+            <div className={styles.footerHeading}>{t('legalHeading')}</div>
+            <ul className={styles.footerLinks}>
+              <li>
+                <span className={styles.footerLink}>{t('links.terms')}</span>
+              </li>
+              <li>
+                <span className={styles.footerLink}>{t('links.privacy')}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className={styles.footerBottom}>
+          <span>
+            © {year} {BRAND_NAME}. {t('rights')} — {t('placeholderNote')}
+          </span>
+          <LocaleSwitcher />
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/SiteHeader.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/SiteHeader.tsx
@@ -1,0 +1,41 @@
+import { useTranslations } from 'next-intl';
+import { BRAND_NAME } from '@/i18n/config';
+import { Link } from '@/i18n/routing';
+import styles from '@/styles/marketing.module.css';
+import { LocaleSwitcher } from './LocaleSwitcher';
+
+export function SiteHeader() {
+  const t = useTranslations('nav');
+
+  return (
+    <header className={styles.header}>
+      <div className={`container ${styles.headerInner}`}>
+        <Link href="/" className={styles.brand} aria-label={BRAND_NAME}>
+          <span className={styles.brandMark} aria-hidden="true">
+            {BRAND_NAME.charAt(0)}
+          </span>
+          {BRAND_NAME}
+        </Link>
+
+        <nav className={`${styles.nav} ${styles.navLinks}`} aria-label="Primary">
+          <a className={styles.navLink} href="#features">
+            {t('features')}
+          </a>
+          <a className={styles.navLink} href="#pricing">
+            {t('pricing')}
+          </a>
+        </nav>
+
+        <div className={styles.navActions}>
+          <LocaleSwitcher />
+          <Link href="/signup" className={`${styles.navLink} ${styles.navLinks}`}>
+            {t('login')}
+          </Link>
+          <Link href="/signup" className="btn btn-md btn-primary">
+            {t('signup')}
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/marketing/Steps.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/Steps.tsx
@@ -1,0 +1,28 @@
+import { useTranslations } from 'next-intl';
+import styles from '@/styles/marketing.module.css';
+
+export function Steps() {
+  const t = useTranslations('steps');
+  const items = [0, 1, 2];
+
+  return (
+    <section className={styles.stepsBand}>
+      <div className={`container ${styles.section}`}>
+        <div className={styles.sectionHead}>
+          <h2 className={styles.sectionTitle}>{t('title')}</h2>
+        </div>
+        <ol className={styles.steps}>
+          {items.map((i) => (
+            <li key={i} className={styles.step}>
+              <span className={styles.stepNum} aria-hidden="true">
+                {i + 1}
+              </span>
+              <h3 className={styles.stepTitle}>{t(`items.${i}.title`)}</h3>
+              <p className={styles.stepBody}>{t(`items.${i}.body`)}</p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}

--- a/frontend/apps/accounting-web/src/components/signup/SignupForm.tsx
+++ b/frontend/apps/accounting-web/src/components/signup/SignupForm.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { Alert, Button, Input } from '@ppt/ui-kit';
+import { useTranslations } from 'next-intl';
+import { type FormEvent, useState } from 'react';
+import styles from '@/styles/signup.module.css';
+
+type Errors = Partial<Record<'company' | 'email' | 'password', string>>;
+
+/**
+ * Signup form for the public surface.
+ *
+ * Copy is fully slot-wired (CMO supplies final strings). The submit handler is
+ * intentionally a no-op-with-feedback for now: the real account-creation call
+ * depends on the accounting-api-client (PAP-303 task #2) and new signup
+ * endpoints, which land in the auth/shell work (#3). Until then we validate
+ * inputs client-side and show a "coming soon" notice — no data is sent or
+ * stored. Swap the TODO block for the API mutation when #2/#3 land.
+ */
+export function SignupForm() {
+  const t = useTranslations('signup');
+  const [errors, setErrors] = useState<Errors>({});
+  const [submitted, setSubmitted] = useState(false);
+
+  function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const data = new FormData(form);
+    const company = String(data.get('company') ?? '').trim();
+    const email = String(data.get('email') ?? '').trim();
+    const password = String(data.get('password') ?? '');
+
+    const next: Errors = {};
+    if (!company) next.company = t('validation.companyRequired');
+    if (!email) next.email = t('validation.emailRequired');
+    else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) next.email = t('validation.emailInvalid');
+    if (password.length < 8) next.password = t('validation.passwordShort');
+
+    setErrors(next);
+    if (Object.keys(next).length === 0) {
+      // TODO(PAP-303 #2/#3): replace with accountingApiClient.signup(...) mutation.
+      setSubmitted(true);
+    }
+  }
+
+  return (
+    <form className={styles.form} onSubmit={onSubmit} noValidate>
+      <div className={styles.field}>
+        <Input
+          name="company"
+          label={t('fields.companyLabel')}
+          placeholder={t('fields.companyPlaceholder')}
+          error={errors.company}
+          fullWidth
+          autoComplete="organization"
+        />
+      </div>
+
+      <div className={styles.field}>
+        <Input
+          name="name"
+          label={t('fields.nameLabel')}
+          placeholder={t('fields.namePlaceholder')}
+          fullWidth
+          autoComplete="name"
+        />
+      </div>
+
+      <div className={styles.field}>
+        <Input
+          name="email"
+          type="email"
+          label={t('fields.emailLabel')}
+          placeholder={t('fields.emailPlaceholder')}
+          error={errors.email}
+          fullWidth
+          autoComplete="email"
+        />
+      </div>
+
+      <div className={styles.field}>
+        <Input
+          name="password"
+          type="password"
+          label={t('fields.passwordLabel')}
+          placeholder={t('fields.passwordPlaceholder')}
+          error={errors.password}
+          helperText={errors.password ? undefined : t('fields.passwordPlaceholder')}
+          fullWidth
+          autoComplete="new-password"
+        />
+      </div>
+
+      <p className={styles.consent}>{t('consent')}</p>
+
+      <div className={styles.submitWrap}>
+        <Button type="submit" variant="primary" size="lg" fullWidth>
+          {t('submit')}
+        </Button>
+      </div>
+
+      {submitted && (
+        <div className={styles.notice}>
+          <Alert variant="info">{t('comingSoon')}</Alert>
+        </div>
+      )}
+    </form>
+  );
+}

--- a/frontend/apps/accounting-web/src/i18n/config.ts
+++ b/frontend/apps/accounting-web/src/i18n/config.ts
@@ -1,0 +1,29 @@
+/**
+ * i18n configuration for the Accounting Portal public surface.
+ *
+ * Market-first locales: cs + sk (the target markets). en/de are roadmap
+ * (PAP-303 §3). Default is `cs` — the largest addressable iDoklad-style
+ * market — with `as-needed` prefixing so `/` serves cs and `/sk/...` serves sk.
+ */
+
+export const locales = ['cs', 'sk'] as const;
+export type Locale = (typeof locales)[number];
+
+export const defaultLocale: Locale = 'cs';
+
+export const localeNames: Record<Locale, string> = {
+  cs: 'Čeština',
+  sk: 'Slovenčina',
+};
+
+export const localeFlags: Record<Locale, string> = {
+  cs: '🇨🇿',
+  sk: '🇸🇰',
+};
+
+/**
+ * PLACEHOLDER brand identity — final product name + domain are a board
+ * decision (PAP-303 open decision #1, "name ≠ iDoklad"). Centralised here so
+ * a rename is a one-line change. Do not hard-code the name elsewhere.
+ */
+export const BRAND_NAME = 'Fakto';

--- a/frontend/apps/accounting-web/src/i18n/index.ts
+++ b/frontend/apps/accounting-web/src/i18n/index.ts
@@ -1,0 +1,9 @@
+export {
+  BRAND_NAME,
+  defaultLocale,
+  type Locale,
+  localeFlags,
+  localeNames,
+  locales,
+} from './config';
+export { getPathname, Link, redirect, routing, usePathname, useRouter } from './routing';

--- a/frontend/apps/accounting-web/src/i18n/request.ts
+++ b/frontend/apps/accounting-web/src/i18n/request.ts
@@ -1,0 +1,15 @@
+import { getRequestConfig } from 'next-intl/server';
+import { defaultLocale, type Locale, locales } from './config';
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale;
+
+  if (!locale || !locales.includes(locale as Locale)) {
+    locale = defaultLocale;
+  }
+
+  return {
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
+  };
+});

--- a/frontend/apps/accounting-web/src/i18n/routing.ts
+++ b/frontend/apps/accounting-web/src/i18n/routing.ts
@@ -1,0 +1,12 @@
+import { createNavigation } from 'next-intl/navigation';
+import { defineRouting } from 'next-intl/routing';
+import { defaultLocale, locales } from './config';
+
+export const routing = defineRouting({
+  locales,
+  defaultLocale,
+  localePrefix: 'as-needed',
+});
+
+// Locale-aware navigation utilities (Link/redirect/hooks honour the prefix).
+export const { Link, redirect, usePathname, useRouter, getPathname } = createNavigation(routing);

--- a/frontend/apps/accounting-web/src/middleware.ts
+++ b/frontend/apps/accounting-web/src/middleware.ts
@@ -1,0 +1,11 @@
+import createMiddleware from 'next-intl/middleware';
+import { routing } from './i18n/routing';
+
+// Plain next-intl locale routing. Unlike reality-web there is no per-tenant
+// kill-switch here — the public marketing/signup surface is single-tenant.
+export default createMiddleware(routing);
+
+export const config = {
+  // Run on everything except API routes, Next internals, and static files.
+  matcher: ['/((?!api|_next|_vercel|.*\\..*).*)'],
+};

--- a/frontend/apps/accounting-web/src/styles/marketing.module.css
+++ b/frontend/apps/accounting-web/src/styles/marketing.module.css
@@ -1,0 +1,522 @@
+/* Marketing surface styles. Every value derives from @ppt/ui-kit tokens. */
+
+/* ─── Header ─────────────────────────────────────────────── */
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: saturate(180%) blur(8px);
+  border-bottom: 1px solid var(--ppt-neutral-200);
+}
+.headerInner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 4rem;
+  gap: var(--ppt-space-6);
+}
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ppt-space-2);
+  font-size: var(--ppt-font-size-xl);
+  font-weight: var(--ppt-font-weight-bold);
+  color: var(--ppt-neutral-900);
+  letter-spacing: -0.01em;
+}
+.brandMark {
+  display: inline-grid;
+  place-items: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--ppt-radius-md);
+  background: var(--ppt-color-primary);
+  color: #fff;
+  font-weight: var(--ppt-font-weight-bold);
+  font-size: var(--ppt-font-size-base);
+}
+.nav {
+  display: flex;
+  align-items: center;
+  gap: var(--ppt-space-6);
+}
+.navLink {
+  font-size: var(--ppt-font-size-sm);
+  font-weight: var(--ppt-font-weight-medium);
+  color: var(--ppt-neutral-600);
+  transition: color 0.15s ease;
+}
+.navLink:hover {
+  color: var(--ppt-color-primary);
+}
+.navActions {
+  display: flex;
+  align-items: center;
+  gap: var(--ppt-space-3);
+}
+@media (max-width: 760px) {
+  .navLinks {
+    display: none;
+  }
+}
+
+/* ─── Section scaffold ───────────────────────────────────── */
+.section {
+  padding-block: var(--ppt-space-12);
+}
+.sectionTight {
+  padding-block: var(--ppt-space-10);
+}
+.sectionHead {
+  max-width: 42rem;
+  margin: 0 auto var(--ppt-space-10);
+  text-align: center;
+}
+.eyebrow {
+  display: inline-block;
+  font-size: var(--ppt-font-size-xs);
+  font-weight: var(--ppt-font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ppt-color-primary);
+  margin-bottom: var(--ppt-space-3);
+}
+.sectionTitle {
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: var(--ppt-font-weight-bold);
+  line-height: var(--ppt-line-height-tight);
+  color: var(--ppt-neutral-900);
+  letter-spacing: -0.02em;
+}
+.sectionSubtitle {
+  margin-top: var(--ppt-space-4);
+  font-size: var(--ppt-font-size-lg);
+  color: var(--ppt-neutral-500);
+  line-height: var(--ppt-line-height-relaxed);
+}
+
+/* ─── Hero ───────────────────────────────────────────────── */
+.hero {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(60% 80% at 80% -10%, var(--ppt-brand-100) 0%, transparent 60%),
+    linear-gradient(180deg, var(--ppt-brand-50) 0%, var(--ppt-neutral-0) 70%);
+  border-bottom: 1px solid var(--ppt-neutral-200);
+}
+.heroInner {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: var(--ppt-space-12);
+  align-items: center;
+  padding-block: var(--ppt-space-12);
+}
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ppt-space-2);
+  background: var(--ppt-color-primary-light);
+  color: var(--ppt-color-primary-dark);
+  font-size: var(--ppt-font-size-xs);
+  font-weight: var(--ppt-font-weight-semibold);
+  padding: var(--ppt-space-1) var(--ppt-space-3);
+  border-radius: var(--ppt-radius-full);
+  margin-bottom: var(--ppt-space-5);
+}
+.heroTitle {
+  font-size: clamp(2.25rem, 5.5vw, 3.5rem);
+  font-weight: var(--ppt-font-weight-bold);
+  line-height: var(--ppt-line-height-tight);
+  letter-spacing: -0.03em;
+  color: var(--ppt-neutral-900);
+}
+.heroSubtitle {
+  margin-top: var(--ppt-space-5);
+  font-size: var(--ppt-font-size-lg);
+  line-height: var(--ppt-line-height-relaxed);
+  color: var(--ppt-neutral-600);
+  max-width: 34rem;
+}
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ppt-space-3);
+  margin-top: var(--ppt-space-8);
+}
+.heroTrust {
+  margin-top: var(--ppt-space-5);
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-500);
+}
+
+/* Hero visual: a stylised invoice card mock built from tokens. */
+.heroVisual {
+  position: relative;
+}
+.invoiceCard {
+  background: var(--ppt-neutral-0);
+  border: 1px solid var(--ppt-neutral-200);
+  border-radius: var(--ppt-radius-xl);
+  box-shadow: var(--ppt-shadow-xl);
+  padding: var(--ppt-space-6);
+}
+.invoiceTop {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding-bottom: var(--ppt-space-4);
+  border-bottom: 1px solid var(--ppt-neutral-100);
+}
+.invoiceLabel {
+  font-size: var(--ppt-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ppt-neutral-400);
+}
+.invoiceNo {
+  font-size: var(--ppt-font-size-lg);
+  font-weight: var(--ppt-font-weight-bold);
+  color: var(--ppt-neutral-900);
+}
+.invoicePaid {
+  font-size: var(--ppt-font-size-xs);
+  font-weight: var(--ppt-font-weight-semibold);
+  color: var(--ppt-color-success-dark);
+  background: var(--ppt-color-success-light);
+  padding: var(--ppt-space-1) var(--ppt-space-3);
+  border-radius: var(--ppt-radius-full);
+}
+.invoiceRow {
+  display: flex;
+  justify-content: space-between;
+  padding-block: var(--ppt-space-3);
+  border-bottom: 1px dashed var(--ppt-neutral-100);
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-600);
+}
+.invoiceTotal {
+  display: flex;
+  justify-content: space-between;
+  padding-top: var(--ppt-space-4);
+  font-weight: var(--ppt-font-weight-bold);
+  font-size: var(--ppt-font-size-xl);
+  color: var(--ppt-neutral-900);
+}
+@media (max-width: 880px) {
+  .heroInner {
+    grid-template-columns: 1fr;
+    gap: var(--ppt-space-8);
+  }
+  .heroVisual {
+    display: none;
+  }
+}
+
+/* ─── Feature grid ───────────────────────────────────────── */
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--ppt-space-6);
+}
+.featureCard {
+  background: var(--ppt-neutral-0);
+  border: 1px solid var(--ppt-neutral-200);
+  border-radius: var(--ppt-radius-lg);
+  padding: var(--ppt-space-6);
+  transition:
+    box-shadow 0.18s ease,
+    transform 0.18s ease,
+    border-color 0.18s ease;
+}
+.featureCard:hover {
+  box-shadow: var(--ppt-shadow-lg);
+  transform: translateY(-2px);
+  border-color: var(--ppt-brand-200);
+}
+.featureIcon {
+  display: inline-grid;
+  place-items: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: var(--ppt-radius-md);
+  background: var(--ppt-color-primary-light);
+  color: var(--ppt-color-primary);
+  margin-bottom: var(--ppt-space-4);
+}
+.featureTitle {
+  font-size: var(--ppt-font-size-lg);
+  font-weight: var(--ppt-font-weight-semibold);
+  color: var(--ppt-neutral-900);
+  margin-bottom: var(--ppt-space-2);
+}
+.featureBody {
+  font-size: var(--ppt-font-size-sm);
+  line-height: var(--ppt-line-height-relaxed);
+  color: var(--ppt-neutral-500);
+}
+@media (max-width: 880px) {
+  .featureGrid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+@media (max-width: 560px) {
+  .featureGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── Steps ──────────────────────────────────────────────── */
+.stepsBand {
+  background: var(--ppt-neutral-50);
+  border-block: 1px solid var(--ppt-neutral-200);
+}
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--ppt-space-8);
+  counter-reset: step;
+}
+.step {
+  position: relative;
+  padding-left: var(--ppt-space-12);
+}
+.stepNum {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: inline-grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--ppt-radius-full);
+  background: var(--ppt-color-primary);
+  color: #fff;
+  font-weight: var(--ppt-font-weight-bold);
+}
+.stepTitle {
+  font-size: var(--ppt-font-size-lg);
+  font-weight: var(--ppt-font-weight-semibold);
+  color: var(--ppt-neutral-900);
+  margin-bottom: var(--ppt-space-2);
+}
+.stepBody {
+  font-size: var(--ppt-font-size-sm);
+  line-height: var(--ppt-line-height-relaxed);
+  color: var(--ppt-neutral-500);
+}
+@media (max-width: 760px) {
+  .steps {
+    grid-template-columns: 1fr;
+    gap: var(--ppt-space-6);
+  }
+}
+
+/* ─── Pricing ────────────────────────────────────────────── */
+.pricingGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--ppt-space-6);
+  align-items: stretch;
+}
+.priceCard {
+  display: flex;
+  flex-direction: column;
+  background: var(--ppt-neutral-0);
+  border: 1px solid var(--ppt-neutral-200);
+  border-radius: var(--ppt-radius-xl);
+  padding: var(--ppt-space-8) var(--ppt-space-6);
+}
+.priceCardFeatured {
+  border-color: var(--ppt-color-primary);
+  box-shadow: var(--ppt-shadow-lg);
+  position: relative;
+}
+.priceTag {
+  position: absolute;
+  top: calc(-1 * var(--ppt-space-3));
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ppt-color-primary);
+  color: #fff;
+  font-size: var(--ppt-font-size-xs);
+  font-weight: var(--ppt-font-weight-semibold);
+  padding: var(--ppt-space-1) var(--ppt-space-3);
+  border-radius: var(--ppt-radius-full);
+}
+.priceName {
+  font-size: var(--ppt-font-size-lg);
+  font-weight: var(--ppt-font-weight-semibold);
+  color: var(--ppt-neutral-900);
+}
+.priceTagline {
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-500);
+  margin-top: var(--ppt-space-1);
+}
+.priceAmount {
+  display: flex;
+  align-items: baseline;
+  gap: var(--ppt-space-1);
+  margin-block: var(--ppt-space-5);
+}
+.priceValue {
+  font-size: 2.5rem;
+  font-weight: var(--ppt-font-weight-bold);
+  color: var(--ppt-neutral-900);
+  letter-spacing: -0.02em;
+}
+.pricePeriod {
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-400);
+}
+.priceFeatures {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ppt-space-3);
+  margin-block: var(--ppt-space-5) var(--ppt-space-8);
+  flex: 1;
+}
+.priceFeature {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ppt-space-2);
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-600);
+}
+.priceCheck {
+  color: var(--ppt-color-success);
+  flex-shrink: 0;
+  margin-top: 0.1rem;
+}
+.priceNote {
+  margin-top: var(--ppt-space-6);
+  text-align: center;
+  font-size: var(--ppt-font-size-xs);
+  color: var(--ppt-neutral-400);
+}
+@media (max-width: 880px) {
+  .pricingGrid {
+    grid-template-columns: 1fr;
+    max-width: 28rem;
+    margin-inline: auto;
+  }
+}
+
+/* ─── Final CTA ──────────────────────────────────────────── */
+.ctaBand {
+  background: linear-gradient(135deg, var(--ppt-brand-700) 0%, var(--ppt-brand-900) 100%);
+}
+.ctaInner {
+  text-align: center;
+  padding-block: var(--ppt-space-12);
+  color: #fff;
+}
+.ctaTitle {
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: var(--ppt-font-weight-bold);
+  letter-spacing: -0.02em;
+}
+.ctaSubtitle {
+  margin-top: var(--ppt-space-3);
+  font-size: var(--ppt-font-size-lg);
+  color: var(--ppt-brand-100);
+}
+.ctaActions {
+  margin-top: var(--ppt-space-8);
+  display: flex;
+  justify-content: center;
+}
+
+/* ─── Footer ─────────────────────────────────────────────── */
+.footer {
+  background: var(--ppt-neutral-900);
+  color: var(--ppt-neutral-300);
+  padding-block: var(--ppt-space-12) var(--ppt-space-8);
+}
+.footerGrid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr 1fr;
+  gap: var(--ppt-space-8);
+}
+.footerBrand {
+  color: #fff;
+  font-size: var(--ppt-font-size-xl);
+  font-weight: var(--ppt-font-weight-bold);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ppt-space-2);
+  margin-bottom: var(--ppt-space-3);
+}
+.footerTagline {
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-400);
+  max-width: 22rem;
+  line-height: var(--ppt-line-height-relaxed);
+}
+.footerHeading {
+  font-size: var(--ppt-font-size-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ppt-neutral-500);
+  margin-bottom: var(--ppt-space-4);
+}
+.footerLinks {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ppt-space-3);
+}
+.footerLink {
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-300);
+  transition: color 0.15s ease;
+}
+.footerLink:hover {
+  color: #fff;
+}
+.footerBottom {
+  margin-top: var(--ppt-space-10);
+  padding-top: var(--ppt-space-6);
+  border-top: 1px solid var(--ppt-neutral-700, #374151);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ppt-space-4);
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--ppt-font-size-xs);
+  color: var(--ppt-neutral-500);
+}
+@media (max-width: 760px) {
+  .footerGrid {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+@media (max-width: 480px) {
+  .footerGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── Locale switcher ────────────────────────────────────── */
+.localeSwitch {
+  display: inline-flex;
+  border: 1px solid var(--ppt-neutral-200);
+  border-radius: var(--ppt-radius-full);
+  overflow: hidden;
+  background: var(--ppt-neutral-0);
+}
+.localeOption {
+  padding: var(--ppt-space-1) var(--ppt-space-3);
+  font-size: var(--ppt-font-size-xs);
+  font-weight: var(--ppt-font-weight-semibold);
+  color: var(--ppt-neutral-500);
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+.localeOptionActive {
+  background: var(--ppt-color-primary);
+  color: #fff;
+}

--- a/frontend/apps/accounting-web/src/styles/signup.module.css
+++ b/frontend/apps/accounting-web/src/styles/signup.module.css
@@ -1,0 +1,124 @@
+/* Signup surface styles. Tokens only. */
+
+.wrap {
+  min-height: calc(100vh - 4rem);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+/* Left: the form column. */
+.formCol {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ppt-space-12) var(--ppt-space-6);
+}
+.formInner {
+  width: 100%;
+  max-width: 26rem;
+}
+.title {
+  font-size: var(--ppt-font-size-2xl);
+  font-weight: var(--ppt-font-weight-bold);
+  color: var(--ppt-neutral-900);
+  letter-spacing: -0.02em;
+}
+.subtitle {
+  margin-top: var(--ppt-space-2);
+  font-size: var(--ppt-font-size-base);
+  color: var(--ppt-neutral-500);
+  line-height: var(--ppt-line-height-relaxed);
+}
+.form {
+  margin-top: var(--ppt-space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ppt-space-5);
+}
+.field {
+  display: flex;
+  flex-direction: column;
+}
+.countryRow {
+  display: flex;
+  gap: var(--ppt-space-3);
+}
+.consent {
+  font-size: var(--ppt-font-size-xs);
+  color: var(--ppt-neutral-500);
+  line-height: var(--ppt-line-height-relaxed);
+}
+.submitWrap {
+  margin-top: var(--ppt-space-2);
+}
+.altAuth {
+  margin-top: var(--ppt-space-6);
+  text-align: center;
+  font-size: var(--ppt-font-size-sm);
+  color: var(--ppt-neutral-500);
+}
+.altAuthLink {
+  color: var(--ppt-color-primary);
+  font-weight: var(--ppt-font-weight-semibold);
+}
+.notice {
+  margin-top: var(--ppt-space-5);
+}
+
+/* Right: a reassurance / benefits panel (brand gradient). */
+.asideCol {
+  background: linear-gradient(160deg, var(--ppt-brand-700) 0%, var(--ppt-brand-900) 100%);
+  color: #fff;
+  padding: var(--ppt-space-12) var(--ppt-space-10);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.asideBrand {
+  font-size: var(--ppt-font-size-xl);
+  font-weight: var(--ppt-font-weight-bold);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ppt-space-2);
+  margin-bottom: var(--ppt-space-8);
+}
+.asideHeading {
+  font-size: var(--ppt-font-size-2xl);
+  font-weight: var(--ppt-font-weight-bold);
+  line-height: var(--ppt-line-height-tight);
+  letter-spacing: -0.02em;
+  max-width: 20rem;
+}
+.benefitList {
+  list-style: none;
+  margin-top: var(--ppt-space-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ppt-space-4);
+}
+.benefit {
+  display: flex;
+  align-items: center;
+  gap: var(--ppt-space-3);
+  font-size: var(--ppt-font-size-base);
+  color: var(--ppt-brand-100);
+}
+.benefitCheck {
+  display: inline-grid;
+  place-items: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--ppt-radius-full);
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  flex-shrink: 0;
+}
+
+@media (max-width: 880px) {
+  .wrap {
+    grid-template-columns: 1fr;
+  }
+  .asideCol {
+    display: none;
+  }
+}

--- a/frontend/apps/accounting-web/tsconfig.json
+++ b/frontend/apps/accounting-web/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev:ppt": "pnpm --filter @ppt/web dev",
     "dev:reality": "pnpm --filter @ppt/reality-web dev",
+    "dev:accounting": "pnpm --filter @ppt/accounting-web dev",
     "dev:mobile": "pnpm --filter @ppt/mobile start",
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -23,6 +23,49 @@ importers:
         specifier: ^5.3.0
         version: 5.9.3
 
+  apps/accounting-web:
+    dependencies:
+      '@ppt/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@ppt/ui-kit':
+        specifier: workspace:*
+        version: link:../../packages/ui-kit
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.0)
+      next:
+        specifier: ^16.2.7
+        version: 16.2.9(@playwright/test@1.61.0)(react-dom@19.2.0)(react@19.2.0)
+      next-intl:
+        specifier: ^4.13.0
+        version: 4.13.0(next@16.2.9)(react@19.2.0)(typescript@5.9.3)
+      react:
+        specifier: 19.2.0
+        version: 19.2.0
+      react-dom:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
+    devDependencies:
+      '@ppt/dev-panel':
+        specifier: workspace:*
+        version: link:../../packages/dev-panel
+      '@ppt/vite-plugin-worktree':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-ppt-worktree
+      '@types/node':
+        specifier: ^25.0.5
+        version: 25.9.3
+      '@types/react':
+        specifier: 19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   apps/admin-web:
     dependencies:
       '@ppt/admin-ui':


### PR DESCRIPTION
## What

Stands up **`@ppt/accounting-web`** — the standalone Accounting Portal's public face — as a Next.js 16 + next-intl app modeled on `reality-web`. This is **PAP-312 / task #9** in the [PAP-303](https://github.com/martin-janci/property-management) accounting-portal tree (the board placed #9 in the "first wave, no blockers").

## Scope (this PR)
- **Landing** (`/[locale]`): sticky header w/ locale toggle, hero (token-built invoice mock), 6-up feature grid, 3-step "how it works", 3-tier pricing teaser, CTA band, footer.
- **Signup** (`/[locale]/signup`): SSR two-column page + client form on `@ppt/ui-kit` `Input`/`Button`/`Alert` with inline validation + benefits panel.
- **i18n**: `cs` (default) + `sk`, `localePrefix: as-needed` → `/` serves cs, `/sk/…` serves sk.
- **SEO**: per-locale `generateMetadata` (canonical + hreflang alternates), `robots.ts`, `sitemap.ts` (hreflang), `manifest.ts`, JSON-LD `SoftwareApplication`, SVG icon. `/app/*` pre-disallowed in robots.
- **Design**: every value from `@ppt/ui-kit` tokens (no one-offs); reused kit components; reduced-motion + skip-link + a11y labels.
- Root `dev:accounting` script.

## Copy & branding (placeholders by design)
- Every string is a **slot** in `messages/{cs,sk}.json` with realistic **PLACEHOLDER** copy + a `_meta` note. **Final copy is CMO's** (looped in on PAP-312).
- Brand name centralized in `i18n/config.ts` (`BRAND_NAME = 'Fakto'`, placeholder pending board name/domain — PAP-303 open-decision #1).

## Deliberately deferred (depends on sibling tasks)
- **Signup POST** is a marked `TODO`: depends on `@ppt/accounting-api-client` (#2) + signup endpoints (#3). The form validates client-side and shows a "coming soon" notice — **no data is sent or stored**.
- **Deploy** (CI build job + subdomain + DNS) is task #10.
- Reconciliation note for **#1 scaffold** (in-progress): this PR lays down the public-surface portion of the scaffold mirroring reality-web exactly, so #1/#3 graft on cleanly.

## Verification (IG3)
- `tsc --noEmit` clean.
- `next build` **green** — `/cs`, `/sk`, `/cs/signup`, `/sk/signup`, `robots.txt`, `sitemap.xml`, `manifest.webmanifest` all prerender as **static/SSG** (confirms SSR-indexable cs/sk landing + signup).
- `biome check` clean.

## Acceptance (PAP-312)
- [x] Public landing + signup render server-side, indexable, cs/sk.
- [x] Copy slots wired (CMO supplies final copy).
- [x] Draft PR against `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)