### PR TITLE
fix(deny): clear RUSTSEC-2026-0187 (lopdf <0.42 stack overflow) [BIT-279]

### DIFF
--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -47,6 +47,26 @@ ignore = [
     # Follow-up: drop when `rsa` ships a constant-time fix, or switch
     # jsonwebtoken to the `aws_lc_rs` backend.
     "RUSTSEC-2023-0071",
+
+    # RUSTSEC-2026-0187 — stack overflow (DoS / SIGABRT) in `lopdf` < 0.42.0
+    # when *parsing* deeply nested PDF objects (~10k levels) without a recursion
+    # depth limit. Pulled in transitively by `genpdf 0.2.0` (-> `lopdf 0.26.0`
+    # and `printpdf 0.3.4` -> `lopdf 0.26.0`).
+    #
+    # No reachable fix: the advisory is patched only in lopdf 0.42.0, but
+    # `genpdf 0.2.0` (the latest published genpdf release) pins `lopdf ^0.26`.
+    # Reaching 0.42.0 means replacing genpdf entirely — a major PDF-stack
+    # migration, out of scope for clearing the deny job.
+    #
+    # Reachability: we only *generate* PDFs (genpdf builders for voting ballots
+    # in servers/api-server/src/routes/voting.rs and financial reports in
+    # routes/financial.rs); lopdf is used on the document-write path. The
+    # vulnerable code is the parser's recursive `Document::load`, which we never
+    # call — we ingest no untrusted PDF input. The crate is in the graph but the
+    # exploitable path is not exercised.
+    # Follow-up: BIT-279 — drop when genpdf ships a release on lopdf >= 0.42.0,
+    # or migrate off genpdf to a maintained PDF generator.
+    "RUSTSEC-2026-0187",
 ]
 
 [bans]


### PR DESCRIPTION
## What

Clears the repo-wide `cargo-deny` failure on RUSTSEC-2026-0187 by adding it to the `ignore` list in `backend/deny.toml` with a written justification + tracked follow-up, matching the existing convention (e.g. RUSTSEC-2023-0071).

## Why ignore rather than bump

- **Source:** `lopdf 0.26.0` is transitive via `genpdf 0.2.0` (→ `lopdf` and `printpdf 0.3.4` → `lopdf`), used by `crates/db` + `api-server`.
- **No reachable fix:** advisory is patched only in **lopdf 0.42.0**, but `genpdf 0.2.0` — the latest published genpdf release — pins `lopdf ^0.26`. Reaching 0.42.0 requires replacing genpdf entirely (major PDF-stack migration, out of scope).
- **Reachability is nil:** the vuln is a stack-overflow DoS in lopdf's PDF **parser** (`Document::load`, unbounded recursion on ~10k-deep nesting). We only **generate** PDFs — genpdf builders for voting ballots (`routes/voting.rs`) and financial reports (`routes/financial.rs`). No `lopdf`/`Document::load` parsing of untrusted input exists anywhere in the tree (verified by grep). The crate is present but the exploitable path is never exercised.

## Follow-up

BIT-279 tracks dropping the ignore once genpdf ships on lopdf ≥ 0.42.0, or we migrate off genpdf.

## Verification

- `deny.toml` parses (validated); RUSTSEC-2026-0187 now in `advisories.ignore`.
- `cargo-deny` job in CI will confirm green. Note: `cargo-deny` is **not** a required check on `dev` (only `check` + `test` are), but this turns the job from red → green repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)