### PR TITLE
79-2-authentication-flow: reality-web SSO callback e2e coverage (gap-79-2-auth-callback-e2e)

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/auth/callback/page.test.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/callback/page.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * SSO callback page integration tests — Story 79.2 (Epic 10A-SSO), reality-web.
+ *
+ * Closes `gap-79-2-auth-callback-e2e` for reality-web. The ppt-web SSO
+ * callback already has `AuthCallbackPage.test.tsx`, but the reality-web
+ * `/[locale]/auth/callback` page (cookie-session SSO consumer) shipped without
+ * an integration test exercising its callback handling end-to-end.
+ *
+ * These tests render the REAL `SsoCallbackPage` and drive it through every
+ * branch of its `useEffect`, mocking only the framework boundary
+ * (`next/navigation` — `useRouter` + `useSearchParams`) and using real
+ * `sessionStorage` for the CSRF state token.
+ *
+ * Covered guarantees:
+ *   1. Happy path: no error, valid/absent state, no redirect_uri → replace('/').
+ *   2. Safe redirect: a same-origin relative `redirect_uri` is honoured.
+ *   3. Open-redirect protection: protocol-relative ("//evil.com") and
+ *      backslash-escape ("/\\evil.com") redirect targets are rejected,
+ *      falling back to '/'.
+ *   4. CSRF: a state-token mismatch renders the "Login Failed" error and does
+ *      NOT redirect.
+ *   5. State cleanup: the saved `sso_state` nonce is consumed on success.
+ *   6. Provider error: `?error=` (with and without `error_description`)
+ *      renders the error and does NOT redirect.
+ */
+/// <reference types="vitest/globals" />
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Framework-boundary mock: next/navigation.
+//
+// The global setup (src/test/setup.tsx) mocks next/navigation with a static
+// useRouter/useSearchParams. Override it here so each test can (a) capture the
+// router.replace spy to assert redirect targets and (b) feed arbitrary query
+// params into useSearchParams.
+// ---------------------------------------------------------------------------
+
+const replaceSpy = vi.fn<(href: string) => void>();
+let currentParams = new URLSearchParams();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: replaceSpy,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/en/auth/callback',
+  useSearchParams: () => currentParams,
+  useParams: () => ({ locale: 'en' }),
+}));
+
+import SsoCallbackPage from './page';
+
+const SSO_STATE_KEY = 'sso_state';
+
+function renderCallback(search: string) {
+  currentParams = new URLSearchParams(search);
+  return render(<SsoCallbackPage />);
+}
+
+describe('SsoCallbackPage — reality-web SSO /auth/callback flow (Story 79.2)', () => {
+  beforeEach(() => {
+    replaceSpy.mockReset();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('redirects to / on success and consumes the saved state nonce', async () => {
+    sessionStorage.setItem(SSO_STATE_KEY, 'nonce-1');
+
+    renderCallback('?state=nonce-1');
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/'));
+    // The one-shot CSRF nonce is cleared after a successful callback.
+    expect(sessionStorage.getItem(SSO_STATE_KEY)).toBeNull();
+    // No error UI on the happy path.
+    expect(screen.queryByText('Login Failed')).not.toBeInTheDocument();
+  });
+
+  it('redirects with no state token present (server already set the cookie)', async () => {
+    renderCallback('');
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/'));
+    expect(screen.queryByText('Login Failed')).not.toBeInTheDocument();
+  });
+
+  it('honours a same-origin relative redirect_uri', async () => {
+    sessionStorage.setItem(SSO_STATE_KEY, 'nonce-1');
+
+    renderCallback('?state=nonce-1&redirect_uri=%2Fdashboard%2Fagency');
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/dashboard/agency'));
+  });
+
+  it('rejects a protocol-relative redirect_uri (open-redirect guard)', async () => {
+    renderCallback('?redirect_uri=%2F%2Fevil.example.com');
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/'));
+    expect(replaceSpy).not.toHaveBeenCalledWith('//evil.example.com');
+  });
+
+  it('rejects a backslash-escaped redirect_uri (open-redirect guard)', async () => {
+    renderCallback('?redirect_uri=%2F%5Cevil.example.com');
+
+    await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/'));
+    expect(replaceSpy).not.toHaveBeenCalledWith('/\\evil.example.com');
+  });
+
+  it('shows Login Failed and does not redirect on a state-token mismatch', async () => {
+    sessionStorage.setItem(SSO_STATE_KEY, 'nonce-1');
+
+    renderCallback('?state=tampered');
+
+    await waitFor(() => {
+      expect(screen.getByText('Login Failed')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/invalid state token/i)).toBeInTheDocument();
+    expect(replaceSpy).not.toHaveBeenCalled();
+    // A recovery affordance back to home is rendered.
+    expect(screen.getByRole('link', { name: /return home/i })).toBeInTheDocument();
+  });
+
+  it('surfaces a provider error_description and does not redirect', async () => {
+    renderCallback('?error=access_denied&error_description=User%20declined%20consent');
+
+    await waitFor(() => {
+      expect(screen.getByText('User declined consent')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Login Failed')).toBeInTheDocument();
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the raw error code when no error_description is present', async () => {
+    renderCallback('?error=server_error');
+
+    await waitFor(() => {
+      expect(screen.getByText('server_error')).toBeInTheDocument();
+    });
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Task
Close the coverage gap for story 79-2 (Authentication Flow / reality-web). `coverage.json` marks 79-2 partial; the open gap is `gap-79-2-auth-callback-e2e` — full e2e verification of the reality-web authentication callback flow is missing. Add the missing e2e coverage so the auth-callback flow is exercised end-to-end.

## Owner
pm-frontend (specialist: nextjs-web)

## What changed
Adds `frontend/apps/reality-web/src/app/[locale]/auth/callback/page.test.tsx` — an integration test for the reality-web SSO callback page (`SsoCallbackPage`).

The ppt-web side of this gap was already closed on `dev` by `AuthCallbackPage.test.tsx` (PRs #568/#609/#642). The **reality-web** SSO consumer (`/[locale]/auth/callback`, cookie-session flow) had **no test** — this PR adds it. It renders the real page and drives every branch of its handler:

- Happy path → `router.replace('/')` and the `sso_state` nonce is consumed.
- No state token present (server already set the cookie) → still redirects.
- Same-origin relative `redirect_uri` is honoured.
- **Open-redirect guard:** protocol-relative (`//evil`) and backslash-escape (`/\evil`) targets are rejected, falling back to `/`.
- **CSRF:** state-token mismatch renders "Login Failed", no redirect, recovery link present.
- Provider `?error=` (with and without `error_description`) renders the error, no redirect.

Mocks only the `next/navigation` framework boundary (to capture `router.replace` and feed query params); uses real `sessionStorage`.

## Regression-guard proof (IG3)
Temporarily weakened the page's open-redirect guard (`router.replace(rawRedirect || '/')` instead of the `isSafeRedirect` check) → the two guard tests FAIL. Restored → all pass. The test genuinely exercises the safety behaviour.

## Tested (Band A — fast check)
- `pnpm -F reality-web exec vitest run "src/app/[locale]/auth/callback/page.test.tsx"` → **8 passed**, exit 0
- `pnpm -F reality-web typecheck` (`tsc --noEmit`) → exit 0
- `pnpm exec biome check "apps/reality-web/src/app/[locale]/auth/callback/page.test.tsx"` → clean, exit 0

Full reality-web suite: 94 passed / 4 failed — the 4 failures are pre-existing in `src/components/agency/RealtorManagement.test.tsx` (fail in isolation on `dev`, unrelated to this change; different component/dir).

## Built (Band B — full build)
Skipped: change is test-only (one new file, +149 LOC), no public API / config / build-output touch.

## CI parity (Band C — hot-path only)
Skipped: test-only addition, no source behaviour change.

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Notes
- Scope: single file under `frontend/apps/reality-web/` — within pm-frontend area, no scope drift.
- Code-reuse: test-only, no new helpers introduced.
- The task text said the gap was "reality-web" but the `coverage.json` evidence block references ppt-web files. Both products have a `/auth/callback`; ppt-web was already covered, so this PR closes the genuinely-uncovered reality-web side, matching the task's explicit "reality-web" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMdbGspG1b7p3uXVS1oRg7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMdbGspG1b7p3uXVS1oRg7)_