### PR TITLE
chore(test): file-level allow(dead_code) across test suite — unbreak real test build (BIT-345)

### DIFF
--- a/backend/servers/api-server/tests/accounting_contacts_authz_tests.rs
+++ b/backend/servers/api-server/tests/accounting_contacts_authz_tests.rs
@@ -7,7 +7,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/accounting_contacts_authz_tests.rs
+++ b/backend/servers/api-server/tests/accounting_contacts_authz_tests.rs
@@ -5,6 +5,8 @@
 //!   - a non-manager tenant member (resident) gets 403
 //!   - a manager gets 200
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/accounting_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/accounting_happy_path_tests.rs
@@ -201,7 +201,7 @@ async fn accounting_endpoints_happy_path(pool: PgPool) {
             app.patch(&format!("/api/v1/accounting/invoices/{invoice_id}"))
                 .bearer(&token)
                 .header("X-Tenant-ID", &tenant)
-                .json(&json!({ "variable_symbol": "VS12345" }))
+                .json(json!({ "variable_symbol": "VS12345" }))
                 .build(),
         )
         .await;

--- a/backend/servers/api-server/tests/accounting_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/accounting_happy_path_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/accounting_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/accounting_happy_path_tests.rs
@@ -23,6 +23,8 @@
 //!  10. POST   /api/v1/accounting/matches/{id}/reject      (reject_match)
 //!  11. DELETE /api/v1/accounting/invoices/{id}            (delete_invoice)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
+++ b/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
@@ -13,6 +13,8 @@
 //!   - Confirmed -> Confirmed / Rejected -> Rejected : idempotent no-op
 //!   - Rejected  -> Confirmed  : ILLEGAL -> 409 Conflict
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
+++ b/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
@@ -108,7 +108,7 @@ async fn confirm_reject_confirm_does_not_inflate_paid_amount(pool: PgPool) {
     set_ctx(&mut conn, org).await;
 
     // Suggested -> Confirmed: applies the full amount.
-    svc.confirm_match(&mut *conn, org, match_id, user)
+    svc.confirm_match(&mut conn, org, match_id, user)
         .await
         .expect("confirm suggested match");
     let (paid, status) = invoice_state(&pool, invoice).await;
@@ -116,7 +116,7 @@ async fn confirm_reject_confirm_does_not_inflate_paid_amount(pool: PgPool) {
     assert_eq!(status, InvoiceStatus::Paid, "fully paid invoice is 'paid'");
 
     // Confirmed -> Rejected: unapplies the amount and reverts status.
-    svc.reject_match(&mut *conn, match_id, user)
+    svc.reject_match(&mut conn, match_id, user)
         .await
         .expect("reject confirmed match");
     let (paid, status) = invoice_state(&pool, invoice).await;
@@ -133,7 +133,7 @@ async fn confirm_reject_confirm_does_not_inflate_paid_amount(pool: PgPool) {
 
     // Rejected -> Confirmed: ILLEGAL. Must 409 and must NOT re-apply.
     let err = svc
-        .confirm_match(&mut *conn, org, match_id, user)
+        .confirm_match(&mut conn, org, match_id, user)
         .await
         .expect_err("confirming a rejected match must fail");
     assert!(
@@ -158,10 +158,10 @@ async fn double_confirm_is_idempotent(pool: PgPool) {
     let mut conn = pool.acquire().await.unwrap();
     set_ctx(&mut conn, org).await;
 
-    svc.confirm_match(&mut *conn, org, match_id, user)
+    svc.confirm_match(&mut conn, org, match_id, user)
         .await
         .expect("first confirm");
-    svc.confirm_match(&mut *conn, org, match_id, user)
+    svc.confirm_match(&mut conn, org, match_id, user)
         .await
         .expect("second confirm is a no-op");
 
@@ -184,10 +184,10 @@ async fn double_reject_is_idempotent(pool: PgPool) {
     let mut conn = pool.acquire().await.unwrap();
     set_ctx(&mut conn, org).await;
 
-    svc.reject_match(&mut *conn, match_id, user)
+    svc.reject_match(&mut conn, match_id, user)
         .await
         .expect("first reject");
-    svc.reject_match(&mut *conn, match_id, user)
+    svc.reject_match(&mut conn, match_id, user)
         .await
         .expect("second reject is a no-op");
 

--- a/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
+++ b/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
@@ -15,7 +15,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use api_server::services::accounting::AccountingService;

--- a/backend/servers/api-server/tests/admin_mfa_disable_tests.rs
+++ b/backend/servers/api-server/tests/admin_mfa_disable_tests.rs
@@ -25,6 +25,8 @@
 //! per the established convention (e.g. `auth_policy_enforcement_tests.rs`).
 //! CI invokes them via `cargo test -- --ignored` against the dev DB.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/admin_mfa_disable_tests.rs
+++ b/backend/servers/api-server/tests/admin_mfa_disable_tests.rs
@@ -27,7 +27,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/admin_mfa_recovery_tests.rs
+++ b/backend/servers/api-server/tests/admin_mfa_recovery_tests.rs
@@ -26,7 +26,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/admin_mfa_recovery_tests.rs
+++ b/backend/servers/api-server/tests/admin_mfa_recovery_tests.rs
@@ -24,6 +24,8 @@
 //! All tests are gated `#[ignore = "requires postgres + migrations"]` per
 //! the established convention.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/admin_mfa_step_up_tests.rs
+++ b/backend/servers/api-server/tests/admin_mfa_step_up_tests.rs
@@ -19,6 +19,8 @@
 //! All tests are gated `#[ignore = "requires postgres + migrations"]` per the
 //! established convention.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/admin_mfa_step_up_tests.rs
+++ b/backend/servers/api-server/tests/admin_mfa_step_up_tests.rs
@@ -21,7 +21,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/agency_authz_idor_tests.rs
+++ b/backend/servers/api-server/tests/agency_authz_idor_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/agency_authz_idor_tests.rs
+++ b/backend/servers/api-server/tests/agency_authz_idor_tests.rs
@@ -23,6 +23,8 @@
 //! regression is `get_agency`, which previously returned 200 with the full
 //! agency record and now returns 4xx.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/ai_auth_tests.rs
+++ b/backend/servers/api-server/tests/ai_auth_tests.rs
@@ -16,6 +16,8 @@
 //! up for the AI router. The contract these tests assert is the security
 //! contract: the request without proof of identity is rejected, full stop.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/ai_auth_tests.rs
+++ b/backend/servers/api-server/tests/ai_auth_tests.rs
@@ -18,7 +18,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/ai_automation_batch1_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch1_tests.rs
@@ -6,7 +6,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/ai_automation_batch1_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch1_tests.rs
@@ -4,6 +4,8 @@
 //! All previous tests in this group were auth-only (401/403); this file
 //! asserts that authenticated requests get 2xx responses.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
@@ -7,6 +7,8 @@
 //!   - /api/v1/ai/equipment
 //!   - /api/v1/ai/workflows
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
@@ -9,7 +9,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
@@ -6,6 +6,8 @@
 //! unless the provider adapter returns an error — in that case we accept
 //! any non-401 status.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
@@ -8,7 +8,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/ai_chat_sentiment_equipment_batch4_tests.rs
+++ b/backend/servers/api-server/tests/ai_chat_sentiment_equipment_batch4_tests.rs
@@ -13,7 +13,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/ai_chat_sentiment_equipment_batch4_tests.rs
+++ b/backend/servers/api-server/tests/ai_chat_sentiment_equipment_batch4_tests.rs
@@ -11,6 +11,8 @@
 //!
 //! BIT-268 / BIT-304
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
@@ -13,6 +13,8 @@
 //!
 //! These tests run fully offline — the route never calls the Airbnb API.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_connections_routes_tests.rs
@@ -15,7 +15,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
@@ -32,7 +32,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_oauth_routes_tests.rs
@@ -30,6 +30,8 @@
 //! Live end-to-end token exchange is covered by the manual QA checklist in
 //! `docs/api/README.md#airbnb-oauth-flow`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/airbnb_sync_reconciliation_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_sync_reconciliation_tests.rs
@@ -66,7 +66,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/airbnb_sync_reconciliation_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_sync_reconciliation_tests.rs
@@ -64,6 +64,8 @@
 //! construction (`AirbnbAppConfig::from_env`). We seed it via a `Once` before
 //! the first `TestApp::new`, mirroring `airbnb_webhook_routes_tests.rs`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/airbnb_webhook_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_webhook_routes_tests.rs
@@ -39,7 +39,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/airbnb_webhook_routes_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_webhook_routes_tests.rs
@@ -37,6 +37,8 @@
 //! it is intentionally left to the per-request unit-level reasoning; the
 //! high-value signature / parse / dedup paths are all covered here.)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
@@ -16,7 +16,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_audit_logging_tests.rs
@@ -14,6 +14,8 @@
 //! in `audit_logs`. They cover the two handlers named in the PAP-42 acceptance
 //! criteria: `review_aml_assessment` and `take_moderation_action`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/aml_dsa_authz_pap60_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_authz_pap60_tests.rs
@@ -32,7 +32,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/aml_dsa_authz_pap60_tests.rs
+++ b/backend/servers/api-server/tests/aml_dsa_authz_pap60_tests.rs
@@ -30,6 +30,8 @@
 //! "non-privileged / cross-tenant caller" the role and ownership gates must
 //! reject, so the HTTP tests assert the rejection direction.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/analytics_esg_reporting_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_esg_reporting_success_tests.rs
@@ -49,7 +49,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/analytics_esg_reporting_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_esg_reporting_success_tests.rs
@@ -47,6 +47,8 @@
 //!   GET    /esg/imports/{id}
 //!   GET    /esg/statistics
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/analytics_government_portal_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_government_portal_success_tests.rs
@@ -30,6 +30,8 @@
 //!   DELETE /government-portal/schedules/{id}
 //!   GET    /government-portal/stats
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/analytics_government_portal_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_government_portal_success_tests.rs
@@ -32,7 +32,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
@@ -34,6 +34,8 @@
 //!   GET    /investor-portal/dashboard/{investor_id}
 //!   POST   /investor-portal/dashboard/{investor_id}/metrics
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
@@ -36,7 +36,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/analytics_portfolio_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_portfolio_success_tests.rs
@@ -63,7 +63,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/analytics_portfolio_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_portfolio_success_tests.rs
@@ -61,6 +61,8 @@
 //!     POST   /portfolio-performance/portfolios/{id}/alerts/{alert_id}/read
 //!     POST   /portfolio-performance/portfolios/{id}/alerts/{alert_id}/resolve
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/announcement_comments_threading_tests.rs
+++ b/backend/servers/api-server/tests/announcement_comments_threading_tests.rs
@@ -30,7 +30,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/announcement_comments_threading_tests.rs
+++ b/backend/servers/api-server/tests/announcement_comments_threading_tests.rs
@@ -28,6 +28,8 @@
 //! non-superuser role so the `announcement_comments` policy (migration 00016)
 //! actually runs.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
+++ b/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
@@ -149,11 +149,11 @@ async fn published_announcements_revoke_on_move_out(pool: PgPool) {
     let mut conn = pool.acquire().await.expect("acquire");
 
     // ---- Current resident sees org-wide + building + unit announcements ----
-    db::set_request_context(&mut conn, Some(org), Some(current), false)
+    db::set_request_context(&mut *conn, Some(org), Some(current), false)
         .await
         .expect("set context (current)");
     let current_titles: Vec<String> = repo
-        .list_published_rls(&mut conn, org, None, None)
+        .list_published_rls(&mut *conn, org, None, None)
         .await
         .expect("list (current)")
         .into_iter()
@@ -167,11 +167,11 @@ async fn published_announcements_revoke_on_move_out(pool: PgPool) {
     );
 
     // ---- Moved-out resident sees ONLY the org-wide announcement ----
-    db::set_request_context(&mut conn, Some(org), Some(ended), false)
+    db::set_request_context(&mut *conn, Some(org), Some(ended), false)
         .await
         .expect("set context (ended)");
     let ended_titles: Vec<String> = repo
-        .list_published_rls(&mut conn, org, None, None)
+        .list_published_rls(&mut *conn, org, None, None)
         .await
         .expect("list (ended)")
         .into_iter()

--- a/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
+++ b/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
@@ -30,7 +30,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use db::repositories::AnnouncementRepository;

--- a/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
+++ b/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
@@ -28,6 +28,8 @@
 //! The CI/test database role bypasses RLS, so these assertions pin the
 //! application-level predicate inside the query.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
+++ b/backend/servers/api-server/tests/announcement_residency_revocation_tests.rs
@@ -149,11 +149,11 @@ async fn published_announcements_revoke_on_move_out(pool: PgPool) {
     let mut conn = pool.acquire().await.expect("acquire");
 
     // ---- Current resident sees org-wide + building + unit announcements ----
-    db::set_request_context(&mut *conn, Some(org), Some(current), false)
+    db::set_request_context(&mut conn, Some(org), Some(current), false)
         .await
         .expect("set context (current)");
     let current_titles: Vec<String> = repo
-        .list_published_rls(&mut *conn, org, None, None)
+        .list_published_rls(&mut conn, org, None, None)
         .await
         .expect("list (current)")
         .into_iter()
@@ -167,11 +167,11 @@ async fn published_announcements_revoke_on_move_out(pool: PgPool) {
     );
 
     // ---- Moved-out resident sees ONLY the org-wide announcement ----
-    db::set_request_context(&mut *conn, Some(org), Some(ended), false)
+    db::set_request_context(&mut conn, Some(org), Some(ended), false)
         .await
         .expect("set context (ended)");
     let ended_titles: Vec<String> = repo
-        .list_published_rls(&mut *conn, org, None, None)
+        .list_published_rls(&mut conn, org, None, None)
         .await
         .expect("list (ended)")
         .into_iter()

--- a/backend/servers/api-server/tests/announcements_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/announcements_happy_path_tests.rs
@@ -32,7 +32,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/announcements_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/announcements_happy_path_tests.rs
@@ -30,6 +30,8 @@
 //! - POST   /api/v1/organizations/{org_id}/critical-notifications/{notification_id}/acknowledge
 //! - GET    /api/v1/organizations/{org_id}/critical-notifications/{notification_id}/stats
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/auth_enumeration_tests.rs
+++ b/backend/servers/api-server/tests/auth_enumeration_tests.rs
@@ -19,6 +19,8 @@
 // Each integration-test binary compiles `common` independently and uses only a
 // subset of its helpers; without this the rest trip `-D dead_code` under CI's
 // `RUSTFLAGS=-Dwarnings`. Matches every other test file in this directory.
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/auth_enumeration_tests.rs
+++ b/backend/servers/api-server/tests/auth_enumeration_tests.rs
@@ -21,7 +21,6 @@
 // `RUSTFLAGS=-Dwarnings`. Matches every other test file in this directory.
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use common::{cleanup_test_user, verify_user_email, TestApp, TestUser};

--- a/backend/servers/api-server/tests/auth_partial_backfill_batch1_tests.rs
+++ b/backend/servers/api-server/tests/auth_partial_backfill_batch1_tests.rs
@@ -15,7 +15,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/auth_partial_backfill_batch1_tests.rs
+++ b/backend/servers/api-server/tests/auth_partial_backfill_batch1_tests.rs
@@ -13,6 +13,8 @@
 //!   - GET  /api/v1/auth/me
 //!   - PATCH /api/v1/auth/me
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/auth_partial_backfill_batch2_tests.rs
+++ b/backend/servers/api-server/tests/auth_partial_backfill_batch2_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/auth_partial_backfill_batch2_tests.rs
+++ b/backend/servers/api-server/tests/auth_partial_backfill_batch2_tests.rs
@@ -23,6 +23,8 @@
 //!   - GET  /api/v1/help/categories/{slug}
 //!   - GET  /api/v1/help/tooltips/{key}
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/automation_auth_tests.rs
+++ b/backend/servers/api-server/tests/automation_auth_tests.rs
@@ -27,6 +27,8 @@
 //! `main.rs`). The test documents the contract; future work can flip the
 //! `#[ignore]` once a multi-tenant fixture builder lands.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/automation_auth_tests.rs
+++ b/backend/servers/api-server/tests/automation_auth_tests.rs
@@ -29,7 +29,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/automation_workflow_batch3_tests.rs
+++ b/backend/servers/api-server/tests/automation_workflow_batch3_tests.rs
@@ -8,6 +8,8 @@
 //!
 //! BIT-268 / BIT-304
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/automation_workflow_batch3_tests.rs
+++ b/backend/servers/api-server/tests/automation_workflow_batch3_tests.rs
@@ -10,7 +10,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/board_meetings_auth_tests.rs
+++ b/backend/servers/api-server/tests/board_meetings_auth_tests.rs
@@ -11,7 +11,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/board_meetings_auth_tests.rs
+++ b/backend/servers/api-server/tests/board_meetings_auth_tests.rs
@@ -9,6 +9,8 @@
 //! No DB seeding: `AuthUser` rejects a request with no bearer token at the
 //! extractor.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/board_meetings_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/board_meetings_cross_org_idor_tests.rs
@@ -24,6 +24,8 @@
 //!      no write.
 //!   3. Org A's member reads its own meeting → allowed (2xx).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/board_meetings_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/board_meetings_cross_org_idor_tests.rs
@@ -26,7 +26,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::{Method, StatusCode};

--- a/backend/servers/api-server/tests/booking_credential_encryption_tests.rs
+++ b/backend/servers/api-server/tests/booking_credential_encryption_tests.rs
@@ -32,6 +32,8 @@
 //! contract is verified deterministically. The handler-wiring guards
 //! (auth/IDOR/route-mounted) are covered in `booking_oauth_routes_tests.rs`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/booking_credential_encryption_tests.rs
+++ b/backend/servers/api-server/tests/booking_credential_encryption_tests.rs
@@ -34,7 +34,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use sqlx::PgPool;

--- a/backend/servers/api-server/tests/booking_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/booking_cross_user_idor_tests.rs
@@ -12,6 +12,8 @@
 //! tokens directly (matching `api_server`'s Claims shape). Only the booking
 //! *owner* needs to be a real user row (FK); the caller does not.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/booking_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/booking_cross_user_idor_tests.rs
@@ -14,7 +14,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/booking_oauth_csrf_tests.rs
+++ b/backend/servers/api-server/tests/booking_oauth_csrf_tests.rs
@@ -41,7 +41,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/booking_oauth_csrf_tests.rs
+++ b/backend/servers/api-server/tests/booking_oauth_csrf_tests.rs
@@ -39,6 +39,8 @@
 //! `StoreUnavailable` and the callback relies on the stateless org-prefix +
 //! membership checks — exactly the path these tests pin.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/booking_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/booking_oauth_routes_tests.rs
@@ -41,7 +41,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/booking_oauth_routes_tests.rs
+++ b/backend/servers/api-server/tests/booking_oauth_routes_tests.rs
@@ -39,6 +39,8 @@
 //! approach" finding (shared `oauth_common` helper). Every guard reachable
 //! without a live provider call is covered here.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/building_manager_rbac_tests.rs
+++ b/backend/servers/api-server/tests/building_manager_rbac_tests.rs
@@ -12,7 +12,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/building_manager_rbac_tests.rs
+++ b/backend/servers/api-server/tests/building_manager_rbac_tests.rs
@@ -10,6 +10,8 @@
 //! report_schedule_org_scope_jwt_tests.rs). A resident must get 403 before the
 //! mutation; the role gate runs after the org-membership check.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/caddy_ask_tests.rs
+++ b/backend/servers/api-server/tests/caddy_ask_tests.rs
@@ -141,7 +141,7 @@ mod test_handler {
 
     async fn host_in_verifying_state(pool: DbPool, host: &str) -> Result<bool, sqlx::Error> {
         let mut conn = pool.acquire().await?;
-        db::tenant_context::set_request_context(&mut *conn, None, None, true).await?;
+        db::tenant_context::set_request_context(&mut conn, None, None, true).await?;
         let result = sqlx::query_scalar::<_, Uuid>(
             r#"
             SELECT organization_id
@@ -150,10 +150,10 @@ mod test_handler {
             "#,
         )
         .bind(host)
-        .fetch_optional(&mut *conn)
+        .fetch_optional(&mut conn)
         .await
         .map(|r| r.is_some());
-        let _ = db::tenant_context::clear_request_context(&mut *conn).await;
+        let _ = db::tenant_context::clear_request_context(&mut conn).await;
         result
     }
 }

--- a/backend/servers/api-server/tests/caddy_ask_tests.rs
+++ b/backend/servers/api-server/tests/caddy_ask_tests.rs
@@ -141,7 +141,7 @@ mod test_handler {
 
     async fn host_in_verifying_state(pool: DbPool, host: &str) -> Result<bool, sqlx::Error> {
         let mut conn = pool.acquire().await?;
-        db::tenant_context::set_request_context(&mut conn, None, None, true).await?;
+        db::tenant_context::set_request_context(&mut *conn, None, None, true).await?;
         let result = sqlx::query_scalar::<_, Uuid>(
             r#"
             SELECT organization_id
@@ -150,10 +150,10 @@ mod test_handler {
             "#,
         )
         .bind(host)
-        .fetch_optional(&mut conn)
+        .fetch_optional(&mut *conn)
         .await
         .map(|r| r.is_some());
-        let _ = db::tenant_context::clear_request_context(&mut conn).await;
+        let _ = db::tenant_context::clear_request_context(&mut *conn).await;
         result
     }
 }

--- a/backend/servers/api-server/tests/data_residency_tests.rs
+++ b/backend/servers/api-server/tests/data_residency_tests.rs
@@ -1,5 +1,7 @@
 //! Integration tests for Data Residency controls (Epic 146).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/data_residency_tests.rs
+++ b/backend/servers/api-server/tests/data_residency_tests.rs
@@ -2,7 +2,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::{Method, StatusCode};

--- a/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
@@ -23,6 +23,8 @@
 //! rejected with 4xx before reaching handler logic.  The security contract
 //! is still satisfied: cross-org mutations never reach the DB row.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/dispute_evidence_auth_tests.rs
+++ b/backend/servers/api-server/tests/dispute_evidence_auth_tests.rs
@@ -12,6 +12,8 @@
 //! runs. The security contract — no evidence persisted without auth — still
 //! holds and is what we assert.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/dispute_evidence_auth_tests.rs
+++ b/backend/servers/api-server/tests/dispute_evidence_auth_tests.rs
@@ -14,7 +14,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::body::Body;

--- a/backend/servers/api-server/tests/document_access_rls_tests.rs
+++ b/backend/servers/api-server/tests/document_access_rls_tests.rs
@@ -149,13 +149,13 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
 
     // ---- Reader IN building B1 and unit U1, with role `owner` ----
     let reader = Uuid::new_v4();
-    db::set_request_context(&mut *conn, Some(org_a), Some(reader), false)
+    db::set_request_context(&mut conn, Some(org_a), Some(reader), false)
         .await
         .expect("set context");
 
     let docs = repo
         .list_accessible_rls(
-            &mut *conn,
+            &mut conn,
             org_a,
             reader,
             &[building_b1],
@@ -199,13 +199,13 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
 
     // ---- Reader with NO building/unit membership and no roles ----
     let stranger = Uuid::new_v4();
-    db::set_request_context(&mut *conn, Some(org_a), Some(stranger), false)
+    db::set_request_context(&mut conn, Some(org_a), Some(stranger), false)
         .await
         .expect("set context");
 
     let docs = repo
         .list_accessible_rls(
-            &mut *conn,
+            &mut conn,
             org_a,
             stranger,
             &[],
@@ -237,7 +237,7 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
     // ---- check_access_rls single-document gate (same org) ----
     // In-scope building doc: granted.
     let in_scope = repo
-        .check_access_rls(&mut *conn, b1_doc, reader, &[building_b1], &[], &[])
+        .check_access_rls(&mut conn, b1_doc, reader, &[building_b1], &[], &[])
         .await
         .expect("check_access_rls in-scope");
     assert!(
@@ -247,7 +247,7 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
 
     // Out-of-scope building doc: denied.
     let out_of_scope = repo
-        .check_access_rls(&mut *conn, b2_doc, reader, &[building_b1], &[], &[])
+        .check_access_rls(&mut conn, b2_doc, reader, &[building_b1], &[], &[])
         .await
         .expect("check_access_rls out-of-scope");
     assert!(
@@ -342,13 +342,13 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     seed_doc(&pool, org, manager, "Unit Doc", "unit", &[unit], &[]).await;
 
     let mut conn = pool.acquire().await.expect("acquire");
-    db::set_request_context(&mut *conn, Some(org), Some(manager), false)
+    db::set_request_context(&mut conn, Some(org), Some(manager), false)
         .await
         .expect("set context");
 
     // ---- Chokepoint: current resident resolves to the unit + building ----
     let (current_buildings, current_units) = repo
-        .user_scope_memberships_rls(&mut *conn, current)
+        .user_scope_memberships_rls(&mut conn, current)
         .await
         .expect("user_scope_memberships_rls (current)");
     assert!(
@@ -359,7 +359,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
 
     // ---- Chokepoint: ended resident resolves to NOTHING ----
     let (ended_buildings, ended_units) = repo
-        .user_scope_memberships_rls(&mut *conn, ended)
+        .user_scope_memberships_rls(&mut conn, ended)
         .await
         .expect("user_scope_memberships_rls (ended)");
     assert!(
@@ -371,7 +371,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     // ---- End-to-end: current resident sees unit/building docs ----
     let current_titles: Vec<String> = repo
         .list_accessible_rls(
-            &mut *conn,
+            &mut conn,
             org,
             current,
             &current_buildings,
@@ -393,7 +393,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     // ---- End-to-end: ended resident sees ONLY org-wide content ----
     let ended_titles: Vec<String> = repo
         .list_accessible_rls(
-            &mut *conn,
+            &mut conn,
             org,
             ended,
             &ended_buildings,
@@ -419,7 +419,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     // ---- Historical records still readable by the manager (creator branch) ----
     let manager_titles: Vec<String> = repo
         .list_accessible_rls(
-            &mut *conn,
+            &mut conn,
             org,
             manager,
             &[],

--- a/backend/servers/api-server/tests/document_access_rls_tests.rs
+++ b/backend/servers/api-server/tests/document_access_rls_tests.rs
@@ -38,7 +38,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use db::models::DocumentListQuery;

--- a/backend/servers/api-server/tests/document_access_rls_tests.rs
+++ b/backend/servers/api-server/tests/document_access_rls_tests.rs
@@ -149,13 +149,13 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
 
     // ---- Reader IN building B1 and unit U1, with role `owner` ----
     let reader = Uuid::new_v4();
-    db::set_request_context(&mut conn, Some(org_a), Some(reader), false)
+    db::set_request_context(&mut *conn, Some(org_a), Some(reader), false)
         .await
         .expect("set context");
 
     let docs = repo
         .list_accessible_rls(
-            &mut conn,
+            &mut *conn,
             org_a,
             reader,
             &[building_b1],
@@ -199,13 +199,13 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
 
     // ---- Reader with NO building/unit membership and no roles ----
     let stranger = Uuid::new_v4();
-    db::set_request_context(&mut conn, Some(org_a), Some(stranger), false)
+    db::set_request_context(&mut *conn, Some(org_a), Some(stranger), false)
         .await
         .expect("set context");
 
     let docs = repo
         .list_accessible_rls(
-            &mut conn,
+            &mut *conn,
             org_a,
             stranger,
             &[],
@@ -237,7 +237,7 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
     // ---- check_access_rls single-document gate (same org) ----
     // In-scope building doc: granted.
     let in_scope = repo
-        .check_access_rls(&mut conn, b1_doc, reader, &[building_b1], &[], &[])
+        .check_access_rls(&mut *conn, b1_doc, reader, &[building_b1], &[], &[])
         .await
         .expect("check_access_rls in-scope");
     assert!(
@@ -247,7 +247,7 @@ async fn list_accessible_rls_enforces_building_scope(pool: PgPool) {
 
     // Out-of-scope building doc: denied.
     let out_of_scope = repo
-        .check_access_rls(&mut conn, b2_doc, reader, &[building_b1], &[], &[])
+        .check_access_rls(&mut *conn, b2_doc, reader, &[building_b1], &[], &[])
         .await
         .expect("check_access_rls out-of-scope");
     assert!(
@@ -342,13 +342,13 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     seed_doc(&pool, org, manager, "Unit Doc", "unit", &[unit], &[]).await;
 
     let mut conn = pool.acquire().await.expect("acquire");
-    db::set_request_context(&mut conn, Some(org), Some(manager), false)
+    db::set_request_context(&mut *conn, Some(org), Some(manager), false)
         .await
         .expect("set context");
 
     // ---- Chokepoint: current resident resolves to the unit + building ----
     let (current_buildings, current_units) = repo
-        .user_scope_memberships_rls(&mut conn, current)
+        .user_scope_memberships_rls(&mut *conn, current)
         .await
         .expect("user_scope_memberships_rls (current)");
     assert!(
@@ -359,7 +359,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
 
     // ---- Chokepoint: ended resident resolves to NOTHING ----
     let (ended_buildings, ended_units) = repo
-        .user_scope_memberships_rls(&mut conn, ended)
+        .user_scope_memberships_rls(&mut *conn, ended)
         .await
         .expect("user_scope_memberships_rls (ended)");
     assert!(
@@ -371,7 +371,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     // ---- End-to-end: current resident sees unit/building docs ----
     let current_titles: Vec<String> = repo
         .list_accessible_rls(
-            &mut conn,
+            &mut *conn,
             org,
             current,
             &current_buildings,
@@ -393,7 +393,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     // ---- End-to-end: ended resident sees ONLY org-wide content ----
     let ended_titles: Vec<String> = repo
         .list_accessible_rls(
-            &mut conn,
+            &mut *conn,
             org,
             ended,
             &ended_buildings,
@@ -419,7 +419,7 @@ async fn user_scope_memberships_rls_revokes_on_move_out(pool: PgPool) {
     // ---- Historical records still readable by the manager (creator branch) ----
     let manager_titles: Vec<String> = repo
         .list_accessible_rls(
-            &mut conn,
+            &mut *conn,
             org,
             manager,
             &[],

--- a/backend/servers/api-server/tests/document_access_rls_tests.rs
+++ b/backend/servers/api-server/tests/document_access_rls_tests.rs
@@ -36,6 +36,8 @@
 //! the application-level predicates inside the query; production additionally
 //! enforces the FORCE-RLS `document_tenant_isolation` policy on top.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/document_download_preview_tests.rs
+++ b/backend/servers/api-server/tests/document_download_preview_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/document_download_preview_tests.rs
+++ b/backend/servers/api-server/tests/document_download_preview_tests.rs
@@ -23,6 +23,8 @@
 //! BEFORE storage, so they are asserted exactly. This keeps the suite
 //! deterministic and DB-only — no live S3 dependency.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/document_folder_tests.rs
+++ b/backend/servers/api-server/tests/document_folder_tests.rs
@@ -32,6 +32,8 @@
 //! ### Schema assertions (FK, column, table existence)
 //! ### Positive AC happy-path coverage (create / move / delete / cycle-guard) **[7A.2 verify]**
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/document_folder_tests.rs
+++ b/backend/servers/api-server/tests/document_folder_tests.rs
@@ -34,7 +34,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/document_share_access_tests.rs
+++ b/backend/servers/api-server/tests/document_share_access_tests.rs
@@ -24,6 +24,8 @@
 //! `argon2` default the create-share handler uses, so `verify_share_password`
 //! accepts it.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/document_share_access_tests.rs
+++ b/backend/servers/api-server/tests/document_share_access_tests.rs
@@ -26,7 +26,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use argon2::{password_hash::PasswordHasher, Argon2};

--- a/backend/servers/api-server/tests/document_upload_tests.rs
+++ b/backend/servers/api-server/tests/document_upload_tests.rs
@@ -21,6 +21,8 @@
 //! at a closed port so `upload()` always returns an error, verifying that the
 //! handler returns 503 and does NOT create an orphan DB record.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/document_upload_tests.rs
+++ b/backend/servers/api-server/tests/document_upload_tests.rs
@@ -23,7 +23,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/documents_core_crud_tests.rs
+++ b/backend/servers/api-server/tests/documents_core_crud_tests.rs
@@ -16,7 +16,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/documents_core_crud_tests.rs
+++ b/backend/servers/api-server/tests/documents_core_crud_tests.rs
@@ -14,6 +14,8 @@
 //! - POST   /api/v1/documents/{id}/shares (create_share)
 //! - DELETE /api/v1/documents/{id}/shares/{share_id} (revoke_share)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/documents_intelligence_templates_tests.rs
+++ b/backend/servers/api-server/tests/documents_intelligence_templates_tests.rs
@@ -21,7 +21,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/documents_intelligence_templates_tests.rs
+++ b/backend/servers/api-server/tests/documents_intelligence_templates_tests.rs
@@ -19,6 +19,8 @@
 //! - DELETE /api/v1/templates/{id}                         (delete_template)
 //! - POST   /api/v1/templates/{id}/generate               (generate_document)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/dsa_report_download_tests.rs
+++ b/backend/servers/api-server/tests/dsa_report_download_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/dsa_report_download_tests.rs
+++ b/backend/servers/api-server/tests/dsa_report_download_tests.rs
@@ -23,6 +23,8 @@
 //! `download_url` pointing back to the same path, so asserting 503 (not 200)
 //! is a clean regression guard.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
@@ -27,7 +27,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/emergency_cross_org_idor_tests.rs
@@ -25,6 +25,8 @@
 //!      test establishes real org/tenant context (the membership row), so the
 //!      cross-org rejection is NOT a trivial "no context" pass.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/endpoints_smoke_tests.rs
+++ b/backend/servers/api-server/tests/endpoints_smoke_tests.rs
@@ -13,6 +13,8 @@
 //! flows are covered by feature-specific test files that build complete
 //! organization + membership fixtures.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/endpoints_smoke_tests.rs
+++ b/backend/servers/api-server/tests/endpoints_smoke_tests.rs
@@ -15,7 +15,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
@@ -21,6 +21,8 @@
 //! happy path because `JwtService` emits an `org_id` claim under a different
 //! name than the `AuthUser` extractor reads.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/enhanced_screening_cross_org_idor_tests.rs
@@ -23,7 +23,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use rust_decimal::Decimal;

--- a/backend/servers/api-server/tests/equipment_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/equipment_cross_tenant_idor_tests.rs
@@ -27,6 +27,8 @@
 //! returns in production. Both are 4xx — the security contract (cross-tenant
 //! request is never applied to the row) is satisfied either way.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/equipment_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/equipment_cross_tenant_idor_tests.rs
@@ -29,7 +29,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/esg_reporting_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/esg_reporting_cross_org_idor_tests.rs
@@ -25,6 +25,8 @@
 //!      no write.
 //!   3. Org A's member reads its own metric → allowed (2xx).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/esg_reporting_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/esg_reporting_cross_org_idor_tests.rs
@@ -27,7 +27,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::{Method, StatusCode};

--- a/backend/servers/api-server/tests/esignature_email_status_tracking_tests.rs
+++ b/backend/servers/api-server/tests/esignature_email_status_tracking_tests.rs
@@ -34,6 +34,8 @@
 //! so the requester completion/decline email send returns `Ok` without an SMTP
 //! server — exercising the send code path without external dependencies.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/esignature_email_status_tracking_tests.rs
+++ b/backend/servers/api-server/tests/esignature_email_status_tracking_tests.rs
@@ -36,7 +36,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
+++ b/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
@@ -21,6 +21,8 @@
 //! once (LazyLock); we pin that secret here and mint tokens with a provider
 //! that shares it, so server-side verification matches.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
+++ b/backend/servers/api-server/tests/esignature_sign_consumer_tests.rs
@@ -23,7 +23,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use std::time::Duration;

--- a/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
+++ b/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
@@ -21,6 +21,8 @@
 //! `X-Webhook-Secret` header validated against `ESIGN_WEBHOOK_SECRET`. We pin
 //! that env var so the handler accepts our forged-but-authentic deliveries.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
+++ b/backend/servers/api-server/tests/esignature_webhook_idempotency_tests.rs
@@ -23,7 +23,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/faults_authz_gap_tests.rs
+++ b/backend/servers/api-server/tests/faults_authz_gap_tests.rs
@@ -25,6 +25,8 @@
 //! which is exactly where the sibling `faults_cross_org_idor_tests.rs` asserts
 //! them. Each test exercises the real query path against a migrated database.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/faults_authz_gap_tests.rs
+++ b/backend/servers/api-server/tests/faults_authz_gap_tests.rs
@@ -27,7 +27,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use db::repositories::{FaultRepository, MembershipRepository};

--- a/backend/servers/api-server/tests/faults_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/faults_behaviour_tests.rs
@@ -7,7 +7,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/faults_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/faults_behaviour_tests.rs
@@ -5,6 +5,8 @@
 //!   confirm_fault, reopen_fault, list_my_faults,
 //!   list_comments, add_comment, add_work_note, get_statistics.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/faults_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/faults_behaviour_tests.rs
@@ -122,7 +122,7 @@ async fn test_update_fault_title(pool: PgPool) {
         .put(&format!("/api/v1/faults/{}", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "title": "Updated Fault Title" }))
+        .json(json!({ "title": "Updated Fault Title" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "update fault: {}", resp.text());
@@ -150,7 +150,7 @@ async fn test_update_fault_status_to_in_progress(pool: PgPool) {
         .put(&format!("/api/v1/faults/{}/status", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "status": "in_progress", "note": "Work started" }))
+        .json(json!({ "status": "in_progress", "note": "Work started" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -177,7 +177,7 @@ async fn test_resolve_fault(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/resolve", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "resolution_notes": "Pipe was replaced." }))
+        .json(json!({ "resolution_notes": "Pipe was replaced." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -205,7 +205,7 @@ async fn test_confirm_fault_resolution(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/resolve", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "resolution_notes": "Fixed." }))
+        .json(json!({ "resolution_notes": "Fixed." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK);
@@ -215,7 +215,7 @@ async fn test_confirm_fault_resolution(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/confirm", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "rating": 5, "feedback": "Great work!" }))
+        .json(json!({ "rating": 5, "feedback": "Great work!" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -254,7 +254,7 @@ async fn test_reopen_resolved_fault(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/resolve", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "resolution_notes": "Fixed temporarily." }))
+        .json(json!({ "resolution_notes": "Fixed temporarily." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK);
@@ -264,7 +264,7 @@ async fn test_reopen_resolved_fault(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/reopen", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "reason": "Problem recurred." }))
+        .json(json!({ "reason": "Problem recurred." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "reopen fault: {}", resp.text());
@@ -334,7 +334,7 @@ async fn test_add_and_list_fault_comments(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/comments", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "note": "Investigating the issue.", "is_internal": false }))
+        .json(json!({ "note": "Investigating the issue.", "is_internal": false }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -377,7 +377,7 @@ async fn test_add_work_note(pool: PgPool) {
         .post(&format!("/api/v1/faults/{}/work-notes", fault_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "note": "Ordered replacement parts." }))
+        .json(json!({ "note": "Ordered replacement parts." }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(

--- a/backend/servers/api-server/tests/faults_tests.rs
+++ b/backend/servers/api-server/tests/faults_tests.rs
@@ -19,6 +19,8 @@
 //! code; they only pin the security contract: an unauthenticated request
 //! MUST be rejected with 4xx.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/faults_tests.rs
+++ b/backend/servers/api-server/tests/faults_tests.rs
@@ -21,7 +21,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/financial_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/financial_cross_org_idor_tests.rs
@@ -20,6 +20,8 @@
 //!   2. Org B's member probes Org A's data → rejected (4xx); no leak / write.
 //!   3. Org A's member reads its own data → allowed (2xx).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/financial_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/financial_cross_org_idor_tests.rs
@@ -22,7 +22,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/financial_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/financial_happy_path_tests.rs
@@ -3,6 +3,8 @@
 //! Exercises 24 different endpoints covering financial accounts, transactions,
 //! fee schedules, invoices, payments, and allocation/reconciliation.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/financial_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/financial_happy_path_tests.rs
@@ -5,7 +5,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
@@ -17,6 +17,8 @@
 //!   7. GET /api/v1/financial/reports/cash-flow
 //!   8. GET /api/v1/financial/reports/income-statement/export
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
@@ -19,7 +19,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
@@ -8,7 +8,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/form_cross_org_idor_tests.rs
@@ -6,6 +6,8 @@
 //! same-org submit still works, while cross-org submit/download attempts
 //! return 404 and leave the target org's rows untouched.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/granular_notif_role_defaults_rbac_tests.rs
+++ b/backend/servers/api-server/tests/granular_notif_role_defaults_rbac_tests.rs
@@ -13,7 +13,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/granular_notif_role_defaults_rbac_tests.rs
+++ b/backend/servers/api-server/tests/granular_notif_role_defaults_rbac_tests.rs
@@ -11,6 +11,8 @@
 //! token, so a freshly-registered/logged-in user is a non-manager and must be
 //! rejected with 403.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/help_tests.rs
+++ b/backend/servers/api-server/tests/help_tests.rs
@@ -21,6 +21,8 @@
 //! 10. GET /api/v1/help/tooltips/:key — returns 404 when no tooltip
 //! 11. POST /api/v1/help/articles/:slug/feedback — 401 without auth
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/help_tests.rs
+++ b/backend/servers/api-server/tests/help_tests.rs
@@ -23,7 +23,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
+++ b/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
+++ b/backend/servers/api-server/tests/infra_migration_platform_admin_tests.rs
@@ -23,6 +23,8 @@
 //! A freshly registered user (`create_authenticated_user`) is an ordinary
 //! tenant user, never a platform admin, so it exercises the 403 path.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
@@ -27,6 +27,8 @@
 //! scrape — returns 2xx anonymously by design) and `POST /api/v1/platform-admin/agencies`
 //! (body validation returns 4xx before the auth gate, so it is not a clean auth probe).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
@@ -6,9 +6,9 @@
 //!   * `/api/v1/infrastructure/**` — traces, feature-flags, jobs, health/alerts
 //!   * `/api/v1/operations/**`     — deployments, migrations, schema, backups, DR, costs
 //!   * `/api/v1/platform-admin/**` — orgs, stats, feature-flags, health, announcements,
-//!                                   maintenance, support
+//!     maintenance, support
 //!   * `/api/v1/admin/**`          — user lifecycle, MFA enroll, notifications,
-//!                                   tenant lifecycle/branding/feature-flags, agencies
+//!     tenant lifecycle/branding/feature-flags, agencies
 //!
 //! All of these are gated for platform operators. We assert the security invariant:
 //!   1. unauthenticated  → 401 (also guards route existence);

--- a/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
@@ -29,7 +29,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
@@ -41,7 +41,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/insurance_cross_tenant_idor_tests.rs
@@ -39,6 +39,8 @@
 //! row) holds either way. The repo-layer tests below pin the positive path
 //! that the HTTP harness cannot reach.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
@@ -36,6 +36,8 @@
 //!   - A legitimate member of Org A passes the guard (NOT `403`) — proving
 //!     the fix does not lock out authorized callers.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/integrations_cross_org_idor_tests.rs
@@ -38,7 +38,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/iot_auth_tests.rs
+++ b/backend/servers/api-server/tests/iot_auth_tests.rs
@@ -12,7 +12,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/iot_auth_tests.rs
+++ b/backend/servers/api-server/tests/iot_auth_tests.rs
@@ -10,6 +10,8 @@
 //! `RequestPrincipal` rejects a request with no `Authorization` header with
 //! 401, so these tests need no DB seeding — they assert the auth gate fires.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/lease_review_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_review_rbac_tests.rs
@@ -13,7 +13,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/lease_review_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_review_rbac_tests.rs
@@ -11,6 +11,8 @@
 //! with 403 before reaching the repository; a **manager** must pass the role
 //! gate (proven by NOT getting a 403). See report_schedule_org_scope_jwt_tests.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
@@ -11,6 +11,8 @@
 //!
 //! Mirrors `lease_review_rbac_tests`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
+++ b/backend/servers/api-server/tests/lease_send_for_signature_rbac_tests.rs
@@ -13,7 +13,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/leases_core_backfill_batch1_tests.rs
+++ b/backend/servers/api-server/tests/leases_core_backfill_batch1_tests.rs
@@ -12,7 +12,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/leases_core_backfill_batch1_tests.rs
+++ b/backend/servers/api-server/tests/leases_core_backfill_batch1_tests.rs
@@ -10,6 +10,8 @@
 //! - Reminders (create, list)
 //! - Dashboard (expiring, statistics)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/legal_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/legal_cross_org_idor_tests.rs
@@ -25,6 +25,8 @@
 //!   - Org B's own valid context reading Org A's document -> 404 (org-scoped
 //!     query finds no row; cross-org is blocked).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/legal_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/legal_cross_org_idor_tests.rs
@@ -27,7 +27,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::{Method, StatusCode};

--- a/backend/servers/api-server/tests/legal_insurance_wave1b_tests.rs
+++ b/backend/servers/api-server/tests/legal_insurance_wave1b_tests.rs
@@ -16,6 +16,8 @@
 //! HTTP status + response shape. All seeding uses static string literals
 //! (sqlx 0.9 SQL-injection lint: no `format!` / `&String` in query macros).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/legal_insurance_wave1b_tests.rs
+++ b/backend/servers/api-server/tests/legal_insurance_wave1b_tests.rs
@@ -18,7 +18,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/listings_core_backfill_batch3_tests.rs
+++ b/backend/servers/api-server/tests/listings_core_backfill_batch3_tests.rs
@@ -7,7 +7,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/listings_core_backfill_batch3_tests.rs
+++ b/backend/servers/api-server/tests/listings_core_backfill_batch3_tests.rs
@@ -5,6 +5,8 @@
 //! - Syndication (publish, global-publish, global-unpublish, dashboard, org-stats, syndications, status)
 //! - Photos (get, add, reorder, delete)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/listings_global_publish_authz_tests.rs
+++ b/backend/servers/api-server/tests/listings_global_publish_authz_tests.rs
@@ -19,7 +19,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/listings_global_publish_authz_tests.rs
+++ b/backend/servers/api-server/tests/listings_global_publish_authz_tests.rs
@@ -17,6 +17,8 @@
 //! carrying `tenant_id` + `role` directly (see the note in
 //! reserve_funds_cross_org_idor_tests.rs).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
@@ -32,7 +32,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
@@ -30,6 +30,8 @@
 //! - GET  /api/v1/marketplace/verifications/expiring — get_expiring_verifications
 //! - GET  /api/v1/marketplace/dashboard          — get_manager_dashboard
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -51,7 +51,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_voting_investor_cross_org_idor_tests.rs
@@ -49,6 +49,8 @@
 //!     with the `tenant_id` claim directly (same approach as
 //!     `reserve_funds_cross_org_idor_tests`).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/messaging_attachments_authz_tests.rs
+++ b/backend/servers/api-server/tests/messaging_attachments_authz_tests.rs
@@ -17,7 +17,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/messaging_attachments_authz_tests.rs
+++ b/backend/servers/api-server/tests/messaging_attachments_authz_tests.rs
@@ -15,6 +15,8 @@
 //! exercise the handler-layer participant/tenant/sender guards — the same
 //! defense-in-depth layer the production RLS policy backstops.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/messaging_behaviour_backfill_tests.rs
+++ b/backend/servers/api-server/tests/messaging_behaviour_backfill_tests.rs
@@ -12,6 +12,8 @@
 //! - POST /api/v1/messages/threads/{id}/archive
 //! - DELETE /api/v1/messages/threads/{id}/archive
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/messaging_behaviour_backfill_tests.rs
+++ b/backend/servers/api-server/tests/messaging_behaviour_backfill_tests.rs
@@ -14,7 +14,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/messaging_group_conversations_tests.rs
+++ b/backend/servers/api-server/tests/messaging_group_conversations_tests.rs
@@ -21,7 +21,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/messaging_group_conversations_tests.rs
+++ b/backend/servers/api-server/tests/messaging_group_conversations_tests.rs
@@ -19,6 +19,8 @@
 //! superuser (bypasses FORCE RLS), so these tests specifically exercise the
 //! org-keyed SQL membership check, not the RLS policy.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/messaging_thread_state_authz_tests.rs
+++ b/backend/servers/api-server/tests/messaging_thread_state_authz_tests.rs
@@ -17,7 +17,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/messaging_thread_state_authz_tests.rs
+++ b/backend/servers/api-server/tests/messaging_thread_state_authz_tests.rs
@@ -15,6 +15,8 @@
 //! here is the handler-layer check, and the per-user list filtering is the
 //! repository SQL (`thread_participant_state` join) — both independent of RLS.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/meters_energy_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/meters_energy_cross_org_idor_tests.rs
@@ -26,7 +26,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/meters_energy_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/meters_energy_cross_org_idor_tests.rs
@@ -24,6 +24,8 @@
 //! gate before any energy query) is asserted for energy; the same-org success
 //! path is proven on the meter endpoints whose tables do exist.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/mfa_disable_rls_scope_tests.rs
+++ b/backend/servers/api-server/tests/mfa_disable_rls_scope_tests.rs
@@ -50,7 +50,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/mfa_disable_rls_scope_tests.rs
+++ b/backend/servers/api-server/tests/mfa_disable_rls_scope_tests.rs
@@ -48,6 +48,8 @@
 //!     exercises only the endpoint under audit and does not depend on TOTP
 //!     timing / encryption config.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
@@ -41,7 +41,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
+++ b/backend/servers/api-server/tests/mfa_recovery_cross_user_idor_tests.rs
@@ -39,6 +39,8 @@
 //!   `/mfa/setup` + `/mfa/verify` flow, so the test exercises only the endpoint
 //!   under audit and does not depend on TOTP timing / encryption config.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/migration_db_tests.rs
+++ b/backend/servers/api-server/tests/migration_db_tests.rs
@@ -3,6 +3,8 @@
 //! Asserts real database effects and round-trips for templates, import jobs,
 //! job validation errors, and exports.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/migration_db_tests.rs
+++ b/backend/servers/api-server/tests/migration_db_tests.rs
@@ -5,7 +5,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/multi_currency_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/multi_currency_cross_org_idor_tests.rs
@@ -22,7 +22,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/multi_currency_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/multi_currency_cross_org_idor_tests.rs
@@ -20,6 +20,8 @@
 //!   - Org A's token reading Org A's property config -> 200 (same-org succeeds).
 //!   - Org B's token reading Org A's property config -> 404 (cross-org blocked).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/my_units_resident_view_tests.rs
+++ b/backend/servers/api-server/tests/my_units_resident_view_tests.rs
@@ -12,6 +12,8 @@
 //! needs only a valid JWT (no `X-Tenant-ID`); buildings/units/residencies are
 //! seeded directly.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/my_units_resident_view_tests.rs
+++ b/backend/servers/api-server/tests/my_units_resident_view_tests.rs
@@ -14,7 +14,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::body::Body;

--- a/backend/servers/api-server/tests/news_articles_tests.rs
+++ b/backend/servers/api-server/tests/news_articles_tests.rs
@@ -26,6 +26,8 @@
 //! - POST   /api/v1/news/{id}/view                        record_view
 //! - GET    /api/v1/news/statistics                       get_statistics
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/news_articles_tests.rs
+++ b/backend/servers/api-server/tests/news_articles_tests.rs
@@ -28,7 +28,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
@@ -66,7 +66,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
@@ -64,6 +64,8 @@
 //!   cargo test -p api-server -- preference_update_publishes_realtime_event --include-ignored
 //! ```
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/oauth_authorization_server_test.rs
+++ b/backend/servers/api-server/tests/oauth_authorization_server_test.rs
@@ -27,6 +27,8 @@
 //! exercised end to end. Seeding/harness helpers mirror
 //! `oauth_integration_tests.rs` rather than re-deriving them.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/oauth_authorization_server_test.rs
+++ b/backend/servers/api-server/tests/oauth_authorization_server_test.rs
@@ -29,7 +29,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use api_server::services::AuthService;

--- a/backend/servers/api-server/tests/oauth_authz_server_edge_tests.rs
+++ b/backend/servers/api-server/tests/oauth_authz_server_edge_tests.rs
@@ -27,6 +27,8 @@
 //! Every test uses `#[sqlx::test(migrator = "db::MIGRATOR")]` so the schema is
 //! current, and drives the full Axum router via `TestApp`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/oauth_authz_server_edge_tests.rs
+++ b/backend/servers/api-server/tests/oauth_authz_server_edge_tests.rs
@@ -29,7 +29,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use api_server::services::AuthService;

--- a/backend/servers/api-server/tests/oauth_client_registration_test.rs
+++ b/backend/servers/api-server/tests/oauth_client_registration_test.rs
@@ -37,6 +37,8 @@
 //! dedup at the service layer), the test documents the actual contract rather
 //! than asserting a validation that does not exist.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/oauth_client_registration_test.rs
+++ b/backend/servers/api-server/tests/oauth_client_registration_test.rs
@@ -39,7 +39,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use api_server::services::JwtService;

--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -14,6 +14,8 @@
 //! is fully up-to-date, and uses `TestApp` so the real Axum router (with all
 //! middleware) is exercised end-to-end.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/oauth_integration_tests.rs
@@ -16,7 +16,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use api_server::services::AuthService;

--- a/backend/servers/api-server/tests/oauth_token_introspection_rotation_test.rs
+++ b/backend/servers/api-server/tests/oauth_token_introspection_rotation_test.rs
@@ -31,7 +31,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use api_server::services::AuthService;

--- a/backend/servers/api-server/tests/oauth_token_introspection_rotation_test.rs
+++ b/backend/servers/api-server/tests/oauth_token_introspection_rotation_test.rs
@@ -29,6 +29,8 @@
 //! Every test uses `#[sqlx::test(migrator = "db::MIGRATOR")]` so the schema is
 //! current, and drives the real Axum router via `TestApp`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
+++ b/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
@@ -10,7 +10,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::{header, Method, Request, StatusCode};

--- a/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
+++ b/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
@@ -8,6 +8,8 @@
 //! - Auth gates: unauthenticated requests are rejected; cross-tenant requests
 //!   (caller not in the meter's org) are rejected.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
@@ -37,7 +37,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
@@ -35,6 +35,8 @@
 //! (`GET /organizations/my`) — are intentionally excluded: they return 2xx by design
 //! and are covered by their own happy-path tests, not by an authz-denial sweep.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/org_property_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/org_property_happy_path_tests.rs
@@ -30,7 +30,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/org_property_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/org_property_happy_path_tests.rs
@@ -28,6 +28,8 @@
 //! the dependent calls, so every assertion exercises a genuine row rather than
 //! a synthetic UUID.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
@@ -21,7 +21,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
@@ -19,6 +19,8 @@
 //!   2. Org B's member probes Org A's unit/valuation → must NOT 200.
 //!   3. Org A's member reads its own unit's valuation → 200 with the row.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -17,7 +17,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -15,6 +15,8 @@
 //! They need a `PgPool` because `TestApp` builds the full `AppState`; CI runs
 //! them against an ephemeral migrated database.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/platform_admin_authz_tests.rs
+++ b/backend/servers/api-server/tests/platform_admin_authz_tests.rs
@@ -14,7 +14,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/platform_admin_authz_tests.rs
+++ b/backend/servers/api-server/tests/platform_admin_authz_tests.rs
@@ -12,6 +12,8 @@
 //! A freshly registered user (`create_authenticated_user`) never holds any
 //! capability grant, so it exercises the 403 leg of every capability layer.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
+++ b/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
@@ -27,7 +27,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
+++ b/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
@@ -25,6 +25,8 @@
 //! under `SQLX_OFFLINE=true` with no DB the harness skips them, and CI runs
 //! them against an ephemeral migrated database.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/predictive_maintenance_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/predictive_maintenance_happy_path_tests.rs
@@ -17,7 +17,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/predictive_maintenance_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/predictive_maintenance_happy_path_tests.rs
@@ -15,6 +15,8 @@
 //! makes them an active `org_admin` of a fresh org, so `ValidatedTenantExtractor`
 //! resolves the tenant. Every request carries `.bearer(token)` + `.tenant(org_id)`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
+++ b/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
+++ b/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
@@ -23,6 +23,8 @@
 //!   - Org B's own valid context probing Org A's log -> 404 (org-scoped
 //!     lookup finds no row; cross-org blocked).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/push_fanout_stale_token_isolation_tests.rs
+++ b/backend/servers/api-server/tests/push_fanout_stale_token_isolation_tests.rs
@@ -20,7 +20,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/push_fanout_stale_token_isolation_tests.rs
+++ b/backend/servers/api-server/tests/push_fanout_stale_token_isolation_tests.rs
@@ -18,6 +18,8 @@
 //! 3. Direct DB isolation: `delete_stale_token`-equivalent DELETE with a
 //!    mismatched `user_id` does NOT remove the token row.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/push_token_tests.rs
+++ b/backend/servers/api-server/tests/push_token_tests.rs
@@ -42,7 +42,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/push_token_tests.rs
+++ b/backend/servers/api-server/tests/push_token_tests.rs
@@ -40,6 +40,8 @@
 //! status code, and we keep multi-tenant positive-path tests under `#[ignore]`
 //! until a fixture builder that wires `host_tenant_middleware` is available.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/regional_compliance_tests.rs
+++ b/backend/servers/api-server/tests/regional_compliance_tests.rs
@@ -1,5 +1,7 @@
 //! Integration tests for Regional Compliance controls (Epic 72).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/regional_compliance_tests.rs
+++ b/backend/servers/api-server/tests/regional_compliance_tests.rs
@@ -2,7 +2,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::{Method, StatusCode};

--- a/backend/servers/api-server/tests/registry_backfill_tests.rs
+++ b/backend/servers/api-server/tests/registry_backfill_tests.rs
@@ -30,6 +30,8 @@
 //! - PUT    /api/v1/registry/buildings/{building_id}/rules
 //! - GET    /api/v1/registry/buildings/{building_id}/statistics
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/registry_backfill_tests.rs
+++ b/backend/servers/api-server/tests/registry_backfill_tests.rs
@@ -12,6 +12,7 @@
 //! - PUT    /api/v1/registry/pets/{id}
 //! - DELETE /api/v1/registry/pets/{id}
 //! - POST   /api/v1/registry/pets/{id}/review
+//!
 //! Vehicles:
 //! - POST   /api/v1/registry/vehicles
 //! - GET    /api/v1/registry/vehicles
@@ -19,12 +20,14 @@
 //! - PUT    /api/v1/registry/vehicles/{id}
 //! - DELETE /api/v1/registry/vehicles/{id}
 //! - POST   /api/v1/registry/vehicles/{id}/review
+//!
 //! Parking spots:
 //! - POST   /api/v1/registry/parking-spots
 //! - GET    /api/v1/registry/parking-spots
 //! - GET    /api/v1/registry/parking-spots/{id}
 //! - PUT    /api/v1/registry/parking-spots/{id}
 //! - DELETE /api/v1/registry/parking-spots/{id}
+//!
 //! Rules + statistics:
 //! - GET    /api/v1/registry/buildings/{building_id}/rules
 //! - PUT    /api/v1/registry/buildings/{building_id}/rules
@@ -32,7 +35,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
+++ b/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
@@ -23,6 +23,8 @@
 //! `AuthUser` extractor expects (`sub`, `exp`, `iat`, `token_type:"access"`,
 //! `email`, `name`), and supply the org via `X-Tenant-ID`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
+++ b/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::body::Body;

--- a/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
+++ b/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
@@ -15,7 +15,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::body::Body;

--- a/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
+++ b/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
@@ -13,6 +13,8 @@
 //! `X-Tenant-ID` header, with `organization_members` seeded so the manager gate
 //! resolves a real role.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
+++ b/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
@@ -11,7 +11,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
+++ b/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
@@ -9,6 +9,8 @@
 //! - Reports (list, preview, create, get, submit)
 //! - iCal feeds (create, update, delete, list-unit)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/report_execution_download_retry_e2e_tests.rs
+++ b/backend/servers/api-server/tests/report_execution_download_retry_e2e_tests.rs
@@ -27,7 +27,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/report_execution_download_retry_e2e_tests.rs
+++ b/backend/servers/api-server/tests/report_execution_download_retry_e2e_tests.rs
@@ -25,6 +25,8 @@
 //! These run as a same-org authenticated **Manager** (retry requires
 //! manager-tier RBAC; download/list require only authentication + membership).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/report_schedule_cron_roundtrip_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_cron_roundtrip_tests.rs
@@ -36,6 +36,8 @@
 //! still validates membership against `organization_members`, which the
 //! fixtures seed below.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/report_schedule_cron_roundtrip_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_cron_roundtrip_tests.rs
@@ -38,7 +38,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/report_schedule_org_scope_jwt_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_org_scope_jwt_tests.rs
@@ -42,7 +42,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/report_schedule_org_scope_jwt_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_org_scope_jwt_tests.rs
@@ -40,6 +40,8 @@
 //! still validates membership against `organization_members`, which the
 //! fixtures seed below.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
@@ -41,7 +41,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
@@ -39,6 +39,8 @@
 //! security mechanism stopped firing, because the outer JWT gate was still
 //! active (issue #696).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
@@ -48,7 +48,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
@@ -46,6 +46,8 @@
 //! in #624/#646/#647). Both must keep passing for the security contract to
 //! hold end-to-end.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
+++ b/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
@@ -16,6 +16,8 @@
 //! `RlsConnection` validates membership against `organization_members`, seeded
 //! below.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
+++ b/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
@@ -18,7 +18,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
@@ -26,6 +26,8 @@
 //!   - Org A's token reading Org A's fund -> 200 (same-org succeeds).
 //!   - Org B's token reading Org A's fund -> 404 (cross-org is blocked).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
@@ -28,7 +28,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
@@ -12,6 +12,8 @@
 //! Each test also has a same-org "golden path" variant to ensure the guard
 //! does not over-block legitimate callers.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
@@ -14,7 +14,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
@@ -24,7 +24,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::{Method, StatusCode};

--- a/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
@@ -22,6 +22,8 @@
 //!   2. Org B's member probes Org A's vendor → rejected (4xx); no leak / write.
 //!   3. Org A's member reads its own vendor → allowed (2xx).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
+++ b/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
@@ -38,7 +38,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
+++ b/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
@@ -36,6 +36,8 @@
 //!     the IDOR fix lives in the WHERE clause; see
 //!     `ai_llm_cross_tenant_idor_tests.rs` for the same rationale.)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
@@ -22,7 +22,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
@@ -20,6 +20,8 @@
 //!   - Org A's token reading Org A's violation -> 200 (same-org succeeds).
 //!   - Org B's token reading Org A's violation -> 404 (cross-org blocked).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
+++ b/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
@@ -21,6 +21,8 @@
 //! valid token is NOT rejected at the auth layer (status is never 401/403),
 //! while an unauthenticated or org-less request IS rejected before any work.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
+++ b/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
@@ -23,7 +23,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/voting_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/voting_behaviour_tests.rs
@@ -134,7 +134,7 @@ async fn publish_vote(app: &TestApp, token: &str, org_id: Uuid, vote_id: Uuid) {
         .post(&format!("/api/v1/voting/{}/publish", vote_id))
         .bearer(token)
         .tenant(org_id)
-        .json(&json!({ "start_at": null }))
+        .json(json!({ "start_at": null }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "publish vote: {}", resp.text());
@@ -156,7 +156,7 @@ async fn test_update_vote_title_succeeds(pool: PgPool) {
         .put(&format!("/api/v1/voting/{}", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "title": "Updated Title" }))
+        .json(json!({ "title": "Updated Title" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "update vote: {}", resp.text());
@@ -207,7 +207,7 @@ async fn test_cancel_active_vote_succeeds(pool: PgPool) {
         .post(&format!("/api/v1/voting/{}/cancel", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "reason": "Test cancellation" }))
+        .json(json!({ "reason": "Test cancellation" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "cancel vote: {}", resp.text());
@@ -286,7 +286,7 @@ async fn test_update_question_text(pool: PgPool) {
         ))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "question_text": "Revised question?" }))
+        .json(json!({ "question_text": "Revised question?" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -419,7 +419,7 @@ async fn test_add_and_list_comments(pool: PgPool) {
         .post(&format!("/api/v1/voting/{}/comments", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "parent_id": null, "content": "A test comment", "ai_consent": false }))
+        .json(json!({ "parent_id": null, "content": "A test comment", "ai_consent": false }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(
@@ -476,7 +476,7 @@ async fn test_hide_comment(pool: PgPool) {
         .post(&format!("/api/v1/voting/{}/comments", vote_id))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "parent_id": null, "content": "To hide", "ai_consent": false }))
+        .json(json!({ "parent_id": null, "content": "To hide", "ai_consent": false }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::CREATED);
@@ -490,7 +490,7 @@ async fn test_hide_comment(pool: PgPool) {
         ))
         .bearer(&token)
         .tenant(org_id)
-        .json(&json!({ "reason": "Inappropriate content" }))
+        .json(json!({ "reason": "Inappropriate content" }))
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "hide comment: {}", resp.text());

--- a/backend/servers/api-server/tests/voting_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/voting_behaviour_tests.rs
@@ -7,6 +7,8 @@
 //!   check_eligibility, get_my_response, add_comment, list_comments,
 //!   list_replies, hide_comment, get_audit_log, list_active_by_building.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/voting_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/voting_behaviour_tests.rs
@@ -9,7 +9,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/voting_report_tests.rs
+++ b/backend/servers/api-server/tests/voting_report_tests.rs
@@ -25,7 +25,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/voting_report_tests.rs
+++ b/backend/servers/api-server/tests/voting_report_tests.rs
@@ -23,6 +23,8 @@
 //! exist`. Kept in a dedicated binary to isolate the heavy schema-full E2E flow
 //! from `voting_tests.rs`'s schema-less auth tests. (BIT-158, #1665)
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -6,6 +6,8 @@
 //! membership. These tests focus on the negative paths so they can run
 //! without provisioning a full tenant + membership fixture.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/voting_tests.rs
+++ b/backend/servers/api-server/tests/voting_tests.rs
@@ -8,7 +8,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
@@ -50,7 +50,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
@@ -48,6 +48,8 @@
 //! gate is bypassed at the DB layer here because the `#[sqlx::test]` pool
 //! connects as a superuser, so `FORCE` RLS does not bind).
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/work_orders_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/work_orders_happy_path_tests.rs
@@ -20,7 +20,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::http::StatusCode;

--- a/backend/servers/api-server/tests/work_orders_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/work_orders_happy_path_tests.rs
@@ -18,6 +18,8 @@
 //! client-supplied `organization_id` (create/list/query) is set to the caller's
 //! own org so `verify_org_access` passes.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/workflow_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/workflow_cross_tenant_idor_tests.rs
@@ -34,6 +34,8 @@
 //! tighten the assertion back to 404; for now this matches the same
 //! gap flagged in `automation_auth_tests.rs`.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/workflow_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/workflow_cross_tenant_idor_tests.rs
@@ -36,7 +36,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::{

--- a/backend/servers/api-server/tests/ws_integration_tests.rs
+++ b/backend/servers/api-server/tests/ws_integration_tests.rs
@@ -18,6 +18,8 @@
 //! and performs the full HTTP/1.1 upgrade + subsequent WS frames over it, so
 //! the session loop in `handle_ws_session` actually runs.
 
+#![allow(dead_code)]
+
 #[allow(dead_code)]
 mod common;
 

--- a/backend/servers/api-server/tests/ws_integration_tests.rs
+++ b/backend/servers/api-server/tests/ws_integration_tests.rs
@@ -20,7 +20,6 @@
 
 #![allow(dead_code)]
 
-#[allow(dead_code)]
 mod common;
 
 use axum::extract::connect_info::MockConnectInfo;

--- a/backend/servers/reality-server/tests/common.rs
+++ b/backend/servers/reality-server/tests/common.rs
@@ -3,6 +3,8 @@
 //! Provides: env setup, JWT minting, AppState construction, and
 //! a convenience oneshot-request helper.
 
+#![allow(dead_code)]
+
 use api_core::{
     middleware::TenantRateLimiterSet, middleware::TenantResolutionCache, PrincipalClaims,
 };


### PR DESCRIPTION
Trunk-wide fix for the recurring backend `test` build failures. Many test files had only item-level `#[allow(dead_code)]` (or none), so other unused helpers (e.g. `seed_verification` in marketplace_provider_profile_tests) stayed uncovered and are fatal under `RUSTFLAGS=-Dwarnings`. The real pull_request `test` build was red for every backend PR — masked on dev only by the push-event gate stub ([#1941](https://github.com/martin-janci/property-management/pull/1941) / [BIT-345](/BIT/issues/BIT-345)). Adds a file-level `#![allow(dead_code)]` to the 132 test files lacking one. Safe/additive, rustfmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)