### PR TITLE
fix(test): allow(dead_code) on unused seed_verification (unblock backend test gate)

### DIFF
--- a/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
@@ -132,6 +132,7 @@ async fn seed_quote(pool: &PgPool, rfq_id: Uuid, provider_id: Uuid) -> Uuid {
     .expect("seed quote")
 }
 
+#[allow(dead_code)]
 async fn seed_verification(pool: &PgPool, provider_id: Uuid) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
         r#"INSERT INTO provider_verifications


### PR DESCRIPTION
## Summary
`marketplace_provider_profile_tests.rs` (BIT-268, #1874) has an unused `seed_verification` helper. Under the `test` job's `RUSTFLAGS=-D warnings`, `dead_code` is a **hard error** → `cargo test --workspace` fails to compile `api-server`, which **blocks the required `test` gate for every backend PR** (e.g. #1934).

## Fix
One line — `#[allow(dead_code)]` on the helper, matching the file's existing per-item convention (it already allows it on `mod common`). Test-only, trunk repair. Same `--no-verify`-drift class as BIT-345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)