### PR TITLE
8a-2-critical-notification-override: reconcile unwired-features registry (no screen-map by design)

### DIFF
--- a/docs/screens/README.md
+++ b/docs/screens/README.md
@@ -39,7 +39,7 @@ Phase 2/3 add: init, update, review (with a visual UI), edit, render (mermaid), 
 ## ppt-web: hidden built-but-unwired features (not in nav)
 
 Per the Stable Beta board decision ([PAP-55](/PAP/issues/PAP-55) / WS-C, recorded
-on [PAP-28](/PAP/issues/PAP-28)), the following **11 ppt-web features are fully
+on [PAP-28](/PAP/issues/PAP-28)), the following **10 ppt-web features are fully
 built with live backends but intentionally NOT wired into the router or nav** —
 they are hidden from customers now and scheduled for deliberate wiring later. The
 code is retained, not deleted.
@@ -48,7 +48,10 @@ code is retained, not deleted.
 **retired** 7 dead scaffolds — `migration`, `integrations`, `multi-currency`,
 `api-ecosystem`, `delegation`, `data-residency`, `packages` — deleting their
 code. Deleted features cannot be re-exposed, so the guard no longer tracks them;
-this list was reconciled 18 → 11 when PAP-55 landed on top of PAP-33.)
+this list was reconciled 18 → 11 when PAP-55 landed on top of PAP-33, then
+11 → 10 when `person-months` was deliberately wired (Story 3.5, #1714) — its
+route group is mounted in `AppRoutes.tsx`, so it is navigable and no longer
+hidden.)
 
 Because they are not navigable, they have **no screen-map entries** here by design
 (a screen-map describes a reachable screen). When one is wired in a future phase,
@@ -56,7 +59,7 @@ create its screen-map at that time and remove its slug from the registry below.
 
 `insurance` · `marketplace` · `forms` · `onboarding` · `critical-notifications` ·
 `subscription` · `government-portal` · `compliance` · `registry` ·
-`portfolio-performance` · `person-months`
+`portfolio-performance`
 
 Source of truth / regression guard:
 `frontend/apps/ppt-web/src/features/unwired-features.ts` and its test


### PR DESCRIPTION
## Task
Coverage gap [mvp]: Critical Notification Override — verify and finish to done. Gaps: no screen-map (orphan epic)

## Owner
pm-frontend

## Verify-first finding (the "gap" is a false positive)

The dispatcher flagged "no screen-map (orphan epic)" for **Critical Notification Override**. Investigation shows this is **working as designed**, not a gap:

- The feature is **fully built** in `frontend/apps/ppt-web/src/features/critical-notifications/` (4 components + 3 pages + barrels).
- It is one of the **intentionally unwired** ppt-web features per board decision **PAP-55 / PAP-28** — no route group, no nav entry, not in `@ppt/sitemap`. It is correctly registered in `frontend/apps/ppt-web/src/features/unwired-features.ts` (`UNWIRED_FEATURES`).
- Per the screen-map README rule, unwired features have **no screen-map entries by design** ("a screen-map describes a reachable screen"). So the absence of a `critical-notifications` screen-map is correct and is CI-guarded by `src/test/unwired-features.test.ts`.

**No code change to the feature is warranted, and no screen-map should be created** while it stays unwired.

## What this PR actually fixes (the genuine, minimal gap)

While verifying, I found `docs/screens/README.md` was **stale** relative to the code source-of-truth:

- It listed **11** hidden features including `person-months`, but `person-months` was deliberately wired in **Story 3.5 (#1714)** and removed from `UNWIRED_FEATURES` (now 10 entries). The code comment in `unwired-features.ts` already documents the 11→10 reconciliation; the README never caught up.

This PR reconciles the human-facing registry with the code guard: count **11→10**, adds the reconciliation note, and drops `person-months` from the slug list. `critical-notifications` stays listed (correctly) as hidden/unwired.

## Tested (Band A — fast check)
- Docs-only change to `docs/screens/README.md` (6 lines). No screen-map frontmatter file touched, so schema validation N/A.
- `bash .claude/skills/ppt-implement/scripts/scope-check.sh --owner pm-frontend --base origin/dev --head HEAD` → exit 0 (no scope drift).
- Verified `unwired-features.ts` array has 10 entries (no `person-months`); `routes/groups/person-months.tsx` exists and is mounted; no `routes/groups/critical-notifications.tsx` and no `docs/screens/ppt/critical-notif*.md` (both correct).

## Built (Band B — full build)
skipped: change <50 LOC, docs-only, no public API/config touch. (No TS/build surface affected; `unwired-features.ts` and its guard test are unchanged.)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs-only, no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Reviewer decision point: confirm the verify-first conclusion — that "Critical Notification Override" needs **no** screen-map while it remains in `UNWIRED_FEATURES`. If the board later wires it, that future phase creates the screen-map and removes its slug (per the README's own instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP)_