### PR TITLE
fix(ci): restore dtolnay/rust-toolchain @1.94.1 (unbreak backend CI repo-wide)

### DIFF
--- a/.github/workflows/backend-dev-push-gate.yml
+++ b/.github/workflows/backend-dev-push-gate.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/backend-fmt-clippy-gate.yml
+++ b/.github/workflows/backend-fmt-clippy-gate.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
         with:
           components: rustfmt, clippy
 
@@ -140,7 +140,7 @@ jobs:
 
       - name: Install Rust
         if: needs.changes.outputs.backend == 'true'
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache Cargo
         if: needs.changes.outputs.backend == 'true'
@@ -261,7 +261,7 @@ jobs:
 
       - name: Install Rust
         if: needs.changes.outputs.backend == 'true'
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache Cargo
         if: needs.changes.outputs.backend == 'true'
@@ -333,7 +333,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -391,7 +391,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -488,7 +488,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
@@ -608,7 +608,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.100.0
+        uses: dtolnay/rust-toolchain@1.94.1
 
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Dependabot #1837 set the action to @1.100.0 (nonexistent Rust → 404 on Install Rust), failing every backend job on every open PR. Restores @1.94.1 to match rust-toolchain.toml. Admin-merging since no CI can pass until this lands.