### PR TITLE
10b-5-support-data-access: finish Support Data Access to done (fix refresh_tokens column bug + reconcile)

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -40,7 +40,7 @@ epics:
     name: "Platform Administration"
     status: in-progress
     stories_total: 7
-    stories_completed: 5  # 10b-1,2,3,4,6 done (coverage.json 2026-05-29: all status=done, high confidence)
+    stories_completed: 6  # 10b-1,2,3,4,5,6 done (10b-5 reconciled 2026-06-24: code + PRs #793/#854 landed, refresh_tokens column bug fixed)
   epic-80:
     name: "Dispute Resolution"
     status: partial
@@ -75,7 +75,7 @@ development_status:
   10b-2-feature-flag-management: done
   10b-3-platform-health-monitoring: done
   10b-4-system-announcements: done  # coverage.json 2026-05-27: handlers fully implemented since cf533ae4; SystemAnnouncementRepository CRUD + maintenance + ack; public_announcements_router; cargo check -p api-server exit 0 (frontend admin-web component still pending — backend story complete)
-  10b-5-support-data-access: ready-for-dev
+  10b-5-support-data-access: done  # GET /api/v1/platform-admin/support-data wired (servers/api-server routes/platform_admin/audit.rs) behind AuditRead + extract_super_admin_token; REPEATABLE READ snapshot reads (PR #793/#628); append-only support_tooling_events audit trail (migration 00163) hardened to RLS + ON DELETE RESTRICT (00165); retention/privacy posture documented (docs/data/support-data-retention-privacy.md, PR #854); admin-web SupportDataPage shipped. Fixed runtime is_revoked/updated_at column bug on refresh_tokens (revoked_at IS NULL) + #[sqlx::test] regression.
   10b-6-user-onboarding-tour: done  # coverage.json 2026-05-27: onboarding.rs routes mounted at /api/v1/onboarding; OnboardingRepository (needs_onboarding/get_tours_for_user/start_tour/complete_step/complete_tour/skip_tour/reset_tour); handlers fully implemented since cf533ae4; cargo check -p api-server exit 0 (frontend component still pending — backend story complete)
   10b-7-contextual-help-documentation: ready-for-dev
   # Epic 80: Dispute Resolution (verified 2026-05-25)
@@ -86,12 +86,12 @@ development_status:
   80-2-dispute-filing-flow: partial
   80-3-mediation-resolution: partial
 
-# ──────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────
 # TEST-HARDENING BATCH — post-merge follow-ups (issues #480-#487)
 # Slotted: 2026-05-26 | Priority: medium
 # Rule: dependent stories MUST NOT be promoted to `done` until each follow-up
 #       issue in this batch is either CLOSED or explicitly DEFERRED.
-# ──────────────────────────────────────────────────────────────────────
+# ─────────────────────────────────────────────────────────
 test_hardening_batch:
   batch_id: thb-2026-05-25
   slotted_at: 2026-05-25

--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -401,7 +401,7 @@ impl PlatformAdminRepository {
             r#"
             SELECT id, created_at, expires_at, last_used_at, user_agent, ip_address
             FROM refresh_tokens
-            WHERE user_id = $1 AND is_revoked = false AND expires_at > NOW()
+            WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > NOW()
             ORDER BY created_at DESC
             "#,
         )
@@ -440,8 +440,8 @@ impl PlatformAdminRepository {
         let result = sqlx::query(
             r#"
             UPDATE refresh_tokens
-            SET is_revoked = true, updated_at = NOW()
-            WHERE user_id = $1 AND is_revoked = false
+            SET revoked_at = NOW()
+            WHERE user_id = $1 AND revoked_at IS NULL
             "#,
         )
         .bind(user_id)
@@ -538,7 +538,8 @@ impl PlatformAdminRepository {
     /// Runs five focused cross-tenant queries:
     ///   1. Total organisation count.
     ///   2. User counts grouped by `status`.
-    ///   3. Active session count (refresh tokens neither revoked nor expired).
+    ///   3. Active session count (refresh tokens with `revoked_at IS NULL` and
+    ///      not yet expired).
     ///   4. Total fault count.
     ///   5. Fault counts per `status` enum value.
     ///
@@ -592,7 +593,7 @@ impl PlatformAdminRepository {
             r#"
             SELECT COUNT(*)
             FROM refresh_tokens
-            WHERE is_revoked = false AND expires_at > NOW()
+            WHERE revoked_at IS NULL AND expires_at > NOW()
             "#,
         )
         .fetch_one(&mut *tx)

--- a/backend/crates/db/tests/support_data_session_columns_tests.rs
+++ b/backend/crates/db/tests/support_data_session_columns_tests.rs
@@ -37,7 +37,13 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
 
 /// Insert a refresh token. `revoked` controls whether `revoked_at` is set;
 /// `expired` controls whether `expires_at` is in the past.
-async fn seed_refresh_token(pool: &PgPool, user_id: Uuid, hash: &str, revoked: bool, expired: bool) {
+async fn seed_refresh_token(
+    pool: &PgPool,
+    user_id: Uuid,
+    hash: &str,
+    revoked: bool,
+    expired: bool,
+) {
     let expires_at = if expired {
         Utc::now() - Duration::hours(1)
     } else {

--- a/backend/crates/db/tests/support_data_session_columns_tests.rs
+++ b/backend/crates/db/tests/support_data_session_columns_tests.rs
@@ -1,0 +1,129 @@
+//! Regression tests for the Support Data session queries (Story 10B.5, #635).
+//!
+//! Background
+//! ----------
+//! `PlatformAdminRepository::get_user_sessions`, `revoke_user_sessions`, and
+//! the `active_sessions` count inside `get_support_data` query the
+//! `refresh_tokens` table. They originally referenced an `is_revoked` boolean
+//! column (and `updated_at`) which does NOT exist on that table — migration
+//! `00002_create_refresh_tokens.sql` only defines `revoked_at TIMESTAMPTZ`
+//! (nullable) and has no `updated_at`. Because these are runtime `query`/
+//! `query_as` calls (not compile-time-checked), `cargo check` accepted the
+//! wrong column names and the bug only surfaced as a Postgres
+//! `column "is_revoked" does not exist` error at request time.
+//!
+//! These tests run the three queries against a real schema-migrated database
+//! via `#[sqlx::test]`, so they would have failed on the pre-fix code and now
+//! prove the queries use the correct `revoked_at IS NULL` semantics.
+
+use chrono::{Duration, Utc};
+use db::repositories::PlatformAdminRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Support Test User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// Insert a refresh token. `revoked` controls whether `revoked_at` is set;
+/// `expired` controls whether `expires_at` is in the past.
+async fn seed_refresh_token(pool: &PgPool, user_id: Uuid, hash: &str, revoked: bool, expired: bool) {
+    let expires_at = if expired {
+        Utc::now() - Duration::hours(1)
+    } else {
+        Utc::now() + Duration::days(7)
+    };
+    let revoked_at = if revoked { Some(Utc::now()) } else { None };
+
+    sqlx::query(
+        r#"
+        INSERT INTO refresh_tokens (user_id, token_hash, expires_at, revoked_at, user_agent, ip_address)
+        VALUES ($1, $2, $3, $4, 'test-agent', '127.0.0.1')
+        "#,
+    )
+    .bind(user_id)
+    .bind(hash)
+    .bind(expires_at)
+    .bind(revoked_at)
+    .execute(pool)
+    .await
+    .expect("seed refresh token");
+}
+
+/// `get_user_sessions` must list only active (non-revoked, non-expired) tokens
+/// and must run without referencing a non-existent `is_revoked` column.
+#[sqlx::test(migrations = "./migrations")]
+async fn get_user_sessions_lists_only_active(pool: PgPool) {
+    let user_id = seed_user(&pool, "sessions@example.com").await;
+    seed_refresh_token(&pool, user_id, "active-1", false, false).await;
+    seed_refresh_token(&pool, user_id, "active-2", false, false).await;
+    seed_refresh_token(&pool, user_id, "revoked", true, false).await;
+    seed_refresh_token(&pool, user_id, "expired", false, true).await;
+
+    let repo = PlatformAdminRepository::new(pool);
+    let sessions = repo
+        .get_user_sessions(user_id)
+        .await
+        .expect("get_user_sessions should not error on column names");
+
+    // Only the two active tokens count; revoked + expired are excluded.
+    assert_eq!(sessions.len(), 2, "should list only active sessions");
+}
+
+/// `revoke_user_sessions` must revoke all currently-active tokens (and only
+/// those) by setting `revoked_at`, returning the affected-row count.
+#[sqlx::test(migrations = "./migrations")]
+async fn revoke_user_sessions_revokes_active_only(pool: PgPool) {
+    let user_id = seed_user(&pool, "revoke@example.com").await;
+    seed_refresh_token(&pool, user_id, "r-active-1", false, false).await;
+    seed_refresh_token(&pool, user_id, "r-active-2", false, false).await;
+    seed_refresh_token(&pool, user_id, "r-already-revoked", true, false).await;
+
+    let repo = PlatformAdminRepository::new(pool.clone());
+    let revoked = repo
+        .revoke_user_sessions(user_id)
+        .await
+        .expect("revoke_user_sessions should not error on column names");
+
+    assert_eq!(revoked, 2, "should revoke the two active tokens only");
+
+    // After revocation there should be no active sessions left.
+    let sessions = repo
+        .get_user_sessions(user_id)
+        .await
+        .expect("get_user_sessions after revoke");
+    assert_eq!(sessions.len(), 0, "all sessions revoked");
+}
+
+/// `get_support_data().active_sessions` must count only active refresh tokens
+/// and must run without referencing a non-existent `is_revoked` column.
+#[sqlx::test(migrations = "./migrations")]
+async fn support_data_active_sessions_counts_active_only(pool: PgPool) {
+    let user_id = seed_user(&pool, "support-data@example.com").await;
+    seed_refresh_token(&pool, user_id, "sd-active-1", false, false).await;
+    seed_refresh_token(&pool, user_id, "sd-active-2", false, false).await;
+    seed_refresh_token(&pool, user_id, "sd-active-3", false, false).await;
+    seed_refresh_token(&pool, user_id, "sd-revoked", true, false).await;
+    seed_refresh_token(&pool, user_id, "sd-expired", false, true).await;
+
+    let repo = PlatformAdminRepository::new(pool);
+    let data = repo
+        .get_support_data()
+        .await
+        .expect("get_support_data should not error on column names");
+
+    assert_eq!(
+        data.active_sessions, 3,
+        "active_sessions should count only non-revoked, non-expired tokens"
+    );
+}

--- a/docs/data/support-data-retention-privacy.md
+++ b/docs/data/support-data-retention-privacy.md
@@ -28,7 +28,7 @@ inside a single `REPEATABLE READ` transaction (consistent snapshot, see #628):
 |-------|----------------------|
 | `total_orgs` | `COUNT(*) FROM organizations` |
 | `total_users` / `active_users` / `pending_users` / `suspended_users` | `COUNT(*) FROM users GROUP BY status` |
-| `active_sessions` | `COUNT(*) FROM refresh_tokens WHERE is_revoked = false AND expires_at > NOW()` |
+| `active_sessions` | `COUNT(*) FROM refresh_tokens WHERE revoked_at IS NULL AND expires_at > NOW()` |
 | `total_faults` | `COUNT(*) FROM faults` |
 | `fault_by_status` | `COUNT(*) FROM faults GROUP BY status` |
 
@@ -45,7 +45,7 @@ These return row-level data for one user and **do contain PII**:
   `organization_name`, `role_name`, `joined_at` (from `organization_members`).
 - **Sessions** (`get_user_sessions`) — from `refresh_tokens`: `id`,
   `created_at`, `expires_at`, `last_used_at`, **`user_agent`**, **`ip_address`**.
-  Filtered to `is_revoked = false AND expires_at > NOW()` (active sessions only).
+  Filtered to `revoked_at IS NULL AND expires_at > NOW()` (active sessions only).
 - **Activity log** (`get_user_activity_log`) — from `audit_logs`: `id`,
   `action`, `resource_type`, `resource_id`, `details` (JSONB), `created_at`.
   Limited via the `limit` query param (default 50, clamped 1–500).
@@ -53,7 +53,7 @@ These return row-level data for one user and **do contain PII**:
 ### Mutating action (for completeness)
 
 `POST /api/v1/platform-admin/support/users/{id}/sessions/revoke`
-(`revoke_user_sessions`) sets `is_revoked = true` on all of the user's active
+(`revoke_user_sessions`) sets `revoked_at = NOW()` on all of the user's active
 refresh tokens. Not a read, but it operates on the same session data.
 
 ## Access control
@@ -99,7 +99,7 @@ resistant record of *who looked at what, when*.
 |----------|-------|---------------------|
 | Sessions | `refresh_tokens` | Token lifetime is **7 days** (`refresh_token_lifetime`, `services/jwt.rs`); access tokens are 15 min. A scheduled cleanup deletes rows where `expires_at < NOW() OR revoked_at < NOW() - INTERVAL '7 days'` — `SessionRepository::cleanup_expired_tokens`, invoked by the background scheduler `cleanup_sessions` (default tick every 60s, `services/scheduler.rs`). So expired/revoked sessions are purged within ~7 days. |
 | Activity log | `audit_logs` | **Append-only, no automated retention/expiry found.** Rows persist indefinitely; `user_id` is `ON DELETE SET NULL` so the entry survives user deletion (anonymised). Used for compliance (Epic 9 / Story 9.6). |
-| Support-tooling events | `support_tooling_events` | **Append-only, immutable, no automated retention found.** `admin_user_id` is `ON DELETE CASCADE`. |
+| Support-tooling events | `support_tooling_events` | **Append-only, immutable, no automated retention found.** `admin_user_id` is `ON DELETE RESTRICT` (migration `00165`) so the audit trail cannot be lost via admin-account deletion; RLS restricts the table to super-admins. |
 | Aggregate counts | n/a (computed) | Not stored; recomputed per request. |
 
 ## PII / GDPR considerations
@@ -137,15 +137,17 @@ Recommendations / gaps:
 
 ## Open questions (verify before relying on this doc)
 
-1. **`is_revoked` vs `revoked_at` column mismatch.** The only DDL for
+1. **`is_revoked` vs `revoked_at` column mismatch — RESOLVED.** The only DDL for
    `refresh_tokens` (migration `00002_create_refresh_tokens.sql`) and the model
    `crates/db/src/models/refresh_token.rs` use `revoked_at TIMESTAMPTZ` (nullable)
-   — but the Support Data queries (`get_user_sessions`, `revoke_user_sessions`,
-   `get_support_data`) reference `is_revoked` (and `updated_at`). No migration
-   adding `is_revoked`/`updated_at` to `refresh_tokens` was found, and these are
-   runtime `query_as` calls (not compile-time-checked, so absent from `.sqlx/`).
-   This may be a latent runtime bug **or** there is an undocumented schema change
-   not present in this checkout. Needs confirmation against the live schema.
+   and have no `updated_at` column. The Support Data queries (`get_user_sessions`,
+   `revoke_user_sessions`, `get_support_data`) previously referenced a
+   non-existent `is_revoked` boolean (and `updated_at`); because these are runtime
+   `query`/`query_as` calls (not compile-time-checked), the bug escaped
+   `cargo check` and would have raised `column "is_revoked" does not exist` at
+   request time. The queries now use `revoked_at IS NULL` / `SET revoked_at = NOW()`
+   to match the schema, covered by
+   `crates/db/tests/support_data_session_columns_tests.rs`.
 2. **`audit_logs` / `support_tooling_events` retention** — is indefinite
    retention an intentional compliance decision, or a missing cleanup job? (See
    recommendation 1.)

--- a/docs/screens/ppt/admin-support-data.md
+++ b/docs/screens/ppt/admin-support-data.md
@@ -10,8 +10,7 @@ implementations:
     buildStatus: shipped
     redesignStatus: not-started
     apiStatus: complete
-endpoints:
-  - get_support_data
+endpoints: []
 relatedScreens:
   - id: ppt/admin-platform-health
     rel: sibling
@@ -60,6 +59,13 @@ RLS-hardened in 00165) so support-tooling access is itself audited.
 
 ### Specific (recent)
 
+- 2026-06-25 — agent: dispatcher followup (PR #1829) — cleared the `endpoints`
+  frontmatter: `get_support_data` is not yet registered in `@ppt/sitemap`, so
+  screen-map strict validation rejected it. The route stays documented under
+  Notes > Broader context. Follow-up: add `get_support_data`
+  (`GET /api/v1/platform-admin/support-data`) to
+  `frontend/packages/sitemap/src/data/api-server/index.ts` (alongside the other
+  Epic-10B platform-admin endpoints), then restore the endpoint ref here.
 - 2026-06-24 — agent: 10b-5-support-data-access — fixed a latent runtime bug:
   the support-data session queries referenced a non-existent `is_revoked` (and
   `updated_at`) column on `refresh_tokens`; corrected to `revoked_at IS NULL` /
@@ -69,6 +75,11 @@ RLS-hardened in 00165) so support-tooling access is itself audited.
 ## Agent Log
 
 <!-- newest entries on top -->
+- 2026-06-25 — agent: dispatcher followup — fixed PR #1829 red CI gates:
+  ran rustfmt on `support_data_session_columns_tests.rs` (clears check / lint /
+  fmt-clippy, which all gate on `cargo fmt --check`) and cleared the
+  unverifiable `get_support_data` endpoint ref (clears screen-map strict
+  validation). Endpoint still documented in Notes.
 - 2026-06-24 — agent: 10b-5-support-data-access — created screen-map (was an
   orphan epic); verified backend wiring (transactional reads, AuditRead +
   super-admin gate, append-only audit trail), fixed `refresh_tokens` column

--- a/docs/screens/ppt/admin-support-data.md
+++ b/docs/screens/ppt/admin-support-data.md
@@ -1,0 +1,76 @@
+---
+id: ppt/admin-support-data
+name: Support Data (Admin)
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: platform/support-data
+    component: SupportDataPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: complete
+endpoints:
+  - get_support_data
+relatedScreens:
+  - id: ppt/admin-platform-health
+    rel: sibling
+  - id: ppt/admin-oauth-clients
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-17
+epics:
+  - Epic-10B-5
+designSources: []
+owner: pm-security
+---
+
+## Functionality Checklist
+
+- [w] User counts section: total / active / pending / suspended stat cards
+- [w] Active sessions stat card (count of non-revoked, non-expired refresh tokens)
+- [w] Fault summary: total faults stat card + fault-by-status table (count + % of total)
+- [w] Manual Refresh button (re-runs `useSupportData`)
+- [w] Error banner if `get_support_data` fails
+- [w] Access gated by `audit_read` capability (mirrors backend `AuditRead` + SuperAdmin)
+
+## States
+
+- **Loading**: "Loading…" text under each section heading while the query is in flight
+- **Error**: Red alert banner with i18n key `admin.supportData.loadError`
+- **Empty faults**: "No faults recorded." message in the fault table
+
+## Notes
+
+### Broader context
+
+Part of Epic 10B Story 10B.5 — the super-admin support-tooling overview. Reads
+only aggregate, non-PII counts; the per-user PII endpoints
+(`support/users/{id}/...`) and the session-revoke action are documented in
+`docs/data/support-data-retention-privacy.md`. Backend route lives at
+`GET /api/v1/platform-admin/support-data`
+(`backend/servers/api-server/src/routes/platform_admin/audit.rs`), gated by
+`RequireCapability(AuditRead)` plus `extract_super_admin_token`. The repository
+`get_support_data` runs five counting queries inside a single `REPEATABLE READ`
+transaction for a consistent snapshot (#628). Every read emits an append-only
+`support_data_viewed` event into `support_tooling_events` (migration 00163,
+RLS-hardened in 00165) so support-tooling access is itself audited.
+
+### Specific (recent)
+
+- 2026-06-24 — agent: 10b-5-support-data-access — fixed a latent runtime bug:
+  the support-data session queries referenced a non-existent `is_revoked` (and
+  `updated_at`) column on `refresh_tokens`; corrected to `revoked_at IS NULL` /
+  `SET revoked_at = NOW()` to match the schema (migration 00002). Added a
+  `#[sqlx::test]` regression and reconciled sprint-status 10B.5 to done.
+
+## Agent Log
+
+<!-- newest entries on top -->
+- 2026-06-24 — agent: 10b-5-support-data-access — created screen-map (was an
+  orphan epic); verified backend wiring (transactional reads, AuditRead +
+  super-admin gate, append-only audit trail), fixed `refresh_tokens` column
+  mismatch in `PlatformAdminRepository`, documented retention/privacy posture
+  delta (FK now ON DELETE RESTRICT), and flipped sprint-status to done.


### PR DESCRIPTION
## Task

Coverage gap [mvp]: Support Data Access — finish to done. Gaps: (1) sprint-status.yaml still 'ready-for-dev' though code + PRs #854/#793 landed — needs status reconciliation to done; (2) support-data access is privacy/security-sensitive: confirm retention + access-audit posture (pm-security); (3) no screen-map (orphan epic).

## Owner

pm-security

## Summary

This is a verification + finish task. The Support Data Access feature was already substantially implemented on `dev` (transactional reads via #793/#628, append-only `support_tooling_events` audit trail via 00163 + RLS hardening 00165, `admin-web/SupportDataPage`, retention/privacy docs via #854). Verifying the security posture surfaced **one real, latent runtime bug**, which this PR fixes, then reconciles the remaining gaps.

### Finding (the load-bearing change): wrong column on `refresh_tokens`

`PlatformAdminRepository::get_user_sessions`, `revoke_user_sessions`, and the `active_sessions` count in `get_support_data` queried a non-existent `is_revoked` boolean column (and `updated_at`) on `refresh_tokens`. That table (migration `00002`) only has `revoked_at TIMESTAMPTZ` (nullable) and no `updated_at`. Because these are runtime `query`/`query_as` calls (not compile-time-checked), `cargo check` passed but every support-data session listing / revoke / the active-session count would fail at request time with `column "is_revoked" does not exist`.

Fixed to the canonical schema semantics used everywhere else (`SessionRepository`, document shares, memberships): `revoked_at IS NULL` for "active" and `SET revoked_at = NOW()` for revoke. Note this is the **same bug class** already tracked for the OAuth path in test-hardening item #481.

### Other gaps closed
- **(1) Status reconciliation:** `sprint-status.yaml` 10B.5 → `done`; epic-10b `stories_completed` 5 → 6.
- **(2) Privacy/security posture:** confirmed defence-in-depth (SuperAdmin role + capability gate), PII-safe audit logging (raw search string not stored), immutable/RLS-locked audit table, FK now `ON DELETE RESTRICT`. Refreshed `docs/data/support-data-retention-privacy.md` (it had stale `ON DELETE CASCADE` and an open `is_revoked` question — both now resolved).
- **(3) Screen-map:** created `docs/screens/ppt/admin-support-data.md` (was an orphan epic), following the sibling `admin-platform-health.md` convention.

## Tested (Band A — fast check)
- `cargo test -p db --no-run --test support_data_session_columns_tests` → exit 0 (new `#[sqlx::test]` regression + db crate compile)

## Built (Band B — full build)
- `cargo clippy -p db --tests -- -D warnings` → exit 0

## CI parity (Band C — hot-path)
- Hot-path (auth/data-integrity): ran clippy with `-D warnings` (above) as the closest local CI parity. The new `#[sqlx::test]` tests require a live Postgres and will run in CI's backend job — they are written to **fail on the pre-fix code** (`column is_revoked does not exist`) and pass after the fix. `act`/`just` not installed in sandbox.

## Remote-tested
skipped (no ppt-bridge MCP)

## Scope drift
None — `scope-check.sh --owner pm-security` exit 0. All paths inside owner area (backend db repo + tests, docs, sprint-status, screen-map).

## Code-reuse review
none — `reuse-grep.sh` clean (no new auth/crypto/http helpers; the fix reuses the existing `revoked_at` pattern).

## Notes
- The `#[sqlx::test]` regression can only be executed against a DB (CI), not in the sandbox; locally verified it compiles and the db crate + clippy are green.
- Goal-check IG1/IG4/IG5/IG6 are N/A here (this is a dispatcher action-list task, no `.research/plans/<slug>.md`; agent must not touch `.research/**`). IG2 expects an `impl/` branch prefix but the dispatcher mandated the `auto-impl/...` branch name. IG3's failing-on-main test is the new `#[sqlx::test]` (bundled in the fix rather than a separate commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JV4zCyVJTpN5KRb2y8mP7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01JV4zCyVJTpN5KRb2y8mP7p)_