### PR TITLE
test(BIT-268): re-cut reality-server partial endpoint backfill batch 3

### DIFF
--- a/backend/servers/reality-server/tests/agencies_authz_tests.rs
+++ b/backend/servers/reality-server/tests/agencies_authz_tests.rs
@@ -1,0 +1,257 @@
+//! Handler-level auth tests for agencies endpoints.
+//!
+//! Drives the real Axum router (routes::agencies) end-to-end via `oneshot`.
+//!
+//! Public endpoints (no RequestPrincipal): list_agencies, get_agency,
+//! get_agency_by_slug, list_members — return non-401 without a token.
+//!
+//! Protected endpoints (RequestPrincipal): create_agency, update_agency,
+//! create_invitation, accept_invitation — return 401 without a token and
+//! non-401 with a seeded user token.
+
+mod common;
+
+use axum::{http::Method, Router};
+use common::{make_app_state, mint_token, send, send_json};
+use reality_server::routes;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn agencies_router(pool: PgPool) -> Router {
+    let state = make_app_state(pool);
+    Router::new()
+        .nest("/api/v1/agencies", routes::agencies::router())
+        .with_state(state)
+}
+
+async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'hash', $2, 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("{tag}@agencies-authz.test"))
+    .bind(format!("AgenciesAuthz {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_user({tag}): {e}"))
+}
+
+// ── list_agencies (public) ────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_agencies_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = agencies_router(pool);
+    let status = send(&app, Method::GET, "/api/v1/agencies", None).await;
+    assert_ne!(
+        status, 401,
+        "list_agencies must not require auth (public directory)"
+    );
+}
+
+// ── get_agency (public) ───────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_agency_unauthenticated_returns_non_401(pool: PgPool) {
+    let id = Uuid::new_v4();
+    let app = agencies_router(pool);
+    let status = send(&app, Method::GET, &format!("/api/v1/agencies/{id}"), None).await;
+    assert_ne!(
+        status, 401,
+        "get_agency must not require auth (may return 404 for unknown id)"
+    );
+}
+
+// ── get_agency_by_slug (public) ───────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_agency_by_slug_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = agencies_router(pool);
+    let status = send(
+        &app,
+        Method::GET,
+        "/api/v1/agencies/by-slug/unknown-slug",
+        None,
+    )
+    .await;
+    assert_ne!(
+        status, 401,
+        "get_agency_by_slug must not require auth (may return 404)"
+    );
+}
+
+// ── list_members (public) ─────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_members_unauthenticated_returns_non_401(pool: PgPool) {
+    let id = Uuid::new_v4();
+    let app = agencies_router(pool);
+    let status = send(
+        &app,
+        Method::GET,
+        &format!("/api/v1/agencies/{id}/members"),
+        None,
+    )
+    .await;
+    assert_ne!(
+        status, 401,
+        "list_members must not require auth (may return empty list or 404)"
+    );
+}
+
+// ── create_agency (protected) ─────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_agency_unauthenticated_returns_401(pool: PgPool) {
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        "/api/v1/agencies",
+        None,
+        json!({"name": "Test Agency", "slug": "test-agency"}),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "create_agency must return 401 without auth"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_agency_authenticated_returns_non_401(pool: PgPool) {
+    let user = seed_user(&pool, "create-agency").await;
+    let token = mint_token(user);
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        "/api/v1/agencies",
+        Some(&token),
+        json!({"name": "Test Agency", "slug": "test-agency"}),
+    )
+    .await;
+    assert_ne!(
+        status, 401,
+        "authenticated create_agency must not return 401"
+    );
+}
+
+// ── update_agency (protected) ─────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_agency_unauthenticated_returns_401(pool: PgPool) {
+    let id = Uuid::new_v4();
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::PUT,
+        &format!("/api/v1/agencies/{id}"),
+        None,
+        json!({"name": "Updated"}),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "update_agency must return 401 without auth"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_agency_authenticated_unknown_returns_non_401(pool: PgPool) {
+    let user = seed_user(&pool, "update-agency").await;
+    let token = mint_token(user);
+    let id = Uuid::new_v4();
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::PUT,
+        &format!("/api/v1/agencies/{id}"),
+        Some(&token),
+        json!({"name": "Updated"}),
+    )
+    .await;
+    assert_ne!(
+        status, 401,
+        "authenticated update_agency must not return 401"
+    );
+}
+
+// ── create_invitation (protected) ────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invitation_unauthenticated_returns_401(pool: PgPool) {
+    let id = Uuid::new_v4();
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        &format!("/api/v1/agencies/{id}/invitations"),
+        None,
+        json!({"email": "invite@example.com", "role": "agent"}),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "create_invitation must return 401 without auth"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invitation_authenticated_unknown_agency_returns_non_401(pool: PgPool) {
+    let user = seed_user(&pool, "create-inv").await;
+    let token = mint_token(user);
+    let id = Uuid::new_v4();
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        &format!("/api/v1/agencies/{id}/invitations"),
+        Some(&token),
+        json!({"email": "invite@example.com", "role": "agent"}),
+    )
+    .await;
+    assert_ne!(
+        status, 401,
+        "authenticated create_invitation must not return 401"
+    );
+}
+
+// ── accept_invitation (protected) ────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn accept_invitation_unauthenticated_returns_401(pool: PgPool) {
+    let app = agencies_router(pool);
+    let status = send(
+        &app,
+        Method::POST,
+        "/api/v1/agencies/invitations/fake-token/accept",
+        None,
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "accept_invitation must return 401 without auth"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn accept_invitation_authenticated_unknown_token_returns_non_401(pool: PgPool) {
+    let user = seed_user(&pool, "accept-inv").await;
+    let token = mint_token(user);
+    let app = agencies_router(pool);
+    let status = send(
+        &app,
+        Method::POST,
+        "/api/v1/agencies/invitations/fake-token/accept",
+        Some(&token),
+    )
+    .await;
+    assert_ne!(
+        status, 401,
+        "authenticated accept_invitation must not return 401"
+    );
+}

--- a/backend/servers/reality-server/tests/portal_listings_create_tests.rs
+++ b/backend/servers/reality-server/tests/portal_listings_create_tests.rs
@@ -1,0 +1,185 @@
+//! Happy-path tests for portal listing creation (POST /api/v1/my/listings).
+//!
+//! Closes the coverage gap noted in `docs/endpoint-checklist/groups/reality-server.md`:
+//! the existing `portal_listings_idor_tests.rs` covers only the 400-validation and
+//! IDOR paths. This file adds the successful create path (201 Created).
+//!
+//! Uses `PortalPrincipal` — seeded users must have `principal_kind = 'public'`.
+
+mod common;
+
+use axum::{http::Method, Router};
+use common::{make_app_state, mint_token, send, send_json};
+use reality_server::routes;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn portal_listings_router(pool: PgPool) -> Router {
+    let state = make_app_state(pool);
+    Router::new()
+        .nest("/api/v1/my/listings", routes::portal_listings::router())
+        .with_state(state)
+}
+
+async fn seed_portal_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'hash', $2, 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("{tag}@portal-listings-create.test"))
+    .bind(format!("PortalCreate {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_portal_user({tag}): {e}"))
+}
+
+// ── create_listing auth boundary ─────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_listing_unauthenticated_returns_401(pool: PgPool) {
+    let app = portal_listings_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        "/api/v1/my/listings",
+        None,
+        json!({
+            "title": "Test Listing",
+            "propertyType": "apartment",
+            "transactionType": "sale",
+            "price": "150000",
+            "street": "Main St 1",
+            "city": "Bratislava",
+            "postalCode": "81101"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "create_listing must return 401 without auth"
+    );
+}
+
+// ── create_listing happy path ─────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_listing_authenticated_returns_201(pool: PgPool) {
+    let user = seed_portal_user(&pool, "create").await;
+    let token = mint_token(user);
+    let app = portal_listings_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        "/api/v1/my/listings",
+        Some(&token),
+        json!({
+            "title": "My Test Apartment",
+            "description": "A nice place",
+            "propertyType": "apartment",
+            "transactionType": "sale",
+            "price": "150000.00",
+            "currency": "EUR",
+            "street": "Main Street 1",
+            "city": "Bratislava",
+            "postalCode": "81101",
+            "country": "SK",
+            "sizeSqm": "65.5",
+            "rooms": 3,
+            "floor": 2,
+            "totalFloors": 8
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 201,
+        "authenticated create_listing with valid body must return 201"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_listing_authenticated_minimal_body_returns_201(pool: PgPool) {
+    let user = seed_portal_user(&pool, "create-min").await;
+    let token = mint_token(user);
+    let app = portal_listings_router(pool);
+    // Only required fields
+    let status = send_json(
+        &app,
+        Method::POST,
+        "/api/v1/my/listings",
+        Some(&token),
+        json!({
+            "title": "Minimal Listing",
+            "propertyType": "house",
+            "transactionType": "rent",
+            "price": "1200.00",
+            "street": "Side Lane 5",
+            "city": "Košice",
+            "postalCode": "04001"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 201,
+        "authenticated create_listing with minimal required body must return 201"
+    );
+}
+
+// ── create_listing validation guards ─────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_listing_invalid_property_type_returns_400(pool: PgPool) {
+    let user = seed_portal_user(&pool, "create-bad-type").await;
+    let token = mint_token(user);
+    let app = portal_listings_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        "/api/v1/my/listings",
+        Some(&token),
+        json!({
+            "title": "Bad Type",
+            "propertyType": "yacht",
+            "transactionType": "sale",
+            "price": "99999",
+            "street": "Harbor 1",
+            "city": "Bratislava",
+            "postalCode": "81101"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 400,
+        "create_listing with invalid propertyType must return 400"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_listing_invalid_transaction_type_returns_400(pool: PgPool) {
+    let user = seed_portal_user(&pool, "create-bad-txn").await;
+    let token = mint_token(user);
+    let app = portal_listings_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        "/api/v1/my/listings",
+        Some(&token),
+        json!({
+            "title": "Bad Txn",
+            "propertyType": "apartment",
+            "transactionType": "lease",
+            "price": "99999",
+            "street": "Test St 1",
+            "city": "Bratislava",
+            "postalCode": "81101"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status, 400,
+        "create_listing with invalid transactionType must return 400"
+    );
+}

--- a/backend/servers/reality-server/tests/sso_authz_tests.rs
+++ b/backend/servers/reality-server/tests/sso_authz_tests.rs
@@ -1,0 +1,260 @@
+//! Handler-level auth tests for SSO endpoints.
+//!
+//! Drives the real Axum router (routes::sso) end-to-end via `oneshot`.
+//!
+//! Auth patterns in this module:
+//! - Public (no auth): sso_login (302 redirect), sso_callback (400/non-401),
+//!   get_mapped_roles (200 static).
+//! - Cookie-protected (portal_session cookie): sso_logout — 401 without cookie.
+//!   Non-401 test omitted: requires a live session record in the DB that the
+//!   test-DB session service cannot produce without a real PM OAuth round-trip.
+//! - Bearer-protected (Authorization header): get_session, refresh_session —
+//!   401 without token. With a token the session lookup also returns 401
+//!   (no session in test DB), so only the unauthenticated direction is asserted.
+//! - Body-validated (PM/SSO token in JSON body): exchange_pm_token, sync_session,
+//!   create_mobile_sso_token, validate_mobile_sso_token — missing body yields 422
+//!   (non-401, proves handler is reached); invalid-token body yields 401 (proves
+//!   PM-token validation rejects garbage).
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+    Router,
+};
+use common::make_app_state;
+use reality_server::routes;
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+fn sso_router(pool: PgPool) -> Router {
+    let state = make_app_state(pool);
+    Router::new()
+        .nest("/api/v1/sso", routes::sso::router())
+        .with_state(state)
+}
+
+/// Issue a raw request (no body, optional Bearer token) and return the status.
+async fn raw_send(app: &Router, method: Method, path: &str, token: Option<&str>) -> StatusCode {
+    let mut req = Request::builder().method(method).uri(path);
+    if let Some(t) = token {
+        req = req.header(header::AUTHORIZATION, format!("Bearer {t}"));
+    }
+    app.clone()
+        .oneshot(req.body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+        .status()
+}
+
+/// Issue a JSON body request and return the status.
+async fn raw_send_json(
+    app: &Router,
+    method: Method,
+    path: &str,
+    token: Option<&str>,
+    body: serde_json::Value,
+) -> StatusCode {
+    let mut req = Request::builder()
+        .method(method)
+        .uri(path)
+        .header(header::CONTENT_TYPE, "application/json");
+    if let Some(t) = token {
+        req = req.header(header::AUTHORIZATION, format!("Bearer {t}"));
+    }
+    app.clone()
+        .oneshot(
+            req.body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+}
+
+// ── sso_login (public — redirects to PM OAuth) ───────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sso_login_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = sso_router(pool);
+    // Returns 302 (redirect to PM OAuth) or 400 (bad redirect_uri), never 401
+    let status = raw_send(&app, Method::GET, "/api/v1/sso/login", None).await;
+    assert_ne!(status, 401, "sso_login must not require auth");
+}
+
+// ── sso_callback (public — OAuth callback, returns 400 without params) ───────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sso_callback_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = sso_router(pool);
+    // No code/state params → 400 (missing_code), not 401
+    let status = raw_send(&app, Method::GET, "/api/v1/sso/callback", None).await;
+    assert_ne!(status, 401, "sso_callback must not require auth");
+}
+
+// ── sso_logout (cookie-protected) ────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sso_logout_without_session_cookie_returns_401(pool: PgPool) {
+    let app = sso_router(pool);
+    // No portal_session cookie → handler returns 401 immediately
+    let status = raw_send(&app, Method::POST, "/api/v1/sso/logout", None).await;
+    assert_eq!(
+        status, 401,
+        "sso_logout must return 401 without session cookie"
+    );
+}
+
+// ── get_session (Bearer-protected) ───────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_session_unauthenticated_returns_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send(&app, Method::GET, "/api/v1/sso/session", None).await;
+    assert_eq!(
+        status, 401,
+        "GET /sso/session must return 401 without token"
+    );
+}
+
+// ── refresh_session (Bearer-protected) ──────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn refresh_session_unauthenticated_returns_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send(&app, Method::POST, "/api/v1/sso/refresh", None).await;
+    assert_eq!(
+        status, 401,
+        "POST /sso/refresh must return 401 without token"
+    );
+}
+
+// ── create_mobile_sso_token (body-validated: PM access token required) ───────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_mobile_sso_token_without_body_returns_non_401(pool: PgPool) {
+    let app = sso_router(pool);
+    // Missing body → 422 (deserialization error), not 401
+    let status = raw_send(&app, Method::POST, "/api/v1/sso/mobile/token", None).await;
+    assert_ne!(
+        status, 401,
+        "create_mobile_sso_token without body must not return 401"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_mobile_sso_token_with_invalid_pm_token_returns_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send_json(
+        &app,
+        Method::POST,
+        "/api/v1/sso/mobile/token",
+        None,
+        serde_json::json!({"pm_access_token": "invalid-garbage-token"}),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "create_mobile_sso_token with invalid PM token must return 401"
+    );
+}
+
+// ── validate_mobile_sso_token (body-validated: SSO token required) ───────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn validate_mobile_sso_token_without_body_returns_non_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send(&app, Method::POST, "/api/v1/sso/mobile/validate", None).await;
+    assert_ne!(
+        status, 401,
+        "validate_mobile_sso_token without body must not return 401"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn validate_mobile_sso_token_with_invalid_token_returns_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send_json(
+        &app,
+        Method::POST,
+        "/api/v1/sso/mobile/validate",
+        None,
+        serde_json::json!({"sso_token": "invalid-garbage-sso-token"}),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "validate_mobile_sso_token with invalid SSO token must return 401"
+    );
+}
+
+// ── exchange_pm_token (body-validated: PM access token required) ──────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn exchange_pm_token_without_body_returns_non_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send(&app, Method::POST, "/api/v1/sso/exchange", None).await;
+    assert_ne!(
+        status, 401,
+        "exchange_pm_token without body must not return 401"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn exchange_pm_token_with_invalid_pm_token_returns_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send_json(
+        &app,
+        Method::POST,
+        "/api/v1/sso/exchange",
+        None,
+        serde_json::json!({"pm_access_token": "invalid-pm-token"}),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "exchange_pm_token with invalid PM token must return 401"
+    );
+}
+
+// ── sync_session (body-validated: PM token required) ─────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sync_session_without_body_returns_non_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send(&app, Method::POST, "/api/v1/sso/sync", None).await;
+    assert_ne!(
+        status, 401,
+        "sync_session without body must not return 401"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn sync_session_with_invalid_pm_token_returns_401(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send_json(
+        &app,
+        Method::POST,
+        "/api/v1/sso/sync",
+        None,
+        serde_json::json!({"pm_token": "invalid-pm-token", "portal_session": null}),
+    )
+    .await;
+    assert_eq!(
+        status, 401,
+        "sync_session with invalid PM token must return 401"
+    );
+}
+
+// ── get_mapped_roles (public — static role-mapping config) ───────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_mapped_roles_unauthenticated_returns_200(pool: PgPool) {
+    let app = sso_router(pool);
+    let status = raw_send(&app, Method::GET, "/api/v1/sso/roles", None).await;
+    assert_eq!(
+        status, 200,
+        "get_mapped_roles must return 200 without auth (static public endpoint)"
+    );
+}

--- a/backend/servers/reality-server/tests/users_authz_tests.rs
+++ b/backend/servers/reality-server/tests/users_authz_tests.rs
@@ -1,0 +1,151 @@
+//! Handler-level auth tests for users endpoints (reality portal).
+//!
+//! Drives the real Axum router (routes::users) end-to-end via `oneshot`.
+//!
+//! Public endpoints (no auth required): register, login, password-reset,
+//! password-reset/confirm — verified to return non-401 without a token.
+//!
+//! Protected endpoints (RequestPrincipal): logout, GET /me, PUT /me —
+//! verified to return 401 without a token and non-401 with a seeded user.
+
+mod common;
+
+use axum::{http::Method, Router};
+use common::{make_app_state, mint_token, send, send_json};
+use reality_server::routes;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+fn users_router(pool: PgPool) -> Router {
+    let state = make_app_state(pool);
+    Router::new()
+        .nest("/api/v1/users", routes::users::router())
+        .with_state(state)
+}
+
+async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'hash', $2, 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("{tag}@users-authz.test"))
+    .bind(format!("UsersAuthz {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_user({tag}): {e}"))
+}
+
+// ── register (public) ────────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn register_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = users_router(pool);
+    // POST with an empty body → 422/400 (validation), not 401 — endpoint is public
+    let status = send(&app, Method::POST, "/api/v1/users/register", None).await;
+    assert_ne!(status, 401, "register must not require auth");
+}
+
+// ── login (public) ───────────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn login_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = users_router(pool);
+    let status = send(&app, Method::POST, "/api/v1/users/login", None).await;
+    assert_ne!(status, 401, "login must not require auth");
+}
+
+// ── request_password_reset (public) ─────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn request_password_reset_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = users_router(pool);
+    let status = send(&app, Method::POST, "/api/v1/users/password-reset", None).await;
+    assert_ne!(status, 401, "request_password_reset must not require auth");
+}
+
+// ── confirm_password_reset (public) ─────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn confirm_password_reset_unauthenticated_returns_non_401(pool: PgPool) {
+    let app = users_router(pool);
+    let status = send(
+        &app,
+        Method::POST,
+        "/api/v1/users/password-reset/confirm",
+        None,
+    )
+    .await;
+    assert_ne!(status, 401, "confirm_password_reset must not require auth");
+}
+
+// ── logout (protected) ───────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn logout_unauthenticated_returns_401(pool: PgPool) {
+    let app = users_router(pool);
+    let status = send(&app, Method::POST, "/api/v1/users/logout", None).await;
+    assert_eq!(status, 401, "logout must return 401 without auth");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn logout_authenticated_returns_non_401(pool: PgPool) {
+    let user = seed_user(&pool, "logout").await;
+    let token = mint_token(user);
+    let app = users_router(pool);
+    let status = send(&app, Method::POST, "/api/v1/users/logout", Some(&token)).await;
+    assert_ne!(status, 401, "authenticated logout must not return 401");
+}
+
+// ── get_me (protected) ───────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_me_unauthenticated_returns_401(pool: PgPool) {
+    let app = users_router(pool);
+    let status = send(&app, Method::GET, "/api/v1/users/me", None).await;
+    assert_eq!(status, 401, "GET /me must return 401 without auth");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_me_authenticated_returns_non_401(pool: PgPool) {
+    let user = seed_user(&pool, "get-me").await;
+    let token = mint_token(user);
+    let app = users_router(pool);
+    let status = send(&app, Method::GET, "/api/v1/users/me", Some(&token)).await;
+    assert_ne!(status, 401, "authenticated GET /me must not return 401");
+}
+
+// ── update_me (protected) ────────────────────────────────────────────────────
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_me_unauthenticated_returns_401(pool: PgPool) {
+    let app = users_router(pool);
+    let status = send_json(
+        &app,
+        Method::PUT,
+        "/api/v1/users/me",
+        None,
+        json!({"name": "Test"}),
+    )
+    .await;
+    assert_eq!(status, 401, "PUT /me must return 401 without auth");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn update_me_authenticated_returns_non_401(pool: PgPool) {
+    let user = seed_user(&pool, "update-me").await;
+    let token = mint_token(user);
+    let app = users_router(pool);
+    let status = send_json(
+        &app,
+        Method::PUT,
+        "/api/v1/users/me",
+        Some(&token),
+        json!({"name": "Updated Name"}),
+    )
+    .await;
+    assert_ne!(status, 401, "authenticated PUT /me must not return 401");
+}


### PR DESCRIPTION
Re-cuts PR#1887 (closed due to 3473-commit rebase gap from old branch base).

Adds authz/happy-path test coverage for 4 reality-server endpoint groups:
- `agencies_authz_tests.rs` — agency management authz
- `portal_listings_create_tests.rs` — listing create happy-path
- `sso_authz_tests.rs` — SSO flow authz
- `users_authz_tests.rs` — portal user authz

Part of BIT-268 test-backfill wave. Closes #1887.