### PR TITLE
fix(api-server): resolve E0515 in ai_automation_batch3_tests — unbreak dev compile-smoke (BIT-345)

### DIFF
--- a/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
@@ -384,9 +384,10 @@ async fn test_delete_chat_session_roundtrip(pool: PgPool) {
         .await;
     assert_eq!(create_resp.status, StatusCode::CREATED, "create session");
 
-    let session_id = create_resp.json_value()["session"]["id"]
+    let create_json = create_resp.json_value();
+    let session_id = create_json["session"]["id"]
         .as_str()
-        .or_else(|| create_resp.json_value()["id"].as_str())
+        .or_else(|| create_json["id"].as_str())
         .expect("session id in response")
         .to_string();
 
@@ -419,9 +420,10 @@ async fn test_list_chat_messages_roundtrip(pool: PgPool) {
         "create session for message list"
     );
 
-    let session_id = create_resp.json_value()["session"]["id"]
+    let create_json = create_resp.json_value();
+    let session_id = create_json["session"]["id"]
         .as_str()
-        .or_else(|| create_resp.json_value()["id"].as_str())
+        .or_else(|| create_json["id"].as_str())
         .expect("session id")
         .to_string();
 
@@ -502,9 +504,10 @@ async fn test_workflow_actions_roundtrip(pool: PgPool) {
         "create workflow for action test"
     );
 
-    let wf_id = create_resp.json_value()["workflow"]["id"]
+    let create_json = create_resp.json_value();
+    let wf_id = create_json["workflow"]["id"]
         .as_str()
-        .or_else(|| create_resp.json_value()["id"].as_str())
+        .or_else(|| create_json["id"].as_str())
         .expect("workflow id")
         .to_string();
 


### PR DESCRIPTION
## What
Fixes **3× E0515 "cannot return value referencing temporary value"** in `backend/servers/api-server/tests/ai_automation_batch3_tests.rs` (lines 389/424/507).

```rust
// before — closure returns &str borrowing a Value temp dropped at the closure boundary
let session_id = create_resp.json_value()["session"]["id"]
    .as_str()
    .or_else(|| create_resp.json_value()["id"].as_str())  // E0515
    .expect("session id").to_string();

// after — bind the owned Value to a local; both lookups index the local
let create_json = create_resp.json_value();
let session_id = create_json["session"]["id"]
    .as_str()
    .or_else(|| create_json["id"].as_str())
    .expect("session id").to_string();
```

## Why it matters (BIT-345)
This is the **actual** dev breakage. The required PR `test` job does **not** compile this integration target (it was green at f255ed83 with the same broken file), so the E0515 only surfaced on the post-merge **Backend dev-push gate** (`cargo check --workspace --tests`), which has been RED on dev (run 28323827744).

The clippy `needless_borrow`/dead_code items listed in BIT-345 are **non-blocking** (clippy `lint` is not a required check and is skipped on dev push). They are red herrings for the merge-block; this E0515 is the real compile failure.

## Verification
No local Rust toolchain (mercury offload down). Verified pre-merge by dispatching **Backend dev-push gate** (`cargo check --workspace --tests`) against this branch — the same command that is red on dev. Required `check` gate verifies rustfmt.

Refs BIT-345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)