### PR TITLE
fix(test): deterministic backend `test` — runtime sqlx queries in ocr_meter_reading_tests (BIT-322)

### DIFF
--- a/backend/servers/api-server/tests/data_residency_tests.rs
+++ b/backend/servers/api-server/tests/data_residency_tests.rs
@@ -231,3 +231,4 @@ async fn test_data_residency_cross_tenant_isolation(pool: PgPool) {
     // member validator blocks requests where caller user is not a member of the X-Tenant-ID header org
     assert_eq!(resp.status, StatusCode::FORBIDDEN);
 }
+

--- a/backend/servers/api-server/tests/data_residency_tests.rs
+++ b/backend/servers/api-server/tests/data_residency_tests.rs
@@ -10,7 +10,6 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use common::{seed_membership, RequestBuilder, TestApp, TestConfig};
-use db::models::data_residency::{AccessType, DataRegion, DataTypeCategory, ResidencyAuditEvent};
 
 #[derive(Serialize)]
 struct TestClaims {

--- a/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
+++ b/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
@@ -172,19 +172,23 @@ async fn process_meter_reading_creates_pending_reading(pool: PgPool) {
     let reading_id =
         Uuid::parse_str(body["reading_id"].as_str().unwrap()).expect("reading_id is a UUID");
 
-    // Verify the row actually landed in the DB.
-    let row = sqlx::query!(
-        r#"SELECT source AS "source!", status AS "status!", photo_url
+    // Verify the row actually landed in the DB. Runtime-checked sqlx
+    // (`query_as`, not the `query!` macro): the `test` CI job compiles tests
+    // against the live DATABASE_URL with no migrations applied, so compile-time
+    // macro checking is non-deterministic (BIT-322). The enum columns are cast
+    // to ::text so they decode straight into String.
+    let (source, status, photo_url): (String, String, Option<String>) = sqlx::query_as(
+        r#"SELECT source::text, status::text, photo_url
            FROM meter_readings WHERE id = $1"#,
-        reading_id
     )
+    .bind(reading_id)
     .fetch_one(&pool)
     .await
     .expect("reading must exist in DB");
 
-    assert_eq!(row.source, "photo", "source must be 'photo'");
-    assert_eq!(row.status, "pending", "status must be 'pending'");
-    assert!(row.photo_url.is_some(), "photo_url must be set");
+    assert_eq!(source, "photo", "source must be 'photo'");
+    assert_eq!(status, "pending", "status must be 'pending'");
+    assert!(photo_url.is_some(), "photo_url must be set");
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -308,19 +312,20 @@ async fn submit_correction_persists_record(pool: PgPool) {
     assert!(body["id"].is_string(), "response must include id");
     let correction_id = Uuid::parse_str(body["id"].as_str().unwrap()).expect("id is a UUID");
 
-    // Round-trip: verify the row is in the DB with correct values.
-    let row = sqlx::query!(
-        r#"SELECT original_value, corrected_value, image_url
+    // Round-trip: verify the row is in the DB with correct values. Runtime
+    // `query_as` (not `query!`) for deterministic CI compilation — see BIT-322.
+    let (corrected_value, image_url): (rust_decimal::Decimal, String) = sqlx::query_as(
+        r#"SELECT corrected_value, image_url
            FROM ocr_meter_corrections WHERE id = $1"#,
-        correction_id
     )
+    .bind(correction_id)
     .fetch_one(&pool)
     .await
     .expect("correction must exist in DB");
 
-    assert_eq!(row.image_url, "https://example.com/meter.jpg");
+    assert_eq!(image_url, "https://example.com/meter.jpg");
     assert_eq!(
-        row.corrected_value,
+        corrected_value,
         rust_decimal::Decimal::try_from(105.5_f64).unwrap()
     );
 }


### PR DESCRIPTION
## Problem (BIT-322)

The required `test` context (`backend.yml`) fails **intermittently** on PR merge-refs with:

```
error: relation "meter_readings" does not exist        ocr_meter_reading_tests.rs:176
error: relation "ocr_meter_corrections" does not exist  ocr_meter_reading_tests.rs:312
```

## Root cause

`servers/api-server/tests/ocr_meter_reading_tests.rs` was the **only** file in the backend still using the compile-time-checked `sqlx::query!` macro (the sibling `vote_delegation_eligibility_tests.rs` only *mentions* `query!` in a doc comment; it already uses runtime queries).

`query!` verifies its SQL against the live `DATABASE_URL` **at compile time**. The `test` job runs `cargo test --workspace` against a fresh empty `test` DB with **no `sqlx migrate run` step** and **no committed `.sqlx` cache**. The schema is never applied there — the runtime `#[sqlx::test]` migrator only builds isolated per-test databases, which happens *after* compilation. So whenever `Swatinem/rust-cache` misses and this one test binary recompiles, the two macros hit an empty DB and the job goes red. Warm-cache `push` runs (binary not recompiled) stay green — hence push-passes / PR-fails on the same SHA.

## Fix

Convert the two `query!` macros to runtime `sqlx::query_as` — the exact pattern the rest of the backend deliberately uses to keep CI free of a compile-time schema dependency (see the `// Runtime-checked sqlx (not \`query!\`)` notes in `src`). Enum columns (`source`, `status`) are cast `::text` so they decode into `String`; rows decode into tuples.

- Removes the compile-time DB coupling **entirely** → `test` compiles deterministically regardless of rust-cache state.
- Runtime behaviour unchanged: `#[sqlx::test]` still migrates each isolated DB and the round-trip assertions run against it.

## Verification

Local Rust/Postgres reproduction is unavailable (no local toolchain; mercury cargo-offload is down — noted in the issue). Verification is this PR's own `test` job: it now compiles `ocr_meter_reading_tests` with no schema dependency and runs the assertions against the migrated `#[sqlx::test]` DB. Will confirm green here before merge.

## Alternative considered

An explicit `sqlx migrate run` step in the `test` job (the issue's suggested approach) also fixes it and additionally guards *future* `query!` tests — but editing `.github/workflows/**` requires a token with `workflow` scope, which the available CI credentials lack. This source-only fix is pushable now, removes the root cause, and aligns with the repo's established runtime-query convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)