### PR TITLE
fix(accounting): enforce payment-match state machine (PAP-325)

### DIFF
--- a/backend/crates/db/src/repositories/accounting.rs
+++ b/backend/crates/db/src/repositories/accounting.rs
@@ -489,7 +489,10 @@ impl AccountingRepository {
                 status = CASE
                     WHEN paid_amount + $1 >= total_amount THEN 'paid'
                     WHEN paid_amount + $1 > 0 THEN 'partially_paid'
-                    ELSE status
+                    -- PAP-325: a negative delta (unapplying a confirmed match)
+                    -- can drive paid_amount back to 0; revert to 'issued' rather
+                    -- than leaving a stale 'paid'/'partially_paid' status.
+                    ELSE 'issued'
                 END,
                 updated_at = NOW()
             WHERE id = $2

--- a/backend/servers/api-server/src/services/accounting.rs
+++ b/backend/servers/api-server/src/services/accounting.rs
@@ -193,8 +193,18 @@ impl AccountingService {
             .map_err(|e| AppError::Database(e.to_string()))?
             .ok_or_else(|| AppError::NotFound(format!("Match {} not found", match_id)))?;
 
-        if p_match.state == PaymentMatchState::Confirmed {
-            return Ok(());
+        // PAP-325: enforce legal transitions. Only a `Suggested` match may be
+        // confirmed. Re-confirming an already-`Confirmed` match is an idempotent
+        // no-op (do NOT re-apply `paid_amount`). A `Rejected` match is terminal —
+        // confirming it would re-apply `paid_amount` and inflate the invoice.
+        match p_match.state {
+            PaymentMatchState::Confirmed => return Ok(()),
+            PaymentMatchState::Rejected => {
+                return Err(AppError::Conflict(format!(
+                    "Match {match_id} is rejected and cannot be confirmed"
+                )));
+            }
+            PaymentMatchState::Suggested => {}
         }
 
         let line = self
@@ -252,6 +262,16 @@ impl AccountingService {
             .map_err(|e| AppError::Database(e.to_string()))?
             .ok_or_else(|| AppError::NotFound(format!("Match {} not found", match_id)))?;
 
+        // PAP-325: enforce legal transitions. Rejecting an already-`Rejected`
+        // match is an idempotent no-op. Rejecting a `Confirmed` match is an
+        // explicit "unapply" — we must subtract the previously-applied
+        // `paid_amount` so AR/paid totals stay consistent.
+        let was_confirmed = match p_match.state {
+            PaymentMatchState::Rejected => return Ok(()),
+            PaymentMatchState::Confirmed => true,
+            PaymentMatchState::Suggested => false,
+        };
+
         // 1. Update match state
         let mut updated_match = p_match.clone();
         updated_match.state = PaymentMatchState::Rejected;
@@ -262,7 +282,30 @@ impl AccountingService {
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
 
-        // 2. Update statement line state if no other suggested matches remain
+        // 2. Unapply a previously-confirmed payment: subtract the line amount
+        //    delta and recompute invoice status so paid totals revert.
+        if was_confirmed {
+            let line = self
+                .repo
+                .find_bank_statement_line_rls(&mut *executor, p_match.statement_line_id)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?
+                .ok_or_else(|| {
+                    AppError::Internal(format!(
+                        "Statement line {} not found",
+                        p_match.statement_line_id
+                    ))
+                })?;
+            self.repo
+                .update_invoice_payment_status_rls(&mut *executor, p_match.invoice_id, -line.amount)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?
+                .ok_or_else(|| {
+                    AppError::NotFound(format!("Invoice {} not found", p_match.invoice_id))
+                })?;
+        }
+
+        // 3. Update statement line state if no other suggested matches remain
         let other_matches = self
             .repo
             .list_payment_matches_by_line_rls(&mut *executor, p_match.statement_line_id)

--- a/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
+++ b/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
@@ -1,0 +1,183 @@
+//! PAP-325: payment-match state-machine integrity tests.
+//!
+//! `AccountingService::{confirm_match, reject_match}` must enforce the legal
+//! match-state transitions so a manager cannot inflate (or corrupt) their own
+//! invoice's `paid_amount` by replaying confirm/reject. These tests assert the
+//! intra-tenant accounting correctness of the state machine — they are NOT
+//! tenant-isolation tests (that surface is covered elsewhere).
+//!
+//! Legal transitions:
+//!   - Suggested -> Confirmed  (apply +line.amount)
+//!   - Suggested -> Rejected   (no financial effect)
+//!   - Confirmed -> Rejected   (explicit unapply: subtract line.amount)
+//!   - Confirmed -> Confirmed / Rejected -> Rejected : idempotent no-op
+//!   - Rejected  -> Confirmed  : ILLEGAL -> 409 Conflict
+
+#[allow(dead_code)]
+mod common;
+
+use api_server::services::accounting::AccountingService;
+use common::seed_org;
+use db::models::accounting::InvoiceStatus;
+use db::repositories::AccountingRepository;
+use rust_decimal_macros::dec;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Bind the request context for `conn` so RLS predicates resolve to `org`.
+async fn set_ctx(conn: &mut sqlx::PgConnection, org: Uuid) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org)
+        .bind(Option::<Uuid>::None)
+        .bind(true)
+        .execute(conn)
+        .await
+        .expect("set request context");
+}
+
+/// Seed an org + contact + invoice (total 100) + statement line (amount 100) +
+/// a `suggested` payment match. Returns (org, invoice_id, match_id).
+async fn seed_match_scenario(pool: &PgPool, slug: &str) -> (Uuid, Uuid, Uuid) {
+    let org = seed_org(pool, slug).await;
+    let contact = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO contact (tenant_id, name) VALUES ($1, 'C') RETURNING id",
+    )
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let invoice = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO invoice (tenant_id, contact_id, number, issue_date, due_date, currency, total_amount, status) \
+         VALUES ($1, $2, 'INV-1', NOW(), NOW(), 'CZK', 100, 'issued') RETURNING id",
+    )
+    .bind(org)
+    .bind(contact)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let stmt = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO bank_statement (tenant_id, source_filename, account_iban) \
+         VALUES ($1, 'S', 'IBAN') RETURNING id",
+    )
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let line = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO bank_statement_line (statement_id, tenant_id, booking_date, amount, currency, match_state) \
+         VALUES ($1, $2, NOW(), 100, 'CZK', 'suggested') RETURNING id",
+    )
+    .bind(stmt)
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let p_match = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO payment_match (tenant_id, statement_line_id, invoice_id, confidence, state) \
+         VALUES ($1, $2, $3, 1.0, 'suggested') RETURNING id",
+    )
+    .bind(org)
+    .bind(line)
+    .bind(invoice)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (org, invoice, p_match)
+}
+
+async fn invoice_state(pool: &PgPool, invoice: Uuid) -> (rust_decimal::Decimal, InvoiceStatus) {
+    sqlx::query_as::<_, (rust_decimal::Decimal, InvoiceStatus)>(
+        "SELECT paid_amount, status FROM invoice WHERE id = $1",
+    )
+    .bind(invoice)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+/// confirm -> reject -> confirm must NOT inflate paid_amount.
+/// After confirm: paid=100/paid. After reject (unapply): paid=0/issued.
+/// The final confirm of a now-rejected match is illegal (409) and leaves paid=0.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn confirm_reject_confirm_does_not_inflate_paid_amount(pool: PgPool) {
+    let (org, invoice, match_id) = seed_match_scenario(&pool, "pap325-replay").await;
+    let svc = AccountingService::new(AccountingRepository::new(pool.clone()));
+    let user = Uuid::new_v4();
+    let mut conn = pool.acquire().await.unwrap();
+    set_ctx(&mut conn, org).await;
+
+    // Suggested -> Confirmed: applies the full amount.
+    svc.confirm_match(&mut *conn, org, match_id, user)
+        .await
+        .expect("confirm suggested match");
+    let (paid, status) = invoice_state(&pool, invoice).await;
+    assert_eq!(paid, dec!(100), "confirm must apply the line amount");
+    assert_eq!(status, InvoiceStatus::Paid, "fully paid invoice is 'paid'");
+
+    // Confirmed -> Rejected: unapplies the amount and reverts status.
+    svc.reject_match(&mut *conn, match_id, user)
+        .await
+        .expect("reject confirmed match");
+    let (paid, status) = invoice_state(&pool, invoice).await;
+    assert_eq!(paid, dec!(0), "rejecting a confirmed match must unapply the amount");
+    assert_eq!(
+        status,
+        InvoiceStatus::Issued,
+        "unapplying back to zero reverts status to 'issued'"
+    );
+
+    // Rejected -> Confirmed: ILLEGAL. Must 409 and must NOT re-apply.
+    let err = svc
+        .confirm_match(&mut *conn, org, match_id, user)
+        .await
+        .expect_err("confirming a rejected match must fail");
+    assert!(
+        matches!(err, ::common::errors::AppError::Conflict(_)),
+        "rejected -> confirmed must be a 409 Conflict, got {err:?}"
+    );
+    let (paid, _) = invoice_state(&pool, invoice).await;
+    assert_eq!(paid, dec!(0), "a rejected match must never re-apply paid_amount");
+}
+
+/// Confirming an already-confirmed match is an idempotent no-op — it must not
+/// re-apply paid_amount.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn double_confirm_is_idempotent(pool: PgPool) {
+    let (org, invoice, match_id) = seed_match_scenario(&pool, "pap325-double-confirm").await;
+    let svc = AccountingService::new(AccountingRepository::new(pool.clone()));
+    let user = Uuid::new_v4();
+    let mut conn = pool.acquire().await.unwrap();
+    set_ctx(&mut conn, org).await;
+
+    svc.confirm_match(&mut *conn, org, match_id, user)
+        .await
+        .expect("first confirm");
+    svc.confirm_match(&mut *conn, org, match_id, user)
+        .await
+        .expect("second confirm is a no-op");
+
+    let (paid, _) = invoice_state(&pool, invoice).await;
+    assert_eq!(paid, dec!(100), "double-confirm must apply the amount exactly once");
+}
+
+/// Rejecting an already-rejected match is an idempotent no-op (no double
+/// subtraction). Here the match was only ever Suggested -> Rejected, so paid
+/// stays 0 and the second reject is harmless.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn double_reject_is_idempotent(pool: PgPool) {
+    let (org, invoice, match_id) = seed_match_scenario(&pool, "pap325-double-reject").await;
+    let svc = AccountingService::new(AccountingRepository::new(pool.clone()));
+    let user = Uuid::new_v4();
+    let mut conn = pool.acquire().await.unwrap();
+    set_ctx(&mut conn, org).await;
+
+    svc.reject_match(&mut *conn, match_id, user)
+        .await
+        .expect("first reject");
+    svc.reject_match(&mut *conn, match_id, user)
+        .await
+        .expect("second reject is a no-op");
+
+    let (paid, _) = invoice_state(&pool, invoice).await;
+    assert_eq!(paid, dec!(0), "rejecting a suggested match never touches paid_amount");
+}


### PR DESCRIPTION
## Summary

Fixes the intra-tenant accounting-integrity bug split out of PAP-321 as **F3** (surfaced during the PAP-315 accounting review). This is **not** a tenant-isolation issue — the manager is authorized for their own org; it is correctness of the payment-match state machine.

`AccountingService::{confirm_match, reject_match}` could inflate an invoice's `paid_amount`:
1. `confirm_match` only short-circuited on an already-`Confirmed` match → a `Rejected` match could be re-confirmed and **re-apply** `paid_amount`.
2. `reject_match` on an already-`Confirmed` match flipped state to `Rejected` but **never subtracted** the previously-applied `paid_amount`.

Combined: `confirm → reject → confirm` inflated AR/paid totals.

## Owner decision — legal transitions (now enforced)

| From | To | Effect |
|------|-----|--------|
| Suggested | Confirmed | apply `+line.amount` |
| Suggested | Rejected | no financial effect |
| Confirmed | Rejected | **unapply**: subtract `line.amount`, recompute status |
| Confirmed | Confirmed | idempotent no-op |
| Rejected | Rejected | idempotent no-op |
| Rejected | Confirmed | **illegal → 409 Conflict** |

`update_invoice_payment_status_rls` now reverts invoice status to `issued` when a negative delta drives `paid_amount` back to 0 (previously it left a stale `paid`/`partially_paid`).

## Changes
- `backend/servers/api-server/src/services/accounting.rs` — transition guards in `confirm_match`/`reject_match`; `Confirmed → Rejected` unapply path.
- `backend/crates/db/src/repositories/accounting.rs` — `ELSE 'issued'` in the status CASE so unapply-to-zero is correct.
- `backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs` — service-level coverage: confirm/reject/confirm no-inflation (asserts 409 + paid stays 0), idempotent double-confirm, idempotent double-reject.

## Verification
Remote build host (mercury) was unreachable this session, so **CI (`backend.yml`: fmt + clippy + test) is the verifier**. The new tests are the smallest checks that prove the state machine (IG3: they fail on `dev` pre-fix — confirm/reject/confirm would inflate `paid_amount` to 200 and `rejected → confirmed` would not 409).

## Residual / out of scope
Confirming **two distinct matches for the same statement line** (matcher can suggest a line against multiple invoices) is a separate matcher-design concern, not part of the per-match state machine; not addressed here.

Closes PAP-325. Part of PAP-321 (F1/F2 ship separately via #1809).