### PR TITLE
bug-risky-churn-pr-963-api-main-rs: wire security-headers into create_router + smoke tests

### DIFF
--- a/backend/servers/api-server/src/lib.rs
+++ b/backend/servers/api-server/src/lib.rs
@@ -436,6 +436,18 @@ pub fn create_router(state: AppState) -> Router {
     // same chain from `main.rs::serve` via `attach_admin_extensions` so the
     // two paths cannot drift.
     attach_admin_extensions(route_table(), &admin_ext)
+        // Baseline security headers (HSTS, nosniff, frame-deny, referrer, CSP)
+        // on every response (#954). This layer is also applied by the
+        // production binary in `main.rs::apply_middleware`; it MUST be mirrored
+        // here so the integration-test path (which exercises `create_router`,
+        // not `main.rs::serve`) actually verifies the header wiring. Before
+        // PR #963's follow-up the layer lived only in `main.rs`, so every
+        // integration test ran without security headers and the wiring was
+        // never exercised end-to-end (regression guarded by
+        // `security_headers_tests.rs` + `router_single_source_tests.rs`).
+        .layer(axum::middleware::from_fn(
+            api_core::middleware::security_headers,
+        ))
         // Middleware
         .layer(TraceLayer::new_for_http())
         // CORS configuration

--- a/backend/servers/api-server/tests/router_single_source_tests.rs
+++ b/backend/servers/api-server/tests/router_single_source_tests.rs
@@ -114,3 +114,42 @@ fn route_table_contains_the_previously_diverged_routers() {
          truth (#867): {missing:?}"
     );
 }
+
+/// Middleware parity guard (#954 / PR #963 follow-up).
+///
+/// The route table is shared via `route_table()`, but middleware layers are
+/// applied separately in two places: the production binary
+/// (`main.rs::apply_middleware`) and the test-side `lib.rs::create_router`.
+/// Security-critical edge middleware that lives in only one of the two paths is
+/// the same drift failure mode #867 fixed for routes — the `security_headers`
+/// layer originally shipped in `main.rs` only, so integration tests ran without
+/// it and the wiring was never exercised.
+///
+/// This is a pure source check (no DB / no runtime) so it runs in every
+/// `cargo test`, complementing the DB-backed runtime assertions in
+/// `security_headers_tests.rs`.
+#[test]
+fn security_headers_layer_is_wired_into_both_router_paths() {
+    let main_src = read_src("main.rs");
+    let lib_src = read_src("lib.rs");
+
+    assert!(
+        main_src.contains("api_core::middleware::security_headers"),
+        "main.rs (production binary) must apply the `security_headers` layer (#954)."
+    );
+
+    // Pin the assertion to the `create_router` body so we are checking the
+    // actual served chain, not a stray mention elsewhere in lib.rs.
+    let start = lib_src
+        .find("pub fn create_router")
+        .expect("create_router must exist in lib.rs");
+    let create_router_body = &lib_src[start..];
+
+    assert!(
+        create_router_body.contains("api_core::middleware::security_headers"),
+        "lib.rs::create_router must apply the `security_headers` layer so the \
+         integration-test path matches production (#954). It previously lived \
+         only in main.rs, leaving every integration test running without \
+         security headers."
+    );
+}

--- a/backend/servers/api-server/tests/security_headers_tests.rs
+++ b/backend/servers/api-server/tests/security_headers_tests.rs
@@ -1,0 +1,143 @@
+//! Integration smoke tests for the baseline security-headers middleware
+//! (#954 / PR #963 follow-up).
+//!
+//! # Why this file exists
+//!
+//! The `security_headers` middleware itself has unit coverage in
+//! `api-core` (`middleware/security_headers.rs::tests`): those assert the
+//! function attaches the right header *values* on a minimal router.
+//!
+//! What was missing — and what PR #963's main.rs wiring shipped without — is a
+//! test proving the layer is actually wired into the served application. The
+//! layer was originally attached ONLY in `main.rs::apply_middleware` (the
+//! production-binary path), while every integration test builds its router via
+//! `api_server::create_router` (the test path). The two chains had drifted
+//! before for routes (#867 / #836) and for `host_tenant_middleware` (see the
+//! `TestApp` caveat in `push_token_tests.rs`), so a security-critical edge
+//! middleware living in only one of the two paths is exactly the failure mode
+//! to guard against.
+//!
+//! These tests exercise the real `create_router` chain end-to-end and assert
+//! the baseline headers appear on the response. A companion static guard in
+//! `router_single_source_tests.rs` keeps the two chains from drifting again
+//! without needing a database (so it runs in every `cargo test`, DB or not).
+
+#[allow(dead_code)]
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use sqlx::PgPool;
+use tower::ServiceExt; // for `oneshot`
+
+use common::TestApp;
+
+/// `/health` is public, dependency-free, and returns 200 without auth — the
+/// cleanest endpoint to prove the security-headers layer fires on a real
+/// served response from `create_router`.
+#[sqlx::test]
+async fn security_headers_present_on_health_response(pool: PgPool) {
+    let app = TestApp::new(pool).await;
+
+    let response = app
+        .router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "/health must return 200 so we are asserting headers on a real handler response"
+    );
+
+    let headers = response.headers();
+
+    // Assert the exact baseline shipped by api-core's `security_headers`. If the
+    // layer is missing from `create_router` (the regression this file guards),
+    // every one of these `.expect(...)` calls fails — proving the wiring, not
+    // just the middleware function in isolation.
+    assert_eq!(
+        headers.get(header::STRICT_TRANSPORT_SECURITY).expect(
+            "HSTS header must be present — security_headers layer not wired into create_router"
+        ),
+        "max-age=63072000; includeSubDomains",
+    );
+    assert_eq!(
+        headers
+            .get(header::X_CONTENT_TYPE_OPTIONS)
+            .expect("X-Content-Type-Options header must be present"),
+        "nosniff",
+    );
+    assert_eq!(
+        headers
+            .get(header::X_FRAME_OPTIONS)
+            .expect("X-Frame-Options header must be present"),
+        "DENY",
+    );
+    assert_eq!(
+        headers
+            .get(header::REFERRER_POLICY)
+            .expect("Referrer-Policy header must be present"),
+        "strict-origin-when-cross-origin",
+    );
+    assert_eq!(
+        headers
+            .get(header::CONTENT_SECURITY_POLICY)
+            .expect("Content-Security-Policy header must be present"),
+        "default-src 'none'",
+    );
+}
+
+/// The headers must also be present on a 4xx response (e.g. an unauthenticated
+/// request to a protected route). Tower layers execute outside-in, so the
+/// security-headers layer wraps the whole stack and must fire regardless of the
+/// inner status. This mirrors the api-core unit test's 5xx/404 cases but proves
+/// it through the full `create_router` chain — security headers must never be
+/// skipped on rejection paths, which is when they matter most.
+#[sqlx::test]
+async fn security_headers_present_on_unauthenticated_4xx(pool: PgPool) {
+    let app = TestApp::new(pool).await;
+
+    // A protected route with no auth headers — `RlsConnection` / auth extractors
+    // reject with a 4xx before any handler logic runs.
+    let response = app
+        .router
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri("/api/v1/users/me/push-tokens")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status().is_client_error() || response.status().is_server_error(),
+        "unauthenticated request to a protected route must be rejected (got {})",
+        response.status()
+    );
+
+    let headers = response.headers();
+    assert!(
+        headers.get(header::STRICT_TRANSPORT_SECURITY).is_some(),
+        "HSTS must be set even on rejected (4xx) responses"
+    );
+    assert!(
+        headers.get(header::X_CONTENT_TYPE_OPTIONS).is_some(),
+        "X-Content-Type-Options must be set even on rejected (4xx) responses"
+    );
+    assert!(
+        headers.get(header::CONTENT_SECURITY_POLICY).is_some(),
+        "CSP must be set even on rejected (4xx) responses"
+    );
+}


### PR DESCRIPTION
## Task
Risky churn: api-server main.rs security-headers wiring (PR #963) shipped without a middleware smoke test. Verify-first: inspect `backend/servers/api-server/src/main.rs` (security-headers layer wiring) and `backend/crates/api-core/src/middleware/security_headers.rs`. Add a focused regression/smoke test that asserts the security-headers middleware actually applies the expected headers (e.g. X-Content-Type-Options, X-Frame-Options, etc.) on a response — at the api-core middleware unit level and/or an api-server integration test, following existing test patterns in the repo. No behavior change to production code unless a genuine bug is found.

## Owner
pm-backend

## Verify-first findings
- **api-core unit level: already covered.** `backend/crates/api-core/src/middleware/security_headers.rs` already ships a 6-test `mod tests` (committed on `dev`) asserting HSTS / X-Content-Type-Options / X-Frame-Options / Referrer-Policy / CSP values on 200, 5xx, and 404 — at the middleware-function level. No new unit test needed there.
- **Genuine bug found at the wiring level.** The `security_headers` layer was applied **only** in the production path `main.rs::apply_middleware`. The test-reachable / integration path `lib.rs::create_router` (which every `#[sqlx::test]` integration test and the `TestApp` harness build from) did **not** apply it. So:
  - Every api-server integration test ran *without* security headers — the wiring was never exercised end-to-end.
  - The in-code comments in both files claimed the production and test chains "cannot drift" / "agree exactly" via `attach_admin_extensions`, but that helper only attaches admin extensions — not security headers, the body cap, or host-tenant middleware. The claim was false for this layer.
  - This is the exact drift class the repo already guards for routes (#867 / #836) and that the `push_token_tests.rs` caveat documents for `host_tenant_middleware`.

## Fix (minimal, production)
- `lib.rs::create_router`: add the missing `security_headers` layer so the integration/test path matches production. This is a behavior fix for the test surface (and makes the documented "cannot drift" guarantee true); production binary behavior is unchanged.

## Tests added
- `tests/security_headers_tests.rs` — DB-backed `#[sqlx::test]` integration smoke tests that exercise the real `create_router` chain end-to-end:
  - headers present + exact values on `GET /health` (200);
  - headers present on an unauthenticated 4xx (rejection paths must not skip them).
- `tests/router_single_source_tests.rs` — new no-DB static guard `security_headers_layer_is_wired_into_both_router_paths` asserting the layer is present in BOTH `main.rs` and `create_router`, so they can't silently drift again. Runs in every `cargo test` regardless of DB availability (complements the DB-backed runtime asserts).

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo fmt -p api-server -p api-core -- --check` → exit 0
- `SQLX_OFFLINE=true cargo check -p api-server --tests` → exit 0
- `SQLX_OFFLINE=true cargo clippy -p api-server --tests -- -D warnings` → exit 0
- `cargo test -p api-server --test router_single_source_tests` → 4 passed (incl. new guard)
- `cargo test -p api-core --lib security_header` → 6 passed (existing unit tests, still green)

The two new `#[sqlx::test]` integration tests compile cleanly but were not executed locally: this runner has no live Postgres (`DATABASE_URL` unset, :5432 unreachable). They run in CI where Postgres is provisioned.

## Built (Band B — full build)
skipped: change is small (1 prod-code layer line + test-only files); no public API / migration / config change.

## CI parity (Band C — hot-path only)
skipped: no production behavior change to the served app (the layer was already in the production binary); this PR closes a test-coverage/wiring gap. The new tests run under the standard backend CI job.

## Scope drift
none — diff is confined to `backend/servers/api-server/{src/lib.rs, tests/*}` (pm-backend area). `scope-check.sh --owner pm-backend --base origin/dev` → exit 0.

## Code-reuse review
none — no new auth/crypto/http-client helper added; reuses the existing `api_core::middleware::security_headers` and the existing `TestApp` harness.

## Notes
- Cargo.lock was intentionally left untouched: an incidental local lock regeneration (hex/sha2/async-trait metadata) unrelated to this change was reverted to keep the diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EtEoUMW67MT3MEgpD6BQLV

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtEoUMW67MT3MEgpD6BQLV)_