### PR TITLE
fix(ci): close push-event test-gate bypass + enumerate broken test files (BIT-346)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -27,6 +27,16 @@ name: Backend
 
 on:
   push:
+    # Restrict push-event runs to the integration branches ONLY. Without this,
+    # `push` fired on every feature-branch push too, so each PR head SHA carried
+    # TWO runs reporting the same required contexts (`check`/`test`): the real
+    # pull_request run AND a push run. Because the push run no-op'd those
+    # contexts green (the `changes` plumbing bug below), GitHub's "latest wins"
+    # resolution among same-named contexts could let the green no-op satisfy the
+    # required gate — broken test code merged on a stale/raced no-op (BIT-346).
+    # Keying push to dev/main leaves the pull_request run as the sole producer of
+    # required contexts on a PR head SHA; push runs now only smoke dev/main tips.
+    branches: [dev, main]
     paths:
       - 'backend/**'
       # Trigger when the workflow itself changes — otherwise edits to
@@ -67,8 +77,17 @@ jobs:
   # suite (matches the pre-#1672 behaviour where those events always ran).
   changes:
     runs-on: ubuntu-latest
+    # Coalesce BOTH producers: on a PR the `filter` step sets the value and
+    # `force` is skipped (empty); on push/schedule/dispatch `filter` is skipped
+    # (empty) and `force` sets it. The previous output read ONLY
+    # steps.filter.outputs.backend, but the force step had no `id`, so its value
+    # never reached the job output — every non-PR event resolved `backend` to ""
+    # and the downstream `check`/`test` jobs silently took the NO-OP path and
+    # reported green WITHOUT compiling. That is the push-event gate bypass at the
+    # heart of BIT-346; the `||` below restores the documented "non-PR events
+    # always run the full suite" behaviour.
     outputs:
-      backend: ${{ steps.filter.outputs.backend }}
+      backend: ${{ steps.filter.outputs.backend || steps.force.outputs.backend }}
     steps:
       - uses: actions/checkout@v6
 
@@ -82,9 +101,11 @@ jobs:
               - 'backend/**'
               - '.github/workflows/backend.yml'
 
-      # Non-PR events (push to backend/**, weekly schedule, manual dispatch)
+      # Non-PR events (push to dev/main, weekly schedule, manual dispatch)
       # always exercise the full suite — there is no diff to filter against.
+      # The `id` is REQUIRED so the job output above can read this value.
       - name: Force backend=true for non-PR events
+        id: force
         if: github.event_name != 'pull_request'
         run: echo "backend=true" >> "$GITHUB_OUTPUT"
 
@@ -294,6 +315,21 @@ jobs:
             /usr/local/lib/android /opt/hostedtoolcache/CodeQL /usr/share/swift
           sudo docker image prune --all --force >/dev/null 2>&1 || true
           echo "Disk after cleanup:"; df -h /
+
+      # Compile EVERY test target before running anything. `--no-fail-fast`
+      # (below) only governs test *execution* — a *compile* error still aborts
+      # the build at the first broken binary, so broken test files surface one
+      # per ~15-min CI cycle and get peeled one merge at a time (BIT-346).
+      # `--keep-going` makes cargo continue compiling the other independent test
+      # targets after one fails and report ALL compile errors in a single run,
+      # so a whole wave of broken files can be enumerated and fixed at once.
+      - name: Compile all test targets (enumerate every compile failure)
+        if: needs.changes.outputs.backend == 'true'
+        working-directory: backend
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
+          RUST_ENV: development
+        run: cargo test --workspace --no-run --keep-going
 
       - name: Run tests
         if: needs.changes.outputs.backend == 'true'

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -323,13 +323,17 @@ jobs:
       # `--keep-going` makes cargo continue compiling the other independent test
       # targets after one fails and report ALL compile errors in a single run,
       # so a whole wave of broken files can be enumerated and fixed at once.
+      # NOTE: `--keep-going` is NOT accepted by `cargo test` in this toolchain
+      # (arg-parse error). `cargo build --workspace --tests --keep-going`
+      # compiles the same test targets (`--tests` => lib/bins-as-unittests +
+      # integration tests) and supports `--keep-going`.
       - name: Compile all test targets (enumerate every compile failure)
         if: needs.changes.outputs.backend == 'true'
         working-directory: backend
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
           RUST_ENV: development
-        run: cargo test --workspace --no-run --keep-going
+        run: cargo build --workspace --tests --keep-going
 
       - name: Run tests
         if: needs.changes.outputs.backend == 'true'


### PR DESCRIPTION
## Problem (BIT-346)

The required `test` check on `dev` could be satisfied by a **no-op push-event run** that never compiles, letting broken integration-test files merge onto `dev`. Once there, every backend PR's real `test` run goes red — and the broken files surfaced **one per ~15-min CI cycle**, blocking the whole BIT-258 backfill wave.

## Root cause (3 confirmed defects)

1. **Duplicate required contexts on PR head SHAs.** `push:` had no `branches:` filter, so `backend.yml` fired on every feature-branch push too. Each PR head SHA carried two runs reporting the same `check`/`test` contexts (real `pull_request` + `push`). Verified live on PR #1937: head SHA had a push-run `test`=success in **26s** alongside the real `pull_request` `test`. GitHub's *latest-wins* resolution among same-named contexts is a race the green no-op can win.
2. **Broken `changes` plumbing.** The job output read only `steps.filter.outputs.backend`; the *Force backend=true* step had **no `id`**, so on push/schedule/dispatch `backend` resolved to `""` and `check`/`test` took the **no-op path** — green without compiling. (The push run on dev tip `f255ed83` no-op'd `check` in 3s / `test` in 28s despite touching `backend/**`.)
3. **Peel-one-at-a-time.** `--no-fail-fast` only covers test *execution*; a *compile* error aborts at the first broken binary.

## Fix

- `push.branches: [dev, main]` → `pull_request` is the sole producer of required contexts on a PR head SHA (no duplicate, no race).
- `changes` output = `steps.filter.outputs.backend || steps.force.outputs.backend` (+ `id: force`) → non-PR events again run the full suite as documented.
- New step `cargo test --workspace --no-run --keep-going` → **one run enumerates every broken test target** instead of peeling.

## Note on this PR's own CI
This PR's `test` run is **expected to go red** until the already-broken files on `dev` are repaired — and that red run is the **enumeration vehicle**: the new `--keep-going` step lists *all* remaining broken files in one pass. Repair commits will be added to this branch (or a stacked PR) to green it. See BIT-346 for the repair-strategy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)