### PR TITLE
fix(db): cast document_share_type enum to text in get_shares_rls (BIT-359)

### DIFF
--- a/backend/crates/db/src/repositories/document/shares.rs
+++ b/backend/crates/db/src/repositories/document/shares.rs
@@ -120,7 +120,9 @@ impl DocumentRepository {
         let rows = sqlx::query(
             r#"
             SELECT
-                s.*,
+                s.id, s.document_id, s.share_type::text AS share_type, s.target_id,
+                s.target_role, s.shared_by, s.share_token, s.password_hash,
+                s.expires_at, s.revoked_at, s.created_at,
                 d.title as document_title,
                 u.name as shared_by_name
             FROM document_shares s

--- a/backend/crates/db/tests/document_shares_enum_decode_tests.rs
+++ b/backend/crates/db/tests/document_shares_enum_decode_tests.rs
@@ -1,0 +1,110 @@
+//! Regression test for BIT-359 — `get_shares_rls` decoded the Postgres enum
+//! `document_share_type` straight into the Rust `String` field
+//! `DocumentShare.share_type`. The `GET /documents/{id}/shares` listing endpoint
+//! (`servers/api-server/src/routes/documents/shares.rs:95`) calls this repo
+//! method; its `SELECT s.*` returned the raw `document_share_type` OID, and
+//! sqlx 0.9 refuses to decode a user-defined ENUM into `String`, so the read
+//! panicked at runtime. Every sibling query in the same file already casts
+//! `share_type::text AS share_type`; only this `SELECT s.*` path forgot.
+//!
+//! The fix replaces `SELECT s.*` with an explicit column list that casts
+//! `s.share_type::text AS share_type`. This test seeds a `'link'` share and
+//! reads it back through `get_shares_rls`; it fails on `main` (decode error)
+//! and passes once the cast is in place.
+
+use db::repositories::DocumentRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Seed org -> user -> document -> `'link'` share under a super-admin RLS
+/// context (which satisfies the `WITH CHECK` legs on the inserts). Returns
+/// `(document_id, share_id)`.
+async fn seed(pool: &PgPool) -> (Uuid, Uuid) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(Option::<Uuid>::None)
+        .bind(Option::<Uuid>::None)
+        .bind(true)
+        .execute(pool)
+        .await
+        .expect("set super-admin context");
+
+    let org_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ('Share Enum Org', 'share-enum-org', 'share-enum@decode.test', 'active')
+        RETURNING id
+        "#,
+    )
+    .fetch_one(pool)
+    .await
+    .expect("seed org");
+
+    let user_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ('share-enum@user.test', 'test_hash', 'Share Enum User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .fetch_one(pool)
+    .await
+    .expect("seed user");
+
+    let document_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO documents (
+            organization_id, title, category, file_key, file_name, mime_type,
+            size_bytes, created_by
+        )
+        VALUES ($1, 'Share Enum Doc', 'other', 's3/share-enum.pdf', 'share-enum.pdf',
+                'application/pdf', 1024, $2)
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed document");
+
+    // Bind the enum column with a literal cast — `'link'::document_share_type` —
+    // rather than a bound `String`, which sqlx 0.9 would reject on the encode
+    // side (a separate strictness from the decode regression under test).
+    let share_id = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO document_shares (document_id, share_type, shared_by, share_token)
+        VALUES ($1, 'link'::document_share_type, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(document_id)
+    .bind(user_id)
+    .bind(format!("tok{}", Uuid::new_v4().simple()))
+    .fetch_one(pool)
+    .await
+    .expect("seed link share");
+
+    (document_id, share_id)
+}
+
+/// `get_shares_rls` must decode the `document_share_type` enum into the
+/// `share_type: String` field. On `main` the `SELECT s.*` path panics on
+/// decode; after the `::text` cast it returns the seeded `'link'` share.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_shares_rls_decodes_document_share_type_enum(pool: PgPool) {
+    let (document_id, share_id) = seed(&pool).await;
+    let repo = DocumentRepository::new(pool.clone());
+
+    let shares = repo
+        .get_shares_rls(&pool, document_id)
+        .await
+        .expect("get_shares_rls must not fail decoding the document_share_type enum (BIT-359)");
+
+    assert_eq!(shares.len(), 1, "the one seeded share must be returned");
+    assert_eq!(shares[0].share.id, share_id);
+    assert_eq!(
+        shares[0].share.share_type, "link",
+        "share_type enum must decode to its text value"
+    );
+    assert_eq!(shares[0].document_title, "Share Enum Doc");
+}


### PR DESCRIPTION
## Bug (BIT-359)

`get_shares_rls` (`backend/crates/db/src/repositories/document/shares.rs:120`) ran `SELECT s.*` over `document_shares` and decoded the result into `DocumentShare.share_type: String`. The `share_type` column is the Postgres enum `document_share_type`; sqlx 0.9 refuses to decode a user-defined ENUM OID into a Rust `String`, so the read **panicked at runtime**.

**Reachability (live, not dead code):** `servers/api-server/src/routes/documents/shares.rs:95` calls `get_shares_rls(...)` — the `GET /documents/{id}/shares` listing endpoint. Listing a document's shares failed at decode time.

Every sibling query in the same file already casts `share_type::text AS share_type` (lines 44/73/97); only this `SELECT s.*` path forgot.

## Fix

Replace `SELECT s.*` with an explicit column list selecting `s.share_type::text AS share_type` (plus the remaining columns and the two joined aliases `document_title`, `shared_by_name`), mirroring the sibling queries.

## Verification (IG3)

New `crates/db/tests/document_shares_enum_decode_tests.rs`: seeds a `'link'::document_share_type` share and reads it back through `get_shares_rls`, asserting `share_type == "link"`. Fails on `main` (decode error), green after the cast. Mirrors the existing `facility_enum_decode_tests.rs` precedent (#859). Verified via the workspace `test` CI gate (no local Rust host — mercury down).

Surfaced by the [BIT-356](https://github.com/martin-janci/property-management) RLS/IDOR/authz quarantine triage (parent BIT-354).

🤖 Generated with [Claude Code](https://claude.com/claude-code)