### PR TITLE
docs(accounting): generalized invoicing/accounting spec (ACC)

### DIFF
--- a/.research/accounting/PRD-ACC-001-invoicing-accounting.md
+++ b/.research/accounting/PRD-ACC-001-invoicing-accounting.md
@@ -1,0 +1,139 @@
+# PRD-ACC-001 — Online Invoicing & Light-Accounting Product
+
+> **Product code:** `ACC` · **Status:** Draft · **Provenance:** Generalized from competitor analysis of a CZ/SK online
+> invoicing SaaS; vendor-neutral, functionality only.
+> **Companions:** [`epics.md`](epics.md) (16 epics) · [`use-cases.md`](use-cases.md) (~140 `UC-ACC-XX.Y`) · [`stories/`](stories/).
+
+---
+
+## 1. Overview
+
+A standalone, cloud-based product that lets freelancers, sole traders, and small businesses **invoice, get paid, track
+costs, and stay tax-compliant** without an accounting background — while giving their accountant 24/7 remote access to
+clean, exportable data. The product spans the full document cycle (quote → order → delivery → invoice → payment),
+expense capture with AI/OCR, automated bank reconciliation, statutory VAT outputs, light inventory, reporting, and a
+public API, delivered on web and mobile.
+
+It is positioned as **light accounting / tax-records** software (document-centric), not a full double-entry general
+ledger. The accountant remains the owner of the statutory close; the product produces the source documents, VAT
+outputs, and a clean export.
+
+## 2. Problem Statement
+
+Small businesses lose time and money on billing admin: manual invoice creation, chasing overdue payments, re-keying
+supplier receipts, reconciling bank statements by hand, and assembling VAT filings. Existing desktop accounting tools
+are heavy and accountant-oriented; spreadsheets don't scale, lack compliance, and create error-prone handoffs.
+
+**The job to be done:** *"Let me bill a customer in under a minute, see what I'm owed, capture my costs without typing
+them, and hand my accountant everything they need — from my phone, compliantly."*
+
+## 3. Goals & Success Metrics
+
+| Goal | Metric | Target |
+|------|--------|--------|
+| Fast onboarding | Time from sign-up to first sent invoice | < 5 min |
+| Frictionless billing | Median time to create a repeat invoice | < 60 s |
+| Get paid sooner | Reduction in average overdue days after dunning enabled | −30% |
+| Hands-off reconciliation | Share of incoming payments auto-matched | > 85% |
+| Cost capture without typing | OCR/AI field accuracy on uploaded documents | > 90% |
+| Compliance confidence | VAT periods filed from product without correction | > 95% |
+| Accountant satisfaction | Clean-export imports needing no manual fixup | > 90% |
+| Retention | Active companies renewing after 12 months | > 70% |
+
+## 4. User Stories (epic-level)
+
+- **As an Owner**, I want to register and operate several companies under one login, so I can manage all my entities in one place. *(EPIC-ACC-01)*
+- **As an Owner**, I want my company identity, numbering, and branding configured once, so every document is correct and on-brand. *(EPIC-ACC-02)*
+- **As a User**, I want a contact directory with registry autocomplete and VAT verification, so I create documents fast and error-free. *(EPIC-ACC-03)*
+- **As a User**, I want a reusable price list, so line items, prices, and VAT are consistent. *(EPIC-ACC-04)*
+- **As a User**, I want to issue, send, and track professional invoices (incl. proformas, credit notes, foreign currency), so I get paid. *(EPIC-ACC-05)*
+- **As a User**, I want quotes/orders/delivery notes that convert into invoices, so I cover the whole sales cycle. *(EPIC-ACC-06)*
+- **As a User**, I want to capture supplier costs by photo/upload with AI extraction, so expenses are recorded in seconds. *(EPIC-ACC-07)*
+- **As a User**, I want cash and bank documents with automatic payment matching, so my books reconcile themselves. *(EPIC-ACC-08)*
+- **As an Owner**, I want online pay-by-link and automatic overdue reminders, so collection is faster and hands-off. *(EPIC-ACC-09)*
+- **As an Owner/Accountant**, I want one-click VAT outputs (return, control/recap statement, EC sales list), so filing is painless. *(EPIC-ACC-10)*
+- **As a User**, I want light stock tracking driven by my documents, so I sell what I have and know my movements. *(EPIC-ACC-11)*
+- **As an Owner**, I want a dashboard and reports plus an accountant export, so I make decisions and hand off cleanly. *(EPIC-ACC-12)*
+- **As an Owner**, I want recurring invoices and automation, so revenue runs without daily effort. *(EPIC-ACC-13)*
+- **As an Owner**, I want a public API and connectors (e-shop, bank, gateway), so data flows in and out automatically. *(EPIC-ACC-14)*
+- **As a User**, I want mobile apps and notifications, so I work anywhere and never miss a paid/overdue event. *(EPIC-ACC-15)*
+- **As an Owner**, I want secure, backed-up, exportable, GDPR-compliant data, so I can trust the platform. *(EPIC-ACC-16)*
+
+## 5. Requirements
+
+### 5.1 Functional Requirements
+
+Each use case in [`use-cases.md`](use-cases.md) is a discrete, testable functional requirement. They map 1:1 as
+**`FR-ACC-XX.Y` ⇔ `UC-ACC-XX.Y`** (same numbering). The headline FRs per epic:
+
+| FR group | Epic | Headline functional requirements |
+|----------|------|----------------------------------|
+| **FR-ACC-01** | Accounts & Access | Registration/login; multi-company (agendas) with strict isolation; user invite + RBAC; accountant access; subscription/plan; 2FA; audit log; GDPR export/delete. |
+| **FR-ACC-02** | Configuration | Company profile; VAT/tax-mode config; gapless numbering series; document designs + branding; default texts/terms; email templates; localization; units; VAT rates; rounding rules. |
+| **FR-ACC-03** | Contacts & CRM | CRUD + merge; registry autocomplete; VAT verification; multiple addresses; per-contact defaults; transaction & communication history; import/export; receivables/credit. |
+| **FR-ACC-04** | Catalog | Item CRUD; price levels (net/gross); VAT & unit; categories/tags; discounts; import/export; stock link; inline quick-add. |
+| **FR-ACC-05** | Sales Invoicing | Invoice/proforma/advance-settlement/credit-note issuance; multi-currency; discounts/VAT/rounding/precision; payment QR; PDF/ISDOC/XML; email + shareable link; attachments/tags; document linking; duplicate; status lifecycle; bulk actions. |
+| **FR-ACC-06** | Quotes/Orders/Delivery | Quote + acceptance; sales order; delivery note; conversions quote→order→delivery→invoice; fulfillment status. |
+| **FR-ACC-07** | Purchases & Expenses | Received-invoice/expense entry; upload inbox; AI/OCR extraction; review & post; categorization; supplier link; attachments; payable tracking. |
+| **FR-ACC-08** | Cash & Bank | Cash receipts/payments; bank accounts; statement import; auto-match; manual match/unmatch; multiple accounts; POS/fiscal ingest; reconciliation. |
+| **FR-ACC-09** | Payments & Collections | Manual payment; online pay-by-link; auto-settle on gateway payment; confirmations; dunning rules + escalation; aging; partial/overpayment; refunds. |
+| **FR-ACC-10** | VAT & Tax | VAT records; VAT return; control/recap statement; EC sales list; reverse-charge; cross-border/OSS; per-document regime; e-file export; period summary; non-payer mode; VAT rounding. |
+| **FR-ACC-11** | Inventory | Stock item/warehouse; stock-in/out via documents; levels; movement history; valuation; low-stock flags; adjustments. |
+| **FR-ACC-12** | Reporting | Dashboard; cashflow; sales; aging; VAT report; list exports (xlsx/csv); accountant export package; date-range filtering; profit overview. |
+| **FR-ACC-13** | Automation | Recurring invoices (idempotent); scheduled reminders; continuous auto-match; auto thank-you; rule-based defaults; FX auto-refresh. |
+| **FR-ACC-14** | Integrations & API | Authenticated REST API; API-key/OAuth management; webhooks; e-shop/bank/gateway connectors; accounting-software export; data import; rate limits/quotas. |
+| **FR-ACC-15** | Mobile & Notifications | Native iOS/Android; mobile invoice create/send; receipt scan; in-app notifications; offline draft+sync; mobile dashboard. |
+| **FR-ACC-16** | Platform | 2FA; RBAC enforcement; daily backups + restore; data export/migration; data import; GDPR DSARs; audit trail; legislative/template updates; session security. |
+
+### 5.2 Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| **NFR-ACC-01** | Multi-tenancy | Strict per-company data isolation (e.g., row-level security); zero cross-company leakage is a release gate. |
+| **NFR-ACC-02** | Security | Argon2-class password hashing; 2FA; encryption in transit and at rest; secret management for connector credentials; session lockout on suspicious login. |
+| **NFR-ACC-03** | Compliance | GDPR (DSAR export/erasure, retention); statutory VAT formats kept current per jurisdiction; legally gapless document numbering. |
+| **NFR-ACC-04** | Localization | Multi-language UI + documents; locale-aware number/date/currency formatting; jurisdiction-pluggable tax rules. |
+| **NFR-ACC-05** | Availability & Durability | Automatic daily backups with tested restore; target ≥ 99.9% uptime; no data loss on a single-node failure. |
+| **NFR-ACC-06** | Performance | Document list/search and dashboard load < 2 s P95 at SMB data volumes; PDF render < 3 s. |
+| **NFR-ACC-07** | Scalability | Linear scaling to many tenants and documents; async processing for OCR, recurring runs, bank sync. |
+| **NFR-ACC-08** | Correctness | Deterministic VAT/rounding/currency math with documented rules; reconciliation must always balance. |
+| **NFR-ACC-09** | Auditability | Immutable change history for documents and settings; who/what/when on every mutation. |
+| **NFR-ACC-10** | API | Versioned, rate-limited, quota-enforced public API; idempotent writes; webhook retry with backoff. |
+| **NFR-ACC-11** | Portability | Full data export at any time (no lock-in); standard electronic document formats (PDF, ISDOC/XML, CSV/XLSX). |
+| **NFR-ACC-12** | Usability | Non-accountant can issue a first invoice unaided; mobile parity for core flows; accessible (WCAG-aligned). |
+
+## 6. Out of Scope (v1)
+
+- Full statutory **double-entry general ledger** and period close (the product feeds the accountant's tools; it is not the ledger of record).
+- **Payroll**, HR, and employee expense workflows.
+- **Bank-specific certifications / direct payment initiation** beyond generic statement + pay-by-link connectors.
+- **Any integration with, or data import from, the analyzed source product** (explicitly excluded — clean-room functionality only).
+- Advanced **manufacturing / multi-warehouse logistics** (inventory is intentionally "light").
+- Jurisdiction tax engines beyond the launch market(s) — built **pluggable**, but only launch locales ship in v1.
+
+## 7. Dependencies
+
+| Dependency | Used by | Notes |
+|------------|---------|-------|
+| Business/VAT registry lookup | FR-ACC-03 | External; cache + graceful degradation when unavailable. |
+| Bank statement/payment connectors | FR-ACC-08, -14 | Per-bank formats/feeds; normalize to a common model. |
+| Payment gateway(s) | FR-ACC-09, -14 | Pay-by-link, webhooks for settlement. |
+| OCR/AI extraction service | FR-ACC-07, -15 | Metered; per-plan free quota + paid overage. |
+| Exchange-rate source | FR-ACC-05, -13 | Daily refresh for foreign-currency documents. |
+| E-file/statutory format definitions | FR-ACC-10 | Per-jurisdiction XML schemas; versioned. |
+| Email/SMTP (and custom SMTP) | FR-ACC-05, -09 | Deliverability; per-company custom SMTP option. |
+
+## 8. Timeline (phased by priority)
+
+| Phase | Scope | Epics |
+|-------|-------|-------|
+| **P1 — MVP** | Register → configure → contacts + catalog → issue/send/track invoices → secure, exportable data | ACC-01, -02, -03, -04, -05, -16 |
+| **P2 — Money in/out** | Expenses + inbox, cash & bank + auto-match, payments & dunning, VAT outputs, reporting | ACC-06, -07, -08, -09, -10, -12 |
+| **P3 — Scale & reach** | Inventory, automation/recurring, API & connectors, mobile & notifications | ACC-11, -13, -14, -15 |
+
+---
+
+### Traceability
+
+`PRD-ACC-001` → `EPIC-ACC-01..16` → `UC-ACC-01..16` (`FR-ACC-XX.Y` ⇔ `UC-ACC-XX.Y`) → `STORY-ACC-XX-NNN`.
+This PRD is the input the BMAD `create-epics-and-stories` workflow consumes (FRs in §5.1, NFRs in §5.2).

--- a/.research/accounting/README.md
+++ b/.research/accounting/README.md
@@ -12,7 +12,7 @@ functionality only — **no dependency on, or integration with, any specific pro
 | [`architecture.md`](architecture.md) | Backend topology decision — separate **`accounting-server` (`:8082`)** sharing `common`/`api-core`/`db` core with `api-server`, like `reality-server`. |
 | [`epics.md`](epics.md) | 17 epics (`EPIC-ACC-01..17`) with business value, actors, stories→UC, dependencies, risks + epic↔UC map. |
 | [`use-cases.md`](use-cases.md) | ~140 use cases (`UC-ACC-XX.Y`, Actor + Description) across 16 categories, with actor hierarchy. |
-| [`stories/EPIC-ACC-05-sales-invoicing.md`](stories/EPIC-ACC-05-sales-invoicing.md) | Worked exemplar: 13 build-ready stories with Given/When/Then covering the flagship epic. |
+| [`stories/`](stories/) | Build-ready Given/When/Then stories for the **full MVP**: ACC-01, -02, -03, -04, -05 (13), -16, -17. |
 
 ## Traceability
 
@@ -41,8 +41,9 @@ advanced manufacturing/logistics, and any tie to the analyzed source product.
 
 ## Status / next steps
 
-- [x] Use-case catalog · [x] Epics catalog · [x] PRD · [x] Architecture (separate `accounting-server`) · [x] Stories for ACC-05 (exemplar)
+- [x] Use-case catalog · [x] Epics catalog · [x] PRD · [x] Architecture (separate `accounting-server`)
+- [x] **Stories for the full MVP** — ACC-01, -02, -03, -04, -05, -16, -17 (Given/When/Then)
 - [x] mef-BIT Paperclip hand-off brief → [`mef-agent-brief.md`](mef-agent-brief.md)
 - [ ] **Create the epic in mef-BIT Paperclip** (drive a `mefistos` session — needs claude-fleet + mef reachable)
-- [ ] Stories for remaining MVP epics (ACC-01, -02, -03, -04, -16, -17)
+- [ ] Stories for P2/P3 epics (ACC-06..15) — same template
 - [ ] Promote into `docs/` (or the `@ppt/accounting-web` repo) once direction is confirmed

--- a/.research/accounting/README.md
+++ b/.research/accounting/README.md
@@ -1,0 +1,48 @@
+# Invoicing & Accounting Product — Functional Spec (`ACC`)
+
+Generalized, **vendor-neutral** functional specification for a standalone online **invoicing + light-accounting**
+SaaS (freelancers / sole traders / SMBs + their accountants). Derived from competitor analysis and abstracted to
+functionality only — **no dependency on, or integration with, any specific product**.
+
+## Contents
+
+| Doc | What it is |
+|-----|------------|
+| [`PRD-ACC-001-invoicing-accounting.md`](PRD-ACC-001-invoicing-accounting.md) | Product requirements — goals, success metrics, FRs (§5.1), NFRs (§5.2), scope, dependencies, phasing. The keystone / BMAD input. |
+| [`architecture.md`](architecture.md) | Backend topology decision — separate **`accounting-server` (`:8082`)** sharing `common`/`api-core`/`db` core with `api-server`, like `reality-server`. |
+| [`epics.md`](epics.md) | 17 epics (`EPIC-ACC-01..17`) with business value, actors, stories→UC, dependencies, risks + epic↔UC map. |
+| [`use-cases.md`](use-cases.md) | ~140 use cases (`UC-ACC-XX.Y`, Actor + Description) across 16 categories, with actor hierarchy. |
+| [`stories/EPIC-ACC-05-sales-invoicing.md`](stories/EPIC-ACC-05-sales-invoicing.md) | Worked exemplar: 13 build-ready stories with Given/When/Then covering the flagship epic. |
+
+## Traceability
+
+```
+PRD-ACC-001
+   └─ EPIC-ACC-01..16
+        └─ UC-ACC-XX.Y   (FR-ACC-XX.Y ⇔ UC-ACC-XX.Y)
+             └─ STORY-ACC-XX-NNN  (G/W/T acceptance criteria)
+```
+
+## Scope at a glance
+
+**In:** accounts/multi-company, configuration, contacts/CRM, price-list catalog, sales invoicing (incl. proforma/advance,
+credit notes, multi-currency, QR, email/link), quotes/orders/delivery, purchases/expenses with AI-OCR inbox, cash & bank
+with auto-matching, payments & dunning, statutory VAT outputs, light inventory, reporting/dashboard, automation/recurring,
+public API & connectors, mobile & notifications, platform security/GDPR/backup.
+
+**Out (v1):** full double-entry general ledger & statutory close, payroll, direct payment initiation/bank certifications,
+advanced manufacturing/logistics, and any tie to the analyzed source product.
+
+## Suggested build order
+
+1. **P1 / MVP** — ACC-01, -02, -03, -04, -05, -16
+2. **P2 / Money in-out** — ACC-06, -07, -08, -09, -10, -12
+3. **P3 / Scale & reach** — ACC-11, -13, -14, -15
+
+## Status / next steps
+
+- [x] Use-case catalog · [x] Epics catalog · [x] PRD · [x] Architecture (separate `accounting-server`) · [x] Stories for ACC-05 (exemplar)
+- [x] mef-BIT Paperclip hand-off brief → [`mef-agent-brief.md`](mef-agent-brief.md)
+- [ ] **Create the epic in mef-BIT Paperclip** (drive a `mefistos` session — needs claude-fleet + mef reachable)
+- [ ] Stories for remaining MVP epics (ACC-01, -02, -03, -04, -16, -17)
+- [ ] Promote into `docs/` (or the `@ppt/accounting-web` repo) once direction is confirmed

--- a/.research/accounting/architecture.md
+++ b/.research/accounting/architecture.md
@@ -1,0 +1,95 @@
+# ACC — Backend Architecture & Service Topology
+
+> Decision record for delivering the `ACC` product as a **separate backend server that shares core crates with
+> `api-server`**, mirroring how `reality-server` is structured today. Grounded in the actual `backend/` workspace.
+
+## Context (as-is)
+
+The Rust backend is a single Cargo workspace = **shared `crates/*`** composed by **thin `servers/*`** binaries:
+
+```
+backend/
+├── crates/                      # shared core (libraries)
+│   ├── common/                  # errors, types, utilities
+│   ├── api-core/                # auth extractors, middleware, cache, OpenAPI plumbing
+│   ├── db/                      # sqlx pool, migrations, RLS-aware queries
+│   ├── tenant-ops/              # tenant/RLS operations
+│   └── integrations/            # external integrations
+└── servers/
+    ├── api-server/      :8080   # Property Mgmt API   (OAuth/JWT issuer)
+    ├── reality-server/ :8081   # Reality Portal API  (SSO consumer; users separate from PM)
+    └── deploy-server/           # worktree deploy control
+```
+
+`reality-server` depends on exactly **`common` + `api-core` + `db`** (`backend/servers/reality-server/Cargo.toml`),
+binds `:8081` (`main.rs`), and owns its `handlers/ routes/ extractors/ state.rs/ observability.rs`. **It shares the
+same PostgreSQL database** with `api-server` (root `CLAUDE.md`: "Shared Database"), but keeps its own user accounts.
+
+The accounting MVP currently lives **embedded in `api-server`** as `/api/v1/accounting/*` (on `origin/dev`, with
+`accounting.tsp` + migrations `00183/00184`, RLS-secured). This decision **extracts it into its own server**.
+
+## Decision
+
+**Add `backend/servers/accounting-server` (port `:8082`), structured as a clone of `reality-server`, sharing the core
+crates with `api-server`; put accounting domain logic in a new `backend/crates/accounting-core`.**
+
+```
+backend/
+├── crates/
+│   ├── common/        ← shared (unchanged)
+│   ├── api-core/       ← shared (unchanged): JWT validation, extractors, middleware, OpenAPI, observability
+│   ├── db/             ← shared (unchanged): pool + migrations (now also accounting tables)
+│   └── accounting-core/   # NEW — invoices, documents, VAT engine, numbering, money/rounding math
+└── servers/
+    └── accounting-server/ :8082   # NEW — thin binary: routes/ handlers/ state.rs/ main.rs/ observability.rs
+                                    #   deps = common + api-core + db + accounting-core
+```
+
+### Why "core" stays in `api-core` / `db` / `common`
+"Share core with api-server" = depend on the **same plumbing crates**, not on `api-server` the binary:
+- **Auth:** `accounting-server` validates the **same JWTs** via `api-core` extractors; `api-server` remains the
+  **OAuth/token issuer**, `accounting-server` is a **resource server** (same pattern as `reality-server` = SSO consumer).
+- **DB:** same `db` crate, same pool, same migrations dir → accounting tables live in the shared Postgres with RLS.
+- **Money/rounding/VAT math** that must be identical everywhere → `accounting-core` (single source), consumed by the
+  server and reusable by any future worker (recurring runs, OCR post, bank-match).
+
+### Key sub-decisions
+
+| Topic | Decision | Note |
+|-------|----------|------|
+| **Port** | `:8082` | After 8080 (api), 8081 (reality). |
+| **Database** | **Shared Postgres**, dedicated accounting tables + RLS | Matches `reality-server`. Keep `db`-crate boundary clean so a future split to a **dedicated accounting DB** is possible if the product is spun out commercially. |
+| **Identity** | Shared auth plumbing (`api-core`), **own account/user domain** | Like reality portal users are "separate from PM". Accounting customers ≠ PPT owners/managers. |
+| **Domain logic** | New `crates/accounting-core` | Server crate stays thin (routes/handlers/state), exactly like `reality-server`. |
+| **OpenAPI/SDK** | Own `/swagger-ui` + spec → `@ppt/accounting-api-client` (hey-api) | `accounting.tsp` already exists on dev. |
+| **Frontend** | `@ppt/accounting-web` (Next.js + next-intl) → `:8082` | Mirrors `reality-web → reality-server`. |
+| **Deploy** | New service in compose/manifests/caddy; CORS origins; per-worktree via `pmctl` | `accounting.dev.*` host like `wt-*` deploys. |
+| **Observability** | Reuse `api-core` OTel/metrics/sentry stack | `reality-server` already does. |
+
+### Migration path (from the dev MVP)
+
+1. Scaffold `crates/accounting-core` + `servers/accounting-server` (copy `reality-server` skeleton).
+2. Move `api-server`'s `handlers/accounting/*` + routes → `accounting-server`; lift pure logic into `accounting-core`.
+3. Keep migrations `00183/00184` (+ new ones) in the shared `db` crate.
+4. Generate `@ppt/accounting-api-client` from the new server's OpenAPI; point `@ppt/accounting-web` at `:8082`.
+5. Remove `/api/v1/accounting/*` from `api-server` once the new server is green (avoid a dual-serve window in prod).
+6. Wire deploy: compose service, caddy route, CORS, `pmctl` worktree target.
+
+## Alternatives considered
+
+- **A. Keep accounting embedded in `api-server`** (status quo on dev). *Rejected* for the standalone-product goal:
+  couples release cadence, auth surface, and scaling of an external SaaS to the internal PM API.
+- **B. Fully standalone service with its own DB + own auth from day one.** *Deferred*: maximal isolation but adds
+  identity federation + cross-DB sync now, for a benefit only realized if/when the product is commercially separated.
+  The chosen design **keeps that door open** (clean `db`/`accounting-core` boundaries) without paying the cost upfront.
+- **C. Separate server, shared DB & shared core** ✅ *Chosen* — consistent with `reality-server`, lowest friction,
+  honors "share core with api-server," and is incrementally splittable later.
+
+## Impact on the epic set
+
+Adds one delivery epic (platform/topology), and refines dependencies of `EPIC-ACC-14/16`:
+
+- **`EPIC-ACC-17` — Backend Service (`accounting-server`) & Shared-Core Integration** (P1, foundational): scaffold the
+  crate+server, share `common`/`api-core`/`db`, bind `:8082`, OpenAPI+SDK, deploy/CORS, extract dev MVP handlers.
+- `EPIC-ACC-01` (auth) now explicitly = **consume** `api-core` JWT validation; `api-server` stays the issuer.
+- `EPIC-ACC-14` (API) = the public REST surface is **served by `accounting-server`**, not `api-server`.

--- a/.research/accounting/epics.md
+++ b/.research/accounting/epics.md
@@ -1,0 +1,214 @@
+# Invoicing & Accounting Product — Epics Catalog
+
+> **Product code:** `ACC` (standalone online invoicing + light-accounting SaaS, e.g. `@ppt/accounting-web`).
+> **Provenance:** Generalized from competitor analysis of a CZ/SK online invoicing SaaS. **Vendor-neutral** — no
+> dependency on, or integration with, any specific product. Functionality only.
+> **Scope:** Self-service invoicing, expenses, contacts/CRM, bank & cash, VAT/tax compliance, light inventory,
+> reporting, automation, API, and mobile — targeted at freelancers, sole traders, and SMBs, plus their accountants.
+> **Maps to:** detailed use-case catalog in [`use-cases.md`](use-cases.md) (`UC-ACC-XX.Y`).
+
+---
+
+## Actors
+
+| Actor | Description |
+|-------|-------------|
+| **Owner / Admin** | Account owner. Manages the company/agenda, subscription, users, and global settings. |
+| **User (Staff)** | Team member with role-based access (issue documents, manage contacts, etc.). |
+| **Accountant** | External collaborator with (often read/export) access; may manage **multiple client companies**; prepares tax filings. |
+| **Customer** | Recipient of issued documents. Limited self-service: views/pays an invoice via shared link. |
+| **Supplier / Vendor** | Counterparty on purchase/expense documents (data subject, not necessarily a system user). |
+| **System / Automation** | Scheduled, non-interactive actor: recurring invoices, reminders, bank sync, exchange-rate refresh, OCR/AI extraction. |
+| **Bank** *(external)* | Provides statement feed / payment data. |
+| **Payment Gateway** *(external)* | Processes online card/bank payments from a pay-by-link. |
+| **Tax Authority** *(external)* | Recipient of VAT/tax filings via export / e-file. |
+| **Business / VAT Registry** *(external)* | Source for company autocomplete and VAT-payer verification. |
+| **E-shop / External System** *(external)* | Integrates via public API / webhooks. |
+
+**RBAC roles (suggested):** Owner, Admin, Standard user, Accountant, Read-only/Viewer.
+
+---
+
+## Epic ↔ Use-Case Map
+
+| Epic | Title | UC Category | Priority |
+|------|-------|-------------|----------|
+| `EPIC-ACC-01` | Accounts, Organizations & Access | UC-ACC-01 | P1 |
+| `EPIC-ACC-02` | Company & Document Configuration | UC-ACC-02 | P1 |
+| `EPIC-ACC-03` | Contacts & CRM | UC-ACC-03 | P1 |
+| `EPIC-ACC-04` | Product & Price-List Catalog | UC-ACC-04 | P1 |
+| `EPIC-ACC-05` | Sales Invoicing | UC-ACC-05 | P1 |
+| `EPIC-ACC-06` | Quotes, Orders & Delivery | UC-ACC-06 | P2 |
+| `EPIC-ACC-07` | Purchases & Expenses | UC-ACC-07 | P2 |
+| `EPIC-ACC-08` | Cash & Bank | UC-ACC-08 | P2 |
+| `EPIC-ACC-09` | Payments & Collections | UC-ACC-09 | P2 |
+| `EPIC-ACC-10` | VAT & Tax Compliance | UC-ACC-10 | P2 |
+| `EPIC-ACC-11` | Inventory / Stock | UC-ACC-11 | P3 |
+| `EPIC-ACC-12` | Reporting, Dashboard & Cashflow | UC-ACC-12 | P2 |
+| `EPIC-ACC-13` | Automation & Recurring | UC-ACC-13 | P3 |
+| `EPIC-ACC-14` | Integrations & API | UC-ACC-14 | P3 |
+| `EPIC-ACC-15` | Mobile & Notifications | UC-ACC-15 | P3 |
+| `EPIC-ACC-16` | Platform: Security, Data & Compliance | UC-ACC-16 | P1 |
+| `EPIC-ACC-17` | Backend Service (`accounting-server`) & Shared-Core Integration | — (platform) | P1 |
+
+**Suggested MVP (P1):** EPIC-ACC-17 (service skeleton), then -01, -02, -03, -04, -05, -16 — stand up the server sharing
+core with `api-server`, then a single user can register a company, configure it, keep contacts and a price list,
+issue/send/track invoices, and have secure, backed-up, exportable data.
+
+> **Deployment topology:** `ACC` ships as a **separate `accounting-server` (`:8082`)** that shares the `common` /
+> `api-core` / `db` core crates with `api-server`, exactly as `reality-server` does. See [`architecture.md`](architecture.md).
+
+---
+
+## EPIC-ACC-01 — Accounts, Organizations & Access
+
+- **Summary:** Account lifecycle, multi-company (agendas), users, role-based access, and accountant collaboration.
+- **Business value:** One login operates many companies; owners delegate safely; accountants get remote 24/7 access without file shuffling.
+- **Primary actors:** Owner/Admin, User, Accountant.
+- **Stories (→ UC):** registration & login (UC-ACC-01.1, .13); create/switch company (01.2–01.3); invite user & assign role (01.4–01.5); deactivate user (01.6); grant accountant access (01.7); manage subscription/plan (01.8); 2FA (01.9); audit log (01.10); GDPR export/delete (01.11–01.12).
+- **Dependencies:** EPIC-ACC-16 (security/RBAC primitives).
+- **Key risks:** Cross-company data isolation (tenant leakage); correct permission enforcement per role.
+
+## EPIC-ACC-02 — Company & Document Configuration
+
+- **Summary:** Per-company settings that drive every document: identity, tax mode, numbering, designs, defaults, localization.
+- **Business value:** Correct, compliant, on-brand documents with zero per-invoice setup.
+- **Primary actors:** Owner/Admin, Accountant.
+- **Stories (→ UC):** company profile & logo (UC-ACC-02.1); VAT/tax-mode config — VAT payer vs non-payer, tax-records vs accounting (02.2); numbering series per doc type/year (02.3); document design/template & branding (02.4); default texts, terms, footers (02.5); email templates (02.6); languages/localization (02.7); units of measure (02.8); VAT rates (02.9); bank accounts on documents (02.10); default currency & rounding (02.11).
+- **Dependencies:** EPIC-ACC-01.
+- **Key risks:** Numbering gaps/duplicates (legal requirement); tax-mode misconfiguration cascading into VAT outputs.
+
+## EPIC-ACC-03 — Contacts & CRM
+
+- **Summary:** Customer/supplier directory with registry autocomplete, VAT verification, per-contact defaults, and history.
+- **Business value:** Faster, error-free document creation; a single view of each relationship.
+- **Primary actors:** User, Owner/Admin; *external:* Business/VAT Registry.
+- **Stories (→ UC):** create/edit/merge contact (UC-ACC-03.1, .5); registry autocomplete (03.2); VAT-payer verification (03.3); multiple billing/delivery addresses (03.4); tags/segments (03.6); transaction history (03.7); communication/email history (03.8); per-contact defaults — currency, price level, terms, discount (03.9); import/export (03.10); receivables/credit per contact (03.11).
+- **Dependencies:** EPIC-ACC-14 (registry lookup integration).
+- **Key risks:** Stale registry data; duplicate contacts.
+
+## EPIC-ACC-04 — Product & Price-List Catalog
+
+- **Summary:** Reusable catalog of goods/services with pricing, VAT, units, and optional stock link.
+- **Business value:** Consistent pricing and tax; one-click line items.
+- **Primary actors:** User, Owner/Admin.
+- **Stories (→ UC):** create item (UC-ACC-04.1); prices incl. multiple price levels & with/without VAT (04.2); VAT rate & unit (04.3); categorize/tag (04.4); discounts (04.5); import/export (04.6); link to stock (04.7); quick-add from invoice line (04.8).
+- **Dependencies:** EPIC-ACC-02 (VAT rates, units); EPIC-ACC-11 (stock link).
+
+## EPIC-ACC-05 — Sales Invoicing
+
+- **Summary:** The core revenue document engine: invoices, advances/proformas + settlement, credit notes, multi-currency, delivery (email/link), and export.
+- **Business value:** Get paid faster with professional, compliant, trackable documents.
+- **Primary actors:** User, Owner/Admin, Customer.
+- **Stories (→ UC):** create invoice & line items (UC-ACC-05.1–.2); discounts/VAT/rounding (05.3, .19–.20); foreign currency w/ exchange rate (05.4); proforma/advance + tax-settlement document (05.5–05.6); credit note/corrective (05.7); payment QR/code (05.8); PDF preview/generate (05.9); send by email (05.10); send via shareable link (05.11); export PDF/ISDOC/XML (05.12); attachments (05.13); tags (05.14); document linking (05.15); duplicate (05.16); status lifecycle (05.17); bulk actions (05.18).
+- **Dependencies:** EPIC-ACC-02, -03, -04; EPIC-ACC-09 (payment status); EPIC-ACC-10 (VAT).
+- **Key risks:** VAT/rounding correctness; currency rounding; status integrity across linked documents.
+
+## EPIC-ACC-06 — Quotes, Orders & Delivery
+
+- **Summary:** Pre-sale and fulfillment documents that convert downstream into invoices.
+- **Business value:** Covers the full sales cycle (quote → order → delivery → invoice) without re-keying.
+- **Primary actors:** User, Customer.
+- **Stories (→ UC):** price quote/offer + acceptance tracking (UC-ACC-06.1–.2); convert quote→order/invoice (06.3); sales order (06.4); delivery note (06.5); convert order→delivery/invoice (06.6); fulfillment status (06.7).
+- **Dependencies:** EPIC-ACC-05; EPIC-ACC-11 (delivery from stock).
+
+## EPIC-ACC-07 — Purchases & Expenses
+
+- **Summary:** Received invoices/expense capture with an inbox and AI/OCR data extraction.
+- **Business value:** Cashflow visibility on the cost side; minutes-not-hours document entry.
+- **Primary actors:** User, Accountant, System (OCR/AI); Supplier.
+- **Stories (→ UC):** record received invoice/bill (UC-ACC-07.1); capture expense (07.2); upload to inbox (07.3); AI/OCR extraction (07.4); review & post (07.5); categorize (07.6); link to supplier (07.7); attach scan/receipt (07.8); payable status & due date (07.9).
+- **Dependencies:** EPIC-ACC-03, -10; EPIC-ACC-14 (AI/OCR service).
+- **Key risks:** OCR accuracy; duplicate-bill detection.
+
+## EPIC-ACC-08 — Cash & Bank
+
+- **Summary:** Cash register documents, bank accounts, statement import, and automatic payment matching.
+- **Business value:** Books that reconcile themselves; less manual matching.
+- **Primary actors:** User, System; *external:* Bank, POS/fiscal device.
+- **Stories (→ UC):** cash receipt/payment (UC-ACC-08.1–.2); manage registers (08.3); add bank account (08.4); import statement (08.5); auto-match payments (08.6); manual match/unmatch (08.7); multiple accounts/registers (08.8); POS/fiscal receipt integration (08.9); reconcile balances (08.10).
+- **Dependencies:** EPIC-ACC-09, -14 (bank connection).
+- **Key risks:** Mismatched/duplicate payment pairing; statement-format variability.
+
+## EPIC-ACC-09 — Payments & Collections
+
+- **Summary:** Recording payments, online pay-by-link, confirmations, and overdue dunning.
+- **Business value:** Faster collection, fewer overdue receivables, less manual chasing.
+- **Primary actors:** User, System, Customer; *external:* Payment Gateway.
+- **Stories (→ UC):** record manual payment (UC-ACC-09.1); enable online payment / pay-by-link (09.2); receive online payment & auto-mark paid (09.3); payment confirmation/thank-you (09.4); configure & send overdue reminders (09.5); reminder escalation levels (09.6); receivables aging (09.7); partial/overpayments (09.8); refunds (09.9).
+- **Dependencies:** EPIC-ACC-05, -08, -14.
+
+## EPIC-ACC-10 — VAT & Tax Compliance
+
+- **Summary:** VAT records and statutory outputs: VAT return, control/recapitulative statement, EC sales list, reverse-charge, cross-border/OSS.
+- **Business value:** Compliance without an accountant for routine periods; clean handoff for complex ones.
+- **Primary actors:** Owner/Admin, Accountant; *external:* Tax Authority.
+- **Stories (→ UC):** VAT records output/input (UC-ACC-10.1); VAT return per period (10.2); control/recapitulative statement (10.3); EC sales list / intra-EU (10.4); reverse-charge handling (10.5); cross-border / OSS VAT (10.6); per-document VAT regime (10.7); export filings XML/e-file (10.8); VAT summary per period (10.9); non-VAT-payer mode (10.10); VAT rounding/reconciliation (10.11).
+- **Dependencies:** EPIC-ACC-02 (tax mode), -05, -07.
+- **Key risks:** Legislative correctness & change cadence; jurisdiction-specific filing formats (keep pluggable).
+
+## EPIC-ACC-11 — Inventory / Stock
+
+- **Summary:** Light warehouse: stock items, movements, levels, valuation — driven by sales/delivery/purchase docs.
+- **Business value:** Sell what you have; accurate cost of goods; movement traceability.
+- **Primary actors:** User, System.
+- **Stories (→ UC):** stock item/warehouse (UC-ACC-11.1); stock-in (11.2); stock-out via invoice/delivery (11.3); stock levels (11.4); movement history (11.5); valuation (11.6); low-stock indicators (11.7); adjustments/corrections (11.8).
+- **Dependencies:** EPIC-ACC-04, -05, -06.
+
+## EPIC-ACC-12 — Reporting, Dashboard & Cashflow
+
+- **Summary:** At-a-glance overview plus sales/receivables/VAT/cashflow reports and accountant export.
+- **Business value:** Decisions from data; painless month-end and accountant handoff.
+- **Primary actors:** Owner/Admin, Accountant.
+- **Stories (→ UC):** dashboard/overview — revenue, receivables, overdue (UC-ACC-12.1); income/expense cashflow (12.2); sales report by period/customer/item (12.3); receivables/payables aging (12.4); VAT report (12.5); list exports xlsx/csv (12.6); accountant export package (12.7); date-range filtering (12.8); profit overview (12.9).
+- **Dependencies:** EPIC-ACC-05, -07, -08, -10.
+
+## EPIC-ACC-13 — Automation & Recurring
+
+- **Summary:** Set-and-forget recurring billing, scheduled reminders, auto-matching, auto-confirmations, exchange-rate refresh.
+- **Business value:** Revenue and collections run without daily human action.
+- **Primary actors:** System, Owner/Admin.
+- **Stories (→ UC):** configure recurring invoice (UC-ACC-13.1); auto-generate & send (13.2); schedule reminders (13.3); auto-match payments (13.4); auto thank-you on payment (13.5); rule-based defaults/templates (13.6); auto-download exchange rates (13.7).
+- **Dependencies:** EPIC-ACC-05, -08, -09.
+- **Key risks:** Idempotency (no duplicate recurring runs); time-zone/scheduling correctness.
+
+## EPIC-ACC-14 — Integrations & API
+
+- **Summary:** Public REST API, webhooks, and connectors: e-shops, banks, payment gateways, registries, accounting software, exchange rates.
+- **Business value:** The product becomes a hub; data flows in/out without manual entry.
+- **Primary actors:** Owner/Admin, External System; *external:* Bank, Gateway, Registry.
+- **Stories (→ UC):** authenticate & call API (UC-ACC-14.1); manage API keys / OAuth clients (14.2); webhooks/events (14.3); e-shop/external connect (14.4); bank connection (14.5); payment gateway (14.6); export to accounting software (14.7); import data (14.8); rate limits/quotas (14.9).
+- **Dependencies:** EPIC-ACC-01 (auth), -16.
+- **Key risks:** Quota/abuse control; third-party API stability; secret management.
+
+## EPIC-ACC-15 — Mobile & Notifications
+
+- **Summary:** Mobile apps for on-the-go invoicing and receipt capture, plus in-app notifications.
+- **Business value:** Invoice and capture costs anywhere; never miss a paid/overdue event.
+- **Primary actors:** User, System.
+- **Stories (→ UC):** mobile app iOS/Android (UC-ACC-15.1); create/send invoice on mobile (15.2); scan receipt/document (15.3); in-app notifications — paid, overdue, etc. (15.4); offline draft & sync (15.5); mobile dashboard (15.6).
+- **Dependencies:** EPIC-ACC-05, -07, -14.
+
+## EPIC-ACC-16 — Platform: Security, Data & Compliance
+
+- **Summary:** Cross-cutting non-functional foundation: 2FA, RBAC, backups, import/export/migration, GDPR, audit trail, legislative updates.
+- **Business value:** Trust — data is safe, portable, compliant, and recoverable.
+- **Primary actors:** Owner/Admin, System.
+- **Stories (→ UC):** 2FA (UC-ACC-16.1); RBAC (16.2); daily backups (16.3); data export/migration (16.4); data import (16.5); GDPR export/erasure (16.6); audit trail (16.7); legislative/template updates (16.8); session/login security (16.9).
+- **Dependencies:** foundational for all epics.
+- **Key risks:** Tenant isolation; backup restorability; secret/credential handling.
+
+## EPIC-ACC-17 — Backend Service (`accounting-server`) & Shared-Core Integration
+
+- **Summary:** Stand up a dedicated `accounting-server` (`:8082`) that shares the `common` / `api-core` / `db` core
+  crates with `api-server` (mirroring `reality-server`), with accounting domain logic in a new `accounting-core` crate.
+- **Business value:** A truly standalone product surface (own release cadence, scaling, API, frontend) without
+  re-implementing auth, DB, tenancy, OpenAPI, or observability — they come from shared core.
+- **Primary actors:** (platform) Owner/Admin, System; *external:* `api-server` as OAuth/JWT issuer.
+- **Stories:** scaffold `crates/accounting-core` + `servers/accounting-server` from the `reality-server` skeleton;
+  wire `common`/`api-core`/`db`; bind `:8082`; JWT validation as a resource server (api-server issues); shared-DB
+  accounting tables + RLS; OpenAPI + `@ppt/accounting-api-client` (hey-api); deploy (compose/caddy/CORS/`pmctl`
+  worktree target); **migrate** `api-server`'s `/api/v1/accounting/*` MVP into the new server; remove the old route.
+- **Dependencies:** EPIC-ACC-01 (shared auth), -14 (public API surface), -16 (platform). Decided in [`architecture.md`](architecture.md).
+- **Key risks:** Dual-serve window during migration (avoid in prod); shared-DB RLS correctness across two servers;
+  keeping `db`/`accounting-core` boundaries clean so a future dedicated-DB split stays possible.

--- a/.research/accounting/mef-agent-brief.md
+++ b/.research/accounting/mef-agent-brief.md
@@ -1,0 +1,61 @@
+# mef-BIT Paperclip hand-off — ACC (Invoicing & Accounting product)
+
+> **Purpose:** Paste this into a **`mefistos`** claude-fleet session (mef-BIT company) to create the ACC epic + MVP
+> tasks in Paperclip. The author session could not write to mef directly (mef uses better-auth, no operator key;
+> writes happen only by driving a mef session). **mef was unreachable at hand-off time** — fire when the tunnel is up.
+
+---
+
+## 🚧 Guardrails (read first)
+
+- **Target company = mef `BIT` "32bit branch"** (`977c0706-8e09-400e-9f6e-76e764e81cd0`), the active implementation fleet.
+  **NOT htz `PAP`.** A prior attempt created this epic on htz-PAP (`PAP-303` + children) — **all cancelled.** Do not repeat.
+- Confirm you are on mef-BIT before any write: this BIT company is **archived on htz**, live on mef.
+- This is a **clean-room** product: copy iDoklad-class *functionality*, **no API integration with, or data import from,
+  iDoklad**; the product name must not be iDoklad. (Board mandate PAP-204.)
+
+## What to create
+
+A parent **epic** + the **P1/MVP** task graph below. Use the `paperclip` skill for the API mechanics (issue document
+with key `plan`, blockers, reassignment) and `paperclip-converting-plans-to-tasks` for assignment discipline.
+
+**Before assigning:** look up mef-BIT's agent roster + specialties (`get_workspace_agents` / equivalent) and assign each
+task to the **best-fit specialty** — do not default everything to one agent. Specialty hints are given per task; treat
+them as hints, match to real agents. Surface any gap (missing skill → hire/decision) instead of papering over it.
+
+### Parent epic
+**Title:** `ACC — Invoicing & Accounting product (iDoklad-class, standalone)`
+**Summary:** Standalone CZ/SK online invoicing + light-accounting SaaS. Separate backend `accounting-server (:8082)`
+sharing core (`common`/`api-core`/`db`) with `api-server` — mirrors `reality-server`. Separate frontend
+`@ppt/accounting-web` (Next.js + next-intl). Full functional spec: see `.research/accounting/` on branch
+`feature/tender-austin-fde5e4` (commit/push to make it fetchable here): `README.md`, `PRD-ACC-001`, `epics.md`
+(17 epics), `use-cases.md` (~140 UC), `architecture.md`, `stories/EPIC-ACC-05-*`.
+
+### MVP task graph (P1) — wire `blockedByIssueIds`, don't write "blocked by" in prose
+
+| # | Task | Specialty | Blocked by |
+|---|------|-----------|------------|
+| **T1** | `EPIC-ACC-17` Scaffold `crates/accounting-core` + `servers/accounting-server` from the `reality-server` skeleton; depend on `common`/`api-core`/`db`; bind `:8082`; health + OpenAPI + `/swagger-ui`; observability via `api-core`. | Backend / Rust | — |
+| **T2** | `EPIC-ACC-01` Accounts & access: validate **api-server-issued JWTs** as a resource server (api-core extractors); multi-company (agendas) with RLS isolation; RBAC; 2FA; audit log; GDPR export/delete. | Backend / Rust | T1 |
+| **T3** | `EPIC-ACC-02` Company & document config: profile, VAT/tax mode, gapless numbering series, document designs/branding, default texts, email templates, units, VAT rates, rounding. | Backend / Rust | T1 |
+| **T4** | `EPIC-ACC-03` Contacts & CRM: CRUD+merge, registry autocomplete, VAT verification, multiple addresses, per-contact defaults, history, import/export, receivables. | Backend / Rust | T1 |
+| **T5** | `EPIC-ACC-04` Price-list catalog: items (goods/services), price levels net/gross, VAT+unit, categories/tags, discounts, import/export, stock link, inline quick-add. | Backend / Rust | T1 |
+| **T6** | `EPIC-ACC-05` Sales invoicing (revenue core): invoices/proforma+advance settlement/credit notes, multi-currency, discounts/VAT/rounding/precision, payment QR, PDF/ISDOC/XML, email + shareable link, attachments/tags, linking, duplicate, status lifecycle, bulk. **(13 G/W/T stories already written — see `stories/EPIC-ACC-05-sales-invoicing.md`.)** | Backend / Rust | T2, T3, T4, T5 |
+| **T7** | `EPIC-ACC-16` Platform: 2FA, RBAC enforcement, daily backups+restore, data export/migration+import, GDPR DSARs, audit trail, session security. | Backend / DevOps | T1 |
+| **T8** | `@ppt/accounting-web` scaffold (Next.js + next-intl sk/cs, modeled on `reality-web`) + generate `@ppt/accounting-api-client` (hey-api) from the server OpenAPI. Invoice UI follows T6. | Frontend | T1 (UI for invoices → T6) |
+| **T9** | Deploy wiring: compose service, caddy route, `CORS_ALLOWED_ORIGINS`, `pmctl` worktree target → `accounting.dev.*`, port `:8082`. | DevOps | T1 |
+
+**Parallelization:** T2–T5, T7, T9 all start once T1 is `done`. T6 waits on T2–T5. T8 starts after T1 (invoice screens after T6). Assign parallel branches concurrently (agents allow concurrent runs).
+
+### Migration note (don't miss)
+The accounting MVP currently lives **embedded in `api-server`** as `/api/v1/accounting/*` on `origin/dev` (with
+`accounting.tsp`, migrations `00183/00184`). T6/T1 must **lift those handlers into `accounting-server`** and **remove
+the old route from `api-server`** once green — avoid a dual-serve window in prod. (Note: dev/main are disjoint.)
+
+### Follow-ups (name as known next epics — do **not** over-split now)
+- **P2 (money in/out):** `EPIC-ACC-06` quotes/orders/delivery · `-07` purchases/expenses + AI-OCR inbox · `-08` cash & bank + auto-match · `-09` payments & dunning · `-10` VAT outputs (return, control/recap, EC sales list, OSS) · `-12` reporting/dashboard + accountant export.
+- **P3 (scale & reach):** `-11` inventory · `-13` automation/recurring · `-14` public API & connectors · `-15` mobile & notifications.
+
+## Done = 
+Parent epic exists on **mef-BIT**; T1–T9 created with correct `blockedByIssueIds`; each assigned to a specialty-matched
+mef-BIT agent; P2/P3 captured as named follow-ups; link back the plan doc. Report the created issue IDs.

--- a/.research/accounting/stories/EPIC-ACC-01-accounts-access.md
+++ b/.research/accounting/stories/EPIC-ACC-01-accounts-access.md
@@ -1,0 +1,100 @@
+# EPIC-ACC-01 — Accounts, Organizations & Access · Stories
+
+> Covers `UC-ACC-01.1–.13`. Format per repo story convention. Platform mechanisms (2FA, audit, GDPR, backups) are
+> implemented in [EPIC-ACC-16](EPIC-ACC-16-platform-security.md) and *consumed* here.
+> **Shared DoD (all stories):** AC pass · unit+integration tests green · **strict per-company isolation verified (RLS)** ·
+> audit-log entry on mutation · i18n externalized · mobile parity where flagged.
+
+---
+
+## STORY-ACC-01-001 — Register company & log in
+*Covers UC-ACC-01.1, .13*
+
+**User Story:** As a new **Owner**, I want to sign up and get a first company, so that I can start using the product immediately.
+
+**Acceptance Criteria**
+- **Given** valid sign-up details, **when** I register, **then** an account + first company (agenda) are created and I land logged-in on an empty dashboard.
+- **Given** an existing account, **when** I log in (credentials or SSO), **then** I resume my last active company.
+- **Given** wrong credentials or an unverified email, **when** I attempt login, **then** access is denied with a clear, non-enumerating message.
+
+**Technical Notes:** account ≠ company; auth via shared `api-core` (api-server issues JWT, accounting-server validates). Password hashing Argon2-class.
+**UI/UX:** minimal sign-up; "remember last company"; mobile-flagged.
+**Test Cases:** duplicate-email rejected; SSO path; last-company resume; rate-limited login.
+
+## STORY-ACC-01-002 — Create & switch companies (agendas)
+*Covers UC-ACC-01.2, .3*
+
+**User Story:** As an **Owner/Accountant**, I want several companies under one login, so that I manage all my entities (or clients) in one place.
+
+**Acceptance Criteria**
+- **Given** my account, **when** I create another company, **then** it is fully isolated — no data bleeds between companies.
+- **Given** multiple companies, **when** I switch the active one, **then** all lists, documents, settings, and numbering scope to it.
+- **Given** a plan company-count limit, **when** I exceed it, **then** creation is blocked with an upgrade prompt.
+
+**Technical Notes:** company = tenant boundary; every query RLS-scoped by company_id; active-company in session context.
+**Test Cases:** cross-company isolation (the release gate, NFR-ACC-01); switch updates scope; plan-limit enforcement.
+
+## STORY-ACC-01-003 — Users & role-based access
+*Covers UC-ACC-01.4, .5, .6*
+
+**User Story:** As an **Owner/Admin**, I want to invite teammates with roles, so that they do their work without over-broad access.
+
+**Acceptance Criteria**
+- **Given** a company, **when** I invite a user by email, **then** they receive an invite and join scoped to that company.
+- **Given** a member, **when** I assign a role (Admin / Standard / Read-only), **then** their visible modules and allowed actions match the role exactly.
+- **Given** a member, **when** I deactivate them, **then** their access is revoked immediately but their authored documents remain intact.
+- **Given** a plan user-count limit, **when** exceeded, **then** invites are blocked with an upgrade prompt.
+
+**Technical Notes:** RBAC enforced server-side (see EPIC-ACC-16.2), not just UI hiding; invitations are expiring tokens.
+**Test Cases:** read-only cannot mutate (server-enforced); deactivation revokes live sessions; authored docs preserved; seat-limit.
+
+## STORY-ACC-01-004 — Accountant access
+*Covers UC-ACC-01.7*
+
+**User Story:** As an **Owner**, I want to grant my accountant ongoing remote access, so that they work without me shuffling files.
+
+**Acceptance Criteria**
+- **Given** an accountant email, **when** I grant access, **then** they get a (typically read+export) role across the company's documents and exports.
+- **Given** an accountant working multiple clients, **when** they log in, **then** they can switch between the companies that granted them access.
+- **Given** I revoke access, **when** done, **then** the accountant immediately loses access to that company only.
+
+**Technical Notes:** accountant is a cross-company principal; access grants are per-company edges; export scope (EPIC-ACC-12.7).
+**Test Cases:** multi-client switch; revoke isolates to one company; export-only role cannot issue documents.
+
+## STORY-ACC-01-005 — Subscription & plan limits
+*Covers UC-ACC-01.8*
+
+**User Story:** As an **Owner**, I want to manage my plan, so that I pay for what I use and understand my limits.
+
+**Acceptance Criteria**
+- **Given** my account, **when** I view billing, **then** I see current plan, usage vs limits (users, companies, API, metered AI reads), and renewal.
+- **Given** a plan change, **when** I upgrade/downgrade, **then** entitlements (and gated features) update accordingly, prorated where applicable.
+- **Given** a metered feature (e.g., AI document reads), **when** I exhaust the free quota, **then** I am offered paid overage and usage is metered.
+
+**Technical Notes:** entitlement checks gate feature access; metered counters per company/period.
+**Test Cases:** downgrade re-gates premium features; overage metering; limit displays match enforcement.
+
+## STORY-ACC-01-006 — Account security & data rights
+*Covers UC-ACC-01.9, .10, .11, .12 (consumes EPIC-ACC-16)*
+
+**User Story:** As an **Owner**, I want 2FA, an activity log, and the ability to export or delete my data, so that I stay secure and in control.
+
+**Acceptance Criteria**
+- **Given** my account, **when** I enable 2FA, **then** subsequent logins require the second factor (mechanism: EPIC-ACC-16.1).
+- **Given** company activity, **when** I open the audit log, **then** I see who changed what and when (source: EPIC-ACC-16.7).
+- **Given** a data request, **when** I export, **then** I receive a complete portable archive (EPIC-ACC-16.4/.6); **when** I delete a company/account, **then** confirmations + retention rules apply (EPIC-ACC-16.6).
+
+**Technical Notes:** thin account-level surface over EPIC-ACC-16 platform capabilities; deletion is guarded + logged.
+**Test Cases:** 2FA enforced on next login; audit entries present for mutations; export completeness; delete confirmation + retention.
+
+---
+
+## Coverage
+| Story | UCs |
+|-------|-----|
+| 001 Register & login | 01.1, 01.13 |
+| 002 Multi-company | 01.2, 01.3 |
+| 003 Users & RBAC | 01.4, 01.5, 01.6 |
+| 004 Accountant access | 01.7 |
+| 005 Subscription | 01.8 |
+| 006 Security & data rights | 01.9, 01.10, 01.11, 01.12 |

--- a/.research/accounting/stories/EPIC-ACC-02-company-config.md
+++ b/.research/accounting/stories/EPIC-ACC-02-company-config.md
@@ -1,0 +1,95 @@
+# EPIC-ACC-02 — Company & Document Configuration · Stories
+
+> Covers `UC-ACC-02.1–.11`. These settings drive every document; correctness here prevents whole classes of downstream bugs.
+> **Shared DoD:** AC pass · tests green · per-company isolation · audit-log on change · i18n externalized.
+
+---
+
+## STORY-ACC-02-001 — Company profile & branding
+*Covers UC-ACC-02.1, .4*
+
+**User Story:** As an **Owner**, I want to set my company identity and branding once, so that every document is correct and on-brand.
+
+**Acceptance Criteria**
+- **Given** company settings, **when** I save legal name, registration IDs, VAT status, addresses, and contact details, **then** they populate document headers/footers automatically.
+- **Given** a logo and color choice, **when** I apply a document design, **then** generated PDFs/links reflect the branding.
+- **Given** invalid/missing mandatory identity fields, **when** I try to issue a document, **then** I'm warned which fields are required for compliance.
+
+**Technical Notes:** identity snapshot is copied onto issued documents (historical immutability).
+**Test Cases:** branding on PDF; mandatory-field guard; identity change doesn't mutate past documents.
+
+## STORY-ACC-02-002 — Tax / VAT mode
+*Covers UC-ACC-02.2*
+
+**User Story:** As an **Owner/Accountant**, I want to configure my tax/VAT mode, so that documents and reports behave correctly for my situation.
+
+**Acceptance Criteria**
+- **Given** settings, **when** I choose VAT-payer vs non-payer, **then** documents show/hide VAT and totals compute accordingly everywhere.
+- **Given** tax-records vs accounting mode, **when** set, **then** available reports and document fields adapt.
+- **Given** a mid-period mode change, **when** applied, **then** existing issued documents are unaffected and the change is dated/audited.
+
+**Technical Notes:** mode is the master switch feeding EPIC-ACC-05 (VAT display) and EPIC-ACC-10 (VAT outputs).
+**Test Cases:** non-payer hides VAT end-to-end; switch dated; historical docs unchanged.
+
+## STORY-ACC-02-003 — Gapless numbering series
+*Covers UC-ACC-02.3*
+
+**User Story:** As an **Owner**, I want numbering series per document type and year, so that my documents are legally sequential.
+
+**Acceptance Criteria**
+- **Given** a document type, **when** I define a series (prefix/format/reset cadence), **then** issuing allocates the next number from it.
+- **Given** concurrent issuance, **when** two documents are issued at once, **then** numbers are unique and **gapless** (no skips, no duplicates).
+- **Given** a yearly reset, **when** the period rolls over, **then** numbering restarts per configuration.
+
+**Technical Notes:** atomic sequence allocation (DB-level) under concurrency — a legal requirement, not best-effort.
+**Test Cases:** concurrency stress → no gaps/dupes; format honored; yearly reset.
+
+## STORY-ACC-02-004 — Document defaults, email templates & languages
+*Covers UC-ACC-02.5, .6, .7*
+
+**User Story:** As an **Owner**, I want default texts, email templates, and languages, so that sending documents is one click and consistent.
+
+**Acceptance Criteria**
+- **Given** defaults (payment terms, footers, notes), **when** I create a document, **then** they prefill and remain editable.
+- **Given** email templates with variables, **when** I send a document/reminder, **then** the rendered email uses the template.
+- **Given** multiple languages, **when** I set a document/contact language, **then** the document and email render in that language.
+
+**Technical Notes:** template variables resolved from document/contact/company; per-document language override.
+**Test Cases:** default prefill + override; template variable rendering; language switch on PDF + email.
+
+## STORY-ACC-02-005 — Units, VAT rates, currency & rounding
+*Covers UC-ACC-02.8, .9, .11*
+
+**User Story:** As an **Owner**, I want to manage units, VAT rates, base currency, and rounding, so that line math and tax are consistent.
+
+**Acceptance Criteria**
+- **Given** settings, **when** I define units and VAT rates, **then** they're selectable on catalog items and document lines.
+- **Given** a base currency and rounding rules, **when** documents total, **then** per-line precision and total rounding follow configuration.
+- **Given** a VAT rate change, **when** applied, **then** new documents use it while issued documents keep their original rate.
+
+**Technical Notes:** feeds the shared money/VAT module (EPIC-ACC-05.2); rounding mode (arithmetic/banker's) configurable.
+**Test Cases:** rate selectable; rounding honored; historical rate immutability.
+
+## STORY-ACC-02-006 — Bank accounts on documents
+*Covers UC-ACC-02.10*
+
+**User Story:** As an **Owner**, I want to set which bank account/payment details show on documents, so that customers pay to the right place.
+
+**Acceptance Criteria**
+- **Given** one or more bank accounts, **when** I mark a default, **then** issued documents show its details and drive the payment QR (EPIC-ACC-05.8).
+- **Given** a foreign-currency document, **when** issued, **then** the matching-currency account is used where configured.
+
+**Technical Notes:** account selection links to auto-match reference (EPIC-ACC-08.6) and QR (05.8).
+**Test Cases:** default account on PDF; currency-matched account; QR uses correct account.
+
+---
+
+## Coverage
+| Story | UCs |
+|-------|-----|
+| 001 Profile & branding | 02.1, 02.4 |
+| 002 Tax/VAT mode | 02.2 |
+| 003 Numbering series | 02.3 |
+| 004 Defaults/templates/languages | 02.5, 02.6, 02.7 |
+| 005 Units/VAT/currency/rounding | 02.8, 02.9, 02.11 |
+| 006 Bank accounts on documents | 02.10 |

--- a/.research/accounting/stories/EPIC-ACC-03-contacts-crm.md
+++ b/.research/accounting/stories/EPIC-ACC-03-contacts-crm.md
@@ -1,0 +1,90 @@
+# EPIC-ACC-03 — Contacts & CRM · Stories
+
+> Covers `UC-ACC-03.1–.11`. **Shared DoD:** AC pass · tests green · per-company isolation · audit-log on mutation · i18n externalized · mobile parity where flagged.
+
+---
+
+## STORY-ACC-03-001 — Contact CRUD, merge & deactivate
+*Covers UC-ACC-03.1, .5*
+
+**User Story:** As a **User**, I want to create and maintain customers/suppliers, so that documents reference accurate parties.
+
+**Acceptance Criteria**
+- **Given** the directory, **when** I create a contact (type customer/supplier/both) with identifiers and addresses, **then** it is saved and selectable on documents.
+- **Given** duplicates, **when** I merge them, **then** documents/history re-point to the surviving contact with no data loss.
+- **Given** an inactive contact, **when** I deactivate it, **then** it's hidden from pickers but its historical documents remain intact.
+
+**Technical Notes:** merge re-keys foreign references transactionally; soft-deactivate, never hard-delete referenced contacts.
+**Test Cases:** merge preserves history; deactivated hidden from picker but documents intact; customer+supplier dual role.
+
+## STORY-ACC-03-002 — Registry autocomplete & VAT verification
+*Covers UC-ACC-03.2, .3*
+
+**User Story:** As a **User**, I want to autofill from the business registry and verify VAT numbers, so that I create contacts fast and correctly.
+
+**Acceptance Criteria**
+- **Given** a company name/ID, **when** I search the registry, **then** official details autofill into the contact.
+- **Given** a VAT number, **when** I verify it, **then** validity/registration status is shown and stored with a timestamp.
+- **Given** the registry/verification service is down, **when** I look up, **then** I can still save manually and the system degrades gracefully (no hard block).
+
+**Technical Notes:** external dependency (EPIC-ACC-14); cache results; never block contact creation on third-party outage.
+**Test Cases:** autofill maps fields; invalid VAT flagged; offline-degradation path.
+
+## STORY-ACC-03-003 — Addresses & per-contact defaults
+*Covers UC-ACC-03.4, .9*
+
+**User Story:** As a **User**, I want multiple addresses and per-contact defaults, so that documents prefill correctly per customer.
+
+**Acceptance Criteria**
+- **Given** a contact, **when** I add billing and one or more delivery addresses, **then** I can pick which appears on a document.
+- **Given** per-contact defaults (currency, price level, payment terms, discount), **when** I create a document for them, **then** those defaults prefill.
+
+**Technical Notes:** defaults feed EPIC-ACC-05 document creation and EPIC-ACC-04 price levels.
+**Test Cases:** address selection on document; defaults prefill + override.
+
+## STORY-ACC-03-004 — Tags & segments
+*Covers UC-ACC-03.6*
+
+**User Story:** As a **User**, I want to tag/segment contacts, so that I can filter and act in bulk.
+
+**Acceptance Criteria**
+- **Given** contacts, **when** I apply tags, **then** I can filter the directory and reports by tag.
+- **Given** a segment filter, **when** I run a bulk action (e.g., export), **then** it applies to exactly the filtered set.
+
+**Test Cases:** tag filter accuracy; bulk action scoping.
+
+## STORY-ACC-03-005 — Transaction & communication history
+*Covers UC-ACC-03.7, .8*
+
+**User Story:** As a **User/Accountant**, I want a single view of each contact's documents and communications, so that I understand the relationship.
+
+**Acceptance Criteria**
+- **Given** a contact, **when** I open it, **then** I see all issued/received documents and payments with status.
+- **Given** a contact, **when** I view communication history, **then** I see emails/documents sent with timestamps (source: EPIC-ACC-05.10).
+
+**Test Cases:** history completeness; payment status reflected; comms entries on send.
+
+## STORY-ACC-03-006 — Import/export & receivables
+*Covers UC-ACC-03.10, .11*
+
+**User Story:** As an **Owner/Accountant**, I want to import/export contacts and see receivables per contact, so that onboarding and collections are easy.
+
+**Acceptance Criteria**
+- **Given** a file, **when** I import contacts, **then** rows validate, duplicates are flagged, and a result summary is shown.
+- **Given** the directory, **when** I export, **then** I get a complete xlsx/csv.
+- **Given** a contact, **when** I view receivables, **then** outstanding balance (and optional credit limit) are shown and a limit breach can warn at document time.
+
+**Technical Notes:** import dedupe on identifiers; receivables derive from open documents (EPIC-ACC-09.7).
+**Test Cases:** import validation/dedupe; export completeness; credit-limit warning.
+
+---
+
+## Coverage
+| Story | UCs |
+|-------|-----|
+| 001 CRUD/merge/deactivate | 03.1, 03.5 |
+| 002 Registry & VAT verify | 03.2, 03.3 |
+| 003 Addresses & defaults | 03.4, 03.9 |
+| 004 Tags & segments | 03.6 |
+| 005 History | 03.7, 03.8 |
+| 006 Import/export & receivables | 03.10, 03.11 |

--- a/.research/accounting/stories/EPIC-ACC-04-catalog.md
+++ b/.research/accounting/stories/EPIC-ACC-04-catalog.md
@@ -1,0 +1,73 @@
+# EPIC-ACC-04 — Product & Price-List Catalog · Stories
+
+> Covers `UC-ACC-04.1–.8`. **Shared DoD:** AC pass · tests green · per-company isolation · audit-log on mutation · i18n externalized.
+
+---
+
+## STORY-ACC-04-001 — Item CRUD with VAT & unit
+*Covers UC-ACC-04.1, .3*
+
+**User Story:** As a **User**, I want to maintain catalog items (goods/services), so that I add consistent lines to documents.
+
+**Acceptance Criteria**
+- **Given** the catalog, **when** I create an item with name, code, description, unit, and VAT rate, **then** it's saved and selectable on document lines.
+- **Given** an item, **when** I edit/deactivate it, **then** existing documents that used it are unaffected (historical snapshot on the line).
+
+**Technical Notes:** document lines snapshot item values at insert time; deactivate ≠ delete when referenced.
+**Test Cases:** item selectable on line; edit doesn't mutate past documents; goods vs service.
+
+## STORY-ACC-04-002 — Pricing: levels, net/gross & discounts
+*Covers UC-ACC-04.2, .5*
+
+**User Story:** As a **User**, I want price levels, net/gross pricing, and discounts, so that pricing is correct per customer.
+
+**Acceptance Criteria**
+- **Given** an item, **when** I define multiple price levels (net and/or gross), **then** the correct level applies based on the contact's default (EPIC-ACC-03.9).
+- **Given** item- or contact-level discounts, **when** added to a document, **then** they reduce the taxable base before VAT and show explicitly.
+
+**Technical Notes:** net↔gross derivation uses the item's VAT rate; level resolution order documented.
+**Test Cases:** level selection by contact; discount-before-VAT; net/gross round-trip.
+
+## STORY-ACC-04-003 — Categories & tags
+*Covers UC-ACC-04.4*
+
+**User Story:** As a **User**, I want to categorize/tag items, so that I can organize and report on the catalog.
+
+**Acceptance Criteria**
+- **Given** items, **when** I assign categories/tags, **then** I can filter the catalog and reports by them.
+
+**Test Cases:** filter accuracy; reporting breakdown by category.
+
+## STORY-ACC-04-004 — Import / export price list
+*Covers UC-ACC-04.6*
+
+**User Story:** As an **Owner**, I want to import/export the price list, so that I onboard and maintain it in bulk.
+
+**Acceptance Criteria**
+- **Given** a file, **when** I import items, **then** rows validate, duplicates (by code) flag, and a result summary shows.
+- **Given** the catalog, **when** I export, **then** I get a complete xlsx/csv.
+
+**Test Cases:** import validation/dedupe by code; export completeness.
+
+## STORY-ACC-04-005 — Stock link & inline quick-add
+*Covers UC-ACC-04.7, .8*
+
+**User Story:** As a **User**, I want to link items to stock and quick-add items from a document line, so that I track inventory and keep flow fast.
+
+**Acceptance Criteria**
+- **Given** an item, **when** I mark it stock-tracked, **then** issuing/receiving documents move stock (EPIC-ACC-11).
+- **Given** the line editor, **when** I type an unknown item, **then** I can create it inline and it's saved to the catalog.
+
+**Technical Notes:** stock link is the join to EPIC-ACC-11; inline-create persists a full catalog item.
+**Test Cases:** stock-tracked flag drives movement; inline-created item persists & reusable.
+
+---
+
+## Coverage
+| Story | UCs |
+|-------|-----|
+| 001 Item CRUD + VAT/unit | 04.1, 04.3 |
+| 002 Pricing & discounts | 04.2, 04.5 |
+| 003 Categories & tags | 04.4 |
+| 004 Import/export | 04.6 |
+| 005 Stock link & quick-add | 04.7, 04.8 |

--- a/.research/accounting/stories/EPIC-ACC-05-sales-invoicing.md
+++ b/.research/accounting/stories/EPIC-ACC-05-sales-invoicing.md
@@ -1,0 +1,225 @@
+# EPIC-ACC-05 — Sales Invoicing · Stories
+
+> Worked exemplar story set for the flagship epic. Format follows the repo story convention (User Story · Acceptance
+> Criteria G/W/T · Technical Notes · UI/UX Notes · Test Cases · Definition of Done). Covers all of `UC-ACC-05.1–.20`.
+> The same pattern applies to the other epics — replicate per `epics.md`.
+
+**Conventions:** `STORY-ACC-05-NNN`. A document's lifecycle status: `draft → issued → sent → (partially_)paid / overdue / cancelled`.
+**Shared Definition of Done (all stories):** acceptance criteria pass; unit + integration tests green; multi-tenant isolation verified; audit-log entry written on mutation; i18n strings externalized; mobile parity where the flow is mobile-flagged; no regression in VAT/rounding math.
+
+---
+
+## STORY-ACC-05-001 — Create & issue an invoice
+*Covers UC-ACC-05.1, .9, .17*
+
+**User Story:** As a **User**, I want to create and issue an invoice to a customer, so that I can request payment with a compliant, numbered document.
+
+**Acceptance Criteria**
+- **Given** an active company with a configured numbering series, **when** I create an invoice, select a contact, and set issue/due/supply dates, **then** the document is saved as `draft` with all customer and company details auto-filled.
+- **Given** a valid draft with at least one line, **when** I issue it, **then** it receives the next gapless number from its series, status becomes `issued`, and the issued document is immutable except via a corrective document.
+- **Given** an issued invoice, **when** I preview it, **then** a print-ready PDF renders with branding, totals, payment details, and legally required fields.
+- **Given** a draft missing a contact or any line, **when** I attempt to issue, **then** issuance is blocked with field-level validation errors.
+
+**Technical Notes:** numbering allocation must be atomic and gap-free under concurrency (sequence per series/period). Issued snapshots persist company/contact data so later edits to master records don't mutate historical documents.
+**UI/UX Notes:** single-screen editor; "Save draft" vs "Issue"; status badge; mobile-flagged.
+**Test Cases:** concurrent issue → no duplicate/gap numbers; issue with empty lines blocked; PDF contains all mandatory fields; issued doc is read-only.
+
+---
+
+## STORY-ACC-05-002 — Compose lines with discounts, VAT, rounding & precision
+*Covers UC-ACC-05.2, .3, .19, .20*
+
+**User Story:** As a **User**, I want to add line items with quantities, prices, discounts and VAT, so that the invoice totals and tax are calculated correctly.
+
+**Acceptance Criteria**
+- **Given** the line editor, **when** I add a catalog item, **then** description, unit price, unit, and VAT rate prefill; **and when** I enter an ad-hoc line, **then** I can set all fields manually.
+- **Given** lines with quantities and prices, **when** totals compute, **then** net, VAT (grouped per rate), and gross are correct and recomputed live on any change.
+- **Given** a line or document discount, **when** applied, **then** it reduces the taxable base before VAT and is shown explicitly.
+- **Given** configured precision (up to 4 decimals) and total-rounding rules, **when** the document totals, **then** per-line precision and the rounding adjustment line both honor configuration.
+
+**Technical Notes:** single deterministic money/VAT calculation module shared by web, mobile, and API; document-level vs line-level VAT computation modes; banker's vs arithmetic rounding configurable.
+**UI/UX Notes:** live totals panel with VAT breakdown by rate.
+**Test Cases:** mixed-rate VAT grouping; discount-before-VAT; rounding line appears/nets to zero; 4-dp precision retained.
+
+---
+
+## STORY-ACC-05-003 — Issue in foreign currency
+*Covers UC-ACC-05.4*
+
+**User Story:** As a **User**, I want to issue an invoice in a foreign currency, so that I can bill international customers correctly.
+
+**Acceptance Criteria**
+- **Given** a currency other than base, **when** I create the invoice, **then** I can set or auto-fetch the exchange rate for the supply date.
+- **Given** a foreign-currency document, **when** it totals, **then** amounts show in document currency with the base-currency equivalent and rate recorded for VAT/reporting.
+- **Given** no rate is available, **when** I issue, **then** I am prompted to enter one (issuance blocked without a rate).
+
+**Technical Notes:** persist rate + source on the document; base-currency conversion drives reporting and VAT records. Depends on FX source (EPIC-ACC-13.7).
+**Test Cases:** rate auto-fetch by date; manual override; base-equivalent on PDF and in reports.
+
+---
+
+## STORY-ACC-05-004 — Proforma / advance + tax settlement document
+*Covers UC-ACC-05.5, .6*
+
+**User Story:** As a **User**, I want to issue a proforma/advance request and later settle it with a tax document, so that I can take prepayments compliantly.
+
+**Acceptance Criteria**
+- **Given** a contact, **when** I issue a proforma/advance, **then** a non-tax request-for-payment is produced (no VAT liability yet) with its own numbering.
+- **Given** a paid advance, **when** I create the tax/settlement document, **then** VAT is recognized on the advance and the final invoice deducts the settled advance from the amount due.
+- **Given** a final invoice with a linked settled advance, **when** totals compute, **then** the remaining balance is correct and the documents are linked (UC-ACC-05.15).
+
+**Technical Notes:** advance VAT recognition on payment; settlement deduction logic; chain proforma → payment → tax document → final invoice.
+**Test Cases:** advance with/without VAT mode; partial advance settlement; double-settlement prevented.
+
+---
+
+## STORY-ACC-05-005 — Credit note / corrective document
+*Covers UC-ACC-05.7*
+
+**User Story:** As a **User**, I want to issue a credit note against an invoice, so that I can correct or cancel it without altering the original.
+
+**Acceptance Criteria**
+- **Given** an issued invoice, **when** I create a corrective document, **then** it references the original, supports full or partial correction, and reverses the corresponding VAT.
+- **Given** a credit note, **when** issued, **then** the original remains immutable, balances/receivables update, and both documents show the link.
+- **Given** a fully credited invoice, **when** viewed, **then** its effective payable is zero and status reflects the correction.
+
+**Technical Notes:** signed corrective amounts; VAT reversal flows into VAT records (EPIC-ACC-10); receivables recompute (EPIC-ACC-09).
+**Test Cases:** partial vs full credit; VAT reversal correct; original untouched; aging updates.
+
+---
+
+## STORY-ACC-05-006 — Payment QR / code on documents
+*Covers UC-ACC-05.8*
+
+**User Story:** As a **User**, I want a scannable payment code on the invoice, so that customers can pay quickly and correctly.
+
+**Acceptance Criteria**
+- **Given** an issued invoice with a bank account, **when** the PDF/link renders, **then** a payment QR encodes amount, currency, account, and a structured payment reference.
+- **Given** a foreign-currency or zero-balance document, **when** rendered, **then** the code reflects the actual amount due (or is omitted when nothing is owed).
+
+**Technical Notes:** standards-based payment-code generation; reference matches the value used by auto-match (EPIC-ACC-08.6).
+**Test Cases:** QR decodes to correct amount/reference; omitted when paid; correct on partial balance.
+
+---
+
+## STORY-ACC-05-007 — Send invoice by email
+*Covers UC-ACC-05.10*
+
+**User Story:** As a **User**, I want to email an invoice to a customer from a template, so that delivery is one click and on-brand.
+
+**Acceptance Criteria**
+- **Given** an issued invoice and a contact email, **when** I send, **then** a templated email goes out with the PDF (and/or link), and status advances to `sent`.
+- **Given** a send, **when** it completes, **then** the event is recorded in the contact's communication history (UC-ACC-03.8) with timestamp and recipient.
+- **Given** a send failure/bounce, **when** it occurs, **then** the user is notified and can retry; status does not falsely show `sent`.
+- **Given** a company with custom SMTP configured, **when** I send, **then** the message uses that SMTP.
+
+**Technical Notes:** async send + delivery-status callback; template variables; optional custom SMTP per company.
+**Test Cases:** template render; bounce handling; history entry; custom-SMTP path.
+
+---
+
+## STORY-ACC-05-008 — Send via shareable link & pay online
+*Covers UC-ACC-05.11*
+
+**User Story:** As a **User**, I want to share a secure link where the customer can view and pay the invoice, so that I get paid faster without attachments.
+
+**Acceptance Criteria**
+- **Given** an issued invoice, **when** I generate a share link, **then** a unique, hard-to-guess, optionally expiring URL renders a read-only view of the document.
+- **Given** online payment is enabled (EPIC-ACC-09.2), **when** the customer opens the link, **then** a Pay action initiates a gateway payment; on success the invoice auto-marks paid (UC-ACC-09.3).
+- **Given** a revoked/expired link, **when** opened, **then** access is denied.
+
+**Technical Notes:** capability-token URLs, no auth required to view; rate-limit/abuse protection; gateway webhook settles the document.
+**Test Cases:** link entropy/expiry/revocation; view records no PII leakage; pay→auto-settle.
+
+---
+
+## STORY-ACC-05-009 — Export invoice (PDF / ISDOC / XML)
+*Covers UC-ACC-05.12*
+
+**User Story:** As a **User/Accountant/System**, I want to export documents in standard electronic formats, so that they integrate with other systems and the accountant's tools.
+
+**Acceptance Criteria**
+- **Given** any issued document, **when** I export, **then** I can produce PDF and a standard structured format (e.g., ISDOC/XML) that validates against its schema.
+- **Given** a bulk selection, **when** I export, **then** a combined archive is produced (ties to UC-ACC-05.18).
+- **Given** the public API, **when** a document is requested, **then** the same export formats are available (EPIC-ACC-14).
+
+**Technical Notes:** schema-valid XML; deterministic PDF; shared export service across UI/API.
+**Test Cases:** XML schema validation; round-trip into a consumer; bulk archive integrity.
+
+---
+
+## STORY-ACC-05-010 — Attachments & tags
+*Covers UC-ACC-05.13, .14*
+
+**User Story:** As a **User**, I want to attach files and tag documents, so that I keep supporting evidence together and can filter/report.
+
+**Acceptance Criteria**
+- **Given** a document, **when** I attach a file, **then** it is stored, virus-scanned, size/type-validated, and downloadable from the document.
+- **Given** documents, **when** I apply tags, **then** I can filter and report lists by tag (feeds EPIC-ACC-12).
+
+**Technical Notes:** object storage with per-tenant scoping; tag taxonomy reused across document types.
+**Test Cases:** disallowed type rejected; attachment tenant-isolated; tag filter accuracy.
+
+---
+
+## STORY-ACC-05-011 — Link related documents
+*Covers UC-ACC-05.15*
+
+**User Story:** As a **User**, I want related documents linked (proforma ↔ invoice ↔ credit note ↔ delivery note), so that I can navigate the full chain.
+
+**Acceptance Criteria**
+- **Given** documents created via conversion or settlement, **when** I view one, **then** all linked documents are listed and navigable with their relationship type.
+- **Given** a linked chain, **when** I open it, **then** a visualization shows the relationships and current statuses.
+
+**Technical Notes:** typed relationship edges; cycle-safe; drives advance settlement (05.6) and conversions (EPIC-ACC-06).
+**Test Cases:** link integrity across conversions; visualization correctness; deletion rules on linked drafts.
+
+---
+
+## STORY-ACC-05-012 — Duplicate invoice
+*Covers UC-ACC-05.16*
+
+**User Story:** As a **User**, I want to duplicate an existing invoice, so that I can quickly create similar ones.
+
+**Acceptance Criteria**
+- **Given** any document, **when** I duplicate it, **then** a new `draft` is created with copied lines/terms, fresh dates, no number, and no payment/links carried over.
+- **Given** a duplicate, **when** I issue it, **then** it allocates its own number independently.
+
+**Technical Notes:** deep-copy of lines, shallow reference to contact/catalog; never copy status/payments/number.
+**Test Cases:** dates reset; status `draft`; no inherited payments/links.
+
+---
+
+## STORY-ACC-05-013 — Bulk document actions
+*Covers UC-ACC-05.18*
+
+**User Story:** As a **User/Owner**, I want to act on many documents at once (send, export, print, tag), so that I save time on routine batches.
+
+**Acceptance Criteria**
+- **Given** a multi-selection, **when** I choose a bulk action, **then** it applies to all eligible items and reports a per-item success/failure summary.
+- **Given** mixed-eligibility selection (e.g., a draft cannot be "sent"), **when** I run the action, **then** ineligible items are skipped with a clear reason, not silently dropped.
+
+**Technical Notes:** async batch with progress + partial-failure reporting; idempotent retries.
+**Test Cases:** partial-failure summary; ineligible-skip reasons; large-batch progress.
+
+---
+
+## Story Index → Use-Case Coverage
+
+| Story | Use cases |
+|-------|-----------|
+| 001 Create & issue | 05.1, 05.9, 05.17 |
+| 002 Lines/VAT/rounding | 05.2, 05.3, 05.19, 05.20 |
+| 003 Foreign currency | 05.4 |
+| 004 Proforma/advance settlement | 05.5, 05.6 |
+| 005 Credit note | 05.7 |
+| 006 Payment QR | 05.8 |
+| 007 Send by email | 05.10 |
+| 008 Shareable link + pay | 05.11 |
+| 009 Export PDF/ISDOC/XML | 05.12 |
+| 010 Attachments & tags | 05.13, 05.14 |
+| 011 Document linking | 05.15 |
+| 012 Duplicate | 05.16 |
+| 013 Bulk actions | 05.18 |
+
+All 20 `UC-ACC-05.*` use cases covered by 13 stories.

--- a/.research/accounting/stories/EPIC-ACC-16-platform-security.md
+++ b/.research/accounting/stories/EPIC-ACC-16-platform-security.md
@@ -1,0 +1,105 @@
+# EPIC-ACC-16 — Platform: Security, Data & Compliance · Stories
+
+> Covers `UC-ACC-16.1–.9`. Cross-cutting foundation consumed by all epics (esp. EPIC-ACC-01).
+> **Shared DoD:** AC pass · tests green · **tenant isolation is a release gate (NFR-ACC-01)** · changes audited · secrets never logged.
+
+---
+
+## STORY-ACC-16-001 — 2FA & session/login security
+*Covers UC-ACC-16.1, .9*
+
+**User Story:** As a **platform**, I want strong login security, so that accounts and their financial data are protected.
+
+**Acceptance Criteria**
+- **Given** a user, **when** they enable 2FA, **then** subsequent logins require the second factor; recovery codes are issued once.
+- **Given** repeated failed logins, **when** a threshold is hit, **then** the account is rate-limited/locked and the event is audited.
+- **Given** active sessions, **when** a user reviews them, **then** they can see and revoke sessions; password change revokes others.
+
+**Technical Notes:** TOTP-class 2FA; lockout + anomaly signals; session store supports revocation.
+**Test Cases:** 2FA enforced next login; lockout after N fails; session revoke kills tokens; recovery-code single-use.
+
+## STORY-ACC-16-002 — Role-based access control (enforcement)
+*Covers UC-ACC-16.2*
+
+**User Story:** As a **platform**, I want server-side RBAC, so that permissions can't be bypassed by the client.
+
+**Acceptance Criteria**
+- **Given** a role, **when** any API action is attempted, **then** authorization is checked **server-side** and denied actions return 403 regardless of UI state.
+- **Given** a read-only role, **when** a mutation is attempted via API directly, **then** it is rejected.
+- **Given** cross-company access, **when** a user requests another company's data, **then** RLS + authz deny it (no leakage).
+
+**Technical Notes:** centralized authorization in `api-core` middleware/extractors; RLS as defense-in-depth.
+**Test Cases:** direct-API privilege escalation blocked; cross-company denied; 403 vs 404 semantics consistent.
+
+## STORY-ACC-16-003 — Daily backups & restore
+*Covers UC-ACC-16.3*
+
+**User Story:** As an **Owner**, I want automatic backups with proven restore, so that I never lose my financial data.
+
+**Acceptance Criteria**
+- **Given** the platform, **when** a day passes, **then** an automated backup is taken and retained per policy.
+- **Given** a backup, **when** a restore is exercised, **then** data is recovered intact within the recovery objective.
+
+**Technical Notes:** restore must be **tested**, not assumed (NFR-ACC-05); per-tenant restore considered.
+**Test Cases:** scheduled backup present; restore drill succeeds; retention pruning.
+
+## STORY-ACC-16-004 — Data export, migration & import
+*Covers UC-ACC-16.4, .5*
+
+**User Story:** As an **Owner**, I want full data export and import, so that I'm never locked in and can onboard from another system.
+
+**Acceptance Criteria**
+- **Given** my company, **when** I export, **then** I receive a complete, portable archive (documents, contacts, items, payments) in standard formats.
+- **Given** a source file/system, **when** I import, **then** records validate, conflicts are reported, and a summary is produced.
+
+**Technical Notes:** export = no lock-in (NFR-ACC-11); import shares validation with EPIC-ACC-03/-04 importers.
+**Test Cases:** export round-trips into import; conflict reporting; large-dataset export.
+
+## STORY-ACC-16-005 — GDPR data-subject requests
+*Covers UC-ACC-16.6*
+
+**User Story:** As an **Owner/platform**, I want to fulfill access and erasure requests, so that we comply with data-protection law.
+
+**Acceptance Criteria**
+- **Given** a data-subject access request, **when** processed, **then** all personal data for the subject is exported.
+- **Given** an erasure request, **when** processed, **then** personal data is erased/anonymized **subject to legal retention** of accounting documents, and the action is logged.
+
+**Technical Notes:** reconcile erasure with statutory retention of invoices (anonymize vs delete); audit every DSAR.
+**Test Cases:** access export completeness; erasure respects retention; DSAR audited.
+
+## STORY-ACC-16-006 — Audit trail
+*Covers UC-ACC-16.7*
+
+**User Story:** As an **Owner/platform**, I want an immutable change history, so that every mutation is accountable.
+
+**Acceptance Criteria**
+- **Given** any document/setting mutation, **when** it occurs, **then** an audit entry records who/what/when/old→new.
+- **Given** the audit log, **when** viewed (EPIC-ACC-01.10), **then** it is filterable and tamper-evident.
+
+**Technical Notes:** append-only audit store; powers EPIC-ACC-01.10 view.
+**Test Cases:** entry on every mutation type; immutability; filter.
+
+## STORY-ACC-16-007 — Legislative & template updates
+*Covers UC-ACC-16.8*
+
+**User Story:** As a **platform**, I want tax rules, statutory formats, and templates kept current, so that customers stay compliant without manual upkeep.
+
+**Acceptance Criteria**
+- **Given** a legislative change (rates, filing formats), **when** an update ships, **then** new documents/filings use the new rules from the effective date while historical ones keep their original rules.
+- **Given** templates, **when** updated centrally, **then** companies pick up improvements without losing custom branding.
+
+**Technical Notes:** versioned, date-effective rule sets (ties to EPIC-ACC-10 e-file formats); pluggable per jurisdiction.
+**Test Cases:** effective-date switchover; historical immutability; branding preserved across template update.
+
+---
+
+## Coverage
+| Story | UCs |
+|-------|-----|
+| 001 2FA & sessions | 16.1, 16.9 |
+| 002 RBAC enforcement | 16.2 |
+| 003 Backups & restore | 16.3 |
+| 004 Export/migration/import | 16.4, 16.5 |
+| 005 GDPR DSARs | 16.6 |
+| 006 Audit trail | 16.7 |
+| 007 Legislative/template updates | 16.8 |

--- a/.research/accounting/stories/EPIC-ACC-17-backend-service.md
+++ b/.research/accounting/stories/EPIC-ACC-17-backend-service.md
@@ -1,0 +1,98 @@
+# EPIC-ACC-17 — Backend Service (`accounting-server`) & Shared-Core Integration · Stories
+
+> Covers the topology decided in [`../architecture.md`](../architecture.md): a separate `accounting-server` (`:8082`)
+> sharing `common`/`api-core`/`db` core with `api-server`, mirroring `reality-server`. Implementation/infra epic.
+> **Shared DoD:** `cargo build --workspace` + `cargo clippy --workspace -- -D warnings` clean · tests green ·
+> no new core-crate API just for this server unless reused · OpenAPI compiles.
+
+---
+
+## STORY-ACC-17-001 — Scaffold `accounting-core` crate + `accounting-server` binary
+*Foundational*
+
+**User Story:** As the **platform**, I want a thin `accounting-server` binary backed by an `accounting-core` crate, so that accounting has its own deployable surface like `reality-server`.
+
+**Acceptance Criteria**
+- **Given** the workspace, **when** I add `crates/accounting-core` and `servers/accounting-server` (copying the `reality-server` skeleton: `routes/ handlers/ extractors/ state.rs/ main.rs/ observability.rs`), **then** both are workspace members and build.
+- **Given** the binary, **when** I run `cargo run -p accounting-server`, **then** it binds `:8082` and serves `/health` + `/swagger-ui`.
+- **Given** domain logic, **when** added, **then** it lives in `accounting-core` and the server crate stays thin (routing/wiring only).
+
+**Technical Notes:** mirror `backend/servers/reality-server` exactly; reuse `api-core` observability (OTel/metrics/sentry).
+**Test Cases:** `:8082/health` 200; swagger served; clippy clean; server crate has no business logic.
+
+## STORY-ACC-17-002 — Share core & validate api-server JWTs (resource server)
+*Foundational*
+
+**User Story:** As the **platform**, I want `accounting-server` to share core crates and trust `api-server`-issued tokens, so that we don't re-implement auth/DB/tenancy.
+
+**Acceptance Criteria**
+- **Given** `accounting-server/Cargo.toml`, **when** declared, **then** its deps include `common`, `api-core`, `db`, `accounting-core` (same pattern as `reality-server` = common+api-core+db).
+- **Given** a valid `api-server`-issued JWT, **when** a request hits a protected `accounting-server` route, **then** the shared `api-core` extractor validates it and resolves tenant/company context.
+- **Given** an invalid/expired token, **when** a request arrives, **then** it's rejected 401; **and** `api-server` remains the sole token **issuer** (accounting-server issues none).
+
+**Technical Notes:** resource-server pattern (like reality-server = SSO consumer); same `JWT_SECRET`/keys; tenant context via `tenant-ops`.
+**Test Cases:** valid token accepted; tampered/expired rejected; tenant context populated; no token-issuing endpoints exist.
+
+## STORY-ACC-17-003 — Shared-DB accounting tables + RLS
+*Foundational*
+
+**User Story:** As the **platform**, I want accounting tables in the shared Postgres with RLS, so that data is isolated per company like the rest of the system.
+
+**Acceptance Criteria**
+- **Given** the `db` crate migrations, **when** accounting migrations are added/kept (`00183/00184` + new), **then** `accounting-server` uses the same pool/migrations as `api-server`.
+- **Given** RLS policies, **when** any accounting query runs, **then** it is scoped to the company; cross-company access returns nothing.
+- **Given** the `db`-crate boundary, **when** reviewed, **then** it stays clean enough that a future **dedicated accounting DB** split is possible without app rewrites.
+
+**Technical Notes:** migrations live in `db` crate (shared); RLS verified by test as defense-in-depth.
+**Test Cases:** migration applies; RLS cross-company isolation; pool shared/configurable via `DATABASE_URL`.
+
+## STORY-ACC-17-004 — OpenAPI + `@ppt/accounting-api-client`
+*Depends on 001–003*
+
+**User Story:** As a **frontend dev**, I want a generated typed client from the server's OpenAPI, so that `@ppt/accounting-web` consumes a contract, not hand-written calls.
+
+**Acceptance Criteria**
+- **Given** `accounting-server` routes, **when** built, **then** they emit an OpenAPI spec (utoipa) served at `/swagger-ui`.
+- **Given** the spec, **when** SDK generation runs (hey-api), **then** `@ppt/accounting-api-client` is produced and type-checks.
+- **Given** a contract change, **when** CI runs, **then** breaking-change detection flags it (consistent with repo API strategy).
+
+**Technical Notes:** `accounting.tsp` already exists on dev — reconcile design-first TypeSpec with utoipa output per repo API strategy.
+**Test Cases:** spec compiles; SDK generates + type-checks; breaking-change check wired.
+
+## STORY-ACC-17-005 — Deploy wiring (`:8082`)
+*Depends on 001*
+
+**User Story:** As **DevOps**, I want `accounting-server` deployable like the other servers, so that worktree/staging/prod targets exist.
+
+**Acceptance Criteria**
+- **Given** compose/manifests, **when** updated, **then** an `accounting-server` service builds and runs on `:8082` with required env (`DATABASE_URL`, `JWT_SECRET`, `CORS_ALLOWED_ORIGINS`).
+- **Given** the `pmctl` worktree system, **when** a worktree is opened, **then** `accounting.dev.*` (and `@ppt/accounting-web` host) resolve and serve.
+- **Given** caddy routing + CORS, **when** the frontend calls `:8082`, **then** requests succeed cross-origin per config.
+
+**Technical Notes:** mirror reality-server deploy; add host to caddy + CORS defaults; `pmctl` target.
+**Test Cases:** service healthy in compose; worktree host reachable; CORS preflight ok.
+
+## STORY-ACC-17-006 — Migrate `/api/v1/accounting/*` out of `api-server`
+*Depends on 001–005*
+
+**User Story:** As the **platform**, I want the embedded accounting MVP moved into the new server, so that there's one owner and no dual-serve.
+
+**Acceptance Criteria**
+- **Given** `api-server`'s `handlers/accounting/*` + routes (on dev), **when** migrated, **then** equivalent endpoints serve from `accounting-server` with pure logic lifted into `accounting-core`.
+- **Given** parity is verified green, **when** the cutover lands, **then** `/api/v1/accounting/*` is **removed from `api-server`** (returns 404) — no dual-serve window in prod.
+- **Given** existing clients, **when** repointed, **then** `@ppt/accounting-web` targets `:8082` and works end-to-end.
+
+**Technical Notes:** dev/main are disjoint — land on the correct base; verify parity before removing the old route.
+**Test Cases:** endpoint parity suite; old route 404 after cutover; web e2e against `:8082`.
+
+---
+
+## Coverage
+| Story | Scope |
+|-------|-------|
+| 001 Scaffold crate+server | accounting-core + accounting-server `:8082` |
+| 002 Share core & JWT | common/api-core/db + resource-server auth |
+| 003 Shared-DB + RLS | migrations in `db`, isolation |
+| 004 OpenAPI + SDK | `@ppt/accounting-api-client` |
+| 005 Deploy wiring | compose/caddy/CORS/`pmctl` |
+| 006 Migrate from api-server | extract `/api/v1/accounting/*`, drop old route |

--- a/.research/accounting/use-cases.md
+++ b/.research/accounting/use-cases.md
@@ -1,0 +1,740 @@
+# Invoicing & Accounting Product — Use Cases
+
+> **Product code:** `ACC` (standalone online invoicing + light-accounting SaaS).
+> **Provenance:** Generalized from competitor analysis of a CZ/SK online invoicing SaaS. **Vendor-neutral**, functionality only.
+> **Companion:** epics in [`epics.md`](epics.md). IDs follow the repo convention `UC-ACC-XX.Y` (XX = category, Y = sequence).
+
+## Actors
+
+### Account Level
+- **Owner / Admin** — Account owner; manages company/agenda, subscription, users, global settings.
+- **User (Staff)** — Team member with role-based access (issue documents, manage contacts, etc.).
+- **Accountant** — External collaborator (often read/export); may manage multiple client companies; prepares filings.
+
+### Counterparties
+- **Customer** — Recipient of issued documents; limited self-service (view/pay an invoice via shared link).
+- **Supplier / Vendor** — Counterparty on purchase/expense documents.
+
+### System & External
+- **System / Automation** — Scheduled, non-interactive actor (recurring invoices, reminders, bank sync, OCR/AI, FX refresh).
+- **Bank** — Statement feed / payment data (external).
+- **Payment Gateway** — Online card/bank payments (external).
+- **Tax Authority** — Recipient of VAT/tax filings via export/e-file (external).
+- **Business / VAT Registry** — Company autocomplete & VAT verification (external).
+- **E-shop / External System** — Integrates via public API / webhooks (external).
+
+### Actor Hierarchy
+```
+Owner / Admin
+├── User (Staff)              [role-based: Standard / Read-only]
+├── Accountant                [cross-company, read/export]
+└── Company (Agenda)          [one Owner operates many]
+        ├── Customer          [via shared link / email]
+        ├── Supplier
+        └── System / Automation
+                ├── Bank (statements, payments)
+                ├── Payment Gateway
+                ├── Tax Authority (filings)
+                ├── Business / VAT Registry (lookup)
+                └── E-shop / External System (API)
+```
+
+---
+
+## UC-ACC-01: Accounts, Organizations & Access (web, mobile)
+
+### UC-ACC-01.1: Register Account
+**Actor:** Owner/Admin
+**Description:** A new user signs up and a first company/agenda is created.
+
+### UC-ACC-01.2: Create Additional Company (Agenda)
+**Actor:** Owner/Admin, Accountant
+**Description:** Add another company under the same login, fully isolated from existing ones.
+
+### UC-ACC-01.3: Switch Active Company
+**Actor:** Owner/Admin, User, Accountant
+**Description:** Change the active company context; all data and documents scope to it.
+
+### UC-ACC-01.4: Invite User
+**Actor:** Owner/Admin
+**Description:** Invite a team member by email to join a company.
+
+### UC-ACC-01.5: Assign Role & Permissions
+**Actor:** Owner/Admin
+**Description:** Grant a role (Admin, Standard, Read-only) controlling visible modules and actions.
+
+### UC-ACC-01.6: Deactivate / Remove User
+**Actor:** Owner/Admin
+**Description:** Revoke a user's access while preserving their authored documents.
+
+### UC-ACC-01.7: Grant Accountant Access
+**Actor:** Owner/Admin
+**Description:** Give an external accountant remote, ongoing access to documents and exports.
+
+### UC-ACC-01.8: Manage Subscription / Plan
+**Actor:** Owner/Admin
+**Description:** View, upgrade, downgrade, or cancel the subscription tier and see usage limits.
+
+### UC-ACC-01.9: Enable Two-Factor Authentication
+**Actor:** Owner/Admin, User
+**Description:** Add a second authentication factor to the account.
+
+### UC-ACC-01.10: View Audit Log / Activity History
+**Actor:** Owner/Admin
+**Description:** Review who changed what and when across the company.
+
+### UC-ACC-01.11: Export Account Data (GDPR)
+**Actor:** Owner/Admin
+**Description:** Export all company/personal data in a portable format.
+
+### UC-ACC-01.12: Delete Account / Company (GDPR)
+**Actor:** Owner/Admin
+**Description:** Permanently delete a company/account with required confirmations and retention rules.
+
+### UC-ACC-01.13: Log In / Single Sign-On
+**Actor:** Owner/Admin, User, Accountant
+**Description:** Authenticate via credentials (or SSO) and resume the last active company.
+
+---
+
+## UC-ACC-02: Company & Document Configuration (web)
+
+### UC-ACC-02.1: Set Company Profile
+**Actor:** Owner/Admin
+**Description:** Maintain legal name, registration IDs, VAT status, addresses, contact details, and logo.
+
+### UC-ACC-02.2: Configure Tax / VAT Mode
+**Actor:** Owner/Admin, Accountant
+**Description:** Choose VAT-payer vs non-payer and tax-records vs full-accounting mode; drives all document tax behavior.
+
+### UC-ACC-02.3: Define Numbering Series
+**Actor:** Owner/Admin
+**Description:** Configure gapless numbering sequences per document type and period/year.
+
+### UC-ACC-02.4: Customize Document Design
+**Actor:** Owner/Admin
+**Description:** Choose a layout/template and apply branding (logo, colors) to generated documents.
+
+### UC-ACC-02.5: Configure Default Texts & Terms
+**Actor:** Owner/Admin
+**Description:** Set default payment terms, footers, headers, and standard notes for documents.
+
+### UC-ACC-02.6: Manage Email Templates
+**Actor:** Owner/Admin
+**Description:** Edit subject/body templates used when sending documents and reminders.
+
+### UC-ACC-02.7: Configure Languages & Localization
+**Actor:** Owner/Admin
+**Description:** Select document/UI languages, number/date formats, and per-document language.
+
+### UC-ACC-02.8: Manage Units of Measure
+**Actor:** Owner/Admin
+**Description:** Define and edit units used on catalog items and document lines.
+
+### UC-ACC-02.9: Configure VAT Rates
+**Actor:** Owner/Admin
+**Description:** Maintain applicable VAT rates and defaults.
+
+### UC-ACC-02.10: Configure Bank Accounts on Documents
+**Actor:** Owner/Admin
+**Description:** Set which bank account(s) and payment details appear on issued documents.
+
+### UC-ACC-02.11: Set Default Currency & Rounding
+**Actor:** Owner/Admin
+**Description:** Choose base currency and rounding rules (total and per-line precision).
+
+---
+
+## UC-ACC-03: Contacts & CRM (web, mobile)
+
+### UC-ACC-03.1: Create Contact
+**Actor:** User, Owner/Admin
+**Description:** Add a customer or supplier with identifiers, addresses, and tax details.
+
+### UC-ACC-03.2: Autocomplete from Business Registry
+**Actor:** User; Business/VAT Registry
+**Description:** Look up a company by name/ID and auto-fill official details.
+
+### UC-ACC-03.3: Verify VAT Payer Status
+**Actor:** User; Business/VAT Registry
+**Description:** Validate a counterparty's VAT number and registration status.
+
+### UC-ACC-03.4: Manage Multiple Addresses
+**Actor:** User
+**Description:** Keep separate billing and one or more delivery addresses per contact.
+
+### UC-ACC-03.5: Edit / Merge / Deactivate Contact
+**Actor:** User, Owner/Admin
+**Description:** Maintain contact data, merge duplicates, or archive an inactive contact.
+
+### UC-ACC-03.6: Tag / Segment Contacts
+**Actor:** User
+**Description:** Apply labels/segments for filtering and bulk operations.
+
+### UC-ACC-03.7: View Contact Transaction History
+**Actor:** User, Owner/Admin, Accountant
+**Description:** See all issued/received documents and payments for a contact.
+
+### UC-ACC-03.8: View Communication History
+**Actor:** User, Owner/Admin
+**Description:** Review emails and documents sent to the contact.
+
+### UC-ACC-03.9: Set Per-Contact Defaults
+**Actor:** User, Owner/Admin
+**Description:** Define default currency, price level, payment terms, and discount per contact.
+
+### UC-ACC-03.10: Import / Export Contacts
+**Actor:** Owner/Admin
+**Description:** Bulk-import contacts from a file and export the directory.
+
+### UC-ACC-03.11: Track Receivables / Credit per Contact
+**Actor:** Owner/Admin, Accountant
+**Description:** Monitor outstanding balance and optional credit limit per contact.
+
+---
+
+## UC-ACC-04: Product & Price-List Catalog (web)
+
+### UC-ACC-04.1: Create Catalog Item
+**Actor:** User, Owner/Admin
+**Description:** Add a good or service with name, code, description, unit, and VAT rate.
+
+### UC-ACC-04.2: Set Prices (Levels, With/Without VAT)
+**Actor:** User, Owner/Admin
+**Description:** Define one or more price levels and net/gross pricing.
+
+### UC-ACC-04.3: Assign VAT Rate & Unit
+**Actor:** User
+**Description:** Attach the correct VAT rate and unit of measure to an item.
+
+### UC-ACC-04.4: Categorize / Tag Items
+**Actor:** User
+**Description:** Organize the catalog with categories and tags.
+
+### UC-ACC-04.5: Manage Discounts
+**Actor:** User, Owner/Admin
+**Description:** Define item- or contact-level discounts applied on documents.
+
+### UC-ACC-04.6: Import / Export Price List
+**Actor:** Owner/Admin
+**Description:** Bulk-import catalog items and export the price list.
+
+### UC-ACC-04.7: Link Item to Stock
+**Actor:** User
+**Description:** Connect a catalog item to an inventory record for stock tracking.
+
+### UC-ACC-04.8: Quick-Add Item from Document Line
+**Actor:** User
+**Description:** Create a new catalog item inline while editing a document line.
+
+---
+
+## UC-ACC-05: Sales Invoicing (web, mobile)
+
+### UC-ACC-05.1: Create Issued Invoice
+**Actor:** User, Owner/Admin
+**Description:** Issue an invoice to a customer with header, due date, and payment details.
+
+### UC-ACC-05.2: Add Line Items
+**Actor:** User
+**Description:** Add lines from the catalog or ad-hoc, with quantity, price, and VAT.
+
+### UC-ACC-05.3: Apply Discounts, VAT & Rounding
+**Actor:** User
+**Description:** Apply line/document discounts and compute VAT and rounded totals.
+
+### UC-ACC-05.4: Issue in Foreign Currency
+**Actor:** User
+**Description:** Create a document in another currency with an exchange rate and dual totals.
+
+### UC-ACC-05.5: Generate Proforma / Advance Invoice
+**Actor:** User
+**Description:** Issue a request-for-payment (proforma/advance) before the taxable supply.
+
+### UC-ACC-05.6: Create Tax / Settlement Document from Advance
+**Actor:** User, Accountant
+**Description:** Convert a received advance into a tax/settlement document and final invoice.
+
+### UC-ACC-05.7: Issue Credit Note / Corrective Document
+**Actor:** User, Owner/Admin
+**Description:** Correct or cancel a prior invoice with a linked corrective document.
+
+### UC-ACC-05.8: Generate Payment QR / Code
+**Actor:** User, System
+**Description:** Embed a scannable payment code with amount and reference on the document.
+
+### UC-ACC-05.9: Preview & Generate PDF
+**Actor:** User
+**Description:** Render a print-ready PDF of the document.
+
+### UC-ACC-05.10: Send Invoice by Email
+**Actor:** User, System
+**Description:** Email the document (PDF/link) to the customer using a template.
+
+### UC-ACC-05.11: Send Invoice via Shareable Link
+**Actor:** User
+**Description:** Share a secure link where the customer can view and pay the invoice.
+
+### UC-ACC-05.12: Export Invoice (PDF / ISDOC / XML)
+**Actor:** User, Accountant, External System
+**Description:** Export a document in a standard electronic format.
+
+### UC-ACC-05.13: Attach Files to Document
+**Actor:** User
+**Description:** Add supporting attachments (contracts, photos) to a document.
+
+### UC-ACC-05.14: Tag Documents
+**Actor:** User
+**Description:** Label documents for filtering and reporting.
+
+### UC-ACC-05.15: Link Related Documents
+**Actor:** User, System
+**Description:** Maintain links across proforma ↔ invoice ↔ credit note ↔ delivery note.
+
+### UC-ACC-05.16: Duplicate Invoice
+**Actor:** User
+**Description:** Create a new document by copying an existing one.
+
+### UC-ACC-05.17: Track Invoice Status
+**Actor:** User, System
+**Description:** Reflect lifecycle: draft → issued → sent → paid / overdue / cancelled.
+
+### UC-ACC-05.18: Bulk Document Actions
+**Actor:** User, Owner/Admin
+**Description:** Send, export, print, or tag multiple documents at once.
+
+### UC-ACC-05.19: Set Decimal Precision per Line
+**Actor:** User
+**Description:** Control per-line decimal precision (e.g., up to 4 places).
+
+### UC-ACC-05.20: Round Document Total
+**Actor:** User, System
+**Description:** Apply configured total rounding and show the rounding line.
+
+---
+
+## UC-ACC-06: Quotes, Orders & Delivery (web)
+
+### UC-ACC-06.1: Create Price Quote / Offer
+**Actor:** User
+**Description:** Issue a quotation to a prospective customer.
+
+### UC-ACC-06.2: Send Quote & Track Acceptance
+**Actor:** User, Customer
+**Description:** Send a quote and record its accepted/rejected status.
+
+### UC-ACC-06.3: Convert Quote → Order / Invoice
+**Actor:** User
+**Description:** Generate an order or invoice from an accepted quote without re-keying.
+
+### UC-ACC-06.4: Create Sales Order
+**Actor:** User
+**Description:** Record a received order to be fulfilled and invoiced.
+
+### UC-ACC-06.5: Create Delivery Note
+**Actor:** User
+**Description:** Issue a delivery/dispatch note for goods, optionally drawing from stock.
+
+### UC-ACC-06.6: Convert Order → Delivery / Invoice
+**Actor:** User
+**Description:** Progress an order into a delivery note and/or invoice.
+
+### UC-ACC-06.7: Track Fulfillment Status
+**Actor:** User
+**Description:** Monitor order/delivery progress (open, partially fulfilled, complete).
+
+---
+
+## UC-ACC-07: Purchases & Expenses (web, mobile)
+
+### UC-ACC-07.1: Record Received Invoice / Bill
+**Actor:** User, Accountant
+**Description:** Enter a supplier invoice with amounts, VAT, and due date.
+
+### UC-ACC-07.2: Capture Expense
+**Actor:** User
+**Description:** Record a cost/expense document (receipt) against a category.
+
+### UC-ACC-07.3: Upload Document to Inbox
+**Actor:** User
+**Description:** Add a scan/PDF/photo to a processing inbox for later posting.
+
+### UC-ACC-07.4: AI / OCR Extract Document Data
+**Actor:** System
+**Description:** Automatically read supplier, amounts, VAT, and dates from an uploaded document.
+
+### UC-ACC-07.5: Review & Post Extracted Document
+**Actor:** User, Accountant
+**Description:** Confirm or correct extracted data and post it as a received document.
+
+### UC-ACC-07.6: Categorize Expense
+**Actor:** User, Accountant
+**Description:** Assign an expense category/cost type for reporting and tax.
+
+### UC-ACC-07.7: Link Expense to Supplier
+**Actor:** User
+**Description:** Associate the document with a supplier contact.
+
+### UC-ACC-07.8: Attach Scan / Receipt
+**Actor:** User
+**Description:** Keep the source image/PDF attached to the posted document.
+
+### UC-ACC-07.9: Track Payable Status & Due Date
+**Actor:** User, System
+**Description:** Monitor unpaid/paid/overdue status of payables.
+
+---
+
+## UC-ACC-08: Cash & Bank (web)
+
+### UC-ACC-08.1: Create Cash Receipt (Income)
+**Actor:** User
+**Description:** Record cash received with an income cash-register document.
+
+### UC-ACC-08.2: Create Cash Payment (Expense)
+**Actor:** User
+**Description:** Record cash paid out with an expense cash-register document.
+
+### UC-ACC-08.3: Manage Cash Registers
+**Actor:** Owner/Admin
+**Description:** Maintain one or more cash registers and their balances.
+
+### UC-ACC-08.4: Add Bank Account
+**Actor:** Owner/Admin
+**Description:** Register a bank account for documents and reconciliation.
+
+### UC-ACC-08.5: Import Bank Statement
+**Actor:** User, System; Bank
+**Description:** Import a statement (file or feed) of bank transactions.
+
+### UC-ACC-08.6: Auto-Match Payments
+**Actor:** System
+**Description:** Automatically pair statement transactions to open documents by reference/amount.
+
+### UC-ACC-08.7: Manually Match / Unmatch Payment
+**Actor:** User
+**Description:** Override matching to pair or unpair a transaction and document.
+
+### UC-ACC-08.8: Manage Multiple Accounts / Registers
+**Actor:** Owner/Admin
+**Description:** Operate several bank accounts and cash registers in one company.
+
+### UC-ACC-08.9: Integrate POS / Fiscal Receipts
+**Actor:** System; POS/fiscal device
+**Description:** Ingest point-of-sale / fiscal receipts into the books.
+
+### UC-ACC-08.10: Reconcile Balances
+**Actor:** User, Accountant
+**Description:** Verify recorded balances against bank/cash actuals.
+
+---
+
+## UC-ACC-09: Payments & Collections (web, mobile)
+
+### UC-ACC-09.1: Record Manual Payment
+**Actor:** User
+**Description:** Mark a document fully or partially paid by hand.
+
+### UC-ACC-09.2: Enable Online Payment (Pay-by-Link)
+**Actor:** Owner/Admin; Payment Gateway
+**Description:** Configure a gateway so customers can pay an invoice online.
+
+### UC-ACC-09.3: Receive Online Payment & Auto-Mark Paid
+**Actor:** System; Customer, Payment Gateway
+**Description:** Capture a gateway payment and automatically settle the document.
+
+### UC-ACC-09.4: Send Payment Confirmation / Thank-You
+**Actor:** System
+**Description:** Automatically email a confirmation when a document is paid.
+
+### UC-ACC-09.5: Configure & Send Overdue Reminders
+**Actor:** Owner/Admin, System
+**Description:** Define dunning rules and send reminders for overdue documents.
+
+### UC-ACC-09.6: Escalate Reminder Levels
+**Actor:** System
+**Description:** Send progressively firmer reminders as overdue age increases.
+
+### UC-ACC-09.7: Track Receivables Aging
+**Actor:** Owner/Admin, Accountant
+**Description:** View outstanding receivables bucketed by overdue age.
+
+### UC-ACC-09.8: Handle Partial Payments & Overpayments
+**Actor:** User, System
+**Description:** Record partial settlements and manage overpayment balances.
+
+### UC-ACC-09.9: Issue Refund
+**Actor:** User, Owner/Admin
+**Description:** Record a refund against a paid document.
+
+---
+
+## UC-ACC-10: VAT & Tax Compliance (web)
+
+### UC-ACC-10.1: Maintain VAT Records
+**Actor:** System, Accountant
+**Description:** Accumulate output/input VAT entries from issued and received documents.
+
+### UC-ACC-10.2: Generate VAT Return
+**Actor:** Owner/Admin, Accountant
+**Description:** Produce the periodic VAT return from recorded entries.
+
+### UC-ACC-10.3: Generate Control / Recapitulative Statement
+**Actor:** Owner/Admin, Accountant
+**Description:** Produce the detailed VAT control/recapitulative statement for the period.
+
+### UC-ACC-10.4: Generate EC Sales List (Intra-EU)
+**Actor:** Owner/Admin, Accountant
+**Description:** Produce the summary of intra-community supplies.
+
+### UC-ACC-10.5: Handle Reverse-Charge Transactions
+**Actor:** User, Accountant
+**Description:** Apply reverse-charge VAT treatment on qualifying documents.
+
+### UC-ACC-10.6: Handle Cross-Border / OSS VAT
+**Actor:** Accountant
+**Description:** Apply destination-country VAT for cross-border B2C (one-stop-shop) sales.
+
+### UC-ACC-10.7: Apply VAT Regime per Document
+**Actor:** User, System
+**Description:** Resolve the correct VAT regime (domestic, EU, export, exempt) per document.
+
+### UC-ACC-10.8: Export Filings (XML / E-File)
+**Actor:** Owner/Admin, Accountant; Tax Authority
+**Description:** Export statutory filings in the authority's electronic format.
+
+### UC-ACC-10.9: View VAT Summary per Period
+**Actor:** Owner/Admin, Accountant
+**Description:** Review VAT liability/credit summarized by period.
+
+### UC-ACC-10.10: Operate in Non-VAT-Payer Mode
+**Actor:** Owner/Admin
+**Description:** Run documents and reports without VAT for non-registered businesses.
+
+### UC-ACC-10.11: Round & Reconcile VAT
+**Actor:** System, Accountant
+**Description:** Apply VAT rounding rules and reconcile to document totals.
+
+---
+
+## UC-ACC-11: Inventory / Stock (web)
+
+### UC-ACC-11.1: Create Stock Item / Warehouse
+**Actor:** Owner/Admin, User
+**Description:** Define a stock-tracked item and the warehouse(s) it lives in.
+
+### UC-ACC-11.2: Receive Stock (Stock-In)
+**Actor:** User
+**Description:** Increase stock from a purchase or manual receipt.
+
+### UC-ACC-11.3: Issue Stock (Stock-Out)
+**Actor:** User, System
+**Description:** Decrease stock via an invoice or delivery note.
+
+### UC-ACC-11.4: View Stock Levels
+**Actor:** User, Owner/Admin
+**Description:** See current quantity on hand per item/warehouse.
+
+### UC-ACC-11.5: View Stock Movement History
+**Actor:** User, Accountant
+**Description:** Audit all stock-in/out movements over time.
+
+### UC-ACC-11.6: Stock Valuation
+**Actor:** Accountant, Owner/Admin
+**Description:** Value inventory on hand (e.g., average/FIFO cost).
+
+### UC-ACC-11.7: Low-Stock Indicators
+**Actor:** System, User
+**Description:** Flag items below a configured reorder threshold.
+
+### UC-ACC-11.8: Stock Adjustments / Corrections
+**Actor:** User, Owner/Admin
+**Description:** Correct stock levels for losses, counts, or errors.
+
+---
+
+## UC-ACC-12: Reporting, Dashboard & Cashflow (web, mobile)
+
+### UC-ACC-12.1: View Dashboard / Overview
+**Actor:** Owner/Admin
+**Description:** See key indicators: revenue, receivables, overdue, recent activity.
+
+### UC-ACC-12.2: Income & Expense (Cashflow) Report
+**Actor:** Owner/Admin, Accountant
+**Description:** Compare income vs expense over a period.
+
+### UC-ACC-12.3: Sales Report
+**Actor:** Owner/Admin, Accountant
+**Description:** Break down sales by period, customer, or item.
+
+### UC-ACC-12.4: Receivables / Payables Aging Report
+**Actor:** Owner/Admin, Accountant
+**Description:** List open receivables and payables by overdue age.
+
+### UC-ACC-12.5: VAT Report
+**Actor:** Owner/Admin, Accountant
+**Description:** Summarize VAT by rate and period.
+
+### UC-ACC-12.6: Export Lists (xlsx / csv)
+**Actor:** Owner/Admin, Accountant, External System
+**Description:** Export any document/contact/item list to spreadsheet formats.
+
+### UC-ACC-12.7: Generate Accountant Export Package
+**Actor:** Accountant, Owner/Admin
+**Description:** Produce a consolidated export for import into accounting software.
+
+### UC-ACC-12.8: Custom Date-Range Filtering
+**Actor:** Owner/Admin, Accountant
+**Description:** Filter reports/lists by arbitrary date ranges and dimensions.
+
+### UC-ACC-12.9: Profit Overview
+**Actor:** Owner/Admin
+**Description:** View an approximate profit (income − expense) summary.
+
+---
+
+## UC-ACC-13: Automation & Recurring (web, system)
+
+### UC-ACC-13.1: Configure Recurring Invoice
+**Actor:** Owner/Admin, User
+**Description:** Define a template, cadence, and recipients for a repeating invoice.
+
+### UC-ACC-13.2: Auto-Generate & Send Recurring Invoices
+**Actor:** System
+**Description:** Create and dispatch recurring invoices on schedule, idempotently.
+
+### UC-ACC-13.3: Schedule Automatic Reminders
+**Actor:** System
+**Description:** Send overdue reminders automatically per configured rules.
+
+### UC-ACC-13.4: Auto-Match Incoming Payments
+**Actor:** System
+**Description:** Continuously pair imported bank transactions to documents.
+
+### UC-ACC-13.5: Auto-Send Thank-You on Payment
+**Actor:** System
+**Description:** Email a confirmation automatically when payment is detected.
+
+### UC-ACC-13.6: Rule-Based Defaults & Templates
+**Actor:** Owner/Admin
+**Description:** Apply automation rules for defaults (terms, numbering, texts) on new documents.
+
+### UC-ACC-13.7: Auto-Download Exchange Rates
+**Actor:** System
+**Description:** Refresh currency exchange rates automatically for foreign-currency documents.
+
+---
+
+## UC-ACC-14: Integrations & API (web, system)
+
+### UC-ACC-14.1: Authenticate & Call Public API
+**Actor:** External System, Owner/Admin
+**Description:** Use authenticated REST endpoints to read/write documents and data.
+
+### UC-ACC-14.2: Manage API Keys / OAuth Clients
+**Actor:** Owner/Admin
+**Description:** Issue, scope, and revoke API credentials.
+
+### UC-ACC-14.3: Subscribe to Webhooks / Events
+**Actor:** External System, Owner/Admin
+**Description:** Receive push notifications for events (document paid, created, etc.).
+
+### UC-ACC-14.4: Connect E-shop / External System
+**Actor:** Owner/Admin; E-shop
+**Description:** Sync orders/invoices with an e-commerce or external platform.
+
+### UC-ACC-14.5: Connect Bank
+**Actor:** Owner/Admin; Bank
+**Description:** Link a bank for automated statement/payment retrieval.
+
+### UC-ACC-14.6: Connect Payment Gateway
+**Actor:** Owner/Admin; Payment Gateway
+**Description:** Link a gateway to accept online payments on invoices.
+
+### UC-ACC-14.7: Export to Accounting Software
+**Actor:** Accountant, External System
+**Description:** Export documents in formats consumable by external accounting software.
+
+### UC-ACC-14.8: Import Data
+**Actor:** Owner/Admin, External System
+**Description:** Import contacts, items, or documents from files/other systems.
+
+### UC-ACC-14.9: Rate Limiting / Quotas
+**Actor:** System
+**Description:** Enforce per-plan API request quotas and rate limits.
+
+---
+
+## UC-ACC-15: Mobile & Notifications (mobile)
+
+### UC-ACC-15.1: Use Mobile App
+**Actor:** User, Owner/Admin
+**Description:** Access core functionality from native iOS/Android apps.
+
+### UC-ACC-15.2: Create / Send Invoice on Mobile
+**Actor:** User
+**Description:** Issue and send an invoice from a phone.
+
+### UC-ACC-15.3: Scan Receipt / Document
+**Actor:** User; System (OCR)
+**Description:** Photograph a receipt and capture it into the inbox for processing.
+
+### UC-ACC-15.4: Receive In-App Notifications
+**Actor:** System, User
+**Description:** Get alerts for paid, overdue, or new-document events.
+
+### UC-ACC-15.5: Offline Draft & Sync
+**Actor:** User, System
+**Description:** Draft documents offline and sync when connectivity returns.
+
+### UC-ACC-15.6: Mobile Dashboard
+**Actor:** Owner/Admin
+**Description:** View key indicators on mobile.
+
+---
+
+## UC-ACC-16: Platform — Security, Data & Compliance (web, system)
+
+### UC-ACC-16.1: Two-Factor Authentication
+**Actor:** Owner/Admin, User
+**Description:** Require a second factor at login.
+
+### UC-ACC-16.2: Role-Based Access Control
+**Actor:** Owner/Admin, System
+**Description:** Enforce per-role visibility and action permissions across modules.
+
+### UC-ACC-16.3: Automatic Daily Backups
+**Actor:** System
+**Description:** Back up company data daily with restore capability.
+
+### UC-ACC-16.4: Data Export / Migration
+**Actor:** Owner/Admin
+**Description:** Export complete data for portability or migration away.
+
+### UC-ACC-16.5: Data Import from Other Systems
+**Actor:** Owner/Admin
+**Description:** Onboard by importing data from a previous system.
+
+### UC-ACC-16.6: GDPR Data-Subject Requests
+**Actor:** Owner/Admin, System
+**Description:** Fulfill access/export and erasure requests for personal data.
+
+### UC-ACC-16.7: Audit Trail / Change History
+**Actor:** System, Owner/Admin
+**Description:** Record an immutable history of document and setting changes.
+
+### UC-ACC-16.8: Legislative / Template Updates
+**Actor:** System
+**Description:** Keep tax rules, statutory formats, and templates current.
+
+### UC-ACC-16.9: Session Management & Login Security
+**Actor:** System, Owner/Admin
+**Description:** Manage active sessions, lockouts, and suspicious-login handling.
+
+---
+
+## Coverage Summary
+
+- **16 categories**, **~140 use cases**, **11 actors**.
+- **MVP (P1):** UC-ACC-01, -02, -03, -04, -05, -16 — register → configure → contacts + price list → issue/send/track invoices → secure, exportable data.
+- **Differentiators to consider beyond parity:** AI/OCR document inbox (UC-ACC-07.4), automatic bank matching (UC-ACC-08.6), one-click statutory VAT filings (UC-ACC-10.2–10.4, 10.8), and recurring/dunning automation (UC-ACC-13).


### PR DESCRIPTION
Adds the vendor-neutral functional spec for the standalone invoicing/accounting product (**ACC**) under `.research/accounting/` — **docs only, no code**. Mirrors what was merged to `dev` in #1817.

- `PRD-ACC-001`, `epics.md` (17 epics), `use-cases.md` (~140 UC), `architecture.md` (separate `accounting-server :8082` sharing core with api-server), `README.md`
- `stories/` full MVP: ACC-01/02/03/04/05/16/17 (Given/When/Then)
- `mef-agent-brief.md` (Paperclip hand-off)

Cherry-picked onto `main` (orig commits f7faada78, 7d54067e9) so only these 13 files land.