### PR TITLE
test(BIT-341): finance/accounting remaining happy-path coverage

### DIFF
--- a/backend/servers/api-server/tests/accounting_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/accounting_happy_path_tests.rs
@@ -1,0 +1,370 @@
+//! Happy-path integration tests for the accounting endpoints
+//! (`/api/v1/accounting/{invoices,statements,lines,matches}`).
+//!
+//! The accounting module is manager-gated through `RlsConnection` (resolved from
+//! the `X-Tenant-ID` header + an `organization_members` row) and, for writes,
+//! the `tenant_id` JWT claim on `AuthUser`. `org_admin` (level 90) satisfies the
+//! `Manager` (level 80) gate, so `create_authenticated_user_with_org` provides a
+//! suitable principal; for `create_invoice` we additionally mint a token that
+//! carries the `tenant_id` claim.
+//!
+//! Coverage is complementary to `accounting_contacts_authz_tests.rs`
+//! (`list_contacts`) and `accounting_payment_match_state_machine_tests.rs`
+//! (service-level, not HTTP). Endpoints covered (BIT-341, Wave 5):
+//!   1. POST   /api/v1/accounting/invoices                 (create_invoice)
+//!   2. GET    /api/v1/accounting/invoices                 (list_invoices)
+//!   3. GET    /api/v1/accounting/invoices/{id}            (get_invoice)
+//!   4. GET    /api/v1/accounting/invoices/{id}/items      (list_invoice_items)
+//!   5. PATCH  /api/v1/accounting/invoices/{id}            (update_invoice)
+//!   6. GET    /api/v1/accounting/statements               (list_statements)
+//!   7. GET    /api/v1/accounting/statements/{id}/lines    (list_statement_lines)
+//!   8. GET    /api/v1/accounting/lines/{id}/matches       (list_matches)
+//!   9. POST   /api/v1/accounting/matches/{id}/confirm     (confirm_match)
+//!  10. POST   /api/v1/accounting/matches/{id}/reject      (reject_match)
+//!  11. DELETE /api/v1/accounting/invoices/{id}            (delete_invoice)
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user_with_org, TestApp, TestUser};
+
+/// Mint an access token carrying a `tenant_id` claim, matching the on-the-wire
+/// shape the `AuthUser` extractor expects. `create_invoice` requires the claim;
+/// the rest of the endpoints resolve their tenant from the `X-Tenant-ID` header.
+fn mint_tenant_token(user_id: Uuid, org_id: Uuid) -> String {
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Claims {
+        sub: String,
+        exp: i64,
+        iat: i64,
+        token_type: String,
+        tenant_id: String,
+        role: Option<String>,
+        email: String,
+        name: String,
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    encode(
+        &Header::default(),
+        &Claims {
+            sub: user_id.to_string(),
+            exp: now + 900,
+            iat: now,
+            token_type: "access".into(),
+            tenant_id: org_id.to_string(),
+            role: None,
+            email: "acc-happy@test.example".into(),
+            name: "Accounting Happy".into(),
+        },
+        &EncodingKey::from_secret(
+            b"test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes",
+        ),
+    )
+    .expect("mint tenant token")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn accounting_endpoints_happy_path(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = TestUser::new();
+    let (_login_token, org_id) = create_authenticated_user_with_org(&app, &user, "acchappy").await;
+
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&app.pool)
+        .await
+        .expect("resolve user id");
+
+    // Token carrying the tenant_id claim (required by create_invoice); it is a
+    // valid access token so it also works for the RlsConnection-gated reads.
+    let token = mint_tenant_token(user_id, org_id);
+    let tenant = org_id.to_string();
+
+    // Seed a billing contact (FK target for invoices).
+    let contact_id = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO contact (tenant_id, name) VALUES ($1, 'Acme Tenant') RETURNING id",
+    )
+    .bind(org_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("seed contact");
+
+    // ========================================================================
+    // 1. POST /api/v1/accounting/invoices -> create_invoice
+    // ========================================================================
+    let create_payload = json!({
+        "tenant_id": org_id,
+        "contact_id": contact_id,
+        "number": "INV-HAPPY-1",
+        "issue_date": "2026-01-01",
+        "due_date": "2026-01-31",
+        "currency": "CZK",
+        "items": [
+            { "description": "Consulting", "qty": "1", "unit_price": "100", "vat_rate": "0" }
+        ]
+    });
+    let resp = app
+        .execute(
+            app.post("/api/v1/accounting/invoices")
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .json(&create_payload)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::CREATED,
+        "create_invoice should succeed: {}",
+        resp.text()
+    );
+    let invoice = resp.json_value();
+    let invoice_id = invoice["id"].as_str().expect("invoice id missing").to_string();
+
+    // ========================================================================
+    // 2. GET /api/v1/accounting/invoices -> list_invoices
+    // ========================================================================
+    let resp = app
+        .execute(
+            app.get("/api/v1/accounting/invoices")
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "list_invoices should succeed: {}",
+        resp.text()
+    );
+    assert!(resp
+        .json_value()
+        .as_array()
+        .map(|a| !a.is_empty())
+        .unwrap_or(false));
+
+    // 3. GET /api/v1/accounting/invoices/{id} -> get_invoice
+    let resp = app
+        .execute(
+            app.get(&format!("/api/v1/accounting/invoices/{invoice_id}"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_invoice should succeed: {}",
+        resp.text()
+    );
+
+    // 4. GET /api/v1/accounting/invoices/{id}/items -> list_invoice_items
+    let resp = app
+        .execute(
+            app.get(&format!("/api/v1/accounting/invoices/{invoice_id}/items"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "list_invoice_items should succeed: {}",
+        resp.text()
+    );
+    assert!(resp
+        .json_value()
+        .as_array()
+        .map(|a| !a.is_empty())
+        .unwrap_or(false));
+
+    // 5. PATCH /api/v1/accounting/invoices/{id} -> update_invoice
+    let resp = app
+        .execute(
+            app.patch(&format!("/api/v1/accounting/invoices/{invoice_id}"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .json(&json!({ "variable_symbol": "VS12345" }))
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "update_invoice should succeed: {}",
+        resp.text()
+    );
+
+    // ========================================================================
+    // Seed a bank statement + line + suggested match (mirrors the proven
+    // service-level seeding) referencing a dedicated issued invoice so the
+    // statement / match read + confirm/reject endpoints have real data.
+    // ========================================================================
+    let match_invoice = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO invoice (tenant_id, contact_id, number, issue_date, due_date, currency, total_amount, status) \
+         VALUES ($1, $2, 'INV-MATCH-1', NOW(), NOW(), 'CZK', 100, 'issued') RETURNING id",
+    )
+    .bind(org_id)
+    .bind(contact_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("seed match invoice");
+
+    let statement_id = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO bank_statement (tenant_id, source_filename, account_iban) \
+         VALUES ($1, 'statement.csv', 'SK0000000000000000000000') RETURNING id",
+    )
+    .bind(org_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("seed bank statement");
+
+    let line_id = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO bank_statement_line (statement_id, tenant_id, booking_date, amount, currency, match_state) \
+         VALUES ($1, $2, NOW(), 100, 'CZK', 'suggested') RETURNING id",
+    )
+    .bind(statement_id)
+    .bind(org_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("seed statement line");
+
+    let match_id = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO payment_match (tenant_id, statement_line_id, invoice_id, confidence, state) \
+         VALUES ($1, $2, $3, 1.0, 'suggested') RETURNING id",
+    )
+    .bind(org_id)
+    .bind(line_id)
+    .bind(match_invoice)
+    .fetch_one(&app.pool)
+    .await
+    .expect("seed payment match");
+
+    // 6. GET /api/v1/accounting/statements -> list_statements
+    let resp = app
+        .execute(
+            app.get("/api/v1/accounting/statements")
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "list_statements should succeed: {}",
+        resp.text()
+    );
+    assert!(resp
+        .json_value()
+        .as_array()
+        .map(|a| !a.is_empty())
+        .unwrap_or(false));
+
+    // 7. GET /api/v1/accounting/statements/{id}/lines -> list_statement_lines
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/accounting/statements/{statement_id}/lines"
+            ))
+            .bearer(&token)
+            .header("X-Tenant-ID", &tenant)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "list_statement_lines should succeed: {}",
+        resp.text()
+    );
+    assert!(resp
+        .json_value()
+        .as_array()
+        .map(|a| !a.is_empty())
+        .unwrap_or(false));
+
+    // 8. GET /api/v1/accounting/lines/{id}/matches -> list_matches
+    let resp = app
+        .execute(
+            app.get(&format!("/api/v1/accounting/lines/{line_id}/matches"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "list_matches should succeed: {}",
+        resp.text()
+    );
+    assert!(resp
+        .json_value()
+        .as_array()
+        .map(|a| !a.is_empty())
+        .unwrap_or(false));
+
+    // 9. POST /api/v1/accounting/matches/{id}/confirm -> confirm_match
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/accounting/matches/{match_id}/confirm"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "confirm_match should succeed: {}",
+        resp.text()
+    );
+
+    // 10. POST /api/v1/accounting/matches/{id}/reject -> reject_match
+    //     Rejecting a now-confirmed match unapplies it and returns 200.
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/accounting/matches/{match_id}/reject"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "reject_match should succeed: {}",
+        resp.text()
+    );
+
+    // 11. DELETE /api/v1/accounting/invoices/{id} -> delete_invoice
+    //     Delete the first invoice (no payment_match references it).
+    let resp = app
+        .execute(
+            app.delete(&format!("/api/v1/accounting/invoices/{invoice_id}"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &tenant)
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::NO_CONTENT,
+        "delete_invoice should succeed: {}",
+        resp.text()
+    );
+}

--- a/backend/servers/api-server/tests/accounting_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/accounting_happy_path_tests.rs
@@ -129,7 +129,10 @@ async fn accounting_endpoints_happy_path(pool: PgPool) {
         resp.text()
     );
     let invoice = resp.json_value();
-    let invoice_id = invoice["id"].as_str().expect("invoice id missing").to_string();
+    let invoice_id = invoice["id"]
+        .as_str()
+        .expect("invoice id missing")
+        .to_string();
 
     // ========================================================================
     // 2. GET /api/v1/accounting/invoices -> list_invoices

--- a/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
@@ -1,0 +1,204 @@
+//! Happy-path integration tests for the financial reporting endpoints
+//! (`/api/v1/financial/{reminder-schedules,late-fee-config,overdue-invoices,reports/*}`).
+//!
+//! These 8 endpoints are the reporting / reminder slice of `financial.rs` that
+//! the broader `financial_happy_path_tests.rs` (accounts / fee-schedules /
+//! invoices / payments) does NOT exercise. All use the same auth model as that
+//! file: a bearer token from `create_authenticated_user_with_org` plus an
+//! `organization_id` query parameter resolved through `verify_org_access`.
+//!
+//! Endpoints covered (BIT-341, Wave 5):
+//!   1. GET /api/v1/financial/reminder-schedules
+//!   2. GET /api/v1/financial/late-fee-config
+//!   3. GET /api/v1/financial/overdue-invoices
+//!   4. GET /api/v1/financial/reports/ar-aging
+//!   5. GET /api/v1/financial/reports/income-statement
+//!   6. GET /api/v1/financial/reports/balance-sheet
+//!   7. GET /api/v1/financial/reports/cash-flow
+//!   8. GET /api/v1/financial/reports/income-statement/export
+
+#[allow(dead_code)]
+mod common;
+
+use axum::http::StatusCode;
+use sqlx::PgPool;
+
+use common::{create_authenticated_user_with_org, TestApp, TestUser};
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn financial_reports_happy_path(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "finreports").await;
+
+    // Seed a late-fee config so `get_late_fee_config` returns 200 instead of the
+    // 404 it emits when an org has not configured late fees.
+    sqlx::query(
+        r#"INSERT INTO late_fee_configs
+               (organization_id, enabled, grace_period_days, fee_type, fee_amount)
+           VALUES ($1, true, 5, 'fixed', 25.00)"#,
+    )
+    .bind(org_id)
+    .execute(&app.pool)
+    .await
+    .expect("seed late fee config");
+
+    // Seed a reminder schedule so the list comes back non-empty.
+    sqlx::query(
+        r#"INSERT INTO reminder_schedules (organization_id, name, days_before_due)
+           VALUES ($1, 'Pre-due reminder', 3)"#,
+    )
+    .bind(org_id)
+    .execute(&app.pool)
+    .await
+    .expect("seed reminder schedule");
+
+    // 1. GET /api/v1/financial/reminder-schedules -> get_reminder_schedules
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/reminder-schedules?organization_id={org_id}"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_reminder_schedules should succeed: {}",
+        resp.text()
+    );
+    assert!(resp
+        .json_value()
+        .as_array()
+        .map(|a| !a.is_empty())
+        .unwrap_or(false));
+
+    // 2. GET /api/v1/financial/late-fee-config -> get_late_fee_config
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/late-fee-config?organization_id={org_id}"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_late_fee_config should succeed: {}",
+        resp.text()
+    );
+
+    // 3. GET /api/v1/financial/overdue-invoices -> get_overdue_invoices
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/overdue-invoices?organization_id={org_id}"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_overdue_invoices should succeed: {}",
+        resp.text()
+    );
+    assert!(resp.json_value().is_array());
+
+    // 4. GET /api/v1/financial/reports/ar-aging -> get_ar_aging_report
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/reports/ar-aging?organization_id={org_id}"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_ar_aging_report should succeed: {}",
+        resp.text()
+    );
+
+    // 5. GET /api/v1/financial/reports/income-statement -> get_income_statement
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/reports/income-statement?organization_id={org_id}&from=2026-01-01&to=2026-12-31"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_income_statement should succeed: {}",
+        resp.text()
+    );
+
+    // 6. GET /api/v1/financial/reports/balance-sheet -> get_balance_sheet
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/reports/balance-sheet?organization_id={org_id}"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_balance_sheet should succeed: {}",
+        resp.text()
+    );
+
+    // 7. GET /api/v1/financial/reports/cash-flow -> get_cash_flow
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/reports/cash-flow?organization_id={org_id}&from=2026-01-01&to=2026-12-31"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "get_cash_flow should succeed: {}",
+        resp.text()
+    );
+
+    // 8. GET /api/v1/financial/reports/income-statement/export -> export_report (xlsx)
+    let resp = app
+        .execute(
+            app.get(&format!(
+                "/api/v1/financial/reports/income-statement/export?organization_id={org_id}&format=xlsx&from=2026-01-01&to=2026-12-31"
+            ))
+            .bearer(&token)
+            .build(),
+        )
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "export_report should succeed: {}",
+        resp.text()
+    );
+    assert_eq!(
+        resp.headers
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok()),
+        Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+    );
+}


### PR DESCRIPTION
## Summary

Wave 5 of the finance-group happy-path test backfill (parent BIT-258, issue BIT-341). Adds HTTP-level `2xx` assertions for **19 finance-group endpoints** that `financial_happy_path_tests.rs` (the 24-endpoint Wave-4 file already on `dev`) does **not** cover. No overlap with that file.

### `financial_reports_happy_path_tests.rs` — 8 endpoints
The reporting / reminder slice of `financial.rs` (bearer + `organization_id` model, same as the existing file):
- `GET /financial/reminder-schedules`
- `GET /financial/late-fee-config` (seeds a `late_fee_configs` row)
- `GET /financial/overdue-invoices`
- `GET /financial/reports/ar-aging`
- `GET /financial/reports/income-statement`
- `GET /financial/reports/balance-sheet`
- `GET /financial/reports/cash-flow`
- `GET /financial/reports/income-statement/export` (xlsx)

### `accounting_happy_path_tests.rs` — 11 endpoints
The `/api/v1/accounting/*` module (manager-gated `RlsConnection` via `X-Tenant-ID` + `org_admin` membership; a minted `tenant_id` JWT for `create_invoice`). Complements the existing `accounting_contacts_authz_tests.rs` (`list_contacts`) and the service-level `accounting_payment_match_state_machine_tests.rs`:
- invoices: `POST`, `GET` list, `GET /{id}`, `GET /{id}/items`, `PATCH /{id}`, `DELETE /{id}`
- statements: `GET` list, `GET /{id}/lines`
- matches: `GET /lines/{id}/matches`, `POST /matches/{id}/confirm`, `POST /matches/{id}/reject`

Seeding mirrors the proven `seed_match_scenario` recipe (`contact` / `invoice` / `bank_statement` / `bank_statement_line` / `payment_match`).

## Verification
Test-only change. **Not compiled locally** — the offload host (mercury) was unreachable this session, so CI (`check` + `test`) is the verification path. Handlers, query params, request/response shapes, auth extractors, role levels (OrgAdmin 90 ≥ Manager 80) and FK cascade behaviour were all read from source before authoring.

## Acceptance (BIT-341)
- [x] Each covered endpoint has a `2xx` HTTP-level assertion
- [x] No duplication with `financial_happy_path_tests.rs`
- [ ] CI green (`check` + `test`) — pending
- [ ] Merged to `dev`
- Newly-covered endpoint count: **19**

🤖 Generated with [Claude Code](https://claude.com/claude-code)