### PR TITLE
8a-3-notification-preference-sync: add screen-map for Notification Preferences

### DIFF
--- a/docs/screens/ppt/settings-notifications.md
+++ b/docs/screens/ppt/settings-notifications.md
@@ -1,0 +1,73 @@
+---
+id: ppt/settings-notifications
+name: Notification Preferences
+product: ppt
+sitemapRefs: {}
+implementations:
+  ppt-web:
+    route: "/settings/notifications"
+    component: NotificationSettingsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: complete
+  mobile:
+    buildStatus: n/a
+    redesignStatus: n/a
+    apiStatus: n/a
+endpoints: []
+relatedScreens:
+  - id: ppt/settings-two-factor
+    rel: sibling
+  - id: ppt/notification-analytics
+    rel: sibling
+sharedComponents:
+  - channel-toggle
+  - disable-all-warning-dialog
+diagrams: []
+useCases:
+  - UC-01.3
+epics:
+  - Epic-8A
+designSources: []
+owner: pm-frontend
+---
+
+# Notification Preferences
+
+Channel-level notification toggles for the signed-in user (Epic 8A, Stories 8A.1 + 8A.3).
+`NotificationSettingsPage` lets the user enable/disable each delivery channel (push, email,
+in-app). Preferences are stored server-side and synced cross-device on page load via
+`useNotificationPreferences` / `useUpdateNotificationPreference` from `@ppt/api-client`.
+
+Disabling the last remaining enabled channel surfaces a confirmation guard
+(`DisableAllWarningDialog`): the PATCH returns `409 ConfirmationRequired` and the UI
+re-issues the update with the confirm flag once the user accepts.
+
+## Backend contract
+
+These operations are not yet registered in `@ppt/sitemap`, so `endpoints:` is left empty
+(consistent with `ppt/notification-analytics`). The live api-server routes are:
+
+- `GET /api/v1/users/me/notification-preferences` — read all channel preferences (RLS-scoped).
+- `PATCH /api/v1/users/me/notification-preferences/{channel}` — update one channel; on
+  Story 8A.3 it publishes a `preference.updated` event to Redis `notifications:{user_id}`
+  for WebSocket clients to consume.
+
+Source: `backend/servers/api-server/src/routes/notification_preferences.rs`,
+`backend/crates/db/src/repositories/notification_preference.rs`.
+
+## Notes
+
+### Specific (recent)
+- 2026-06-28 — agent: orphan-epic reconciliation for Epic 8A. AC-1 (cross-device sync via
+  server-side storage) is shipped. AC-2 (real-time WebSocket push of `preference.updated`)
+  is deferred — `usePreferenceSync` in `@ppt/api-client` is a placeholder returning
+  `isConnected: false` pending WebSocket infrastructure (Epic 2B). AC-3 (mobile OS
+  integration) is deferred — no RN/mobile screen yet (`mobile` impl = n/a).
+- The advanced/granular category preferences live on a separate route
+  (`/settings/notifications/advanced`, Epic 40) and are out of scope for this screen-map.
+
+## Agent Log
+- 2026-06-28 — agent: 8a-3-notification-preference-sync — verify-first coverage gap. Created
+  the missing screen-map for the orphan Epic 8A route `/settings/notifications`; recorded
+  AC-1 shipped, AC-2/AC-3 deferred. No code change — feature was already on dev.


### PR DESCRIPTION
## Task
Coverage gap [mvp]: Notification Preference Sync — verify and finish to done. Gaps: no screen-map (orphan epic)

## Owner
pm-frontend

## Summary
Verify-first task. The Notification Preference Sync feature (Epic 8A, Stories 8A.1 + 8A.3) is **already shipped on `dev`** — no code change needed. The genuine gap was the missing screen-map for the orphan route `/settings/notifications`, which this PR adds: `docs/screens/ppt/settings-notifications.md`.

Verified the feature exists end-to-end:
- Frontend page: `frontend/apps/ppt-web/src/features/settings/notifications/NotificationSettingsPage.tsx` (channel toggles + disable-all confirmation guard)
- Route: `/settings/notifications` registered in `frontend/apps/ppt-web/src/routes/groups/core.tsx`
- API client: `frontend/packages/api-client/src/notification-preferences/{api,hooks,sync}.ts`
- Backend: `backend/servers/api-server/src/routes/notification_preferences.rs` + `backend/crates/db/src/repositories/notification_preference.rs`

Acceptance criteria status recorded in the screen-map:
- AC-1 (cross-device sync via server-side storage): **shipped**
- AC-2 (real-time WebSocket push of `preference.updated`): **deferred** — `usePreferenceSync` is a placeholder pending WebSocket infra (Epic 2B)
- AC-3 (mobile OS integration): **deferred** — no RN screen yet (`mobile` impl = n/a)

`endpoints:` left empty (consistent with `ppt/notification-analytics`) because the notification-preference operationIds are not registered in `@ppt/sitemap`; the live routes are documented in the body instead.

## Tested (Band A — fast check)
Docs-only change (screen-map markdown); typecheck/lint do not apply. Ran the screen-map validator (the relevant gate):

```
pnpm -F @ppt/screen-map cli validate --root <repo> --strict
  ok  docs/screens/ppt/settings-notifications.md
Validated 159 screen-maps: 0 errors, 0 warnings.    (exit 0)
```

## Built (Band B — full build)
skipped: docs-only change (<50 LOC, no public API/migration/config touch)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- No production code modified — this PR is pure screen-map reconciliation for an orphan epic.
- Scope-check (owner=pm-frontend) clean; diff touches only `docs/screens/ppt/settings-notifications.md`.
- goal-check IG1/IG2/IG8 "fails" are not applicable to this verify-first task: there is no `.research/plans/` file (dispatcher-owned, off-limits), the branch is the dispatcher-chosen `auto-impl/...` name, and no archive move applies. The substantive gate (`/screens validate`) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP)_