### PR TITLE
fix(backend): scoped-ignore RUSTSEC-2026-0187 (lopdf) so cargo-deny is green on dev [BIT-319]

### DIFF
--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -47,6 +47,28 @@ ignore = [
     # Follow-up: drop when `rsa` ships a constant-time fix, or switch
     # jsonwebtoken to the `aws_lc_rs` backend.
     "RUSTSEC-2023-0071",
+
+    # RUSTSEC-2026-0187 — Stack overflow in `lopdf` (<= 0.41.0) via deeply
+    # nested PDF objects. Unbounded recursion in the PARSER entry points
+    # (`lopdf::Document::load_mem` / `load*`) lets a crafted PDF (~10k levels
+    # of nesting) exhaust the call stack. Fixed in lopdf >= 0.42.0.
+    #
+    # We pull lopdf 0.26.0 transitively: genpdf 0.2.0 -> printpdf 0.3.4 ->
+    # lopdf ^0.26. genpdf 0.2.0 is the latest (and now-unmaintained) genpdf
+    # release; printpdf 0.3.4 pins lopdf 0.26, so `cargo update -p lopdf`
+    # cannot reach 0.42 without replacing the whole PDF-generation stack
+    # (a feature migration, not a maintenance fix — out of scope here).
+    #
+    # Reachability: we only GENERATE PDFs (genpdf `Document::render` ->
+    # invoices, income statements, voting reports — see
+    # servers/api-server/src/routes/financial.rs & voting.rs). We never call
+    # any lopdf `load*` parser entry point and never parse attacker-supplied
+    # PDFs; `grep -rn 'lopdf|load_mem|Document::load'` over the backend is
+    # empty. The vulnerable recursive-parse path is therefore unreachable.
+    # Scoped ignore keeps every OTHER advisory enforced (no `--admin` bypass).
+    # Tracking: BIT-319. Follow-up: drop once the genpdf/printpdf stack is
+    # upgraded to a build that resolves lopdf >= 0.42.0.
+    "RUSTSEC-2026-0187",
 ]
 
 [bans]

--- a/backend/servers/api-server/tests/data_residency_tests.rs
+++ b/backend/servers/api-server/tests/data_residency_tests.rs
@@ -10,7 +10,6 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use common::{seed_membership, RequestBuilder, TestApp, TestConfig};
-use db::models::data_residency::{AccessType, DataRegion, DataTypeCategory, ResidencyAuditEvent};
 
 #[derive(Serialize)]
 struct TestClaims {

--- a/backend/servers/api-server/tests/regional_compliance_tests.rs
+++ b/backend/servers/api-server/tests/regional_compliance_tests.rs
@@ -179,7 +179,7 @@ async fn test_slovak_voting_config_lifecycle(pool: PgPool) {
     resp.assert_status(StatusCode::OK);
     let body: SlovakVotingConfig = serde_json::from_value(resp.json_value()).unwrap();
     assert_eq!(body.building_id, building_id);
-    assert_eq!(body.enabled, true);
+    assert!(body.enabled);
     assert_eq!(body.min_notice_days, 15);
 
     // 3. Get updated voting config
@@ -220,7 +220,7 @@ async fn test_gdpr_consent_lifecycle(pool: PgPool) {
         .iter()
         .find(|c| c.category == GdprConsentCategory::Essential)
         .unwrap();
-    assert_eq!(essential.granted, true);
+    assert!(essential.granted);
 
     // 2. Grant Marketing consent
     let record_payload = serde_json::json!({
@@ -253,7 +253,7 @@ async fn test_gdpr_consent_lifecycle(pool: PgPool) {
         .iter()
         .find(|c| c.category == GdprConsentCategory::Marketing)
         .unwrap();
-    assert_eq!(marketing.granted, true);
+    assert!(marketing.granted);
     assert_eq!(marketing.consent_version.as_deref(), Some("1.2"));
 
     // 4. Withdraw Marketing consent
@@ -287,5 +287,5 @@ async fn test_gdpr_consent_lifecycle(pool: PgPool) {
         .iter()
         .find(|c| c.category == GdprConsentCategory::Marketing)
         .unwrap();
-    assert_eq!(marketing.granted, false);
+    assert!(!marketing.granted);
 }


### PR DESCRIPTION
## BIT-319 — cargo-deny red dev-wide: RUSTSEC-2026-0187 (lopdf 0.26.0)

`cargo-deny` was failing as a hard `deny` on **every backend PR and `dev`** for **RUSTSEC-2026-0187** (*Stack overflow in lopdf <=0.41.0 via deeply nested PDF objects*). The only way PRs merged was `gh pr merge --admin`, which silently bypasses cargo-deny for **all** advisories.

### Why not bump (Option 1)?
lopdf 0.26.0 is **transitive**: `genpdf 0.2.0` → `printpdf 0.3.4` → `lopdf ^0.26`.
- The patched lopdf is **>= 0.42.0**.
- `genpdf 0.2.0` is the latest (now-unmaintained) genpdf release; `printpdf 0.3.4` pins lopdf 0.26.
- So `cargo update -p lopdf --precise 0.42.0` cannot resolve — reaching 0.42 means replacing the whole PDF-generation stack (a feature migration, out of scope for a security-maintenance ticket, and risky mid Stable-Beta).

### Fix (Option 2): scoped, time-boxed ignore
Added `RUSTSEC-2026-0187` to `[advisories] ignore` in `backend/deny.toml` with a full written justification, alongside the existing 4 documented ignores. **Every other advisory stays enforced** — no blanket `--admin` bypass.

### Reachability (why this is safe)
The advisory is in the **parser** (`lopdf::Document::load_mem` / `load*`, unbounded recursion on nested objects). We only **generate** PDFs:
- `genpdf::Document::render(&mut bytes)` — invoices, income statements, voting reports (`servers/api-server/src/routes/financial.rs`, `voting.rs`).
- `grep -rn 'lopdf|load_mem|Document::load'` over the backend is **empty** — we never invoke a lopdf parser entry point and never parse attacker-supplied PDFs.

The vulnerable recursive-parse path is therefore unreachable.

### Toolchain warning (from ticket)
The `override toolchain '1.94.1-...' is not installed` line is **cosmetic**: the cargo-deny-action runs with `rust-version: stable` and evaluates the advisory DB against `Cargo.lock` without compiling the workspace — confirmed by the fact it still emitted the advisory error. Not masking the real run.

### Done
- [x] `RUSTSEC-2026-0187` scoped-ignored with tracking comment → BIT-319
- [x] All other advisories remain hard-enforced (no `--admin` needed)
- [ ] CI: cargo-deny job green on this PR (verify on Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)