### PR TITLE
chore(research): stale-PR guard — flag stranded 'done' PRs (BIT-325 AC#4)

### DIFF
--- a/.github/workflows/stale-pr-guard.yml
+++ b/.github/workflows/stale-pr-guard.yml
@@ -1,0 +1,86 @@
+name: Stale-PR guard
+
+# Periodic "stranded done" alarm (BIT-325, remediation of BIT-324 F1/F2).
+#
+# `done` in Paperclip != merged on dev. When the merge pipeline stalls, ready
+# PRs age out and the "done" coverage is never realized. Nothing watched for
+# that — auto-rebase-stale-drafts.yml only unsticks *draft* conflicts. This job
+# runs .research/stale-pr-guard.sh daily, flags every open non-draft PR that is
+# open > STALE_DAYS or > BEHIND_LIMIT commits behind dev, and writes the list to
+# the run summary. Flag-only: it never merges, closes, or rebases.
+
+on:
+  schedule:
+    # 06:00 UTC daily — after the nightly auto-rebase (03:00) has had its pass.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      stale_days:
+        description: 'Flag PRs open longer than this many days'
+        required: false
+        default: '3'
+      behind_limit:
+        description: 'Flag PRs more than this many commits behind dev'
+        required: false
+        default: '200'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: stale-pr-guard
+  cancel-in-progress: false
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          # Full history so `git rev-list --count <head>..origin/dev` is exact.
+          fetch-depth: 0
+
+      - name: Fetch dev + all PR head branches
+        # Pull every branch head so `git rev-list <prHead>..origin/dev` can
+        # compute commits-behind exactly. Without this, same-repo PR head shas
+        # may be absent and the guard degrades to age-only (still correct, just
+        # blind to the >BEHIND_LIMIT signal).
+        run: git fetch origin '+refs/heads/*:refs/remotes/origin/*' --quiet
+
+      - name: Self-test (offline fixture)
+        run: |
+          set -euo pipefail
+          bash .research/stale-pr-guard.test.sh
+
+      - name: Run guard
+        id: run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASE: origin/dev
+          STALE_DAYS: ${{ github.event.inputs.stale_days || '3' }}
+          BEHIND_LIMIT: ${{ github.event.inputs.behind_limit || '200' }}
+        run: |
+          set -euo pipefail
+          # Record-only: the guard exits 0 even when it flags PRs (no GUARD_ENFORCE).
+          # stdout = flagged[] JSON; stderr = human table (-> the Actions log).
+          FLAGGED=$(./.research/stale-pr-guard.sh --json)
+          COUNT=$(echo "$FLAGGED" | jq 'length')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Stale-PR guard — $COUNT flagged"
+            echo
+            echo "Open non-draft PRs vs \`dev\` that are open > ${STALE_DAYS}d or > ${BEHIND_LIMIT} commits behind."
+            echo
+            if [ "$COUNT" -eq 0 ]; then
+              echo "_Nothing flagged — merge queue is healthy._"
+            else
+              echo "| PR | subtask | age (d) | behind | reasons | title |"
+              echo "|----|---------|---------|--------|---------|-------|"
+              echo "$FLAGGED" | jq -r '.[] | "| #\(.number) | \(.subtask // "—") | \(.ageDays) | \(if .commitsBehind < 0 then "?" else .commitsBehind|tostring end) | \(.reasons|join(", ")) | \(.title) |"'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.research/stale-pr-guard.sh
+++ b/.research/stale-pr-guard.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# stale-pr-guard.sh — flag "stranded done" PRs so `done` can't silently mean
+# "open forever, never merged."
+#
+# Why this script exists (BIT-325, audit remediation of BIT-324 F1/F2):
+#
+#   A subtask gets marked `done` in Paperclip the moment its implementer opens
+#   a green PR. But `done` != merged: if the dispatcher merge pipeline stalls
+#   (auto-merge enabled but never fires, flaky `test`, silent merge conflicts),
+#   the PR sits open for days and the "done" coverage is never realized on
+#   `dev`. The BIT-324 Audit of Done found ~36 BIT-258/268 backfill PRs in
+#   exactly this state — `done` in Paperclip, 0% landed on `dev`.
+#
+#   There was no alarm for this. `auto-rebase-stale-drafts.yml` only unsticks
+#   *draft* conflicts; nothing watches *ready* PRs that age out. This guard is
+#   that missing alarm: a read-only, periodic sweep that flags any open
+#   non-draft PR against the integration branch that is either
+#     - open  > STALE_DAYS  (default 3)   days, OR
+#     - more  > BEHIND_LIMIT (default 200) commits behind $BASE.
+#
+#   It does NOT merge, close, or rebase anything — flag-only, by design. The
+#   operator (or a follow-up drain task) decides per PR. Pair with
+#   auto-rebase-stale-drafts.yml (mechanical un-sticking) and the dispatcher
+#   merge phase (the actual lander).
+#
+# Correlation to "done subtasks": the Paperclip `done` status is not reachable
+# from CI, so this guard keys off the GitHub-observable proxy — an open PR IS
+# the landing vehicle for an in-flight/`done` subtask. The BIT-<n> id is parsed
+# from the branch/title into `subtask` so the operator can cross-reference the
+# board.
+#
+# Idempotent + read-only: computes and prints; writes nothing to git or the
+# board. Safe to run on any schedule.
+#
+# Usage:
+#   ./.research/stale-pr-guard.sh                 # human table on stderr, exit 0
+#   ./.research/stale-pr-guard.sh --json          # flagged[] JSON to stdout
+#   STALE_DAYS=2 BEHIND_LIMIT=100 ./.research/stale-pr-guard.sh
+#   GUARD_ENFORCE=1 ./.research/stale-pr-guard.sh  # exit 1 if anything flagged
+#   PRS_FILE=fixture.json ./.research/stale-pr-guard.sh --json   # offline test
+#
+# Offline test injection:
+#   PRS_FILE — a JSON array shaped like `gh pr list --json number,title,
+#   headRefName,headRefOid,createdAt,isDraft`. Each row MAY carry a precomputed
+#   integer `commitsBehind`; when present the script trusts it and skips git
+#   (so the unit test needs no repo history). NOW_EPOCH overrides the clock.
+set -euo pipefail
+
+BASE="${BASE:-origin/dev}"
+STALE_DAYS="${STALE_DAYS:-3}"
+BEHIND_LIMIT="${BEHIND_LIMIT:-200}"
+ENFORCE="${GUARD_ENFORCE:-0}"
+REPO="${REPO:-}"
+EMIT_JSON=0
+[ "${1:-}" = "--json" ] && EMIT_JSON=1
+
+NOW="${NOW_EPOCH:-$(date -u +%s)}"
+STALE_SECS=$(( STALE_DAYS * 86400 ))
+
+# 1. Source the open, non-draft PR set — from a fixture (offline) or live gh.
+if [ -n "${PRS_FILE:-}" ]; then
+  PRS=$(cat "$PRS_FILE")
+else
+  repo_flag=()
+  [ -n "$REPO" ] && repo_flag=(--repo "$REPO")
+  PRS=$(gh pr list "${repo_flag[@]}" --base "${BASE#origin/}" --state open --limit 200 \
+    --json number,title,headRefName,headRefOid,createdAt,isDraft)
+fi
+
+# 2. Resolve commits-behind for each non-draft PR. Trust a fixture-provided
+#    commitsBehind; otherwise ask git (merge-base..BASE). A head sha we cannot
+#    resolve locally yields -1 (reported as "unknown", never flagged on behind).
+behind_for() {
+  local sha="$1"
+  [ -z "$sha" ] && { echo -1; return; }
+  if git rev-parse --verify --quiet "$sha^{commit}" >/dev/null 2>&1; then
+    git rev-list --count "$sha..$BASE" 2>/dev/null || echo -1
+  else
+    echo -1
+  fi
+}
+
+ROWS='[]'
+while read -r row; do
+  [ -z "$row" ] && continue
+  number=$(echo "$row"   | jq -r '.number')
+  title=$(echo "$row"    | jq -r '.title')
+  head=$(echo "$row"     | jq -r '.headRefName')
+  sha=$(echo "$row"      | jq -r '.headRefOid // ""')
+  created=$(echo "$row"  | jq -r '.createdAt')
+  preset=$(echo "$row"   | jq -r '.commitsBehind // empty')
+
+  created_epoch=$(date -u -d "$created" +%s 2>/dev/null || echo 0)
+  age_days=$(( (NOW - created_epoch) / 86400 ))
+
+  if [ -n "$preset" ]; then behind="$preset"; else behind=$(behind_for "$sha"); fi
+
+  # Subtask id from branch then title (first BIT-<n> / story / epic token).
+  subtask=$(printf '%s %s' "$head" "$title" \
+    | grep -oiE '(BIT-[0-9]+|epic-[0-9]+|story-[0-9.]+)' | head -1 || true)
+
+  reasons='[]'
+  (( (NOW - created_epoch) > STALE_SECS )) && \
+    reasons=$(echo "$reasons" | jq -c --arg d "$STALE_DAYS" '. + ["open>" + $d + "d"]')
+  if [ "$behind" -ge 0 ] 2>/dev/null && [ "$behind" -gt "$BEHIND_LIMIT" ]; then
+    reasons=$(echo "$reasons" | jq -c --arg l "$BEHIND_LIMIT" '. + ["behind>" + $l]')
+  fi
+
+  if [ "$(echo "$reasons" | jq 'length')" -gt 0 ]; then
+    ROWS=$(echo "$ROWS" | jq -c \
+      --argjson n "$number" --arg t "$title" --arg b "$head" \
+      --argjson age "$age_days" --argjson beh "$behind" \
+      --arg sub "${subtask:-}" --argjson r "$reasons" \
+      '. + [{number:$n, subtask:$sub, ageDays:$age, commitsBehind:$beh, branch:$b, title:$t, reasons:$r}]')
+  fi
+done < <(echo "$PRS" | jq -c '.[] | select(.isDraft == false)')
+
+# 3. Emit. Always sorted oldest-first so the worst offenders lead.
+ROWS=$(echo "$ROWS" | jq -c 'sort_by(-.ageDays)')
+COUNT=$(echo "$ROWS" | jq 'length')
+
+if [ "$EMIT_JSON" -eq 1 ]; then
+  echo "$ROWS"
+fi
+
+{
+  echo "stale-pr-guard: $COUNT flagged (open>${STALE_DAYS}d or >${BEHIND_LIMIT} behind $BASE)"
+  echo "$ROWS" | jq -r '.[] | "  #\(.number)  \(.subtask // "—")  age=\(.ageDays)d  behind=\(if .commitsBehind < 0 then "?" else .commitsBehind|tostring end)  [\(.reasons|join(","))]  \(.title[0:48])"'
+} >&2
+
+if [ "$ENFORCE" = "1" ] && [ "$COUNT" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/.research/stale-pr-guard.test.sh
+++ b/.research/stale-pr-guard.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# stale-pr-guard.test.sh — offline unit test for stale-pr-guard.sh.
+# No git history or gh needed: drives the guard with a PRS_FILE fixture whose
+# rows carry a precomputed commitsBehind, and a frozen NOW_EPOCH. Sibling of
+# dispatcher-self-test.sh. Run by .github/workflows/stale-pr-guard.yml and
+# locally: `bash .research/stale-pr-guard.test.sh`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$HERE/stale-pr-guard.sh"
+NOW=$(date -u -d '2026-06-28T12:00:00Z' +%s)
+FIX="$(mktemp)"
+trap 'rm -f "$FIX"' EXIT
+
+cat > "$FIX" <<'EOF'
+[
+  {"number":1903,"title":"test(BIT-268): ai batch","headRefName":"test/bit-268-ai","headRefOid":"x","createdAt":"2026-06-27T00:00:00Z","isDraft":false,"commitsBehind":3500},
+  {"number":1860,"title":"test: BIT-263 financial","headRefName":"test/bit-263","headRefOid":"x","createdAt":"2026-06-23T00:00:00Z","isDraft":false,"commitsBehind":12},
+  {"number":1842,"title":"chore(deps): bump","headRefName":"dependabot/x","headRefOid":"x","createdAt":"2026-06-28T09:00:00Z","isDraft":false,"commitsBehind":4},
+  {"number":1754,"title":"chore: draft","headRefName":"chore/epic-2","headRefOid":"x","createdAt":"2026-06-23T00:00:00Z","isDraft":true,"commitsBehind":900}
+]
+EOF
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+OUT=$(NOW_EPOCH="$NOW" PRS_FILE="$FIX" BASE=origin/dev STALE_DAYS=3 BEHIND_LIMIT=200 "$GUARD" --json)
+
+# 1. Exactly two flagged: #1860 (age) and #1903 (behind).
+[ "$(echo "$OUT" | jq 'length')" = "2" ] || fail "expected 2 flagged, got $(echo "$OUT" | jq 'length')"
+# 2. #1860 flagged on age, not behind.
+echo "$OUT" | jq -e '.[]|select(.number==1860)|.reasons==["open>3d"]' >/dev/null || fail "#1860 reasons wrong"
+# 3. #1903 flagged on behind.
+echo "$OUT" | jq -e '.[]|select(.number==1903)|.reasons==["behind>200"]' >/dev/null || fail "#1903 reasons wrong"
+# 4. Recent, in-range #1842 NOT flagged.
+echo "$OUT" | jq -e 'any(.[]; .number==1842) | not' >/dev/null || fail "#1842 should not be flagged"
+# 5. Draft #1754 excluded even though 900 behind.
+echo "$OUT" | jq -e 'any(.[]; .number==1754) | not' >/dev/null || fail "draft #1754 must be excluded"
+# 6. subtask id parsed.
+echo "$OUT" | jq -e '.[]|select(.number==1903)|.subtask=="bit-268"' >/dev/null || fail "subtask parse wrong"
+
+# 7. Enforce mode exits non-zero when flagged.
+if NOW_EPOCH="$NOW" PRS_FILE="$FIX" BASE=origin/dev GUARD_ENFORCE=1 "$GUARD" >/dev/null 2>&1; then
+  fail "GUARD_ENFORCE=1 should exit non-zero with flagged PRs"
+fi
+
+# 8. Clean set -> exit 0 under enforce.
+CLEAN="$(mktemp)"; trap 'rm -f "$FIX" "$CLEAN"' EXIT
+echo '[{"number":1,"title":"x","headRefName":"y","headRefOid":"z","createdAt":"2026-06-28T11:00:00Z","isDraft":false,"commitsBehind":1}]' > "$CLEAN"
+NOW_EPOCH="$NOW" PRS_FILE="$CLEAN" BASE=origin/dev GUARD_ENFORCE=1 "$GUARD" >/dev/null 2>&1 || fail "clean set should exit 0"
+
+echo "stale-pr-guard.test.sh: all 8 assertions passed"


### PR DESCRIPTION
## What

Adds the **stale-PR guard** (BIT-325 AC#4 / BIT-324 audit F1-F2): a periodic, read-only alarm so a Paperclip `done` subtask can't silently mean "PR open forever, never merged."

The BIT-324 Audit of Done found ~36 BIT-258/268 backfill PRs `done` in Paperclip but 0% landed on `dev` — and nothing watched for it (`auto-rebase-stale-drafts.yml` only unsticks *draft* conflicts). This is that missing alarm.

## How
- **`.research/stale-pr-guard.sh`** — flags open non-draft PRs vs `dev` that are open > `STALE_DAYS` (3) **or** > `BEHIND_LIMIT` (200) commits behind. Human table on stderr, `--json` to stdout. `GUARD_ENFORCE=1` for a hard-fail CI gate later. `PRS_FILE`/`NOW_EPOCH` offline injection. Idempotent, read-only — never merges/closes/rebases.
- **`.research/stale-pr-guard.test.sh`** — 8 offline assertions (no git/gh needed).
- **`.github/workflows/stale-pr-guard.yml`** — daily 06:00 UTC + `workflow_dispatch`; runs the self-test then writes the flagged table to the run summary.

## Verification
- `bash .research/stale-pr-guard.test.sh` → all 8 assertions pass.
- Live smoke against `dev`: 9 PRs flagged (age>3d), commits-behind computed exactly after fetching PR heads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)