### PR TITLE
80-3-mediation-resolution: wire dispute party submissions endpoints

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -84,7 +84,7 @@ development_status:
   # Epic 80: Dispute Resolution (verified 2026-05-25)
   80-1-disputes-api-integration: done
   80-2-dispute-filing-flow: partial
-  80-3-mediation-resolution: partial
+  80-3-mediation-resolution: done  # promoted 2026-06-25 (80-3-mediation-resolution): final gap closed — party submissions endpoints (GET/POST /api/v1/disputes/{id}/submissions, already on backend) wired into the frontend. Added @ppt/api-client listSubmissions/submitResponse + useDisputeSubmissions/useSubmitResponse (snake_case wire types PartySubmission/SubmitResponseRequest matching backend serde). Surfaced as a "Submissions" tab in MediationWorkspacePage via new MediationSubmissionsPanel (list + party composer with type/visibility). i18n added for all 6 locales; MediationSubmissionsPanel.test.tsx (5 tests). Prior wiring (DisputeDetailRoute/MediationWorkspacePage, mediation hooks, sessions) already shipped. Band A typecheck+biome clean; Band B ppt-web build clean; full dispute suite 152 tests green.
 
 # ───────────────────────────────────────────────────
 # TEST-HARDENING BATCH — post-merge follow-ups (issues #480-#487)
@@ -193,6 +193,7 @@ test_hardening_batch:
 # Notes and blockers
 notes:
   - "Story 80-3 verified 2026-05-25: DisputeDetailPage.tsx+MediationPage.tsx+all hooks confirmed implemented; DisputeDetailRoute in App.tsx is inline JSX stub not using DisputeDetailPage; no /disputes/:id/mediation route; useEscalateDispute/useResolveDispute/useAssignMediator not wired from App.tsx — story stays partial, follow-up wiring task needed"
+  - "Story 80-3 COMPLETED 2026-06-25: route wiring (DisputeMediationRoute + /disputes/:id/mediation), mediation hooks, and mediation sessions were already shipped on dev. Final remaining gap — party submissions endpoints (GET/POST /api/v1/disputes/{id}/submissions) — now wired: api-client listSubmissions/submitResponse + useDisputeSubmissions/useSubmitResponse, MediationSubmissionsPanel surfaced as a Submissions tab in MediationWorkspacePage, i18n × 6 locales, 5-test suite. screen-map ppt/dispute-detail apiStatus flipped partial→shipped. Story promoted to done."
   - "Epic 6 depends on Epic 2B Notification Infrastructure for sending notifications on publish"
   - "Story 6.1 is the foundation - other stories build on announcement infrastructure"
   - "Story 6.1 completed 2025-12-21 - awaiting code review"

--- a/docs/screens/ppt/dispute-detail.md
+++ b/docs/screens/ppt/dispute-detail.md
@@ -9,7 +9,7 @@ implementations:
     component: DisputeDetailPage
     buildStatus: shipped
     redesignStatus: in-progress
-    apiStatus: partial
+    apiStatus: complete
   mobile:
     buildStatus: n/a
     redesignStatus: n/a
@@ -84,12 +84,14 @@ UC-38 single-dispute deep view. Combines patterns from `ppt/announcements` (chro
 - Discussion bubbles: 4 distinct speaker types (plaintiff/defendant/mediator/system). Mediator gets violet (event-soft); system messages are neutral muted with icon prefix.
 - Audit log writes are append-only — design assumes immutability; flag for engineering.
 - Sticky rail uses `position: sticky; top: 84px` matching header height.
-- Mediation sessions are now wired in the workspace sidebar (MediationSessionsPanel) with a schedule/reschedule dialog (MediationSessionDialog) and cancel action, backed by `/api/v1/disputes/{id}/sessions*`. Session JSON is snake_case on the wire (backend has no serde rename) — the `MediationSession` api-client type matches that exactly. Party submissions endpoints remain unwired (apiStatus stays partial).
+- Mediation sessions are now wired in the workspace sidebar (MediationSessionsPanel) with a schedule/reschedule dialog (MediationSessionDialog) and cancel action, backed by `/api/v1/disputes/{id}/sessions*`. Session JSON is snake_case on the wire (backend has no serde rename) — the `MediationSession` api-client type matches that exactly.
+- Party submissions are now wired (apiStatus → complete): `/api/v1/disputes/{id}/submissions` (GET list + POST submit). The submission UI lives in MediationWorkspacePage as a "Submissions" tab (MediationSubmissionsPanel) — list view plus a party composer (submission type, content, visible-to-all toggle). `PartySubmission`/`SubmitResponseRequest` api-client types are snake_case on the wire (backend has no serde rename). POST resolves the submitting party from the authed user server-side; the composer only shows for parties (`isParty`).
 
 ## Agent Log
 
 <!-- newest entries on top -->
 
+- 2026-06-25 — agent: 80-3-mediation-resolution — closed the final 80-3 gap: wired party submissions endpoints (`GET/POST /api/v1/disputes/{id}/submissions`, already present on backend). Added @ppt/api-client `listSubmissions`/`submitResponse` + `useDisputeSubmissions`/`useSubmitResponse` + `PartySubmission`/`SubmitResponseRequest` snake_case wire types. New MediationSubmissionsPanel surfaced as a "Submissions" tab in MediationWorkspacePage (list + party composer gated on `isParty`). i18n for all 6 locales; MediationSubmissionsPanel.test.tsx (5 tests). Band A typecheck + biome clean; Band B ppt-web build clean; full dispute suite 152 tests green. Flipped apiStatus partial→complete; sprint-status 80-3 promoted to done.
 - 2026-06-03 — agent: gap-80-3-mediation-sessions-ui — built session scheduling UI in MediationWorkspacePage: added MediationSessionsPanel (sidebar list, upcoming-first ordering, reschedule/cancel) + MediationSessionDialog (datetime-local picker, type/duration/location/meeting-url; schedule + reschedule modes). Added session api-client layer (listSessions/scheduleSession/updateSession/cancelSession + useMediationSessions/useScheduleSession/useUpdateSession/useCancelSession + types) wired to `/api/v1/disputes/{id}/sessions*`. i18n keys added for all 6 locales. New Vitest suite (5 tests) for the panel. Band A typecheck + biome clean; Band B ppt-web build clean. apiStatus stays partial (submissions still pending).
 - 2026-05-26 — agent: gap-80-3-mediation-ui — built full mediation workspace (MediationWorkspacePage, MediationChatThread, MediationResolutionForm); wired DisputeMediationRoute to use all mediation API hooks (useResolveDispute, useEscalateDispute, useAssignMediator, useMediationNotes, useAddMediationNote); dispute timeline now uses useDisputeTimeline directly; chat thread uses real MediationNote API; resolution form covers all 5 ResolutionType options; Band A typecheck + biome lint clean.
 - 2026-05-25 — agent: story 80-3 wired — replaced inline DisputeDetailRoute stub in App.tsx with full DisputeDetailPage integration (all props, hooks, type mapping); added DisputeMediationRoute function; added /disputes/:disputeId/mediation route element; added DisputeDetailPage + MediationPage lazy exports to lazyRoutes.tsx; Band A typecheck + Band B build clean; apiStatus remains partial (sessions/submissions endpoints pending).

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -590,6 +590,26 @@
       },
       "errors": {
         "detailsMinLength": "Podrobnosti musí obsahovat alespoň 10 znaků."
+      },
+      "tabSubmissions": "Podání",
+      "submissions": {
+        "title": "Podání stran",
+        "subtitle": "Vyjádření a reakce podané stranami tohoto sporu.",
+        "empty": "Zatím žádná podání.",
+        "privateNote": "Viditelné pouze pro mediátora",
+        "composerTitle": "Podat podání",
+        "typeLabel": "Typ podání",
+        "typeStatement": "Vyjádření",
+        "typeEvidence": "Důkaz",
+        "typeResponse": "Reakce",
+        "typeRequest": "Žádost",
+        "contentLabel": "Obsah",
+        "contentPlaceholder": "Napište své podání…",
+        "visibleToAll": "Viditelné pro všechny strany",
+        "submit": "Odeslat",
+        "submitting": "Odesílá se…",
+        "submittedSuccess": "Podání odesláno",
+        "submitError": "Podání se nepodařilo odeslat"
       }
     },
     "draftSavedAgo": "Návrh uložen · {{time}}",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -543,6 +543,26 @@
       },
       "errors": {
         "detailsMinLength": "Details müssen mindestens 10 Zeichen enthalten."
+      },
+      "tabSubmissions": "Eingaben",
+      "submissions": {
+        "title": "Eingaben der Parteien",
+        "subtitle": "Stellungnahmen und Antworten der Parteien dieses Streitfalls.",
+        "empty": "Noch keine Eingaben.",
+        "privateNote": "Nur für Mediator sichtbar",
+        "composerTitle": "Eingabe einreichen",
+        "typeLabel": "Art der Eingabe",
+        "typeStatement": "Stellungnahme",
+        "typeEvidence": "Beweismittel",
+        "typeResponse": "Antwort",
+        "typeRequest": "Antrag",
+        "contentLabel": "Inhalt",
+        "contentPlaceholder": "Verfassen Sie Ihre Eingabe…",
+        "visibleToAll": "Für alle Parteien sichtbar",
+        "submit": "Einreichen",
+        "submitting": "Wird gesendet…",
+        "submittedSuccess": "Eingabe eingereicht",
+        "submitError": "Eingabe konnte nicht eingereicht werden"
       }
     },
     "draftSavedAgo": "Entwurf gespeichert · {{time}}",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -651,6 +651,26 @@
       },
       "errors": {
         "detailsMinLength": "Details must be at least 10 characters."
+      },
+      "tabSubmissions": "Submissions",
+      "submissions": {
+        "title": "Party Submissions",
+        "subtitle": "Statements and responses filed by the parties to this dispute.",
+        "empty": "No submissions yet.",
+        "privateNote": "Visible to mediator only",
+        "composerTitle": "File a submission",
+        "typeLabel": "Submission type",
+        "typeStatement": "Statement",
+        "typeEvidence": "Evidence",
+        "typeResponse": "Response",
+        "typeRequest": "Request",
+        "contentLabel": "Content",
+        "contentPlaceholder": "Write your submission…",
+        "visibleToAll": "Visible to all parties",
+        "submit": "Submit",
+        "submitting": "Submitting…",
+        "submittedSuccess": "Submission filed",
+        "submitError": "Failed to file submission"
       }
     },
     "draftSavedAgo": "Draft saved · {{time}}",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -543,6 +543,26 @@
       },
       "errors": {
         "detailsMinLength": "A részleteknek legalább 10 karaktert kell tartalmazniuk."
+      },
+      "tabSubmissions": "Beadványok",
+      "submissions": {
+        "title": "Felek beadványai",
+        "subtitle": "A vita feleinek nyilatkozatai és válaszai.",
+        "empty": "Még nincsenek beadványok.",
+        "privateNote": "Csak a közvetítő számára látható",
+        "composerTitle": "Beadvány benyújtása",
+        "typeLabel": "Beadvány típusa",
+        "typeStatement": "Nyilatkozat",
+        "typeEvidence": "Bizonyíték",
+        "typeResponse": "Válasz",
+        "typeRequest": "Kérelem",
+        "contentLabel": "Tartalom",
+        "contentPlaceholder": "Írja meg beadványát…",
+        "visibleToAll": "Minden fél számára látható",
+        "submit": "Beküldés",
+        "submitting": "Beküldés folyamatban…",
+        "submittedSuccess": "Beadvány benyújtva",
+        "submitError": "A beadvány benyújtása sikertelen"
       }
     },
     "draftSavedAgo": "Piszkozat mentve · {{time}}",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -545,6 +545,26 @@
       },
       "errors": {
         "detailsMinLength": "Szczegóły muszą zawierać co najmniej 10 znaków."
+      },
+      "tabSubmissions": "Pisma",
+      "submissions": {
+        "title": "Pisma stron",
+        "subtitle": "Oświadczenia i odpowiedzi złożone przez strony tego sporu.",
+        "empty": "Brak pism.",
+        "privateNote": "Widoczne tylko dla mediatora",
+        "composerTitle": "Złóż pismo",
+        "typeLabel": "Typ pisma",
+        "typeStatement": "Oświadczenie",
+        "typeEvidence": "Dowód",
+        "typeResponse": "Odpowiedź",
+        "typeRequest": "Wniosek",
+        "contentLabel": "Treść",
+        "contentPlaceholder": "Napisz swoje pismo…",
+        "visibleToAll": "Widoczne dla wszystkich stron",
+        "submit": "Wyślij",
+        "submitting": "Wysyłanie…",
+        "submittedSuccess": "Pismo złożone",
+        "submitError": "Nie udało się złożyć pisma"
       }
     },
     "draftSavedAgo": "Szkic zapisany · {{time}}",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -592,6 +592,26 @@
       },
       "errors": {
         "detailsMinLength": "Podrobnosti musia obsahovať aspoň 10 znakov."
+      },
+      "tabSubmissions": "Podania",
+      "submissions": {
+        "title": "Podania strán",
+        "subtitle": "Vyjadrenia a reakcie podané stranami tohto sporu.",
+        "empty": "Zatiaľ žiadne podania.",
+        "privateNote": "Viditeľné len pre mediátora",
+        "composerTitle": "Podať podanie",
+        "typeLabel": "Typ podania",
+        "typeStatement": "Vyjadrenie",
+        "typeEvidence": "Dôkaz",
+        "typeResponse": "Reakcia",
+        "typeRequest": "Žiadosť",
+        "contentLabel": "Obsah",
+        "contentPlaceholder": "Napíšte svoje podanie…",
+        "visibleToAll": "Viditeľné pre všetky strany",
+        "submit": "Odoslať",
+        "submitting": "Odosiela sa…",
+        "submittedSuccess": "Podanie odoslané",
+        "submitError": "Podanie sa nepodarilo odoslať"
       }
     },
     "draftSavedAgo": "Návrh uložený · {{time}}",

--- a/frontend/apps/ppt-web/src/features/disputes/components/MediationSubmissionsPanel.test.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/MediationSubmissionsPanel.test.tsx
@@ -1,0 +1,143 @@
+/// <reference types="vitest/globals" />
+/**
+ * MediationSubmissionsPanel component tests (Story 80.3).
+ * Covers list rendering, empty state, private-note badge, and the party
+ * composer (visible only when canSubmit, submits via useSubmitResponse).
+ */
+import type { PartySubmission } from '@ppt/api-client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MediationSubmissionsPanel } from './MediationSubmissionsPanel';
+
+let mockSubmissions: PartySubmission[] = [];
+let mockIsLoading = false;
+const mutateAsync = vi.fn().mockResolvedValue({});
+
+vi.mock('@ppt/api-client', () => ({
+  useDisputeSubmissions: () => ({ data: mockSubmissions, isLoading: mockIsLoading }),
+  useSubmitResponse: () => ({ mutateAsync, isPending: false }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'disputes.mediation.submissions.title': 'Party Submissions',
+        'disputes.mediation.submissions.subtitle': 'Statements and responses.',
+        'disputes.mediation.submissions.empty': 'No submissions yet.',
+        'disputes.mediation.submissions.privateNote': 'Visible to mediator only',
+        'disputes.mediation.submissions.composerTitle': 'File a submission',
+        'disputes.mediation.submissions.typeLabel': 'Submission type',
+        'disputes.mediation.submissions.typeStatement': 'Statement',
+        'disputes.mediation.submissions.typeEvidence': 'Evidence',
+        'disputes.mediation.submissions.typeResponse': 'Response',
+        'disputes.mediation.submissions.typeRequest': 'Request',
+        'disputes.mediation.submissions.contentLabel': 'Content',
+        'disputes.mediation.submissions.contentPlaceholder': 'Write your submission…',
+        'disputes.mediation.submissions.visibleToAll': 'Visible to all parties',
+        'disputes.mediation.submissions.submit': 'Submit',
+        'disputes.mediation.submissions.submitting': 'Submitting…',
+      };
+      return map[key] ?? key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+function makeSubmission(overrides: Partial<PartySubmission>): PartySubmission {
+  return {
+    id: 's-1',
+    dispute_id: 'd-1',
+    party_id: 'p-1',
+    submission_type: 'statement',
+    content: 'My statement',
+    is_visible_to_all: true,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const noop = () => {};
+
+describe('MediationSubmissionsPanel', () => {
+  beforeEach(() => {
+    mockSubmissions = [];
+    mockIsLoading = false;
+    mutateAsync.mockClear();
+  });
+
+  it('shows the empty state when there are no submissions', () => {
+    render(
+      <MediationSubmissionsPanel
+        disputeId="d-1"
+        canSubmit={false}
+        onToastSuccess={noop}
+        onToastError={noop}
+      />
+    );
+    expect(screen.getByText('No submissions yet.')).toBeInTheDocument();
+  });
+
+  it('renders submissions and the private-note badge for restricted ones', () => {
+    mockSubmissions = [
+      makeSubmission({ id: 'pub', content: 'Public one', is_visible_to_all: true }),
+      makeSubmission({ id: 'priv', content: 'Private one', is_visible_to_all: false }),
+    ];
+    render(
+      <MediationSubmissionsPanel
+        disputeId="d-1"
+        canSubmit={false}
+        onToastSuccess={noop}
+        onToastError={noop}
+      />
+    );
+    expect(screen.getByText('Public one')).toBeInTheDocument();
+    expect(screen.getByText('Private one')).toBeInTheDocument();
+    // Only one private-note badge (for the restricted submission).
+    expect(screen.getAllByText('Visible to mediator only')).toHaveLength(1);
+  });
+
+  it('hides the composer when canSubmit is false', () => {
+    render(
+      <MediationSubmissionsPanel
+        disputeId="d-1"
+        canSubmit={false}
+        onToastSuccess={noop}
+        onToastError={noop}
+      />
+    );
+    expect(screen.queryByText('File a submission')).not.toBeInTheDocument();
+  });
+
+  it('submits a response via useSubmitResponse when a party files one', async () => {
+    const onToastSuccess = vi.fn();
+    render(
+      <MediationSubmissionsPanel
+        disputeId="d-1"
+        canSubmit
+        onToastSuccess={onToastSuccess}
+        onToastError={noop}
+      />
+    );
+    fireEvent.change(screen.getByLabelText('Content'), {
+      target: { value: 'Here is my response' },
+    });
+    fireEvent.click(screen.getByText('Submit'));
+    expect(mutateAsync).toHaveBeenCalledWith({
+      submission_type: 'statement',
+      content: 'Here is my response',
+      is_visible_to_all: true,
+    });
+  });
+
+  it('disables submit when content is empty', () => {
+    render(
+      <MediationSubmissionsPanel
+        disputeId="d-1"
+        canSubmit
+        onToastSuccess={noop}
+        onToastError={noop}
+      />
+    );
+    expect(screen.getByText('Submit')).toBeDisabled();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/disputes/components/MediationSubmissionsPanel.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/components/MediationSubmissionsPanel.tsx
@@ -1,0 +1,189 @@
+/**
+ * MediationSubmissionsPanel — lists party submissions for a dispute and, for
+ * parties to the dispute, provides a composer to file a new submission.
+ *
+ * Wires the previously-unwired submissions endpoints
+ * (`GET/POST /api/v1/disputes/{id}/submissions`) via useDisputeSubmissions +
+ * useSubmitResponse.
+ *
+ * Epic 80: Dispute Resolution (Story 80.3)
+ */
+
+import { useDisputeSubmissions, useSubmitResponse } from '@ppt/api-client';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Spinner } from '../../../components/Spinner';
+
+/** Submission types the backend accepts (free-form string column, curated here). */
+const SUBMISSION_TYPES = ['statement', 'evidence', 'response', 'request'] as const;
+type SubmissionType = (typeof SUBMISSION_TYPES)[number];
+
+const submissionTypeLabelKeys: Record<SubmissionType, string> = {
+  statement: 'disputes.mediation.submissions.typeStatement',
+  evidence: 'disputes.mediation.submissions.typeEvidence',
+  response: 'disputes.mediation.submissions.typeResponse',
+  request: 'disputes.mediation.submissions.typeRequest',
+};
+
+export interface MediationSubmissionsPanelProps {
+  disputeId: string;
+  /** Whether the current user is a party (filer/respondent) and may submit. */
+  canSubmit: boolean;
+  onToastSuccess: (title: string, message?: string) => void;
+  onToastError: (title: string, message?: string) => void;
+}
+
+export function MediationSubmissionsPanel({
+  disputeId,
+  canSubmit,
+  onToastSuccess,
+  onToastError,
+}: MediationSubmissionsPanelProps) {
+  const { t } = useTranslation();
+  const { data: submissions = [], isLoading } = useDisputeSubmissions(disputeId);
+  const submitResponse = useSubmitResponse(disputeId);
+
+  const [submissionType, setSubmissionType] = useState<SubmissionType>('statement');
+  const [content, setContent] = useState('');
+  const [isVisibleToAll, setIsVisibleToAll] = useState(true);
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+  const submissionTypeLabel = (type: string) => {
+    const key = submissionTypeLabelKeys[type as SubmissionType];
+    return key ? t(key) : type;
+  };
+
+  const handleSubmit = async () => {
+    const trimmed = content.trim();
+    if (!trimmed) return;
+    try {
+      await submitResponse.mutateAsync({
+        submission_type: submissionType,
+        content: trimmed,
+        is_visible_to_all: isVisibleToAll,
+      });
+      onToastSuccess(t('disputes.mediation.submissions.submittedSuccess'));
+      setContent('');
+      setSubmissionType('statement');
+      setIsVisibleToAll(true);
+    } catch (err) {
+      onToastError(
+        t('disputes.mediation.submissions.submitError'),
+        err instanceof Error ? err.message : undefined
+      );
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-base font-semibold text-gray-900 mb-1">
+        {t('disputes.mediation.submissions.title')} ({submissions.length})
+      </h2>
+      <p className="text-sm text-gray-500 mb-4">{t('disputes.mediation.submissions.subtitle')}</p>
+
+      {isLoading ? (
+        <div className="flex justify-center py-8">
+          <Spinner size="md" />
+        </div>
+      ) : submissions.length === 0 ? (
+        <p className="text-sm text-gray-400 py-4">{t('disputes.mediation.submissions.empty')}</p>
+      ) : (
+        <ul className="space-y-3">
+          {submissions.map((submission) => (
+            <li key={submission.id} className="p-3 border border-gray-100 rounded-lg bg-gray-50">
+              <div className="flex items-center justify-between gap-2 mb-1.5">
+                <span className="px-2 py-0.5 text-xs font-medium rounded bg-violet-100 text-violet-800">
+                  {submissionTypeLabel(submission.submission_type)}
+                </span>
+                <span className="text-xs text-gray-400">{formatDate(submission.created_at)}</span>
+              </div>
+              <p className="text-sm text-gray-700 whitespace-pre-wrap">{submission.content}</p>
+              {!submission.is_visible_to_all && (
+                <p className="text-xs text-amber-600 mt-1.5">
+                  {t('disputes.mediation.submissions.privateNote')}
+                </p>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {canSubmit && (
+        <div className="mt-6 pt-6 border-t border-gray-100">
+          <h3 className="text-sm font-semibold text-gray-900 mb-3">
+            {t('disputes.mediation.submissions.composerTitle')}
+          </h3>
+          <div className="space-y-3">
+            <div>
+              <label
+                htmlFor="submission-type"
+                className="block text-xs font-medium text-gray-600 mb-1"
+              >
+                {t('disputes.mediation.submissions.typeLabel')}
+              </label>
+              <select
+                id="submission-type"
+                value={submissionType}
+                onChange={(e) => setSubmissionType(e.target.value as SubmissionType)}
+                className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500"
+              >
+                {SUBMISSION_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {t(submissionTypeLabelKeys[type])}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label
+                htmlFor="submission-content"
+                className="block text-xs font-medium text-gray-600 mb-1"
+              >
+                {t('disputes.mediation.submissions.contentLabel')}
+              </label>
+              <textarea
+                id="submission-content"
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                rows={4}
+                placeholder={t('disputes.mediation.submissions.contentPlaceholder')}
+                className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-violet-500 focus:border-violet-500"
+              />
+            </div>
+
+            <label className="flex items-center gap-2 text-sm text-gray-700">
+              <input
+                type="checkbox"
+                checked={isVisibleToAll}
+                onChange={(e) => setIsVisibleToAll(e.target.checked)}
+                className="rounded border-gray-300 text-violet-600 focus:ring-violet-500"
+              />
+              {t('disputes.mediation.submissions.visibleToAll')}
+            </label>
+
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!content.trim() || submitResponse.isPending}
+                className="px-4 py-2 text-sm bg-violet-600 text-white rounded-lg hover:bg-violet-700 font-medium disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {submitResponse.isPending
+                  ? t('disputes.mediation.submissions.submitting')
+                  : t('disputes.mediation.submissions.submit')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
+++ b/frontend/apps/ppt-web/src/features/disputes/pages/MediationWorkspacePage.tsx
@@ -21,10 +21,11 @@ import { MediationEscalateDialog } from '../components/MediationEscalateDialog';
 import { MediationResolutionForm } from '../components/MediationResolutionForm';
 import { MediationSessionDialog } from '../components/MediationSessionDialog';
 import { MediationSessionsPanel } from '../components/MediationSessionsPanel';
+import { MediationSubmissionsPanel } from '../components/MediationSubmissionsPanel';
 import { MediationTimelineView } from '../components/MediationTimelineView';
 import { formatDisputeReference } from '../utils/formatReference';
 
-type Tab = 'timeline' | 'chat' | 'resolve';
+type Tab = 'timeline' | 'chat' | 'submissions' | 'resolve';
 
 const statusColors: Record<string, string> = {
   filed: 'bg-blue-100 text-blue-800',
@@ -252,6 +253,7 @@ export function MediationWorkspacePage({
   const tabs: { id: Tab; label: string }[] = [
     { id: 'timeline', label: t('disputes.mediation.tabTimeline') },
     { id: 'chat', label: t('disputes.mediation.tabDiscussion') },
+    { id: 'submissions', label: t('disputes.mediation.tabSubmissions') },
     { id: 'resolve', label: t('disputes.mediation.tabResolution') },
   ];
 
@@ -469,6 +471,15 @@ export function MediationWorkspacePage({
                     </p>
                   )}
                 </>
+              )}
+
+              {activeTab === 'submissions' && (
+                <MediationSubmissionsPanel
+                  disputeId={disputeId}
+                  canSubmit={isParty}
+                  onToastSuccess={onToastSuccess}
+                  onToastError={onToastError}
+                />
               )}
 
               {activeTab === 'resolve' && (

--- a/frontend/packages/api-client/src/disputes/api.ts
+++ b/frontend/packages/api-client/src/disputes/api.ts
@@ -19,8 +19,10 @@ import type {
   MediationNote,
   MediationSession,
   PaginatedDisputes,
+  PartySubmission,
   ResolveDisputeRequest,
   ScheduleSessionRequest,
+  SubmitResponseRequest,
   TimelineEvent,
   TimelineQuery,
   UpdateDisputeStatusRequest,
@@ -247,6 +249,29 @@ export async function cancelSession(
 ): Promise<MediationSession> {
   return apiRequest<MediationSession>(`${API_BASE}/${disputeId}/sessions/${sessionId}/cancel`, {
     method: 'POST',
+  });
+}
+
+// ============================================
+// Party Submissions (Story 80.3)
+// ============================================
+
+/** List all party submissions for a dispute. */
+export async function listSubmissions(disputeId: string): Promise<PartySubmission[]> {
+  return apiRequest<PartySubmission[]>(`${API_BASE}/${disputeId}/submissions`);
+}
+
+/**
+ * Submit a party response/statement for a dispute. The backend resolves the
+ * submitting party from the authenticated user's membership in the dispute.
+ */
+export async function submitResponse(
+  disputeId: string,
+  data: SubmitResponseRequest
+): Promise<PartySubmission> {
+  return apiRequest<PartySubmission>(`${API_BASE}/${disputeId}/submissions`, {
+    method: 'POST',
+    body: JSON.stringify(data),
   });
 }
 

--- a/frontend/packages/api-client/src/disputes/hooks.ts
+++ b/frontend/packages/api-client/src/disputes/hooks.ts
@@ -15,6 +15,7 @@ import type {
   EscalateDisputeRequest,
   ResolveDisputeRequest,
   ScheduleSessionRequest,
+  SubmitResponseRequest,
   TimelineQuery,
   UpdateDisputeStatusRequest,
   UpdateSessionRequest,
@@ -35,6 +36,7 @@ export const disputeKeys = {
   evidence: (id: string) => [...disputeKeys.detail(id), 'evidence'] as const,
   notes: (id: string) => [...disputeKeys.detail(id), 'notes'] as const,
   sessions: (id: string) => [...disputeKeys.detail(id), 'sessions'] as const,
+  submissions: (id: string) => [...disputeKeys.detail(id), 'submissions'] as const,
   statistics: (orgId: string) => [...disputeKeys.all, 'statistics', orgId] as const,
 };
 
@@ -137,6 +139,30 @@ export function useCancelSession(disputeId: string) {
     mutationFn: (sessionId: string) => api.cancelSession(disputeId, sessionId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: disputeKeys.sessions(disputeId) });
+      queryClient.invalidateQueries({ queryKey: disputeKeys.timeline(disputeId) });
+    },
+  });
+}
+
+// ============================================
+// Party Submission Queries & Mutations (Story 80.3)
+// ============================================
+
+export function useDisputeSubmissions(disputeId: string) {
+  return useQuery({
+    queryKey: disputeKeys.submissions(disputeId),
+    queryFn: () => api.listSubmissions(disputeId),
+    enabled: !!disputeId,
+    staleTime: 30_000,
+  });
+}
+
+export function useSubmitResponse(disputeId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: SubmitResponseRequest) => api.submitResponse(disputeId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: disputeKeys.submissions(disputeId) });
       queryClient.invalidateQueries({ queryKey: disputeKeys.timeline(disputeId) });
     },
   });

--- a/frontend/packages/api-client/src/disputes/types.ts
+++ b/frontend/packages/api-client/src/disputes/types.ts
@@ -216,6 +216,41 @@ export interface UpdateSessionRequest {
 }
 
 // ============================================
+// Party Submission Types (Story 80.3)
+// ============================================
+
+/**
+ * A submission filed by a party during mediation
+ * (`GET /api/v1/disputes/{id}/submissions`).
+ *
+ * Field names mirror the backend `PartySubmission` model exactly. The backend
+ * serializes with serde defaults (no `rename_all`), so the wire format is
+ * snake_case — these property names match the JSON on the wire.
+ */
+export interface PartySubmission {
+  id: string;
+  dispute_id: string;
+  party_id: string;
+  submission_type: string;
+  content: string;
+  is_visible_to_all: boolean;
+  created_at: string;
+}
+
+/**
+ * Request body for submitting a party response
+ * (`POST /api/v1/disputes/{id}/submissions`).
+ *
+ * The backend derives `dispute_id` from the path and `party_id` from the
+ * authenticated user's party membership, so neither needs to be sent.
+ */
+export interface SubmitResponseRequest {
+  submission_type: string;
+  content: string;
+  is_visible_to_all: boolean;
+}
+
+// ============================================
 // Timeline Types (Story 80.3)
 // ============================================
 


### PR DESCRIPTION
## Task
Coverage gap [mvp]: Mediation and Resolution — verify and finish to done. Gaps: Party submissions endpoints unwired (apiStatus stays partial per dispute-detail screen-map); Mediation-resolution flow not promoted to done in sprint-status — story remains partial pending submissions integration.

## Owner
pm-frontend

## What was already shipped on `dev` (verified, not re-done)
- `DisputeMediationRoute` + `/disputes/:disputeId/mediation` route, `MediationWorkspacePage`, mediation hooks (`useResolveDispute`/`useEscalateDispute`/`useAssignMediator`/`useMediationNotes`/`useAddMediationNote`), and the full mediation **sessions** layer (api-client + `MediationSessionsPanel` + `MediationSessionDialog`).

## What this PR adds (the genuine remaining gap)
The backend party-submissions endpoints (`GET`/`POST /api/v1/disputes/{id}/submissions`) were live in `routes/disputes.rs` + `dispute` repo but **had no frontend wiring at all**. This PR closes that:
- **api-client** (`@ppt/api-client`): `listSubmissions` / `submitResponse` functions, `useDisputeSubmissions` / `useSubmitResponse` hooks, `disputeKeys.submissions` query key, and `PartySubmission` / `SubmitResponseRequest` types. Wire format is **snake_case** (backend `PartySubmission` has no serde rename — mirrors the existing `MediationSession` convention).
- **ppt-web**: new `MediationSubmissionsPanel` (submissions list + party composer with type / content / visible-to-all), surfaced as a new **"Submissions" tab** in `MediationWorkspacePage`. Composer is gated on `isParty`; POST resolves the submitting party server-side from the authed user.
- **i18n**: `tabSubmissions` + a `submissions` block added for all 6 locales (en, sk, cs, de, hu, pl).
- **test**: `MediationSubmissionsPanel.test.tsx` (5 tests — empty state, list + private-note badge, composer hidden when not a party, submit-via-hook, disabled-when-empty).
- **docs**: `docs/screens/ppt/dispute-detail.md` apiStatus `partial → complete` + agent log/notes; `_bmad-output/.../sprint-status.yaml` `80-3-mediation-resolution` `partial → done`.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client typecheck` → exit 0
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm exec biome check <changed files>` → exit 0 (1 format autofix applied)
- `pnpm -F @ppt/web exec vitest run src/features/disputes` → **152 passed** (incl. new 5)

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production) → exit 0 (only pre-existing chunk-size / ineffective-dynamic-import warnings)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — read/write of dispute party submissions, gated by existing AuthUser + party-membership check on the backend).

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Scope drift
`scope-check.sh` flagged **`_bmad-output/implementation-artifacts/sprint-status.yaml`** as outside pm-frontend code areas. This is the **task-mandated status promotion** ("Mediation-resolution flow not promoted to done in sprint-status") — an intentional, requested edit, not unrelated drift. All other 13 changed files are under `frontend/` (pm-frontend) or `docs/screens/` (screen-map self-management protocol).

## Code-reuse review
`reuse-grep.sh` emitted two prefix-match false positives — `useD` vs `frontend/packages/reality-api-client/.../favorites/hooks.ts` and `useS` vs the screen-map review-server client. These are truncated-prefix matches against unrelated hooks in different packages; the new hooks (`useDisputeSubmissions`/`useSubmitResponse`) live in the disputes module and mirror the existing `useMediationSessions` pattern. No real duplication.

## Notes
- Goal-check (`goal-check.sh`) reports IG1/IG2/IG4–IG6 fails/skips because they assume the `.research/plans/<slug>.md` + `impl/<slug>` plan-flow; this is a dispatcher `auto-impl/...` coverage-gap task with no plan file (and `.research/**` is dispatcher-owned, off-limits to the implementer). IG3's substance (a regression test exists) is met by `MediationSubmissionsPanel.test.tsx`, just not split into a separate `test:` commit. The real verify gate (Step 3) is fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BR9rJ7ecJ3Tr8NaiSVE6oC

---
_Generated by [Claude Code](https://claude.ai/code/session_01BR9rJ7ecJ3Tr8NaiSVE6oC)_