### PR TITLE
fix(api-server): fix doc_lazy_continuation in org_property_authz_backfill (BIT-345)

### DIFF
--- a/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
@@ -24,6 +24,7 @@
 //!   * `TenantExtractor` + agency-membership (agencies) → 403 once the tenant gate is
 //!     cleared;
 //!   * the org-scoped inline check (organizations) → 403 for a non-member.
+//!
 //! Pinning a single code here would be brittle and was the reason the original
 //! re-cuts could not be made green without a live DB. Asserting "rejected 4xx on an
 //! existing route" captures the actual security property and is stable across all


### PR DESCRIPTION
## Summary
- Adds missing blank `//!` line before continuation paragraph in `org_property_authz_backfill_bit331_tests.rs:27` to satisfy `clippy::doc_lazy_continuation`
- This is the one remaining clippy failure after PR #1945 merged — that PR fixed the bulk of BIT-345 but this file was caught by the subsequent CI run

## Test plan
- [ ] CI `lint` and `fmt-clippy` green on this PR
- [ ] Unblocks remaining backend PRs on dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)