### PR TITLE
81-1-report-schedule-editing: reconcile frontend cron validator with backend (#1368)

### DIFF
--- a/docs/screens/ppt/reports.md
+++ b/docs/screens/ppt/reports.md
@@ -23,6 +23,7 @@ owner: pm-frontend
 
 ## Agent Log
 
+- 2026-06-28 — agent: gap-81-1 follow-up (#1368): reconciled frontend `isValidCron` (CronPicker) with the backend `validate_cron_expression` parse order — split each field on `,` first, then `/`, then `-`. Previously `1-5/2,10` was a frontend false-negative; because `scheduleToInitialCron` gates surfacing the persisted `cron_expression` on `isValidCron`, that silently flattened a backend-accepted cron back to the legacy time-derived form (silent #616 reintroduction). Flipped cron-validator-drift regression test to assert the validators now agree and the read path surfaces the persisted cron verbatim. apiStatus still partial (schedule create stub remains).
 - 2026-05-27 — agent: gap-81-1: EditScheduleModal rebuilt for cron-based PUT endpoint. CronPicker added (preset tabs + custom free-text with live validation). Pause/Resume props replaced by enabled toggle in modal (maps to `enabled` field in CronScheduleUpdateRequest). useUpdateScheduleCron hook wired. apiStatus remains partial (schedule create stub still absent).
 - 2026-05-25 — agent: Created screen-map. Route /reports wrapped in ProtectedRoute (PR #489 fix). Hooks pagination cache key fixed (executionOffset included). apiStatus=partial (schedule CRUD + execution history wired; download/retry stubs).
 

--- a/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/CronPicker.tsx
@@ -67,43 +67,50 @@ const MINUTES = [
 // Helpers
 // ─────────────────────────────────────────────────────────────
 
-/** Validate a 5-field UNIX cron expression — mirrors backend logic. */
+/**
+ * Validate a 5-field UNIX cron expression — mirrors the backend authority
+ * `validate_cron_expression` (backend/servers/api-server/src/routes/reports.rs).
+ *
+ * Field-parse order is load-bearing and MUST match the backend exactly to avoid
+ * the #1368 cross-validator drift: split on `,` FIRST (a field is a list of
+ * parts), then on `/` (step), then on `-` (range). Parsing `/` before `,` makes
+ * the combined form `1-5/2,10` a false-negative — and because the read path
+ * (`scheduleToInitialCron`) gates surfacing the persisted cron on this
+ * validator, a false-negative silently flattens a backend-accepted expression
+ * back to the legacy `time`-derived form, reintroducing #616 for that subset.
+ */
 export function isValidCron(expr: string): boolean {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) return false;
 
   function validField(field: string, min: number, max: number): boolean {
-    // wildcard
-    if (field === '*') return true;
+    // A field is a comma-separated list of parts (split on `,` FIRST — same as
+    // the backend). Each part is an optional `base/step`.
+    for (const part of field.split(',')) {
+      const slash = part.indexOf('/');
+      const base = slash === -1 ? part : part.slice(0, slash);
+      const step = slash === -1 ? undefined : part.slice(slash + 1);
 
-    // step: */n or x-y/n
-    if (field.includes('/')) {
-      const parts = field.split('/');
-      if (parts.length !== 2) return false;
-      const step = Number(parts[1]);
-      if (!Number.isInteger(step) || step <= 0) return false;
-      if (parts[0] !== '*') {
-        // range/step: 1-5/2
-        return validField(parts[0], min, max);
+      // step must be a positive integer when present
+      if (step !== undefined) {
+        const s = Number(step);
+        if (!Number.isInteger(s) || s <= 0) return false;
       }
-      return true;
-    }
 
-    // range: x-y
-    if (field.includes('-')) {
-      const [a, b] = field.split('-').map(Number);
-      if (Number.isNaN(a) || Number.isNaN(b) || a > b) return false;
-      return a >= min && b <= max;
+      if (base !== '*') {
+        if (base.includes('-')) {
+          // range: x-y
+          const [a, b] = base.split('-').map(Number);
+          if (!Number.isInteger(a) || !Number.isInteger(b) || a > b) return false;
+          if (a < min || b > max) return false;
+        } else {
+          // single number
+          const n = Number(base);
+          if (!Number.isInteger(n) || n < min || n > max) return false;
+        }
+      }
     }
-
-    // list: 1,2,3
-    if (field.includes(',')) {
-      return field.split(',').every((v) => validField(v, min, max));
-    }
-
-    // single number
-    const n = Number(field);
-    return Number.isInteger(n) && n >= min && n <= max;
+    return true;
   }
 
   return (

--- a/frontend/apps/ppt-web/src/features/reports/components/cron-validator-drift.test.ts
+++ b/frontend/apps/ppt-web/src/features/reports/components/cron-validator-drift.test.ts
@@ -15,31 +15,24 @@
  * `scheduleToInitialCron`, the `stored && isValidCron(stored)` guard). #1368
  * pointed out the trap: the frontend `isValidCron` and the backend
  * `validate_cron_expression` (backend/servers/api-server/src/routes/reports.rs)
- * are independent reimplementations that DISAGREE on at least one combined
- * form. For any expression the backend accepts but the frontend rejects, the
- * read path silently falls back to lossy reconstruction — i.e. #616 comes back
+ * were independent reimplementations that DISAGREED on at least one combined
+ * form. For any expression the backend accepted but the frontend rejected, the
+ * read path silently fell back to lossy reconstruction — i.e. #616 came back
  * for that subset, invisibly (no error surfaced).
  *
- * This file is the regression net the #1368 "Tests" finding asked for. It does
- * two things, both load-bearing:
+ * STATUS: #1368 is now FIXED. `isValidCron` was rewritten to mirror the backend
+ * parse order (split each field on `,` FIRST, then `/`, then `-`), so the two
+ * validators agree on the combined forms. This file is the regression net that
+ * keeps them in lockstep:
  *
  *   1. Pins the verbatim round-trip for combined `,`/`/`/`-` expressions that
- *      BOTH validators currently accept, so the happy-path fix can't regress.
+ *      BOTH validators accept, so the happy-path can't regress.
  *
- *   2. Pins the KNOWN drift fixture (`1-5/2,10 * * * *`) as a documented
- *      cross-validator disagreement. This test is intentionally an assertion
- *      about the *current* (buggy-for-this-subset) behaviour: the moment
- *      anyone changes either validator OR the read-path guard, this test goes
- *      red and forces a deliberate decision — reconcile the validators and
- *      surface the stored cron, or update the contract on purpose. That is
- *      exactly what stops #616 from silently creeping back in.
- *
- * NOTE (QA scope): this guard does not change product behaviour. The proper
- * fix (#1368: make the backend the single validation authority and stop
- * gating the read path on a frontend false-negative) is owned by the frontend
- * specialist. When that fix lands, the `drift — current behaviour` block below
- * must be flipped to assert verbatim surfacing (the `EXPECTED AFTER FIX`
- * comments mark each line).
+ *   2. Pins the former drift fixture (`1-5/2,10 * * * *`) — now accepted by
+ *      BOTH validators and surfaced verbatim. If anyone changes either
+ *      validator OR the read-path guard such that they disagree again, this
+ *      test goes red and forces a deliberate decision. That is exactly what
+ *      stops #616 from silently creeping back in.
  */
 
 import type { ReportSchedule } from '@ppt/api-client';
@@ -120,6 +113,8 @@ describe('cron validator drift — #616 reintroduction guard (#1368)', () => {
       '5-15/3 * * * *', // range-with-step in the minute field
       '0,15,30,45 9-17 * * 1-5', // list minute + range hour + range dow
       '*/15 9-17 * * 1-5', // step + range (the canonical #616 custom expr)
+      '1-5/2,10 * * * *', // range-with-step + list member (former #1368 drift)
+      '0,15/3 * * * *', // single + range-with-step in one list (split-`,`-first)
     ])('surfaces %s verbatim (backend-valid AND frontend-valid)', (expr) => {
       // Precondition: both validators agree this is valid.
       expect(backendValidateCron(expr)).toBe(true);
@@ -137,36 +132,31 @@ describe('cron validator drift — #616 reintroduction guard (#1368)', () => {
     });
   });
 
-  describe('cross-validator drift fixture (the #1368 trap)', () => {
+  describe('cross-validator agreement on the former drift fixture (#1368 fixed)', () => {
     // `1-5/2,10` is accepted by the backend (splits on `,` first → `1-5/2` and
-    // `10`) but REJECTED by the frontend `isValidCron` (takes the `/` branch on
-    // the whole `2,10` token → Number("2,10") = NaN → false).
-    const DRIFT_EXPR = '1-5/2,10 * * * *';
+    // `10`). Before #1368 the frontend `isValidCron` took the `/` branch on the
+    // whole `2,10` token → Number("2,10") = NaN → false, a false-negative that
+    // silently flattened the persisted cron (reintroducing #616). The fix made
+    // `isValidCron` split on `,` first, mirroring the backend authority.
+    const FORMER_DRIFT_EXPR = '1-5/2,10 * * * *';
 
-    it('the two validators genuinely disagree on the drift fixture', () => {
-      expect(backendValidateCron(DRIFT_EXPR)).toBe(true);
-      // Frontend false-negative — this is the root cause of the silent #616
-      // reintroduction. Pinned so a future "fix" to either validator is
-      // forced to be deliberate.
-      expect(isValidCron(DRIFT_EXPR)).toBe(false);
+    it('the two validators now agree on the former drift fixture', () => {
+      expect(backendValidateCron(FORMER_DRIFT_EXPR)).toBe(true);
+      // Frontend now mirrors the backend parse order (split `,` first) — no
+      // more false-negative. If either validator drifts again this goes red.
+      expect(isValidCron(FORMER_DRIFT_EXPR)).toBe(true);
     });
 
-    it('CURRENT behaviour: a backend-accepted cron the frontend rejects is silently flattened (#616 reintroduced)', () => {
+    it('surfaces a backend-accepted combined cron verbatim — no silent flatten (#616 stays closed)', () => {
       const schedule = makeSchedule({
-        cron_expression: DRIFT_EXPR, // backend persisted this exact value
+        cron_expression: FORMER_DRIFT_EXPR, // backend persisted this exact value
         frequency: 'daily',
         time: '07:15',
       });
 
-      // EXPECTED AFTER #1368 FIX: scheduleToInitialCron should return DRIFT_EXPR
-      // verbatim (backend is the validation authority; never silently flatten a
-      // persisted cron). Until that fix lands, the read path flattens it back
-      // to the legacy time-derived expression — this assertion documents the
-      // live bug so the fix has a red→green target and so the regression can't
-      // slip back in unnoticed.
-      const flattened = scheduleToInitialCron(schedule);
-      expect(flattened).not.toBe(DRIFT_EXPR); // <-- flip to .toBe(DRIFT_EXPR) when #1368 is fixed
-      expect(flattened).toBe('15 7 * * *'); // lossy reconstruction from `time`
+      // With #1368 fixed the read path surfaces the persisted cron verbatim
+      // instead of falling back to the lossy `time`-derived reconstruction.
+      expect(scheduleToInitialCron(schedule)).toBe(FORMER_DRIFT_EXPR);
     });
   });
 });


### PR DESCRIPTION
## Task

Coverage gap [phase2]: Report Schedule Editing — verify and finish to done. Gaps: sprint-status.yaml has no 81-1 key (only epic-80 keys present); classification driven by code+screen+PR consensus; Screen apiStatus: partial and several gap-81-1 follow-up PRs indicate minor edge-case/RBAC fixes were needed post-delivery.

## Verify-first outcome

The Report Schedule Editing feature (gap-81-1) is **already shipped on `dev`** and substantially complete: `EditScheduleModal` + `CronPicker` + `RecipientManager` wired to `PUT /api/v1/reports/schedules/{id}`, with RBAC (manager-tier, DB-backed via `RlsConnection`, closes #614), cross-tenant scoping (#624), and the #616 cron round-trip fix. Backend + frontend regression tests exist.

The one **genuine open edge-case** found: an in-tree regression test (`cron-validator-drift.test.ts`, raised by #1368) **documented a still-live bug** — it pinned the buggy behaviour with `EXPECTED AFTER FIX` markers rather than asserting correctness. The frontend `isValidCron` parsed each cron field on `/` **before** `,`, so the combined form `1-5/2,10` was a frontend false-negative. Because `scheduleToInitialCron` gates surfacing the persisted `cron_expression` on `isValidCron`, that false-negative **silently flattened** a backend-accepted cron back to the legacy time-derived form — a silent reintroduction of #616 for that subset.

## Change

- `CronPicker.tsx` — rewrite `isValidCron` to mirror the **backend** parse order (`validate_cron_expression`): split each field on `,` FIRST, then `/` (step), then `-` (range). The two validators now agree on combined forms.
- `cron-validator-drift.test.ts` — flip the drift fixture from "documents the live bug" to asserting the validators agree and the read path surfaces the persisted cron verbatim; add `1-5/2,10 * * * *` and `0,15/3 * * * *` to the both-valid round-trip set.
- `docs/screens/ppt/reports.md` — Agent Log entry for the #1368 reconciliation (apiStatus stays `partial`; schedule **create** stub is the remaining known gap, out of scope here).

Net substantive logic change is small (~30 LOC in `isValidCron`), no public API / migration / config touched.

## Owner

pm-frontend (specialist: react-web). Scope-drift check: clean (exit 0) — all paths under `frontend/apps/ppt-web/...` + the pm-frontend-owned screen-map.

## Tested (Band A — fast check)

- `pnpm -F @ppt/web exec tsc --noEmit` → exit 0
- `pnpm exec biome check` on both changed source files → exit 0 (CLAUDE.md / CI linter is Biome; repo's `eslint` script is broken under eslint v10 in this env — pre-existing, unrelated to this change)
- `pnpm -F @ppt/web exec vitest run src/features/reports/components/cron-validator-drift.test.ts EditScheduleModal.test.ts` → 14 passed
- `pnpm -F @ppt/web exec vitest run src/features/reports` (full feature dir) → 61 passed

## Built (Band B — full build)

skipped: substantive change < 50 LOC, no public API / migration / config touch.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no auth/billing/data-integrity backend change; this is a frontend validator-parity fix with full unit coverage).

## Remote-tested

skipped (no ppt-bridge MCP in session).

## Notes

- Code-reuse pre-flight: clean (no new helper added — modified the existing `isValidCron`).
- The backend `validate_cron_expression` remains the single source of truth; this PR brings the frontend validator into lockstep with it. A follow-up could DRY the two into one shared validator, but that crosses the frontend/backend boundary and is intentionally out of scope.
- Remaining apiStatus=partial driver (schedule **create** stub) is a separate gap, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sr2HcKJveKwsqqE5UguSZP)_