### PR TITLE
fix(ci): apply migrations in backend test job so sqlx query! macros compile (BIT-323)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -295,6 +295,33 @@ jobs:
           sudo docker image prune --all --force >/dev/null 2>&1 || true
           echo "Disk after cleanup:"; df -h /
 
+      # The api-server test binaries contain the ONLY compile-time-checked
+      # `sqlx::query!` macros in the whole backend (ocr_meter_reading_tests.rs
+      # lines 176 & 312 — every other DB access uses RUNTIME `sqlx::query()`).
+      # Those macros connect to DATABASE_URL at COMPILE time to validate their
+      # SQL against the live schema. With no committed `.sqlx` offline cache and
+      # no migrations applied, the `test` DB is empty, so they fail with
+      # `relation "meter_readings"/"ocr_meter_corrections" does not exist`.
+      # This was intermittent (BIT-323): `Swatinem/rust-cache` may reuse an
+      # already-compiled test binary, so the macro is never re-evaluated and the
+      # job is green — but on a cold/different cache key (e.g. the PR merge-ref)
+      # the binary recompiles against the empty DB and the job goes red on the
+      # same SHA a `push` run passed. Apply migrations BEFORE `cargo test` so the
+      # schema deterministically exists for the query-macro check.
+      #
+      # sqlx-cli is pinned to the workspace's SQLx version (0.9) to match the
+      # proc-macro, mirroring the `sqlx-migrations` gate below.
+      - name: Install SQLx CLI
+        if: needs.changes.outputs.backend == 'true'
+        run: cargo install sqlx-cli --version 0.9.0 --no-default-features --features native-tls,postgres --locked
+
+      - name: Run database migrations
+        if: needs.changes.outputs.backend == 'true'
+        working-directory: backend/crates/db
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
+        run: sqlx database create && sqlx migrate run
+
       - name: Run tests
         if: needs.changes.outputs.backend == 'true'
         working-directory: backend


### PR DESCRIPTION
## Summary

Fixes **BIT-323** — the required `test` context (`backend.yml`) fails deterministically on PR merge-refs with sqlx compile-time errors:

```
relation "meter_readings" does not exist     ocr_meter_reading_tests.rs:176
relation "ocr_meter_corrections" does not exist  ocr_meter_reading_tests.rs:312
```

## Root cause

The `test` job runs `cargo test --workspace` against a **fresh empty `test` DB**, with **no `sqlx migrate run` step** and **no committed `.sqlx` offline cache**.

The two `sqlx::query!` macros in `servers/api-server/tests/ocr_meter_reading_tests.rs` (lines 176 & 312) are the **only compile-time-checked** query macros in the entire backend — every other DB access uses runtime `sqlx::query()`. Compile-time `query!` connects to `DATABASE_URL` at **build time** to validate SQL against the live schema, so on an empty DB it fails with `relation … does not exist`.

This was **intermittent** because `Swatinem/rust-cache` may reuse an already-compiled test binary (macro never re-evaluated → green). On a cold/different cache key — e.g. the PR merge-ref — the binary recompiles against the empty DB and the required `test` context goes red on the same SHA that a `push` run passed. That matches the reported behaviour exactly (PR #1897: `pull_request` red twice, `push` green).

## Fix

Add `Install SQLx CLI` + `Run database migrations` steps to the `test` job before `cargo test`, mirroring the existing `rls-smoke-test` / `rls-penetration-test` / `sqlx-migrations` jobs that already run `sqlx database create && sqlx migrate run` from `backend/crates/db` and are green on `dev` (proving the migrations apply in order and create both tables). sqlx-cli pinned to `0.9.0` to match the workspace SQLx proc-macro version.

## Verification

- YAML parses; new steps ordered correctly (Free disk space → Install SQLx CLI → Run database migrations → Run tests), each gated on `needs.changes.outputs.backend == 'true'`.
- Local Rust/Postgres toolchain unavailable (mercury offload down), so end-to-end verification is **this PR's own `test` run on the merge-ref** — the exact context that was failing.

Unblocks BIT-319 PR #1897 landing without `--admin`.

Co-Authored-By: Paperclip <noreply@paperclip.ing>