### PR TITLE
ci(BIT-342): verify backend fmt gate green on current dev

### DIFF
--- a/backend/.bit342-fmt-probe.md
+++ b/backend/.bit342-fmt-probe.md
@@ -1,0 +1,2 @@
+BIT-342 fmt-gate verification probe — safe to delete.
+Triggers backend.yml real check on current dev to confirm cargo fmt --all is green tree-wide.


### PR DESCRIPTION
Probe PR to run the required backend `check` (cargo fmt --all --check) against current dev tip. The 4 files flagged in BIT-342 were already reformatted by #1821 (merged ~10m ago); this confirms the tree is fmt-green so the stalled backend queue can proceed. Throwaway probe file; will close (or convert to a real fix) based on the check result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)