### PR TITLE
fix(api-server): unbreak dev test gate — compile + -Dwarnings clean (BIT-345)

### DIFF
--- a/backend/servers/api-server/tests/accounting_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/accounting_happy_path_tests.rs
@@ -200,7 +200,7 @@ async fn accounting_endpoints_happy_path(pool: PgPool) {
             app.patch(&format!("/api/v1/accounting/invoices/{invoice_id}"))
                 .bearer(&token)
                 .header("X-Tenant-ID", &tenant)
-                .json(&json!({ "variable_symbol": "VS12345" }))
+                .json(json!({ "variable_symbol": "VS12345" }))
                 .build(),
         )
         .await;

--- a/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
@@ -384,9 +384,10 @@ async fn test_delete_chat_session_roundtrip(pool: PgPool) {
         .await;
     assert_eq!(create_resp.status, StatusCode::CREATED, "create session");
 
-    let session_id = create_resp.json_value()["session"]["id"]
+    let create_json = create_resp.json_value();
+    let session_id = create_json["session"]["id"]
         .as_str()
-        .or_else(|| create_resp.json_value()["id"].as_str())
+        .or_else(|| create_json["id"].as_str())
         .expect("session id in response")
         .to_string();
 
@@ -419,9 +420,10 @@ async fn test_list_chat_messages_roundtrip(pool: PgPool) {
         "create session for message list"
     );
 
-    let session_id = create_resp.json_value()["session"]["id"]
+    let create_json = create_resp.json_value();
+    let session_id = create_json["session"]["id"]
         .as_str()
-        .or_else(|| create_resp.json_value()["id"].as_str())
+        .or_else(|| create_json["id"].as_str())
         .expect("session id")
         .to_string();
 
@@ -502,9 +504,10 @@ async fn test_workflow_actions_roundtrip(pool: PgPool) {
         "create workflow for action test"
     );
 
-    let wf_id = create_resp.json_value()["workflow"]["id"]
+    let create_json = create_resp.json_value();
+    let wf_id = create_json["workflow"]["id"]
         .as_str()
-        .or_else(|| create_resp.json_value()["id"].as_str())
+        .or_else(|| create_json["id"].as_str())
         .expect("workflow id")
         .to_string();
 

--- a/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
@@ -197,6 +197,7 @@ async fn seed_capital_call(
 // Shared fixture
 // ---------------------------------------------------------------------------
 
+#[allow(dead_code)]
 struct Fixture {
     app: TestApp,
     token: String,

--- a/backend/servers/api-server/tests/analytics_owner_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_owner_success_tests.rs
@@ -167,15 +167,17 @@ async fn oa_create_valuation_succeeds(pool: PgPool) {
     });
 
     let resp = app
-        .post(&format!(
-            "/api/v1/owner-analytics/units/{unit_id}/valuation"
-        ))
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.post(&format!(
+                "/api/v1/owner-analytics/units/{unit_id}/valuation"
+            ))
+            .bearer(&token)
+            .json(&body)
+            .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -189,14 +191,16 @@ async fn oa_get_valuation_with_comparables_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-gvc@oa.test", org_id);
 
     let resp = app
-        .get(&format!(
-            "/api/v1/owner-analytics/valuations/{valuation_id}"
-        ))
-        .bearer(&token)
-        .send()
+        .execute(
+            app.get(&format!(
+                "/api/v1/owner-analytics/valuations/{valuation_id}"
+            ))
+            .bearer(&token)
+            .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -220,15 +224,17 @@ async fn oa_add_comparable_succeeds(pool: PgPool) {
     });
 
     let resp = app
-        .post(&format!(
-            "/api/v1/owner-analytics/valuations/{valuation_id}/comparables"
-        ))
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.post(&format!(
+                "/api/v1/owner-analytics/valuations/{valuation_id}/comparables"
+            ))
+            .bearer(&token)
+            .json(&body)
+            .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -241,14 +247,16 @@ async fn oa_get_value_history_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-vh@oa.test", org_id);
 
     let resp = app
-        .get(&format!(
-            "/api/v1/owner-analytics/units/{unit_id}/value-history"
-        ))
-        .bearer(&token)
-        .send()
+        .execute(
+            app.get(&format!(
+                "/api/v1/owner-analytics/units/{unit_id}/value-history"
+            ))
+            .bearer(&token)
+            .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -262,14 +270,16 @@ async fn oa_get_value_trend_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-vt@oa.test", org_id);
 
     let resp = app
-        .get(&format!(
-            "/api/v1/owner-analytics/units/{unit_id}/value-trend"
-        ))
-        .bearer(&token)
-        .send()
+        .execute(
+            app.get(&format!(
+                "/api/v1/owner-analytics/units/{unit_id}/value-trend"
+            ))
+            .bearer(&token)
+            .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -290,13 +300,15 @@ async fn oa_calculate_roi_succeeds(pool: PgPool) {
     });
 
     let resp = app
-        .post(&format!("/api/v1/owner-analytics/units/{unit_id}/roi"))
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.post(&format!("/api/v1/owner-analytics/units/{unit_id}/roi"))
+                .bearer(&token)
+                .json(&body)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -309,14 +321,15 @@ async fn oa_get_cash_flow_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-cf@oa.test", org_id);
 
     let resp = app
+        .execute(app
         .get(&format!(
             "/api/v1/owner-analytics/units/{unit_id}/cash-flow?from_date=2024-01-01&to_date=2024-12-31"
         ))
         .bearer(&token)
-        .send()
+        .build())
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -329,14 +342,15 @@ async fn oa_get_roi_dashboard_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-rd@oa.test", org_id);
 
     let resp = app
+        .execute(app
         .get(&format!(
             "/api/v1/owner-analytics/units/{unit_id}/roi-dashboard?from_date=2024-01-01&to_date=2024-12-31"
         ))
         .bearer(&token)
-        .send()
+        .build())
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -347,12 +361,14 @@ async fn oa_get_portfolio_summary_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-ps@oa.test", org_id);
 
     let resp = app
-        .get("/api/v1/owner-analytics/portfolio")
-        .bearer(&token)
-        .send()
+        .execute(
+            app.get("/api/v1/owner-analytics/portfolio")
+                .bearer(&token)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -367,13 +383,15 @@ async fn oa_compare_properties_succeeds(pool: PgPool) {
     let body = serde_json::json!({ "unit_ids": [unit_id] });
 
     let resp = app
-        .post("/api/v1/owner-analytics/portfolio/compare")
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.post("/api/v1/owner-analytics/portfolio/compare")
+                .bearer(&token)
+                .json(&body)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -384,12 +402,14 @@ async fn oa_list_auto_approval_rules_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-lr@oa.test", org_id);
 
     let resp = app
-        .get("/api/v1/owner-analytics/expense-rules")
-        .bearer(&token)
-        .send()
+        .execute(
+            app.get("/api/v1/owner-analytics/expense-rules")
+                .bearer(&token)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -407,13 +427,15 @@ async fn oa_create_auto_approval_rule_succeeds(pool: PgPool) {
     });
 
     let resp = app
-        .post("/api/v1/owner-analytics/expense-rules")
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.post("/api/v1/owner-analytics/expense-rules")
+                .bearer(&token)
+                .json(&body)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -430,13 +452,15 @@ async fn oa_update_auto_approval_rule_succeeds(pool: PgPool) {
     });
 
     let resp = app
-        .put(&format!("/api/v1/owner-analytics/expense-rules/{rule_id}"))
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.put(&format!("/api/v1/owner-analytics/expense-rules/{rule_id}"))
+                .bearer(&token)
+                .json(&body)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -448,12 +472,14 @@ async fn oa_delete_auto_approval_rule_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-dr@oa.test", org_id);
 
     let resp = app
-        .delete(&format!("/api/v1/owner-analytics/expense-rules/{rule_id}"))
-        .bearer(&token)
-        .send()
+        .execute(
+            app.delete(&format!("/api/v1/owner-analytics/expense-rules/{rule_id}"))
+                .bearer(&token)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(resp.status, StatusCode::NO_CONTENT);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -474,13 +500,15 @@ async fn oa_submit_expense_succeeds(pool: PgPool) {
     });
 
     let resp = app
-        .post("/api/v1/owner-analytics/expenses/submit")
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.post("/api/v1/owner-analytics/expenses/submit")
+                .bearer(&token)
+                .json(&body)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -491,12 +519,14 @@ async fn oa_list_expense_requests_succeeds(pool: PgPool) {
     let token = mint(user_id, "oa-le@oa.test", org_id);
 
     let resp = app
-        .get("/api/v1/owner-analytics/expenses")
-        .bearer(&token)
-        .send()
+        .execute(
+            app.get("/api/v1/owner-analytics/expenses")
+                .bearer(&token)
+                .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -515,13 +545,15 @@ async fn oa_review_expense_succeeds(pool: PgPool) {
     });
 
     let resp = app
-        .post(&format!(
-            "/api/v1/owner-analytics/expenses/{expense_id}/review"
-        ))
-        .bearer(&token)
-        .json(&body)
-        .send()
+        .execute(
+            app.post(&format!(
+                "/api/v1/owner-analytics/expenses/{expense_id}/review"
+            ))
+            .bearer(&token)
+            .json(&body)
+            .build(),
+        )
         .await;
 
-    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.status, StatusCode::OK);
 }

--- a/backend/servers/api-server/tests/common/mod.rs
+++ b/backend/servers/api-server/tests/common/mod.rs
@@ -5,6 +5,12 @@
 //! - Request helpers
 //! - Response extractors
 //! - Test fixtures for users and organizations
+//!
+//! Helpers here are shared across many integration-test binaries; each binary
+//! `mod common;`-includes the whole module but uses only a subset, so unused
+//! items are expected per-binary. Allow dead_code so the shared harness does
+//! not trip the `-Dwarnings` test gate (BIT-345).
+#![allow(dead_code)]
 
 use axum::{
     body::Body,

--- a/backend/servers/api-server/tests/faults_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/faults_behaviour_tests.rs
@@ -121,7 +121,7 @@ async fn test_update_fault_title(pool: PgPool) {
         .put(&format!("/api/v1/faults/{}", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "title": "Updated Fault Title" }))
+        .json(json!({ "title": "Updated Fault Title" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "update fault: {}", resp.text());
@@ -149,7 +149,7 @@ async fn test_update_fault_status_to_in_progress(pool: PgPool) {
         .put(&format!("/api/v1/faults/{}/status", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "status": "in_progress", "note": "Work started" }))
+        .json(json!({ "status": "in_progress", "note": "Work started" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -176,7 +176,7 @@ async fn test_resolve_fault(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/resolve", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "resolution_notes": "Pipe was replaced." }))
+        .json(json!({ "resolution_notes": "Pipe was replaced." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -204,7 +204,7 @@ async fn test_confirm_fault_resolution(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/resolve", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "resolution_notes": "Fixed." }))
+        .json(json!({ "resolution_notes": "Fixed." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK);
@@ -214,7 +214,7 @@ async fn test_confirm_fault_resolution(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/confirm", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "rating": 5, "feedback": "Great work!" }))
+        .json(json!({ "rating": 5, "feedback": "Great work!" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -253,7 +253,7 @@ async fn test_reopen_resolved_fault(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/resolve", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "resolution_notes": "Fixed temporarily." }))
+        .json(json!({ "resolution_notes": "Fixed temporarily." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK);
@@ -263,7 +263,7 @@ async fn test_reopen_resolved_fault(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/reopen", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "reason": "Problem recurred." }))
+        .json(json!({ "reason": "Problem recurred." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "reopen fault: {}", resp.text());
@@ -333,7 +333,7 @@ async fn test_add_and_list_fault_comments(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/comments", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "note": "Investigating the issue.", "is_internal": false }))
+        .json(json!({ "note": "Investigating the issue.", "is_internal": false }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -376,7 +376,7 @@ async fn test_add_work_note(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/work-notes", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "note": "Ordered replacement parts." }))
+        .json(json!({ "note": "Ordered replacement parts." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(

--- a/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
@@ -132,6 +132,7 @@ async fn seed_quote(pool: &PgPool, rfq_id: Uuid, provider_id: Uuid) -> Uuid {
     .expect("seed quote")
 }
 
+#[allow(dead_code)]
 async fn seed_verification(pool: &PgPool, provider_id: Uuid) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
         r#"INSERT INTO provider_verifications

--- a/backend/servers/api-server/tests/voting_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/voting_behaviour_tests.rs
@@ -133,7 +133,7 @@ async fn publish_vote(app: &TestApp, token: &str, org_id: Uuid, vote_id: Uuid) {
         .post(&format!("/api/v1/voting/{}/publish", vote_id))
         .bearer(token)
         .tenant(org_id)
-        .json(&json!({ "start_at": null }))
+        .json(json!({ "start_at": null }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "publish vote: {}", resp.text());
@@ -155,7 +155,7 @@ async fn test_update_vote_title_succeeds(pool: PgPool) {
         .put(&format!("/api/v1/voting/{}", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "title": "Updated Title" }))
+        .json(json!({ "title": "Updated Title" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "update vote: {}", resp.text());
@@ -206,7 +206,7 @@ async fn test_cancel_active_vote_succeeds(pool: PgPool) {
         .post(&format!("/api/v1/voting/{}/cancel", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "reason": "Test cancellation" }))
+        .json(json!({ "reason": "Test cancellation" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "cancel vote: {}", resp.text());
@@ -285,7 +285,7 @@ async fn test_update_question_text(pool: PgPool) {
         ))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "question_text": "Revised question?" }))
+        .json(json!({ "question_text": "Revised question?" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -418,7 +418,7 @@ async fn test_add_and_list_comments(pool: PgPool) {
         .post(&format!("/api/v1/voting/{}/comments", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "parent_id": null, "content": "A test comment", "ai_consent": false }))
+        .json(json!({ "parent_id": null, "content": "A test comment", "ai_consent": false }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -475,7 +475,7 @@ async fn test_hide_comment(pool: PgPool) {
         .post(&format!("/api/v1/voting/{}/comments", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "parent_id": null, "content": "To hide", "ai_consent": false }))
+        .json(json!({ "parent_id": null, "content": "To hide", "ai_consent": false }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::CREATED);
@@ -489,7 +489,7 @@ async fn test_hide_comment(pool: PgPool) {
         ))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "reason": "Inappropriate content" }))
+        .json(json!({ "reason": "Inappropriate content" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "hide comment: {}", resp.text());


### PR DESCRIPTION
## Summary
Makes the required backend **`test`** gate (`RUSTFLAGS=-Dwarnings`) and the post-merge **compile-smoke** green on `dev`. Consolidates every test-code fix in the backfill wave that was breaking the build — including the two real `-Dwarnings` blockers that no existing PR covered.

Root cause: the `test` gate compiles test targets with `-Dwarnings`, so any dead_code/unused becomes a hard error; agents merging with `--no-verify` (mercury cargo-offload down, no local toolchain) accumulated drift. The post-merge compile-smoke (`cargo check --workspace --tests`, no `-Dwarnings`) caught the hard compile errors but not the warning-fatal ones.

## Fixes (8 files)
- `ai_automation_batch3_tests` — bind `json_value()` to a local → fixes 3× **E0515** (was #1939)
- `analytics_owner_success_tests` — dead `.send()/.status()` harness API → `.execute()+.status` (was #1933)
- `analytics_investor_portal_success_tests` — `#[allow(dead_code)]` on `Fixture` (was #1933)
- `accounting_happy_path` / `faults_behaviour` / `voting_behaviour` — `.json(&json!())` → `.json(json!())` (needless_borrow) (was #1933)
- **`common/mod.rs`** — module-level `#![allow(dead_code)]` for the shared harness (each test binary `mod common`s the whole module but uses only a subset → 15 dead_code errors under `-Dwarnings`). **New — not in any prior PR.**
- **`marketplace_provider_profile_tests`** — `#[allow(dead_code)]` on unused `seed_verification`. **New.**

## How the complete set was found
With no local Rust toolchain, I enumerated via a temporary `cargo check --workspace --tests --keep-going` **with `RUSTFLAGS=-Dwarnings`** dispatched on a throwaway branch — this compiles *every* target in one run (cargo otherwise aborts at the first failure) and faithfully mirrors the `test` gate. After applying #1933 + #1939's fixes, only `common/mod.rs` (15) + `marketplace` (1) remained; both are fixed here.

## Verification
This PR's own `check` + `test` jobs are the authoritative `-Dwarnings` verifier.

Supersedes #1933 and #1939.

Closes BIT-345 (repair track).