### PR TITLE
85-2-build-configuration: reconcile shipped build-config story + screen-map

### DIFF
--- a/_bmad-output/implementation-artifacts/stories/85-2-build-configuration.md
+++ b/_bmad-output/implementation-artifacts/stories/85-2-build-configuration.md
@@ -1,6 +1,29 @@
 # Story 85.2: Build Configuration by Environment
 
-Status: pending
+Status: done
+
+> Reconciliation note (2026-06-28): implementation shipped on `dev` ahead of this
+> status flip. All five acceptance criteria are satisfied in source:
+> - **AC-1 Android flavors** — `mobile-native/androidApp/build.gradle.kts`
+>   (`flavorDimensions += "environment"`; `development`/`staging`/`production`
+>   flavors with `applicationIdSuffix`, `versionNameSuffix`, per-flavor
+>   `app_name` + `API_BASE_URL`/`ENVIRONMENT`/`ENABLE_LOGGING` `buildConfigField`s;
+>   release `signingConfigs` keyed off `KEYSTORE_*` env vars; debug `.debug` suffix).
+> - **AC-2 iOS schemes** — `mobile-native/iosApp/xcschemes/RealityPortal-{Dev,Staging,Prod}.xcscheme`
+>   + `mobile-native/iosApp/Configurations/{Base,Development,Staging,Production}.xcconfig`
+>   (per-config `PRODUCT_BUNDLE_IDENTIFIER`, `BUNDLE_DISPLAY_NAME`, `API_BASE_URL`,
+>   `CODE_SIGN_STYLE`).
+> - **AC-3 KMP variants** — `mobile-native/shared/build.gradle.kts`; under the AGP 9
+>   `com.android.kotlin.multiplatform.library` plugin the shared module is
+>   variant-agnostic (no BuildConfig), with the iOS `framework` block configured
+>   for `iosX64`/`iosArm64`/`iosSimulatorArm64`.
+> - **AC-4 distinguishability** — distinct app names (`Reality (Dev)`,
+>   `Reality (Staging)`, `Reality Portal`) + bundle/app-id suffixes per environment.
+> - **AC-5 build scripts** — `scripts/build-mobile.sh` (orchestrator),
+>   `scripts/build-android.sh`, `scripts/build-ios.sh` (each tagged
+>   "Epic 85 - Story 85.2"). Note: these live at repo-root `scripts/`, not under
+>   `mobile-native/` — an earlier coverage scan looked only under `mobile-native/`
+>   and reported a false-negative AC-5 gap.
 
 ## Story
 
@@ -44,38 +67,51 @@ So that **I can easily build and deploy to different environments with proper se
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Configure Android Build System (AC: 1, 4)
-  - [ ] 1.1 Set up product flavors (dev, staging, prod)
-  - [ ] 1.2 Configure application ID suffixes
-  - [ ] 1.3 Create app icons per flavor
-  - [ ] 1.4 Configure app names per flavor
-  - [ ] 1.5 Set up signing configs
+- [x] Task 1: Configure Android Build System (AC: 1, 4)
+  - [x] 1.1 Set up product flavors (dev, staging, prod)
+  - [x] 1.2 Configure application ID suffixes
+  - [~] 1.3 Create app icons per flavor — per-flavor `app_name` strings ship;
+    per-flavor `ic_launcher` mipmaps NOT yet generated (no `src/staging/res`,
+    no `src/development/res/mipmap-*`). Visual distinction is via app name only.
+  - [x] 1.4 Configure app names per flavor
+  - [x] 1.5 Set up signing configs
 
-- [ ] Task 2: Configure iOS Build System (AC: 2, 4)
-  - [ ] 2.1 Create build schemes (Development, Staging, Production)
-  - [ ] 2.2 Configure bundle ID per scheme
-  - [ ] 2.3 Create app icons per scheme
-  - [ ] 2.4 Configure display names per scheme
-  - [ ] 2.5 Set up provisioning profiles
+- [x] Task 2: Configure iOS Build System (AC: 2, 4)
+  - [x] 2.1 Create build schemes (Development, Staging, Production)
+  - [x] 2.2 Configure bundle ID per scheme
+  - [~] 2.3 Create app icons per scheme — `AppIcon`, `AppIcon-Dev`,
+    `AppIcon-Staging` `.appiconset` directories exist and are referenced via
+    `ASSETCATALOG_COMPILER_APPICON_NAME`, but the sets currently hold only
+    `Contents.json` (no badge image assets generated yet).
+  - [x] 2.4 Configure display names per scheme
+  - [~] 2.5 Set up provisioning profiles — `CODE_SIGN_STYLE = Automatic`;
+    no manual provisioning profiles committed (intentional for CI).
 
-- [ ] Task 3: Configure KMP Build Variants (AC: 3)
-  - [ ] 3.1 Set up Gradle build types
-  - [ ] 3.2 Configure shared module variants
-  - [ ] 3.3 Set up Android library variants
-  - [ ] 3.4 Configure iOS framework variants
+- [x] Task 3: Configure KMP Build Variants (AC: 3)
+  - [x] 3.1 Set up Gradle build types
+  - [x] 3.2 Configure shared module variants — under AGP 9
+    `com.android.kotlin.multiplatform.library` the shared module is
+    variant-agnostic by design (no build types / flavors / BuildConfig).
+  - [x] 3.3 Set up Android library variants
+  - [x] 3.4 Configure iOS framework variants
 
-- [ ] Task 4: Create App Icons and Assets (AC: 4)
-  - [ ] 4.1 Create development app icon (with "DEV" badge)
-  - [ ] 4.2 Create staging app icon (with "STG" badge)
-  - [ ] 4.3 Create production app icon
+- [~] Task 4: Create App Icons and Assets (AC: 4)
+  - [~] 4.1 Create development app icon (with "DEV" badge) — set scaffolded, image pending
+  - [~] 4.2 Create staging app icon (with "STG" badge) — set scaffolded, image pending
+  - [~] 4.3 Create production app icon — set scaffolded, image pending
   - [ ] 4.4 Generate all required sizes
+  - Note: icon-badge artwork is the only remaining piece; tracked as a
+    design-asset follow-up. App distinguishability (AC-4) is already met via
+    distinct app names + bundle/app-id suffixes per environment.
 
-- [ ] Task 5: Create Build Scripts (AC: 5)
-  - [ ] 5.1 Create Android build script
-  - [ ] 5.2 Create iOS build script
-  - [ ] 5.3 Create KMP build script
-  - [ ] 5.4 Create unified build script
-  - [ ] 5.5 Document build commands
+- [x] Task 5: Create Build Scripts (AC: 5)
+  - [x] 5.1 Create Android build script (`scripts/build-android.sh`)
+  - [x] 5.2 Create iOS build script (`scripts/build-ios.sh`)
+  - [x] 5.3 Create KMP build script — covered by `build-android.sh`
+    (`./gradlew` assemble) and `build-ios.sh` (framework link) which drive the
+    shared KMP module; no separate script needed.
+  - [x] 5.4 Create unified build script (`scripts/build-mobile.sh`)
+  - [x] 5.5 Document build commands (usage headers in each script)
 
 ## Dev Notes
 

--- a/docs/screens/reality-mobile/project-setup.md
+++ b/docs/screens/reality-mobile/project-setup.md
@@ -23,6 +23,7 @@ diagrams: []
 useCases: []
 epics:
   - "82"
+  - "85"
 designSources: []
 owner: reality-frontend
 ---
@@ -78,6 +79,41 @@ on top of. Findings are grounded in the static audit
   `AuthManager`, another in `DependencyContainer.shared.ssoService`; the two
   are independent and their session state can diverge.
 
+### Build configuration by environment (Epic 85, Story 85.2)
+
+Cross-platform build-config layer that sits alongside the iOS app-shell above.
+Verified shipped on `dev` by the 2026-06-28 coverage reconciliation.
+
+- [x] [m] **Android product flavors.**
+  `mobile-native/androidApp/build.gradle.kts` declares
+  `flavorDimensions += "environment"` with `development` / `staging` /
+  `production` flavors. Each sets `applicationIdSuffix` (`.dev` / `.staging`),
+  `versionNameSuffix`, a per-flavor `app_name` resValue
+  (`Reality (Dev)` / `Reality (Staging)` / `Reality Portal`), and
+  `API_BASE_URL` / `ENVIRONMENT` / `ENABLE_LOGGING` `buildConfigField`s.
+  Release `signingConfigs` read `KEYSTORE_FILE` / `KEYSTORE_PASSWORD` /
+  `KEY_ALIAS` / `KEY_PASSWORD` env vars; debug applies a `.debug` suffix.
+- [x] [m] **iOS schemes + xcconfig matrix.**
+  `iosApp/xcschemes/RealityPortal-{Dev,Staging,Prod}.xcscheme` pair with
+  `iosApp/Configurations/{Base,Development,Staging,Production}.xcconfig`
+  for per-environment `PRODUCT_BUNDLE_IDENTIFIER`, `BUNDLE_DISPLAY_NAME`,
+  `API_BASE_URL`, and `CODE_SIGN_STYLE = Automatic`.
+- [x] [m] **KMP shared module (variant-agnostic).** Under the AGP 9
+  `com.android.kotlin.multiplatform.library` plugin the shared module carries
+  no build types / flavors / BuildConfig; the iOS `framework` block targets
+  `iosX64` / `iosArm64` / `iosSimulatorArm64`.
+- [x] [m] **CLI build scripts.** `scripts/build-mobile.sh` (orchestrator) →
+  `scripts/build-android.sh` + `scripts/build-ios.sh`, each tagged
+  "Epic 85 - Story 85.2". (They live at repo-root `scripts/`, not under
+  `mobile-native/` — the original coverage gap was a false negative from
+  scanning only `mobile-native/`.)
+- [ ] [m] **GAP — per-flavor / per-scheme app-icon artwork.** Android per-flavor
+  `ic_launcher` mipmaps are not generated (only `src/development/res/xml`),
+  and the iOS `AppIcon`, `AppIcon-Dev`, `AppIcon-Staging` `.appiconset`
+  directories currently hold only `Contents.json` with no badge images.
+  Distinguishability (AC-4) is met via app name + bundle/app-id suffix today;
+  the DEV/STG badge artwork is a design-asset follow-up.
+
 ## States
 
 - **Cold launch**: `configureApp()` restores Keychain session + navigation
@@ -108,9 +144,16 @@ counterpart is the KMP `composeApp` shell; the shared KMP module under
 - Three non-blocking gaps recorded: tab titles unlocalized, `DependencyContainer`
   defaulting to unauthenticated repositories, and `SsoService` being
   instantiated twice. None block epic-82 functionality; tracked as follow-ups.
+- Story 85.2 (Build Configuration by Environment) verified shipped on `dev`
+  (2026-06-28 coverage reconciliation): Android product flavors, iOS schemes +
+  xcconfig matrix, variant-agnostic KMP shared module, and the
+  `scripts/build-{mobile,android,ios}.sh` CLI build scripts. One follow-up gap:
+  per-flavor / per-scheme app-icon badge artwork is not yet generated
+  (icon sets are scaffolded with `Contents.json` only).
 
 ## Agent Log
 
 <!-- newest entries on top -->
 
+- 2026-06-28 — agent: extended this infra map to cover Epic 85 / Story 85.2 (Build Configuration by Environment) — added epic "85" to frontmatter and a "Build configuration by environment" functionality section documenting Android product flavors, iOS schemes + xcconfig matrix, the variant-agnostic KMP shared module, and the repo-root `scripts/build-{mobile,android,ios}.sh` CLI scripts (verified shipped on `dev`). Recorded one open gap: per-flavor / per-scheme app-icon badge artwork not yet generated. Chose to extend the existing project-setup infra map rather than create an orphan screen-map for non-visible build infrastructure. The earlier "AC-5 build scripts not found under mobile-native" coverage gap was a false negative — the scripts live at repo-root `scripts/`.
 - 2026-06-17 — agent: created the missing Story-82.1 (SwiftUI Project Setup & App Shell) infrastructure screen-map. Reality-mobile had maps for all 11 visible screens + the 82.2 navigation infra, but no map for the 82.1 project-setup layer. Content grounded in the 2026-05-25 static audit (`docs/superpowers/plans/gap-82-1-swiftui-audit.md`): bundle/xcconfig/Info.plist config, KMP bridge, Keychain, localization, `@main` entry. Carried over the three audit gaps (unlocalized tab titles, unauthenticated default repositories, duplicate `SsoService`).


### PR DESCRIPTION
## Task
Coverage gap [mvp]: Build Configuration by Environment — verify and finish to done. Gaps: AC-5 automated build scripts not found under mobile-native (no build*.sh located) — verify CLI build automation exists; Story markdown still Status: pending (stale vs. merged code); no screen-map (orphan epic).

## Owner
pm-frontend

## Verify-first outcome
This is a **verify-first** task. The implementation for Story 85.2 (Build
Configuration by Environment) is **already shipped on `dev`**; this PR only
reconciles the stale docs. No mobile/Kotlin/Swift code was changed.

Evidence the feature is shipped (verified on `origin/dev`):
- **AC-1 Android flavors** — `mobile-native/androidApp/build.gradle.kts`:
  `flavorDimensions += "environment"` with `development`/`staging`/`production`
  flavors (per-flavor `applicationIdSuffix`, `versionNameSuffix`, `app_name`
  resValue, `API_BASE_URL`/`ENVIRONMENT`/`ENABLE_LOGGING` buildConfigFields),
  release `signingConfigs` keyed off `KEYSTORE_*` env vars, `.debug` suffix.
- **AC-2 iOS schemes** — `mobile-native/iosApp/xcschemes/RealityPortal-{Dev,Staging,Prod}.xcscheme`
  + `mobile-native/iosApp/Configurations/{Base,Development,Staging,Production}.xcconfig`.
- **AC-3 KMP variants** — `mobile-native/shared/build.gradle.kts` (AGP 9
  `com.android.kotlin.multiplatform.library` → variant-agnostic by design;
  iOS framework targets iosX64/iosArm64/iosSimulatorArm64).
- **AC-4 distinguishability** — distinct app names + bundle/app-id suffixes per env.
- **AC-5 build scripts** — `scripts/build-mobile.sh`, `scripts/build-android.sh`,
  `scripts/build-ios.sh` (each tagged "Epic 85 - Story 85.2").

### The reported AC-5 gap was a FALSE NEGATIVE
"AC-5 automated build scripts not found under mobile-native (no build*.sh
located)" — the scripts exist; they live at **repo-root `scripts/`**, not under
`mobile-native/`. The coverage scan only looked under `mobile-native/`. All three
scripts pass `bash -n` (syntax OK).

## Changes (docs-only)
- `_bmad-output/.../85-2-build-configuration.md` — flip `Status: pending → done`;
  add a per-AC reconciliation note; mark tasks complete; flag the one genuine
  open follow-up (per-flavor / per-scheme app-icon **badge artwork** is not yet
  generated — icon sets are scaffolded with `Contents.json` only; Android
  per-flavor `ic_launcher` mipmaps absent). AC-4 distinguishability is already
  met via app names + suffixes, so this is a non-blocking design-asset follow-up.
- `docs/screens/reality-mobile/project-setup.md` — extend the existing iOS
  app-shell **infrastructure** screen-map to also cover Epic 85 (added epic `85`
  to frontmatter + a "Build configuration by environment" functionality section
  + Agent Log entry). Chose to extend this infra map rather than create an
  orphan screen-map, since build config has **no visible route**.

## Tested (Band A — fast check)
- `git diff --check` → exit 0
- `bash -n scripts/build-{mobile,android,ios}.sh` → all syntax OK
- Specialist: `generic` (docs-only; nothing to compile/build).

## Built (Band B — full build)
skipped: docs-only change, no public API / build-output / config code touched.

## CI parity (Band C — screen-map validate, the relevant gate for `docs/screens/**`)
- `pnpm cli validate --root <repo>` (`@ppt/screen-map`) →
  **Validated 158 screen-maps: 0 errors, 0 warnings** (includes the edited
  `reality-mobile/project-setup.md`).

## Remote-tested
skipped (ppt-bridge MCP not used).

## Scope drift
`scope-check.sh --owner pm-frontend` flags
`_bmad-output/.../85-2-build-configuration.md` as outside pm-frontend's area
(`_bmad-output/**` maps to pm-tech-lead / pm-scrum-master). This is **expected
and justified** for a status-reconciliation task — the story status flip is the
core deliverable. `docs/screens/**` is inside pm-frontend scope.

## Code-reuse review
`reuse-grep.sh` → none (no new helpers; docs-only).

## Notes
- IG goal-check reports IG1/IG4/IG5/IG6 (plan-absent — this is an action-list
  coverage task, not a `.research/plans/` task) and IG3 (no test commit — pure
  docs reconciliation, no code, so no regression test applies). Branch name is
  the dispatcher-assigned `auto-impl/...` (IG2 expects `impl/...`). None of these
  indicate a verify failure; the substantive gate (diff-check + screen-map
  validate) is green.
- Remaining follow-up worth a separate task: generate DEV/STG app-icon badge
  artwork (Android per-flavor mipmaps + iOS `AppIcon-Dev`/`AppIcon-Staging`
  image assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP)_