### PR TITLE
fix(accounting): PAP-321 F1/F2 — 404-not-500 + skip-serializing provider secrets

### DIFF
--- a/backend/crates/db/src/models/accounting_provider.rs
+++ b/backend/crates/db/src/models/accounting_provider.rs
@@ -23,7 +23,11 @@ pub struct AccountingProviderConnection {
     pub auth_flow: AccountingProviderAuthFlow,
     pub provider_account_name: String,
     pub client_id: String,
+    /// AES-256-GCM ciphertext — never serialize into an API response.
+    #[serde(skip_serializing)]
     pub client_secret_enc: Option<String>,
+    /// AES-256-GCM ciphertext — never serialize into an API response.
+    #[serde(skip_serializing)]
     pub refresh_token_enc: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -90,4 +94,46 @@ pub struct AccountingProviderPaymentMatchSnapshot {
     pub confidence: Decimal,
     pub amount: Decimal,
     pub matched_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// PAP-321 F2: the AES-256-GCM ciphertext fields must never appear in a
+    /// serialized representation, so that a future provider-connection handler
+    /// (PAP-191) cannot accidentally leak encrypted secrets into a response.
+    #[test]
+    fn provider_connection_does_not_serialize_encrypted_secrets() {
+        let conn = AccountingProviderConnection {
+            tenant_id: Uuid::nil(),
+            auth_flow: AccountingProviderAuthFlow::Acf,
+            provider_account_name: "acme".to_string(),
+            client_id: "client-123".to_string(),
+            client_secret_enc: Some("CIPHERTEXT_SECRET".to_string()),
+            refresh_token_enc: Some("CIPHERTEXT_REFRESH".to_string()),
+            created_at: DateTime::from_timestamp(0, 0).unwrap(),
+            updated_at: DateTime::from_timestamp(0, 0).unwrap(),
+        };
+
+        let json = serde_json::to_string(&conn).expect("serialize");
+
+        assert!(
+            !json.contains("client_secret_enc"),
+            "client_secret_enc key must be skipped on serialize: {json}"
+        );
+        assert!(
+            !json.contains("refresh_token_enc"),
+            "refresh_token_enc key must be skipped on serialize: {json}"
+        );
+        assert!(
+            !json.contains("CIPHERTEXT_SECRET") && !json.contains("CIPHERTEXT_REFRESH"),
+            "encrypted secret values must not leak into serialized output: {json}"
+        );
+        // Non-secret fields are still serialized.
+        assert!(
+            json.contains("client-123"),
+            "client_id must still serialize"
+        );
+    }
 }

--- a/backend/crates/db/src/repositories/accounting.rs
+++ b/backend/crates/db/src/repositories/accounting.rs
@@ -193,7 +193,7 @@ impl AccountingRepository {
         executor: E,
         id: Uuid,
         data: UpdateInvoice,
-    ) -> Result<Invoice, sqlx::Error>
+    ) -> Result<Option<Invoice>, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
@@ -227,7 +227,7 @@ impl AccountingRepository {
         .bind(data.status)
         .bind(data.paid_amount)
         .bind(id)
-        .fetch_one(executor)
+        .fetch_optional(executor)
         .await
     }
 
@@ -477,7 +477,7 @@ impl AccountingRepository {
         executor: E,
         id: Uuid,
         paid_amount_delta: Decimal,
-    ) -> Result<Invoice, sqlx::Error>
+    ) -> Result<Option<Invoice>, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
@@ -498,7 +498,7 @@ impl AccountingRepository {
         )
         .bind(paid_amount_delta)
         .bind(id)
-        .fetch_one(executor)
+        .fetch_optional(executor)
         .await
     }
 }

--- a/backend/crates/db/tests/accounting_rls_repo_tests.rs
+++ b/backend/crates/db/tests/accounting_rls_repo_tests.rs
@@ -1,6 +1,6 @@
 //! RLS isolation tests for native Accounting MVP (PAP-206).
 
-use db::models::accounting::{Contact, CreateInvoice, CreateInvoiceItem, Invoice};
+use db::models::accounting::{Contact, CreateInvoice, CreateInvoiceItem, Invoice, UpdateInvoice};
 use db::repositories::accounting::AccountingRepository;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -905,5 +905,55 @@ async fn create_invoice_header_totals_equal_sum_of_rounded_lines(pool: PgPool) {
     assert_eq!(
         invoice.total_amount, total_sum,
         "header total_amount must equal the sum of stored line total_amounts"
+    );
+}
+
+/// PAP-321 F1: `update_invoice_rls` on a missing (or RLS-excluded) id must return
+/// `Ok(None)` so the handler can map it to 404, rather than bubbling a
+/// `RowNotFound` error up to a 500. Pre-fix the method used `.fetch_one`, which
+/// returned `Err(RowNotFound)` for the no-rows-affected case.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_invoice_missing_id_returns_none_not_error(pool: PgPool) {
+    let org = seed_org(&pool, "inv-update-404").await;
+    set_ctx(&pool, Some(org), None, true).await;
+
+    let repo = AccountingRepository::new(pool.clone());
+    let mut conn = pool.acquire().await.expect("acquire");
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(Some(org))
+        .bind(Option::<Uuid>::None)
+        .bind(true)
+        .execute(&mut *conn)
+        .await
+        .expect("set ctx on conn");
+
+    let data = UpdateInvoice {
+        contact_id: None,
+        number: Some("WONT-APPLY".to_string()),
+        issue_date: None,
+        due_date: None,
+        taxable_supply_date: None,
+        currency: None,
+        variable_symbol: None,
+        status: None,
+        paid_amount: None,
+    };
+
+    let res = repo
+        .update_invoice_rls(&mut *conn, Uuid::new_v4(), data)
+        .await
+        .expect("update on missing id must not be a DB error");
+    assert!(
+        res.is_none(),
+        "updating a non-existent invoice id must return Ok(None), not a row"
+    );
+
+    let res = repo
+        .update_invoice_payment_status_rls(&mut *conn, Uuid::new_v4(), dec!(50))
+        .await
+        .expect("payment-status update on missing id must not be a DB error");
+    assert!(
+        res.is_none(),
+        "applying a payment to a non-existent invoice id must return Ok(None)"
     );
 }

--- a/backend/servers/api-server/src/routes/accounting/invoices.rs
+++ b/backend/servers/api-server/src/routes/accounting/invoices.rs
@@ -330,7 +330,8 @@ pub async fn update_invoice(
         .map_err(|e| {
             tracing::error!("Failed to update invoice {}: {}", id, e);
             StatusCode::INTERNAL_SERVER_ERROR
-        })?;
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
 
     rls.release().await;
     Ok(Json(invoice))

--- a/backend/servers/api-server/src/services/accounting.rs
+++ b/backend/servers/api-server/src/services/accounting.rs
@@ -233,7 +233,10 @@ impl AccountingService {
         self.repo
             .update_invoice_payment_status_rls(&mut *executor, p_match.invoice_id, line.amount)
             .await
-            .map_err(|e| AppError::Database(e.to_string()))?;
+            .map_err(|e| AppError::Database(e.to_string()))?
+            .ok_or_else(|| {
+                AppError::NotFound(format!("Invoice {} not found", p_match.invoice_id))
+            })?;
 
         Ok(())
     }


### PR DESCRIPTION
## PAP-321 — Accounting security hardening follow-ups (F1, F2)

Low-severity, **intra-tenant** hardening items from the PAP-315 accounting RLS/authz review. No cross-tenant data-leak path is involved — tenant isolation (FORCE RLS + \`get_current_org_id()\`, \`RlsConnection\` + manager-gated handlers) is unchanged.

### F1 — 404 instead of 500 for missing / RLS-excluded invoice ids
\`update_invoice_rls\` and \`update_invoice_payment_status_rls\` used \`.fetch_one()\`, so a non-existent (or RLS-hidden, cross-tenant) id produced \`RowNotFound\` → handler returned **500**. They now use \`fetch_optional\` and return \`Option<Invoice>\`:
- \`update_invoice\` handler maps \`None → 404\` (matches the existing \`get_invoice\` contract).
- \`confirm_match\` service maps \`None → AppError::NotFound\` (404).

No isolation change: RLS already blocks the row (UPDATE affects 0 rows); this only fixes the client-facing status code.

### F2 — provider connection no longer serializes encrypted secrets
\`AccountingProviderConnection.client_secret_enc\` / \`refresh_token_enc\` hold AES-256-GCM ciphertext and derived \`Serialize\`. Added \`#[serde(skip_serializing)]\` to both. Not exposed today (no route returns the struct), but defense-in-depth for the PAP-191 provider-connection CRUD roadmap.

### F3 — out of scope (routed)
The confirm/reject \`paid_amount\` state-machine integrity bug is **intra-tenant accounting correctness, not security/isolation**. Routed to the accounting owner as a child issue of PAP-321.

## Tests (IG3)
- \`update_invoice_missing_id_returns_none_not_error\` — proves both repo methods return \`Ok(None)\` for a missing id (the 404 path). Fails on \`dev\` (pre-fix returns \`Err(RowNotFound)\` / different signature).
- \`provider_connection_does_not_serialize_encrypted_secrets\` — proves the \`*_enc\` fields and their values never appear in serialized output.

Local clippy on a cold remote builder was still running at PR time; CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)