### PR TITLE
test(BIT-360): bulk re-enable 718 BIT-351-quarantined tests (146 files)

### DIFF
--- a/backend/crates/db/tests/acc_mvp_rls_tests.rs
+++ b/backend/crates/db/tests/acc_mvp_rls_tests.rs
@@ -81,7 +81,6 @@ async fn count_on(conn: &mut sqlx::PgConnection, table: &str) -> i64 {
 /// expression is bound to get_current_org_id(). Catalog reads are not
 /// tenant-scoped, so the pool superuser is fine here.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn acc_mvp_all_new_tables_force_rls_with_tenant_policy(pool: PgPool) {
     for t in NEW_TABLES {
         let forced: bool =
@@ -118,7 +117,6 @@ async fn acc_mvp_all_new_tables_force_rls_with_tenant_policy(pool: PgPool) {
 /// none of them, cross-tenant writes are rejected, and the audit log is
 /// append-only.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn acc_mvp_force_rls_cross_tenant_isolation(pool: PgPool) {
     // ---- Seed fixtures on the (superuser) pool; superusers bypass RLS, so the
     // explicit tenant_id values are what matter. ----

--- a/backend/crates/db/tests/accounting_provider_rls_repo_tests.rs
+++ b/backend/crates/db/tests/accounting_provider_rls_repo_tests.rs
@@ -32,7 +32,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_provider_connection_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     // Seed as superuser
     set_ctx(&pool, None, None, true).await;

--- a/backend/crates/db/tests/accounting_rls_repo_tests.rs
+++ b/backend/crates/db/tests/accounting_rls_repo_tests.rs
@@ -34,7 +34,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_contact_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     // Seed as superuser
     set_ctx(&pool, None, None, true).await;
@@ -151,7 +150,6 @@ async fn accounting_contact_force_rls_blocks_cross_tenant_read(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_invoice_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     // Seed as superuser
     set_ctx(&pool, None, None, true).await;
@@ -294,7 +292,6 @@ async fn accounting_invoice_force_rls_blocks_cross_tenant_read(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_bank_statement_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     let org_a = seed_org(&pool, "org-a-stmt").await;
@@ -374,7 +371,6 @@ async fn accounting_bank_statement_force_rls_blocks_cross_tenant_read(pool: PgPo
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_payment_match_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     let org_a = seed_org(&pool, "org-a-match").await;
@@ -462,7 +458,6 @@ async fn accounting_payment_match_force_rls_blocks_cross_tenant_read(pool: PgPoo
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_invoice_item_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     let org_a = seed_org(&pool, "org-a-item").await;
@@ -562,7 +557,6 @@ async fn accounting_invoice_item_force_rls_blocks_cross_tenant_read(pool: PgPool
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_bank_statement_line_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     let org_a = seed_org(&pool, "org-a-line").await;
@@ -639,7 +633,6 @@ async fn accounting_bank_statement_line_force_rls_blocks_cross_tenant_read(pool:
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_invoice_force_rls_blocks_cross_tenant_write(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     let org_a = seed_org(&pool, "org-a-write").await;
@@ -756,7 +749,6 @@ async fn accounting_invoice_force_rls_blocks_cross_tenant_write(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accounting_confirm_match_cross_tenant_denied(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
     let org_a = seed_org(&pool, "org-a-match-fail").await;
@@ -839,7 +831,6 @@ async fn accounting_confirm_match_cross_tenant_denied(pool: PgPool) {
 /// header off by a cent from the sum of its items. The single-pass round-once
 /// fix makes the header == sum(items) by construction.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_invoice_header_totals_equal_sum_of_rounded_lines(pool: PgPool) {
     let org = seed_org(&pool, "inv-round").await;
     set_ctx(&pool, Some(org), None, true).await;
@@ -922,7 +913,6 @@ async fn create_invoice_header_totals_equal_sum_of_rounded_lines(pool: PgPool) {
 /// `RowNotFound` error up to a 500. Pre-fix the method used `.fetch_one`, which
 /// returned `Err(RowNotFound)` for the no-rows-affected case.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_invoice_missing_id_returns_none_not_error(pool: PgPool) {
     let org = seed_org(&pool, "inv-update-404").await;
     set_ctx(&pool, Some(org), None, true).await;

--- a/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
+++ b/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
@@ -100,7 +100,6 @@ async fn seed_session(pool: &PgPool, org_id: Uuid, user_id: Uuid, title: &str) -
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ai_chat_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = AiChatRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/announcement_targeting_visibility_tests.rs
+++ b/backend/crates/db/tests/announcement_targeting_visibility_tests.rs
@@ -152,7 +152,6 @@ async fn visible_count(pool: &PgPool, repo: &AnnouncementRepository, org: Uuid, 
 }
 
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn published_feed_is_filtered_by_targeting(pool: PgPool) {
     // ---- seed everything under a super-admin context (bypasses RLS WITH CHECK) ----
     let mut sa = pool.acquire().await.unwrap();

--- a/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_developer_force_rls_tests.rs
@@ -171,7 +171,6 @@ async fn seed_usage_log(pool: &PgPool, api_key_id: Uuid) -> Uuid {
 /// `api_key_usage_logs`) were forced in `00181` — `developer_oauth_apps` holds
 /// `client_secret_hash` (credential-class), making it the highest-value target.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn api_ecosystem_catalog_and_developer_tables_are_force_rls(pool: PgPool) {
     let tables = [
         "marketplace_integrations",
@@ -215,7 +214,6 @@ async fn api_ecosystem_catalog_and_developer_tables_are_force_rls(pool: PgPool) 
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn developer_portal_force_rls_cross_user_isolation(pool: PgPool) {
     let repo = ApiEcosystemRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/api_ecosystem_rls_repo_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_rls_repo_tests.rs
@@ -104,7 +104,6 @@ async fn seed_webhook(pool: &PgPool, org_id: Uuid, created_by: Uuid, name: &str)
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn api_ecosystem_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = ApiEcosystemRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/auth_policy_tests.rs
+++ b/backend/crates/db/tests/auth_policy_tests.rs
@@ -25,7 +25,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn missing_row_falls_back_to_default(pool: PgPool) {
     let org = seed_org(&pool, "default-fallback").await;
 
@@ -35,7 +34,6 @@ async fn missing_row_falls_back_to_default(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn empty_jsonb_falls_back_to_default(pool: PgPool) {
     let org = seed_org(&pool, "empty-jsonb").await;
 
@@ -52,7 +50,6 @@ async fn empty_jsonb_falls_back_to_default(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn full_override_loads_back_intact(pool: PgPool) {
     let org = seed_org(&pool, "full-override").await;
 
@@ -78,7 +75,6 @@ async fn full_override_loads_back_intact(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn partial_override_inherits_remaining_defaults(pool: PgPool) {
     let org = seed_org(&pool, "partial-override").await;
 
@@ -105,7 +101,6 @@ async fn partial_override_inherits_remaining_defaults(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn malformed_jsonb_falls_back_to_default(pool: PgPool) {
     let org = seed_org(&pool, "malformed").await;
 
@@ -124,7 +119,6 @@ async fn malformed_jsonb_falls_back_to_default(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn loader_does_not_leave_rls_context_dirty(pool: PgPool) {
     // The loader sets a super-admin RLS context for the read; it must clear
     // it before returning the connection to the pool. Otherwise subsequent

--- a/backend/crates/db/tests/background_jobs_stuck_retry_budget_tests.rs
+++ b/backend/crates/db/tests/background_jobs_stuck_retry_budget_tests.rs
@@ -70,7 +70,6 @@ async fn seed_stuck_job(pool: &PgPool, attempts: i32, max_attempts: i32) -> Uuid
 }
 
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn stuck_job_with_remaining_budget_is_reset_to_pending(pool: PgPool) {
     // attempts (1) < max_attempts (3): still retriable.
     let job_id = seed_stuck_job(&pool, 1, 3).await;
@@ -105,7 +104,6 @@ async fn stuck_job_with_remaining_budget_is_reset_to_pending(pool: PgPool) {
 }
 
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn stuck_job_with_exhausted_budget_is_timed_out_not_recycled(pool: PgPool) {
     // attempts (3) == max_attempts (3): budget exhausted. On `main` this came
     // back as `pending` and looped forever; the fix sends it to `timed_out`.

--- a/backend/crates/db/tests/board_meetings_list_join_tests.rs
+++ b/backend/crates/db/tests/board_meetings_list_join_tests.rs
@@ -45,7 +45,6 @@ async fn seed_user(pool: &PgPool, email: &str, name: &str) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_board_members_and_motions_populate_joined_user_name(pool: PgPool) {
     let org = seed_org(&pool, "board-join").await;
     let user = seed_user(&pool, "director@board-join.test", "Jane Director").await;

--- a/backend/crates/db/tests/budget_rls_repo_tests.rs
+++ b/backend/crates/db/tests/budget_rls_repo_tests.rs
@@ -147,7 +147,6 @@ async fn seed_budget_item(pool: &PgPool, budget_id: Uuid, category_id: Uuid) -> 
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn budget_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = BudgetRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/building_certification_rls_repo_tests.rs
+++ b/backend/crates/db/tests/building_certification_rls_repo_tests.rs
@@ -120,7 +120,6 @@ async fn seed_cert(pool: &PgPool, org_id: Uuid, building_id: Uuid, user_id: Uuid
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn building_certification_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = BuildingCertificationRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/capability_revoke_mfa_constraint_tests.rs
+++ b/backend/crates/db/tests/capability_revoke_mfa_constraint_tests.rs
@@ -48,7 +48,6 @@ async fn seed_grant(pool: &PgPool, user_id: Uuid, granted_by: Uuid) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoke_without_mfa_timestamp_is_rejected(pool: PgPool) {
     let target = seed_user(&pool, "e3-target-no-mfa@phase2.test").await;
     let granter = seed_user(&pool, "e3-granter-no-mfa@phase2.test").await;
@@ -93,7 +92,6 @@ async fn revoke_without_mfa_timestamp_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoke_with_stale_mfa_timestamp_is_rejected(pool: PgPool) {
     let target = seed_user(&pool, "e3-target-stale@phase2.test").await;
     let granter = seed_user(&pool, "e3-granter-stale@phase2.test").await;
@@ -140,7 +138,6 @@ async fn revoke_with_stale_mfa_timestamp_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoke_with_current_mfa_timestamp_succeeds(pool: PgPool) {
     let target = seed_user(&pool, "e3-target-ok@phase2.test").await;
     let granter = seed_user(&pool, "e3-granter-ok@phase2.test").await;
@@ -199,7 +196,6 @@ async fn revoke_with_current_mfa_timestamp_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unrelated_update_is_not_affected_by_trigger(pool: PgPool) {
     let target = seed_user(&pool, "e3-target-note@phase2.test").await;
     let granter = seed_user(&pool, "e3-granter-note@phase2.test").await;

--- a/backend/crates/db/tests/dispute_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/dispute_cross_tenant_tests.rs
@@ -39,7 +39,6 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_status_rejects_cross_tenant_caller(pool: PgPool) {
     let org_a = seed_org(&pool, "dispute-a").await;
     let org_b = seed_org(&pool, "dispute-b").await;

--- a/backend/crates/db/tests/dispute_lifecycle_tests.rs
+++ b/backend/crates/db/tests/dispute_lifecycle_tests.rs
@@ -90,7 +90,6 @@ fn transition(dispute_id: Uuid, org_id: Uuid, by: Uuid, status: &str) -> UpdateD
 /// `filed → under_review → mediation → resolved → closed`. Each step must
 /// succeed and the persisted status must reflect the transition.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn file_then_full_status_lifecycle(pool: PgPool) {
     let org = seed_org(&pool, "lc").await;
     let complainant = seed_user(&pool, "complainant@dispute-lifecycle.test").await;
@@ -157,7 +156,6 @@ async fn file_then_full_status_lifecycle(pool: PgPool) {
 /// (`find_by_id_with_details_for_org`, `update_status`, `withdraw`) must deny
 /// the foreign org while the owning org succeeds.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn cross_tenant_access_is_denied(pool: PgPool) {
     let org_a = seed_org(&pool, "iso-a").await;
     let org_b = seed_org(&pool, "iso-b").await;
@@ -236,7 +234,6 @@ async fn cross_tenant_access_is_denied(pool: PgPool) {
 /// an illegal one (e.g. `filed → resolved`, skipping review) is rejected with
 /// `BadRequest`, leaving the row untouched.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn status_machine_rejects_illegal_transitions(pool: PgPool) {
     let org = seed_org(&pool, "sm").await;
     let user = seed_user(&pool, "sm@dispute-lifecycle.test").await;
@@ -322,7 +319,6 @@ async fn status_machine_rejects_illegal_transitions(pool: PgPool) {
 /// HTTP-layer auth guard on the evidence-upload route is covered in the
 /// api-server test `dispute_evidence_auth_tests.rs`.)
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_evidence_persists_and_records_activity(pool: PgPool) {
     let org = seed_org(&pool, "ev").await;
     let user = seed_user(&pool, "ev@dispute-lifecycle.test").await;

--- a/backend/crates/db/tests/document_shares_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/document_shares_rls_cross_tenant_tests.rs
@@ -135,7 +135,6 @@ async fn seed_access_log(pool: &PgPool, share_id: Uuid) -> Uuid {
 /// context (the public share-token path) sees both. Without 00178's FORCE +
 /// policy fix this isolation is absent (the IDOR PAP-21 closes).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn document_shares_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     // --- Seed as superuser (super-admin context satisfies the org/role RLS
     //     WITH CHECK fired by the inserts). ---

--- a/backend/crates/db/tests/document_template_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/document_template_cross_tenant_tests.rs
@@ -77,7 +77,6 @@ async fn seed_template(repo: &DocumentTemplateRepository, org_id: Uuid, created_
 
 /// A caller in org B cannot read a template owned by org A by guessing its UUID.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_by_id_is_org_scoped(pool: PgPool) {
     let repo = DocumentTemplateRepository::new(pool.clone());
     let org_a = seed_org(&pool, "a-read").await;
@@ -114,7 +113,6 @@ async fn find_by_id_is_org_scoped(pool: PgPool) {
 
 /// A caller in org B cannot update a template owned by org A.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_is_org_scoped(pool: PgPool) {
     let repo = DocumentTemplateRepository::new(pool.clone());
     let org_a = seed_org(&pool, "a-upd").await;
@@ -152,7 +150,6 @@ async fn update_is_org_scoped(pool: PgPool) {
 
 /// A caller in org B cannot soft-delete a template owned by org A.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_is_org_scoped(pool: PgPool) {
     let repo = DocumentTemplateRepository::new(pool.clone());
     let org_a = seed_org(&pool, "a-del").await;

--- a/backend/crates/db/tests/documents_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/documents_rls_cross_tenant_tests.rs
@@ -68,7 +68,6 @@ async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &st
 /// org's document. Without 00163's FORCE + policy fix, the cross-tenant row
 /// would be visible (the IDOR in #754).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn documents_force_rls_blocks_cross_tenant_read(pool: PgPool) {
     // --- Seed as superuser (super-admin context satisfies the roles-trigger
     //     RLS WITH CHECK fired by INSERT INTO organizations). ---

--- a/backend/crates/db/tests/emergency_rls_repo_tests.rs
+++ b/backend/crates/db/tests/emergency_rls_repo_tests.rs
@@ -110,7 +110,6 @@ async fn seed_protocol(pool: &PgPool, org_id: Uuid, name: &str) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn emergency_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = EmergencyRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/enhanced_tenant_screening_rls_repo_tests.rs
+++ b/backend/crates/db/tests/enhanced_tenant_screening_rls_repo_tests.rs
@@ -102,7 +102,6 @@ fn model_req(name: &str) -> CreateAiRiskScoringModel {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn screening_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = EnhancedTenantScreeningRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/epic11_org_guc_rls_tests.rs
+++ b/backend/crates/db/tests/epic11_org_guc_rls_tests.rs
@@ -190,7 +190,6 @@ const ORG_GUC_CLUSTER_TABLES: [&str; 135] = [
 /// with `relrowsecurity = true` (ENABLE, from the create migrations) still in
 /// place. Pre-migration these are `(true, false)`, so this fails on origin/dev.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn org_guc_cluster_tables_have_force_rls_enabled(pool: PgPool) {
     let rows: Vec<(String, bool, bool)> = sqlx::query_as(
         r#"
@@ -231,7 +230,6 @@ async fn org_guc_cluster_tables_have_force_rls_enabled(pool: PgPool) {
 /// FORCE RLS with no policy is an implicit deny-all; FORCE RLS with policies is
 /// real enforcement. Assert each table still carries at least one RLS policy.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn org_guc_cluster_tables_have_rls_policies(pool: PgPool) {
     for table in ORG_GUC_CLUSTER_TABLES {
         let policy_count: i64 = sqlx::query_scalar(
@@ -261,7 +259,6 @@ async fn org_guc_cluster_tables_have_rls_policies(pool: PgPool) {
 /// (USING) and `with_check` expressions are inspected as text. Fails on
 /// origin/dev (policies still on `app.current_organization_id`).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn org_guc_cluster_policies_use_canonical_org_guc(pool: PgPool) {
     let offenders: Vec<(String, String)> = sqlx::query_as(
         r#"

--- a/backend/crates/db/tests/equipment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/equipment_rls_repo_tests.rs
@@ -113,7 +113,6 @@ async fn seed_equipment(pool: &PgPool, org_id: Uuid, building_id: Uuid) -> Uuid 
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn equipment_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = EquipmentRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/esg_force_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/esg_force_rls_cross_tenant_tests.rs
@@ -86,7 +86,6 @@ async fn seed_metric_raw(pool: &PgPool, org_id: Uuid, user_id: Uuid) -> Uuid {
 /// produces deny-all when no RLS context is set — proving the primary policy
 /// boundary, independent of the `organization_id = $2` application-layer guard.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn esg_metrics_force_rls_blocks_cross_tenant_and_deny_all(pool: PgPool) {
     let org_a = seed_org(&pool, "esg-rls-a").await;
     let org_b = seed_org(&pool, "esg-rls-b").await;

--- a/backend/crates/db/tests/esignature_workflow_repo_tests.rs
+++ b/backend/crates/db/tests/esignature_workflow_repo_tests.rs
@@ -117,7 +117,6 @@ async fn seed_workflow(
 /// `find_esignature_workflow_by_external_id` returns the correct org/user
 /// row for a known envelope id.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_esignature_workflow_returns_correct_row(pool: PgPool) {
     ensure_esignature_workflows_table(&pool).await;
 
@@ -153,7 +152,6 @@ async fn find_esignature_workflow_returns_correct_row(pool: PgPool) {
 
 /// An unknown envelope id returns `None` — the handler's "ignore" branch.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_esignature_workflow_returns_none_for_unknown_envelope(pool: PgPool) {
     ensure_esignature_workflows_table(&pool).await;
 

--- a/backend/crates/db/tests/facility_enum_decode_tests.rs
+++ b/backend/crates/db/tests/facility_enum_decode_tests.rs
@@ -82,7 +82,6 @@ async fn seed(pool: &PgPool) -> (Uuid, Uuid, Uuid) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_by_id_decodes_facility_type_enum(pool: PgPool) {
     let (_building_id, facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -98,7 +97,6 @@ async fn find_by_id_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_by_building_decodes_facility_type_enum(pool: PgPool) {
     let (building_id, _facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -112,7 +110,6 @@ async fn find_by_building_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_bookable_decodes_facility_type_enum(pool: PgPool) {
     let (building_id, _facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -126,7 +123,6 @@ async fn find_bookable_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn booking_read_paths_decode_booking_status_enum(pool: PgPool) {
     let (building_id, facility_id, user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -207,7 +203,6 @@ async fn booking_read_paths_decode_booking_status_enum(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn facility_update_decodes_facility_type_enum(pool: PgPool) {
     let (_building_id, facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -246,7 +241,6 @@ async fn facility_update_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn booking_transitions_decode_status_enum(pool: PgPool) {
     let (_building_id, facility_id, user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());

--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -152,7 +152,6 @@ async fn drop_rls_role(pool: &PgPool, role: &str) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = FormRepository::new(pool.clone());
 
@@ -352,7 +351,6 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
 ///      is the enforcer) cannot `update` (errors `RowNotFound`) or `delete`
 ///      (0 rows) it, and org B's form is left fully intact.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn form_repo_force_rls_write_paths_and_cross_tenant(pool: PgPool) {
     let repo = FormRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/inquiry_mark_read_idor_tests.rs
+++ b/backend/crates/db/tests/inquiry_mark_read_idor_tests.rs
@@ -88,7 +88,6 @@ async fn seed_inquiry(pool: &PgPool, listing_id: Uuid, realtor_id: Uuid) -> Uuid
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn realtor_b_cannot_mark_realtor_a_inquiry_read(pool: PgPool) {
     let org_id = seed_org(&pool, "idor-inq").await;
     let pm_user = seed_pm_user(&pool, "inq-pm@idor.test").await;

--- a/backend/crates/db/tests/insurance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/insurance_rls_repo_tests.rs
@@ -127,7 +127,6 @@ fn sample_policy(suffix: &str) -> CreateInsurancePolicy {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn insurance_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = InsuranceRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/integration_rls_repo_tests.rs
+++ b/backend/crates/db/tests/integration_rls_repo_tests.rs
@@ -131,7 +131,6 @@ async fn seed_subscription(pool: &PgPool, org_id: Uuid, created_by: Uuid, name: 
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn integration_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     // Crypto None for determinism: secrets round-trip as plaintext.
     let repo = IntegrationRepository::with_crypto(pool.clone(), None);

--- a/backend/crates/db/tests/legal_rls_repo_tests.rs
+++ b/backend/crates/db/tests/legal_rls_repo_tests.rs
@@ -119,7 +119,6 @@ fn sample_create() -> CreateLegalDocument {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legal_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = LegalRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/llm_document_rls_repo_tests.rs
+++ b/backend/crates/db/tests/llm_document_rls_repo_tests.rs
@@ -122,7 +122,6 @@ async fn seed_embedding(pool: &PgPool, org_id: Uuid, document_id: Uuid, text: &s
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn llm_document_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = LlmDocumentRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/membership_revocation_tests.rs
+++ b/backend/crates/db/tests/membership_revocation_tests.rs
@@ -44,7 +44,6 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoke_flips_is_active_immediately(pool: PgPool) {
     let org_id = seed_org(&pool, "phase2-rev-1").await;
     let user_id = seed_user(&pool, "rev1@phase2.test").await;
@@ -79,7 +78,6 @@ async fn revoke_flips_is_active_immediately(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoke_on_other_org_does_not_affect_first(pool: PgPool) {
     let org_a = seed_org(&pool, "phase2-rev-a").await;
     let org_b = seed_org(&pool, "phase2-rev-b").await;
@@ -113,7 +111,6 @@ async fn revoke_on_other_org_does_not_affect_first(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn re_grant_after_revoke_works(pool: PgPool) {
     let org = seed_org(&pool, "phase2-rev-regrant").await;
     let user = seed_user(&pool, "regrant@phase2.test").await;

--- a/backend/crates/db/tests/messaging_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/messaging_rls_cross_tenant_tests.rs
@@ -50,7 +50,6 @@ const MESSAGING_TABLES: [&str; 3] = ["message_threads", "messages", "user_blocks
 /// table, with `relrowsecurity = true` (ENABLE, from 00017) still in place.
 /// Pre-migration these would be `(true, false)`, so this fails on origin/dev.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn messaging_tables_have_force_rls_enabled(pool: PgPool) {
     let rows: Vec<(String, bool, bool)> = sqlx::query_as(
         r#"
@@ -90,7 +89,6 @@ async fn messaging_tables_have_force_rls_enabled(pool: PgPool) {
 /// policy, so 00171's FORCE is enforcing the participant/tenant policies rather
 /// than locking the tables out entirely.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn messaging_tables_have_rls_policies(pool: PgPool) {
     for table in MESSAGING_TABLES {
         let policy_count: i64 = sqlx::query_scalar(

--- a/backend/crates/db/tests/my_units_privacy_tests.rs
+++ b/backend/crates/db/tests/my_units_privacy_tests.rs
@@ -108,7 +108,6 @@ async fn insert_ended_resident(conn: &mut PgConnection, unit: Uuid, user: Uuid) 
 /// Alice's own association — Bob's residency is never surfaced, proving other
 /// residents' PII is filtered server-side.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_my_units_returns_only_callers_association(pool: PgPool) {
     let mut conn = pool.acquire().await.expect("acquire");
     let org = insert_org(&mut conn, "shared").await;
@@ -149,7 +148,6 @@ async fn find_my_units_returns_only_callers_association(pool: PgPool) {
 
 /// A user with no residency (and other tenants' units in the DB) sees nothing.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_my_units_is_scoped_strictly_by_user(pool: PgPool) {
     let mut conn = pool.acquire().await.expect("acquire");
     let org = insert_org(&mut conn, "scope").await;
@@ -175,7 +173,6 @@ async fn find_my_units_is_scoped_strictly_by_user(pool: PgPool) {
 
 /// Ended residencies (moved-out) are excluded; only active associations show.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_my_units_excludes_ended_residencies(pool: PgPool) {
     let mut conn = pool.acquire().await.expect("acquire");
     let org = insert_org(&mut conn, "ended").await;

--- a/backend/crates/db/tests/notification_events_repo_tests.rs
+++ b/backend/crates/db/tests/notification_events_repo_tests.rs
@@ -37,7 +37,6 @@ fn many(channel: &str, event: &str, n: usize, at: DateTime<Utc>) -> Vec<NewNotif
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn insert_aggregate_and_alert_fires(pool: PgPool) {
     let repo = NotificationEventRepository::new(pool.clone());
     let now = Utc::now();
@@ -94,7 +93,6 @@ async fn insert_aggregate_and_alert_fires(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn min_attempts_guard_suppresses_noisy_alert(pool: PgPool) {
     let repo = NotificationEventRepository::new(pool.clone());
     let now = Utc::now();
@@ -118,7 +116,6 @@ async fn min_attempts_guard_suppresses_noisy_alert(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn channel_filter_and_empty_window(pool: PgPool) {
     let repo = NotificationEventRepository::new(pool.clone());
     let now = Utc::now();
@@ -157,7 +154,6 @@ async fn channel_filter_and_empty_window(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn service_role_rls_allows_unset_guc_denies_user(pool: PgPool) {
     let now = Utc::now();
 

--- a/backend/crates/db/tests/notification_rls_guc_tests.rs
+++ b/backend/crates/db/tests/notification_rls_guc_tests.rs
@@ -50,7 +50,6 @@ const NOTIFICATION_TABLES: [&str; 3] = [
 /// still in place. Pre-migration these are `(true, false)`, so this fails on
 /// origin/dev.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn notification_tables_have_force_rls_enabled(pool: PgPool) {
     let rows: Vec<(String, bool, bool)> = sqlx::query_as(
         r#"
@@ -88,7 +87,6 @@ async fn notification_tables_have_force_rls_enabled(pool: PgPool) {
 /// FORCE RLS with no policy is an implicit deny-all; FORCE RLS with policies is
 /// real enforcement. Assert each table still carries at least one RLS policy.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn notification_tables_have_rls_policies(pool: PgPool) {
     for table in NOTIFICATION_TABLES {
         let policy_count: i64 = sqlx::query_scalar(
@@ -118,7 +116,6 @@ async fn notification_tables_have_rls_policies(pool: PgPool) {
 /// expressions are inspected as text. Fails on origin/dev (policies still on
 /// `request.user_id` / `request.org_id`).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn notification_policies_use_app_guc_not_request(pool: PgPool) {
     let offenders: Vec<(String, String)> = sqlx::query_as(
         r#"

--- a/backend/crates/db/tests/oauth_refresh_token_tests.rs
+++ b/backend/crates/db/tests/oauth_refresh_token_tests.rs
@@ -45,7 +45,6 @@ async fn seed_client(repo: &OAuthRepository, suffix: &str) -> String {
 /// otherwise a revoked refresh token could be exchanged for a fresh access
 /// token (RFC 9700 violation).
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoked_refresh_token_is_invisible_to_production_lookup(pool: PgPool) {
     let repo = OAuthRepository::new(pool.clone());
     let user_id = seed_user(&pool, "oauth-rt-1@test").await;
@@ -94,7 +93,6 @@ async fn revoked_refresh_token_is_invisible_to_production_lookup(pool: PgPool) {
 /// The reuse-detection lookup MUST return revoked rows so the service layer
 /// can spot replay attacks and burn the rest of the token family.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn including_revoked_lookup_sees_revoked_rows(pool: PgPool) {
     let repo = OAuthRepository::new(pool.clone());
     let user_id = seed_user(&pool, "oauth-rt-2@test").await;

--- a/backend/crates/db/tests/payment_management_tests.rs
+++ b/backend/crates/db/tests/payment_management_tests.rs
@@ -107,7 +107,6 @@ async fn invoice_balance(pool: &PgPool, invoice_id: Uuid) -> Decimal {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_payments_is_org_scoped_and_counted(pool: PgPool) {
     let repo = FinancialRepository::new(pool.clone());
     let org_a = seed_org(&pool, "list-a").await;
@@ -142,7 +141,6 @@ async fn list_payments_is_org_scoped_and_counted(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unallocated_list_drops_a_payment_once_fully_allocated(pool: PgPool) {
     let repo = FinancialRepository::new(pool.clone());
     let org = seed_org(&pool, "unalloc").await;
@@ -169,7 +167,6 @@ async fn unallocated_list_drops_a_payment_once_fully_allocated(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn allocate_clamps_to_invoice_balance_and_is_org_scoped(pool: PgPool) {
     let repo = FinancialRepository::new(pool.clone());
     let org = seed_org(&pool, "alloc").await;
@@ -205,7 +202,6 @@ async fn allocate_clamps_to_invoice_balance_and_is_org_scoped(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn auto_match_allocates_oldest_first(pool: PgPool) {
     let repo = FinancialRepository::new(pool.clone());
     let org = seed_org(&pool, "auto").await;

--- a/backend/crates/db/tests/portal_imports_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/portal_imports_cross_org_idor_tests.rs
@@ -58,7 +58,6 @@ async fn seed_agency(pool: &PgPool, slug: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn import_job_by_id_is_scoped_to_owning_user(pool: PgPool) {
     let user_a = seed_user(&pool, "import-a@idor.test").await;
     let user_b = seed_user(&pool, "import-b@idor.test").await;
@@ -143,7 +142,6 @@ async fn import_job_by_id_is_scoped_to_owning_user(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn feed_subscription_by_id_is_scoped_to_owning_agency(pool: PgPool) {
     let agency_a = seed_agency(&pool, "feed-idor-a").await;
     let agency_b = seed_agency(&pool, "feed-idor-b").await;

--- a/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/predictive_maintenance_rls_repo_tests.rs
@@ -112,7 +112,6 @@ async fn seed_equipment(pool: &PgPool, org_id: Uuid, building_id: Uuid, name: &s
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn predictive_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = PredictiveMaintenanceRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/predictive_maintenance_sort_injection_tests.rs
+++ b/backend/crates/db/tests/predictive_maintenance_sort_injection_tests.rs
@@ -106,7 +106,6 @@ async fn seed_equipment(
 /// alter the query: the call returns the seeded rows normally and the table
 /// still exists afterwards.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn malicious_sort_order_does_not_inject(pool: PgPool) {
     let repo = PredictiveMaintenanceRepository::new(pool.clone());
 
@@ -143,7 +142,6 @@ async fn malicious_sort_order_does_not_inject(pool: PgPool) {
 /// A malicious `sort_by` (subquery injection) must fall back to the default
 /// column and return normal results without error.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn malicious_sort_by_does_not_inject(pool: PgPool) {
     let repo = PredictiveMaintenanceRepository::new(pool.clone());
 
@@ -169,7 +167,6 @@ async fn malicious_sort_by_does_not_inject(pool: PgPool) {
 
 /// Sanity: the legitimate `desc` ordering is still honoured after the fix.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legitimate_desc_ordering_still_works(pool: PgPool) {
     let repo = PredictiveMaintenanceRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/principal_kind_actor_check_tests.rs
+++ b/backend/crates/db/tests/principal_kind_actor_check_tests.rs
@@ -44,7 +44,6 @@ async fn set_session_user(
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn forged_actor_is_rejected(pool: PgPool) {
     let target = create_user(&pool, "n3-target-forge@phase2.test").await;
     let real_caller = create_user(&pool, "n3-real-caller@phase2.test").await;
@@ -88,7 +87,6 @@ async fn forged_actor_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn matching_actor_succeeds(pool: PgPool) {
     let target = create_user(&pool, "n3-target-ok@phase2.test").await;
     let actor = create_user(&pool, "n3-actor-ok@phase2.test").await;
@@ -148,7 +146,6 @@ async fn matching_actor_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn missing_session_user_is_rejected(pool: PgPool) {
     let target = create_user(&pool, "n3-target-no-session@phase2.test").await;
     let actor = create_user(&pool, "n3-actor-no-session@phase2.test").await;

--- a/backend/crates/db/tests/principal_kind_guard_tests.rs
+++ b/backend/crates/db/tests/principal_kind_guard_tests.rs
@@ -32,7 +32,6 @@ async fn create_user(pool: &PgPool, email: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn raw_update_to_principal_kind_is_rejected(pool: PgPool) {
     let id = create_user(&pool, "guard-raw@phase2.test").await;
 
@@ -65,7 +64,6 @@ async fn raw_update_to_principal_kind_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn set_principal_kind_succeeds_and_writes_audit_row(pool: PgPool) {
     let target = create_user(&pool, "guard-target@phase2.test").await;
     let actor = create_user(&pool, "guard-actor@phase2.test").await;

--- a/backend/crates/db/tests/public_plans_rls_tests.rs
+++ b/backend/crates/db/tests/public_plans_rls_tests.rs
@@ -52,7 +52,6 @@ async fn seed_plan(pool: &PgPool, name: &str, is_active: bool, is_public: bool) 
 /// `list_public_plans` returns only plans where `is_active AND is_public`,
 /// even on a connection with no RLS context set.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_public_plans_filters_correctly_without_rls_context(pool: PgPool) {
     // Seed four variants.
     let public_active = seed_plan(&pool, "plan-pub-act", true, true).await;
@@ -98,7 +97,6 @@ async fn list_public_plans_filters_correctly_without_rls_context(pool: PgPool) {
 /// `list_public_plans` still works when RLS context IS set (i.e., the
 /// cleared path is not the only path — authenticated callers can also see plans).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_public_plans_works_with_rls_context_set(pool: PgPool) {
     let public_active = seed_plan(&pool, "plan-ctx-pub-act", true, true).await;
 

--- a/backend/crates/db/tests/rag_similarity_search_tests.rs
+++ b/backend/crates/db/tests/rag_similarity_search_tests.rs
@@ -110,7 +110,6 @@ async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &st
 ///   B. Org-scoping: org A query must never surface org B chunks
 ///   C. Stats view: regression guard for migration 00203
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn rag_retrieval_correctness(pool: PgPool) {
     set_super_ctx(&pool).await;
     let repo = LlmDocumentRepository::new(pool.clone());

--- a/backend/crates/db/tests/record_payment_atomicity_tests.rs
+++ b/backend/crates/db/tests/record_payment_atomicity_tests.rs
@@ -171,7 +171,6 @@ async fn payments_count(pool: &PgPool, action_id: Uuid) -> i64 {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn sequential_payments_accumulate_and_mark_paid(pool: PgPool) {
     let (repo, org, user, action_id) = seed_action(&pool, "seq").await;
 
@@ -225,7 +224,6 @@ async fn sequential_payments_accumulate_and_mark_paid(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn concurrent_payments_accumulate_without_lost_update(pool: PgPool) {
     let (_repo, org, user, action_id) = seed_action(&pool, "conc").await;
 

--- a/backend/crates/db/tests/registry_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_enum_decode_tests.rs
@@ -103,7 +103,6 @@ async fn seed_parking_spot(pool: &PgPool, org_id: Uuid, building_id: Uuid, spot:
 /// enum columns must decode into the `String` model fields, and `unit_number`
 /// must resolve from `units.designation`.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn registry_reads_decode_enums_and_resolve_designation(pool: PgPool) {
     let org = seed_org(&pool, "pap158").await;
     let owner = seed_user(&pool, "owner@pap158.test").await;
@@ -322,7 +321,6 @@ async fn seed_vehicle_registration_with_spot(
 /// the same leak PAP-143 closed on the by-id detail path. PAP-158 scopes the
 /// join; this test pins it (pre-fix: leaks "B-007"; post-fix: None).
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn vehicle_list_does_not_leak_cross_tenant_parking_spot(pool: PgPool) {
     let org_a = seed_org(&pool, "list-a").await;
     let org_b = seed_org(&pool, "list-b").await;

--- a/backend/crates/db/tests/registry_parking_spot_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/registry_parking_spot_cross_tenant_tests.rs
@@ -120,7 +120,6 @@ async fn seed_vehicle_registration(
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn details_does_not_leak_cross_tenant_parking_spot(pool: PgPool) {
     let org_a = seed_org(&pool, "registry-a").await;
     let org_b = seed_org(&pool, "registry-b").await;
@@ -154,7 +153,6 @@ async fn details_does_not_leak_cross_tenant_parking_spot(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn details_returns_same_tenant_parking_spot(pool: PgPool) {
     let org_a = seed_org(&pool, "registry-ok").await;
     let owner = seed_user(&pool, "owner@registry-ok.test").await;

--- a/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
+++ b/backend/crates/db/tests/registry_rules_enum_decode_tests.rs
@@ -39,7 +39,6 @@ async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn registry_rules_decode_allowed_pet_types_enum_array(pool: PgPool) {
     let org = seed_org(&pool, "rules_fix").await;
     let building = seed_building(&pool, org, "rules_fix").await;
@@ -106,7 +105,6 @@ async fn registry_rules_decode_allowed_pet_types_enum_array(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn registry_rules_decode_unknown_pet_type_variant_gracefully(pool: PgPool) {
     // GH #1363 / #1366 — audit of the allowed_pet_types enum decode path.
     //
@@ -195,7 +193,6 @@ async fn registry_rules_decode_unknown_pet_type_variant_gracefully(pool: PgPool)
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn registry_rules_insert_branch_none_booleans_use_schema_defaults(pool: PgPool) {
     // GH #1406 — the NOT-NULL COALESCE on the INSERT branch of upsert_registry_rules
     // (COALESCE($3, TRUE) / COALESCE($4, TRUE) / COALESCE($9, FALSE)) was added to

--- a/backend/crates/db/tests/rental_booking_nullable_decimal_tests.rs
+++ b/backend/crates/db/tests/rental_booking_nullable_decimal_tests.rs
@@ -17,7 +17,6 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_booking_by_id_decodes_null_fees(pool: PgPool) {
     // Super-admin context satisfies the rental_bookings RLS policies for seeding
     // and for the unscoped by-id read below.
@@ -94,7 +93,6 @@ async fn find_booking_by_id_decodes_null_fees(pool: PgPool) {
 /// covers both the model decode AND the create RETURNING projection in one shot
 /// (the read-path test above only seeds a literal row and reads it).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_booking_round_trips_null_fees(pool: PgPool) {
     sqlx::query("SELECT set_request_context($1, $2, $3)")
         .bind(Option::<Uuid>::None)

--- a/backend/crates/db/tests/rental_cross_tenant_upsert_tests.rs
+++ b/backend/crates/db/tests/rental_cross_tenant_upsert_tests.rs
@@ -42,7 +42,6 @@ async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
 /// After both calls org A's row must still have organization_id = org_a,
 /// org B's row must have organization_id = org_b, and tokens must not bleed.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn airbnb_upsert_nil_unit_id_is_org_scoped(pool: PgPool) {
     let org_a = seed_org(&pool, "airbnb-a").await;
     let org_b = seed_org(&pool, "airbnb-b").await;
@@ -100,7 +99,6 @@ async fn airbnb_upsert_nil_unit_id_is_org_scoped(pool: PgPool) {
 /// When org B refreshes its token after both orgs are connected, org A's row
 /// must remain untouched.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn airbnb_upsert_refresh_does_not_rebind_other_org(pool: PgPool) {
     let org_a = seed_org(&pool, "airbnb-ra").await;
     let org_b = seed_org(&pool, "airbnb-rb").await;
@@ -137,7 +135,6 @@ async fn airbnb_upsert_refresh_does_not_rebind_other_org(pool: PgPool) {
 
 /// Mirrors the Airbnb tests for upsert_booking_oauth_connection.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn booking_oauth_upsert_nil_unit_id_is_org_scoped(pool: PgPool) {
     let org_a = seed_org(&pool, "booking-a").await;
     let org_b = seed_org(&pool, "booking-b").await;
@@ -178,7 +175,6 @@ async fn booking_oauth_upsert_nil_unit_id_is_org_scoped(pool: PgPool) {
 
 /// organization_id must be stable after an idempotent re-upsert by the same org.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn booking_oauth_upsert_idempotent_same_org(pool: PgPool) {
     let org_a = seed_org(&pool, "booking-idem").await;
     let repo = RentalRepository::new(pool.clone());

--- a/backend/crates/db/tests/rental_enum_decode_tests.rs
+++ b/backend/crates/db/tests/rental_enum_decode_tests.rs
@@ -115,7 +115,6 @@ async fn seed(pool: &PgPool) -> (Uuid, Uuid, Uuid, Uuid) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_booking_by_id_decodes_platform_and_status_enums(pool: PgPool) {
     let (_org, _unit, _conn, booking_id) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -131,7 +130,6 @@ async fn find_booking_by_id_decodes_platform_and_status_enums(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_booking_for_org_decodes_enums(pool: PgPool) {
     let (org_id, _unit, _conn, booking_id) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -146,7 +144,6 @@ async fn find_booking_for_org_decodes_enums(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_booking_returning_decodes_enums(pool: PgPool) {
     let (_org, _unit, _conn, booking_id) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -178,7 +175,6 @@ async fn update_booking_returning_decodes_enums(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn connection_read_paths_decode_platform_enum(pool: PgPool) {
     let (org_id, _unit, conn_id, _booking) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -200,7 +196,6 @@ async fn connection_read_paths_decode_platform_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_airbnb_tokens_returning_decodes_platform_enum(pool: PgPool) {
     let (_org, _unit, conn_id, _booking) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());

--- a/backend/crates/db/tests/rental_guest_ical_enum_decode_tests.rs
+++ b/backend/crates/db/tests/rental_guest_ical_enum_decode_tests.rs
@@ -161,7 +161,6 @@ async fn seed(pool: &PgPool) -> (Uuid, Uuid, Uuid, Uuid, Uuid, Uuid, String) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_guest_by_id_decodes_status(pool: PgPool) {
     let (_org, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -175,7 +174,6 @@ async fn find_guest_by_id_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_guest_for_org_decodes_status(pool: PgPool) {
     let (org_id, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -189,7 +187,6 @@ async fn find_guest_for_org_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_guest_returning_decodes_status(pool: PgPool) {
     let (_org, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -222,7 +219,6 @@ async fn update_guest_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_guest_for_org_returning_decodes_status(pool: PgPool) {
     let (org_id, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -259,7 +255,6 @@ async fn update_guest_for_org_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_guest_returning_decodes_status(pool: PgPool) {
     let (_org, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -271,7 +266,6 @@ async fn register_guest_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_guest_for_org_returning_decodes_status(pool: PgPool) {
     let (org_id, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -287,7 +281,6 @@ async fn register_guest_for_org_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_guests_for_booking_decodes_status(pool: PgPool) {
     let (_org, _unit, booking_id, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -305,7 +298,6 @@ async fn get_guests_for_booking_decodes_status(pool: PgPool) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_calendar_block_returning_decodes_source_platform(pool: PgPool) {
     let (org_id, unit_id, _booking, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -333,7 +325,6 @@ async fn create_calendar_block_returning_decodes_source_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn seeded_calendar_block_source_platform_decodes_via_raw_query(pool: PgPool) {
     use db::models::rental::CalendarBlock;
 
@@ -370,7 +361,6 @@ async fn seeded_calendar_block_source_platform_decodes_via_raw_query(pool: PgPoo
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_ical_feed_by_token_decodes_import_platform(pool: PgPool) {
     let (_org, _unit, _booking, _guest, _block, _feed, feed_token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -384,7 +374,6 @@ async fn find_ical_feed_by_token_decodes_import_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_ical_feeds_for_unit_decodes_import_platform(pool: PgPool) {
     let (_org, unit_id, _booking, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -398,7 +387,6 @@ async fn get_ical_feeds_for_unit_decodes_import_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_ical_feeds_for_unit_in_org_decodes_import_platform(pool: PgPool) {
     let (org_id, unit_id, _booking, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -412,7 +400,6 @@ async fn get_ical_feeds_for_unit_in_org_decodes_import_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_ical_feed_for_org_returning_decodes_import_platform(pool: PgPool) {
     let (org_id, _unit, _booking, _guest, _block, feed_id, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -437,7 +424,6 @@ async fn update_ical_feed_for_org_returning_decodes_import_platform(pool: PgPool
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_ical_feed_returning_decodes_import_platform(pool: PgPool) {
     let (_org, _unit, _booking, _guest, _block, feed_id, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());

--- a/backend/crates/db/tests/reserve_atomicity_tests.rs
+++ b/backend/crates/db/tests/reserve_atomicity_tests.rs
@@ -50,7 +50,6 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
 // auto-deref does not work here due to lifetime constraints in sqlx's impl.
 #[allow(clippy::explicit_auto_deref)]
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_reserve_fund_management_transaction_atomicity(pool: PgPool) {
     let repo = ReserveFundRepository::new();
 

--- a/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
+++ b/backend/crates/db/tests/reserve_funds_rls_repo_tests.rs
@@ -105,7 +105,6 @@ async fn seed_fund(pool: &PgPool, org_id: Uuid, name: &str, user_id: Uuid) -> Uu
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn reserve_fund_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = ReserveFundRepository::new();
 
@@ -301,7 +300,6 @@ async fn reserve_fund_repo_force_rls_deny_all_and_fix(pool: PgPool) {
 /// Additionally verifies that an INSERT into org-B's fund via org-A context
 /// fails (the INSERT-path RLS WITH CHECK guard).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn reserve_fund_child_table_idor_blocked(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
 

--- a/backend/crates/db/tests/rls_context_bleed_tests.rs
+++ b/backend/crates/db/tests/rls_context_bleed_tests.rs
@@ -72,7 +72,6 @@ async fn read_super_admin(pool: &PgPool) -> Option<String> {
 /// `RlsGuard::drop` spawns a Tokio cleanup task. We yield with a short sleep
 /// so that task executes before we re-acquire.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn normal_drop_clears_org_id_guc(pool: PgPool) {
     let rls_pool = RlsPool::new(pool.clone());
 
@@ -125,7 +124,6 @@ async fn normal_drop_clears_org_id_guc(pool: PgPool) {
 /// This is the "mid-request panic" scenario — the most dangerous path for
 /// context bleeding.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn panic_drop_clears_org_id_guc(pool: PgPool) {
     let rls_pool = RlsPool::new(pool.clone());
 
@@ -171,7 +169,6 @@ async fn panic_drop_clears_org_id_guc(pool: PgPool) {
 /// Acquire a guard with super-admin context. Confirm all three GUCs are set.
 /// Drop normally. Confirm all three GUCs are cleared.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn normal_drop_clears_all_gucs(pool: PgPool) {
     let rls_pool = RlsPool::new(pool.clone());
 
@@ -241,7 +238,6 @@ async fn normal_drop_clears_all_gucs(pool: PgPool) {
 
 /// Same as `normal_drop_clears_all_gucs` but with a panic in the middle.
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn panic_drop_clears_all_gucs(pool: PgPool) {
     let rls_pool = RlsPool::new(pool.clone());
 

--- a/backend/crates/db/tests/search_alert_delivery_tests.rs
+++ b/backend/crates/db/tests/search_alert_delivery_tests.rs
@@ -47,7 +47,6 @@ async fn seed_saved_search(repo: &RealityPortalRepository, user_id: Uuid, name: 
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn search_alert_delivery_lifecycle(pool: PgPool) {
     let repo = RealityPortalRepository::new(pool.clone());
     let user = seed_portal_user(&pool, "alerts-lifecycle@test.sk").await;
@@ -99,7 +98,6 @@ async fn search_alert_delivery_lifecycle(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn search_alert_read_is_owner_scoped(pool: PgPool) {
     let repo = RealityPortalRepository::new(pool.clone());
     let owner = seed_portal_user(&pool, "alerts-owner@test.sk").await;
@@ -146,7 +144,6 @@ async fn search_alert_read_is_owner_scoped(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn search_alerts_paginate_with_limit_and_offset(pool: PgPool) {
     let repo = RealityPortalRepository::new(pool.clone());
     let user = seed_portal_user(&pool, "alerts-pagination@test.sk").await;

--- a/backend/crates/db/tests/sensor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sensor_rls_repo_tests.rs
@@ -90,7 +90,6 @@ async fn seed_sensor(
 /// method the IoT handlers call — so this is a behavioral test of the RLS
 /// routing, not just of the raw SQL policy.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn sensors_force_rls_requires_context_and_blocks_cross_tenant(pool: PgPool) {
     // --- Seed as superuser (super-admin context satisfies the roles-trigger
     //     RLS WITH CHECK fired by INSERT INTO organizations). ---
@@ -243,7 +242,6 @@ async fn sensors_force_rls_requires_context_and_blocks_cross_tenant(pool: PgPool
 /// collapse to empty — the same cross-tenant isolation guarantee as the parent
 /// table test above.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn sensor_readings_child_table_idor_blocked(pool: PgPool) {
     set_ctx(&pool, None, None, true).await;
 

--- a/backend/crates/db/tests/sentiment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/sentiment_rls_repo_tests.rs
@@ -99,7 +99,6 @@ async fn seed_alert(pool: &PgPool, org_id: Uuid) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn sentiment_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = SentimentRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/subscription_rls_repo_tests.rs
+++ b/backend/crates/db/tests/subscription_rls_repo_tests.rs
@@ -128,7 +128,6 @@ async fn seed_subscription(pool: &PgPool, org_id: Uuid, plan_id: Uuid) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn subscription_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = SubscriptionRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/support_data_session_columns_tests.rs
+++ b/backend/crates/db/tests/support_data_session_columns_tests.rs
@@ -69,7 +69,6 @@ async fn seed_refresh_token(
 /// `get_user_sessions` must list only active (non-revoked, non-expired) tokens
 /// and must run without referencing a non-existent `is_revoked` column.
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_user_sessions_lists_only_active(pool: PgPool) {
     let user_id = seed_user(&pool, "sessions@example.com").await;
     seed_refresh_token(&pool, user_id, "active-1", false, false).await;
@@ -90,7 +89,6 @@ async fn get_user_sessions_lists_only_active(pool: PgPool) {
 /// `revoke_user_sessions` must revoke all currently-active tokens (and only
 /// those) by setting `revoked_at`, returning the affected-row count.
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoke_user_sessions_revokes_active_only(pool: PgPool) {
     let user_id = seed_user(&pool, "revoke@example.com").await;
     seed_refresh_token(&pool, user_id, "r-active-1", false, false).await;
@@ -116,7 +114,6 @@ async fn revoke_user_sessions_revokes_active_only(pool: PgPool) {
 /// `get_support_data().active_sessions` must count only active refresh tokens
 /// and must run without referencing a non-existent `is_revoked` column.
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn support_data_active_sessions_counts_active_only(pool: PgPool) {
     let user_id = seed_user(&pool, "support-data@example.com").await;
     seed_refresh_token(&pool, user_id, "sd-active-1", false, false).await;

--- a/backend/crates/db/tests/thread_participant_state_tests.rs
+++ b/backend/crates/db/tests/thread_participant_state_tests.rs
@@ -63,7 +63,6 @@ async fn seed_thread(pool: &PgPool, org_id: Uuid, a: Uuid, b: Uuid) -> Uuid {
 /// Per-user delete hides the thread from that user's list only; the other
 /// participant's view is untouched.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn per_user_delete_hides_only_for_deleting_user(pool: PgPool) {
     let repo = MessagingRepository::new(pool.clone());
     let org = seed_org(&pool, "tps-del").await;
@@ -139,7 +138,6 @@ async fn per_user_delete_hides_only_for_deleting_user(pool: PgPool) {
 /// Archiving moves the thread to the archived tab for that user only; it leaves
 /// the default inbox (and the other participant) unchanged.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn archive_moves_thread_to_archived_tab_per_user(pool: PgPool) {
     let repo = MessagingRepository::new(pool.clone());
     let org = seed_org(&pool, "tps-arch").await;
@@ -202,7 +200,6 @@ async fn archive_moves_thread_to_archived_tab_per_user(pool: PgPool) {
 /// security with at least one policy (so FORCE enforces a real policy rather
 /// than an implicit deny-all). Mirrors `messaging_rls_cross_tenant_tests.rs`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn thread_participant_state_has_force_rls_and_policy(pool: PgPool) {
     let (relrowsecurity, relforcerowsecurity): (bool, bool) = sqlx::query_as(
         r#"

--- a/backend/crates/db/tests/unified_portal_user_tests.rs
+++ b/backend/crates/db/tests/unified_portal_user_tests.rs
@@ -29,7 +29,6 @@ async fn seed_user_with_kind(pool: &PgPool, email: &str, kind: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_writes_to_users_only(pool: PgPool) {
     let repo = UnifiedPortalUserRepo::new(pool.clone());
     let email = "create-single@n1.test";
@@ -66,7 +65,6 @@ async fn create_writes_to_users_only(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_profile_updates_users_row(pool: PgPool) {
     let repo = UnifiedPortalUserRepo::new(pool.clone());
     let email = "update-profile@n1.test";
@@ -106,7 +104,6 @@ async fn update_profile_updates_users_row(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn password_change_updates_users_row(pool: PgPool) {
     let repo = UnifiedPortalUserRepo::new(pool.clone());
     let email = "password-change@n1.test";
@@ -138,7 +135,6 @@ async fn password_change_updates_users_row(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn sso_upsert_handles_collision(pool: PgPool) {
     // Stage: a STAFF principal already owns the email in `users`. An SSO
     // sign-in for the same email arrives. The repo MUST refuse rather than
@@ -226,7 +222,6 @@ async fn sso_upsert_handles_collision(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn sso_upsert_creates_then_updates_for_public(pool: PgPool) {
     // Happy path: no existing identity, then a second sign-in of the same
     // user. First call creates the users row; second call updates the name.

--- a/backend/crates/db/tests/user_invite_tests.rs
+++ b/backend/crates/db/tests/user_invite_tests.rs
@@ -42,7 +42,6 @@ async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accept_succeeds_once(pool: PgPool) {
     let org = seed_org(&pool, "inv-once").await;
     let user = seed_user(&pool, "accept-once@phase2.test").await;
@@ -79,7 +78,6 @@ async fn accept_succeeds_once(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn second_accept_with_same_token_is_rejected(pool: PgPool) {
     let org = seed_org(&pool, "inv-twice").await;
     let user_a = seed_user(&pool, "accept-twice-a@phase2.test").await;
@@ -124,7 +122,6 @@ async fn second_accept_with_same_token_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accept_after_expiry_is_rejected(pool: PgPool) {
     let org = seed_org(&pool, "inv-exp").await;
     let user = seed_user(&pool, "expired@phase2.test").await;
@@ -155,7 +152,6 @@ async fn accept_after_expiry_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn accept_with_wrong_email_is_rejected(pool: PgPool) {
     let org = seed_org(&pool, "inv-mismatch").await;
     let user = seed_user(&pool, "actual@phase2.test").await;
@@ -185,7 +181,6 @@ async fn accept_with_wrong_email_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unknown_token_is_rejected(pool: PgPool) {
     let user = seed_user(&pool, "no-such-token@phase2.test").await;
     let repo = UserInviteRepository::new(pool.clone());
@@ -202,7 +197,6 @@ async fn unknown_token_is_rejected(pool: PgPool) {
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn token_is_stored_only_as_hash(pool: PgPool) {
     let org = seed_org(&pool, "inv-hash").await;
     let repo = UserInviteRepository::new(pool.clone());

--- a/backend/crates/db/tests/vendor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/vendor_rls_repo_tests.rs
@@ -96,7 +96,6 @@ async fn seed_vendor(pool: &PgPool, org_id: Uuid, name: &str) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn vendor_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = VendorRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/violations_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/violations_cross_org_idor_tests.rs
@@ -121,7 +121,6 @@ fn new_action_req() -> CreateEnforcementAction {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn community_rule_cross_org_mutations_rejected(pool: PgPool) {
     let repo = ViolationRepository::new(pool.clone());
     let org_a = seed_org(&pool, "rule-a").await;
@@ -196,7 +195,6 @@ async fn community_rule_cross_org_mutations_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn violation_cross_org_mutations_rejected(pool: PgPool) {
     let repo = ViolationRepository::new(pool.clone());
     let org_a = seed_org(&pool, "vio-a").await;
@@ -379,7 +377,6 @@ async fn violation_cross_org_mutations_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn enforcement_cross_org_mutations_rejected(pool: PgPool) {
     let repo = ViolationRepository::new(pool.clone());
     let org_a = seed_org(&pool, "enf-a").await;
@@ -479,7 +476,6 @@ async fn enforcement_cross_org_mutations_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn appeal_cross_org_mutations_rejected(pool: PgPool) {
     let repo = ViolationRepository::new(pool.clone());
     let org_a = seed_org(&pool, "app-a").await;

--- a/backend/crates/db/tests/vote_cast_regression_tests.rs
+++ b/backend/crates/db/tests/vote_cast_regression_tests.rs
@@ -167,7 +167,6 @@ async fn seed_active_vote(
 // ---------------------------------------------------------------------------
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn cast_vote_rls_stores_unit_ownership_share_as_weight(pool: PgPool) {
     let repo = VoteRepository::new(pool.clone());
     let org = seed_org(&pool, "weight").await;
@@ -215,7 +214,6 @@ async fn cast_vote_rls_stores_unit_ownership_share_as_weight(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn cast_vote_rls_writes_ballot_cast_audit_row(pool: PgPool) {
     let repo = VoteRepository::new(pool.clone());
     let org = seed_org(&pool, "audit").await;
@@ -262,7 +260,6 @@ async fn cast_vote_rls_writes_ballot_cast_audit_row(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn cast_vote_rls_increments_participation_count(pool: PgPool) {
     let repo = VoteRepository::new(pool.clone());
     let org = seed_org(&pool, "part").await;
@@ -315,7 +312,6 @@ async fn cast_vote_rls_increments_participation_count(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_poll_results_rls_returns_live_tally_for_active_vote(pool: PgPool) {
     let repo = VoteRepository::new(pool.clone());
     let org = seed_org(&pool, "results").await;

--- a/backend/crates/db/tests/vote_delegation_eligibility_tests.rs
+++ b/backend/crates/db/tests/vote_delegation_eligibility_tests.rs
@@ -171,7 +171,6 @@ async fn cast_guard_delegation_valid(
 }
 
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn active_voting_delegation_makes_delegate_eligible(pool: PgPool) {
     let mut sa = pool.acquire().await.unwrap();
     set_ctx(&mut sa, None, None, true).await;
@@ -214,7 +213,6 @@ async fn active_voting_delegation_makes_delegate_eligible(pool: PgPool) {
 }
 
 #[sqlx::test(migrations = "./migrations")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn revoked_delegation_is_rejected_by_eligibility_and_cast_guard(pool: PgPool) {
     let mut sa = pool.acquire().await.unwrap();
     set_ctx(&mut sa, None, None, true).await;

--- a/backend/crates/db/tests/webhook_repo_dedup_tests.rs
+++ b/backend/crates/db/tests/webhook_repo_dedup_tests.rs
@@ -16,7 +16,6 @@ use uuid::Uuid;
 
 /// First call returns `Ok(true)` (row inserted); redelivery returns `Ok(false)`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn record_airbnb_webhook_event_first_seen_and_redelivery(pool: PgPool) {
     let repo = RentalRepository::new(pool.clone());
 
@@ -58,7 +57,6 @@ async fn record_airbnb_webhook_event_first_seen_and_redelivery(pool: PgPool) {
 
 /// Distinct `event_id`s are independent — each records its own row.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn record_airbnb_webhook_event_distinct_ids_are_independent(pool: PgPool) {
     let repo = RentalRepository::new(pool.clone());
 

--- a/backend/crates/db/tests/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/work_order_rls_repo_tests.rs
@@ -152,7 +152,6 @@ async fn seed_completed_work_order(
 /// method the work-order handlers call — so this is a behavioral test of the RLS
 /// routing, not just of the raw SQL policy.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn work_orders_force_rls_requires_context_and_blocks_cross_tenant(pool: PgPool) {
     // --- Seed as superuser (super-admin context satisfies the roles-trigger
     //     RLS WITH CHECK fired by INSERT INTO organizations). ---
@@ -322,7 +321,6 @@ async fn work_orders_force_rls_requires_context_and_blocks_cross_tenant(pool: Pg
 /// FORCE-RLS harness used by
 /// `work_orders_force_rls_requires_context_and_blocks_cross_tenant` above.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn service_history_force_rls_blocks_cross_tenant(pool: PgPool) {
     // --- Seed under super-admin context (satisfies the org roles-trigger). ---
     sqlx::query("SELECT set_request_context(NULL, NULL, true)")

--- a/backend/crates/db/tests/workflow_rls_repo_tests.rs
+++ b/backend/crates/db/tests/workflow_rls_repo_tests.rs
@@ -112,7 +112,6 @@ fn sample_create() -> CreateWorkflow {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn workflow_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     let repo = WorkflowRepository::new(pool.clone());
 

--- a/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
+++ b/backend/servers/api-server/tests/accounting_payment_match_state_machine_tests.rs
@@ -100,7 +100,6 @@ async fn invoice_state(pool: &PgPool, invoice: Uuid) -> (rust_decimal::Decimal, 
 /// After confirm: paid=100/paid. After reject (unapply): paid=0/issued.
 /// The final confirm of a now-rejected match is illegal (409) and leaves paid=0.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn confirm_reject_confirm_does_not_inflate_paid_amount(pool: PgPool) {
     let (org, invoice, match_id) = seed_match_scenario(&pool, "pap325-replay").await;
     let svc = AccountingService::new(AccountingRepository::new(pool.clone()));
@@ -152,7 +151,6 @@ async fn confirm_reject_confirm_does_not_inflate_paid_amount(pool: PgPool) {
 /// Confirming an already-confirmed match is an idempotent no-op — it must not
 /// re-apply paid_amount.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn double_confirm_is_idempotent(pool: PgPool) {
     let (org, invoice, match_id) = seed_match_scenario(&pool, "pap325-double-confirm").await;
     let svc = AccountingService::new(AccountingRepository::new(pool.clone()));
@@ -179,7 +177,6 @@ async fn double_confirm_is_idempotent(pool: PgPool) {
 /// subtraction). Here the match was only ever Suggested -> Rejected, so paid
 /// stays 0 and the second reject is harmless.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn double_reject_is_idempotent(pool: PgPool) {
     let (org, invoice, match_id) = seed_match_scenario(&pool, "pap325-double-reject").await;
     let svc = AccountingService::new(AccountingRepository::new(pool.clone()));

--- a/backend/servers/api-server/tests/ai_automation_batch1_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch1_tests.rs
@@ -402,7 +402,6 @@ async fn test_delete_parking_spot_not_found_returns_client_error(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_registry_rules_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();

--- a/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
@@ -86,7 +86,6 @@ async fn seed_workflow(pool: &PgPool, org_id: Uuid, creator: Uuid) -> Uuid {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_automation_rules_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -100,7 +99,6 @@ async fn test_list_automation_rules_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_automation_rule_returns_201(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -137,7 +135,6 @@ async fn test_get_automation_rule_not_found(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_automation_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -329,7 +326,6 @@ async fn test_get_sentiment_dashboard_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_equipment_returns_201(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -354,7 +350,6 @@ async fn test_create_equipment_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_equipment_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -467,7 +462,6 @@ async fn test_list_maintenance_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_workflow_returns_201(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -490,7 +484,6 @@ async fn test_create_workflow_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_workflows_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -546,7 +539,6 @@ async fn test_list_workflow_executions_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_workflow_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -565,7 +557,6 @@ async fn test_list_workflow_templates_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_builtin_workflow_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();

--- a/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch3_tests.rs
@@ -71,7 +71,6 @@ async fn seed_equipment(pool: &PgPool, org_id: Uuid, building_id: Uuid) -> Uuid 
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_lease_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -90,7 +89,6 @@ async fn test_list_lease_templates_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_lease_template_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -112,7 +110,6 @@ async fn test_get_lease_template_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_listing_descriptions_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -134,7 +131,6 @@ async fn test_list_listing_descriptions_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_escalation_config_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -153,7 +149,6 @@ async fn test_get_escalation_config_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_escalation_config_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -180,7 +175,6 @@ async fn test_update_escalation_config_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_ai_statistics_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -199,7 +193,6 @@ async fn test_get_ai_statistics_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_generation_requests_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -218,7 +211,6 @@ async fn test_list_generation_requests_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_generation_request_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -240,7 +232,6 @@ async fn test_get_generation_request_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_photo_enhancement_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -262,7 +253,6 @@ async fn test_get_photo_enhancement_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_voice_devices_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -377,7 +367,6 @@ async fn test_delete_automation_rule_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_chat_session_roundtrip(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -451,7 +440,6 @@ async fn test_list_chat_messages_roundtrip(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_sentiment_thresholds_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -495,7 +483,6 @@ async fn test_acknowledge_sentiment_alert_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_workflow_actions_roundtrip(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -607,7 +594,6 @@ async fn test_update_equipment_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_equipment_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();

--- a/backend/servers/api-server/tests/ai_chat_sentiment_equipment_batch4_tests.rs
+++ b/backend/servers/api-server/tests/ai_chat_sentiment_equipment_batch4_tests.rs
@@ -192,7 +192,6 @@ async fn create_chat_session_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_chat_sessions_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -206,7 +205,6 @@ async fn list_chat_sessions_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_chat_session_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -229,7 +227,6 @@ async fn get_chat_session_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_chat_session_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -248,7 +245,6 @@ async fn delete_chat_session_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_chat_messages_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -268,7 +264,6 @@ async fn list_chat_messages_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn provide_chat_feedback_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -317,7 +312,6 @@ async fn get_sentiment_trends_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_sentiment_alerts_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -363,7 +357,6 @@ async fn get_sentiment_thresholds_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_sentiment_thresholds_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -397,7 +390,6 @@ async fn get_sentiment_dashboard_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_equipment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -421,7 +413,6 @@ async fn create_equipment_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_equipment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -535,7 +526,6 @@ async fn create_equipment_maintenance_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_equipment_maintenance_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -638,7 +628,6 @@ async fn create_pet_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_pet_registrations_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -652,7 +641,6 @@ async fn list_pet_registrations_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_pet_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -765,7 +753,6 @@ async fn create_vehicle_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_vehicle_registrations_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -779,7 +766,6 @@ async fn list_vehicle_registrations_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vehicle_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -888,7 +874,6 @@ async fn create_parking_spot_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_parking_spots_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -961,7 +946,6 @@ async fn delete_parking_spot_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_registry_rules_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/analytics_esg_reporting_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_esg_reporting_success_tests.rs
@@ -300,7 +300,6 @@ async fn esg_list_metrics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn esg_create_metric_succeeds(pool: PgPool) {
     let f = setup(pool, "esg-create-metric").await;
     let resp = f
@@ -421,7 +420,6 @@ async fn esg_list_carbon_footprints_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn esg_create_carbon_footprint_succeeds(pool: PgPool) {
     let f = setup(pool, "esg-create-carbon").await;
     let resp = f
@@ -472,7 +470,6 @@ async fn esg_get_carbon_summary_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn esg_get_carbon_footprint_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "esg-get-carbon").await;
     let carbon_id = seed_carbon(&pool, f.org_id).await;
@@ -538,7 +535,6 @@ async fn esg_list_benchmarks_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn esg_create_benchmark_succeeds(pool: PgPool) {
     let f = setup(pool, "esg-create-bm").await;
     let resp = f
@@ -611,7 +607,6 @@ async fn esg_list_targets_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn esg_create_target_succeeds(pool: PgPool) {
     let f = setup(pool, "esg-create-tgt").await;
     let resp = f
@@ -724,7 +719,6 @@ async fn esg_list_reports_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn esg_create_report_succeeds(pool: PgPool) {
     let f = setup(pool, "esg-create-rep").await;
     let resp = f

--- a/backend/servers/api-server/tests/analytics_government_portal_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_government_portal_success_tests.rs
@@ -386,7 +386,6 @@ async fn gp_list_templates_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn gp_get_template_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "gp-get-tpl").await;
     let tpl_id = seed_template(&pool).await;
@@ -709,7 +708,6 @@ async fn gp_list_schedules_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn gp_create_schedule_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "gp-create-sched").await;
     let conn_id = seed_connection(&pool, f.org_id, f.user_id).await;
@@ -737,7 +735,6 @@ async fn gp_create_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn gp_get_schedule_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "gp-get-sched").await;
     let conn_id = seed_connection(&pool, f.org_id, f.user_id).await;
@@ -757,7 +754,6 @@ async fn gp_get_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn gp_update_schedule_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "gp-upd-sched").await;
     let conn_id = seed_connection(&pool, f.org_id, f.user_id).await;
@@ -785,7 +781,6 @@ async fn gp_update_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn gp_delete_schedule_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "gp-del-sched").await;
     let conn_id = seed_connection(&pool, f.org_id, f.user_id).await;

--- a/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_investor_portal_success_tests.rs
@@ -247,7 +247,6 @@ async fn ip_list_investors_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_create_investor_succeeds(pool: PgPool) {
     let f = setup(pool, "ip-create-inv").await;
     let resp = f
@@ -381,7 +380,6 @@ async fn ip_list_portfolios_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_create_portfolio_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-create-pf").await;
     let inv_id = seed_investor(&pool, f.org_id).await;
@@ -504,7 +502,6 @@ async fn ip_list_investor_portfolios_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_add_portfolio_property_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-add-prop").await;
     let inv_id = seed_investor(&pool, f.org_id).await;
@@ -609,7 +606,6 @@ async fn ip_list_roi_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_create_roi_calculation_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-create-roi").await;
     let inv_id = seed_investor(&pool, f.org_id).await;
@@ -670,7 +666,6 @@ async fn ip_get_latest_roi_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_create_distribution_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-create-dist").await;
     let inv_id = seed_investor(&pool, f.org_id).await;
@@ -754,7 +749,6 @@ async fn ip_update_distribution_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_create_report_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-create-rpt").await;
     let inv_id = seed_investor(&pool, f.org_id).await;
@@ -807,7 +801,6 @@ async fn ip_list_investor_reports_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_get_report_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-get-rpt").await;
     let inv_id = seed_investor(&pool, f.org_id).await;
@@ -842,7 +835,6 @@ async fn ip_get_report_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_create_capital_call_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-create-cc").await;
     let inv_id = seed_investor(&pool, f.org_id).await;
@@ -949,7 +941,6 @@ async fn ip_get_investor_dashboard_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ip_upsert_dashboard_metrics_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "ip-dash-metrics").await;
     let inv_id = seed_investor(&pool, f.org_id).await;

--- a/backend/servers/api-server/tests/analytics_owner_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_owner_success_tests.rs
@@ -342,7 +342,6 @@ async fn oa_get_roi_dashboard_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn oa_get_portfolio_summary_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "portfolio").await;

--- a/backend/servers/api-server/tests/analytics_portfolio_success_tests.rs
+++ b/backend/servers/api-server/tests/analytics_portfolio_success_tests.rs
@@ -254,7 +254,6 @@ async fn setup(pool: PgPool, slug: &str) -> Fixture {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_get_portfolio_summary_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-summary").await;
     let resp = f
@@ -271,7 +270,6 @@ async fn pa_get_portfolio_summary_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_list_benchmarks_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-list-bench").await;
     let resp = f
@@ -293,7 +291,6 @@ async fn pa_list_benchmarks_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_create_benchmark_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-create-bench").await;
     let resp = f
@@ -320,7 +317,6 @@ async fn pa_create_benchmark_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_get_benchmark_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pa-get-bench").await;
     let bench_id = seed_pa_benchmark(&pool, f.org_id).await;
@@ -345,7 +341,6 @@ async fn pa_get_benchmark_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_update_benchmark_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pa-upd-bench").await;
     let bench_id = seed_pa_benchmark(&pool, f.org_id).await;
@@ -371,7 +366,6 @@ async fn pa_update_benchmark_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_delete_benchmark_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pa-del-bench").await;
     let bench_id = seed_pa_benchmark(&pool, f.org_id).await;
@@ -396,7 +390,6 @@ async fn pa_delete_benchmark_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_list_property_metrics_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-list-pm").await;
     let resp = f
@@ -418,7 +411,6 @@ async fn pa_list_property_metrics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_upsert_property_metrics_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-upsert-pm").await;
     let resp = f
@@ -448,7 +440,6 @@ async fn pa_upsert_property_metrics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_get_property_metrics_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-get-bldg-metrics").await;
     let resp = f
@@ -473,7 +464,6 @@ async fn pa_get_property_metrics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_get_portfolio_metrics_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-get-metrics").await;
     let resp = f
@@ -495,7 +485,6 @@ async fn pa_get_portfolio_metrics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_calculate_portfolio_metrics_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-calc-metrics").await;
     let resp = f
@@ -521,7 +510,6 @@ async fn pa_calculate_portfolio_metrics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pa_list_comparisons_succeeds(pool: PgPool) {
     let f = setup(pool, "pa-list-comp").await;
     let resp = f
@@ -547,7 +535,6 @@ async fn pa_list_comparisons_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_create_portfolio_succeeds(pool: PgPool) {
     let f = setup(pool, "pp-create-pf").await;
     let resp = f
@@ -658,7 +645,6 @@ async fn pp_delete_portfolio_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_add_property_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-add-prop").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -788,7 +774,6 @@ async fn pp_remove_property_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_create_transaction_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-create-tx").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -844,7 +829,6 @@ async fn pp_list_transactions_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_get_transaction_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-get-tx").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -871,7 +855,6 @@ async fn pp_get_transaction_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_update_transaction_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-upd-tx").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -899,7 +882,6 @@ async fn pp_update_transaction_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_delete_transaction_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-del-tx").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -982,7 +964,6 @@ async fn pp_get_cash_flows_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_calculate_metrics_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-calc-metrics").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -1035,7 +1016,6 @@ async fn pp_get_latest_metrics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_get_metrics_summary_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-metrics-summary").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -1060,7 +1040,6 @@ async fn pp_get_metrics_summary_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_create_benchmark_succeeds(pool: PgPool) {
     let f = setup(pool, "pp-create-bench").await;
     let resp = f
@@ -1181,7 +1160,6 @@ async fn pp_delete_benchmark_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_create_comparison_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-create-cmp").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -1272,7 +1250,6 @@ async fn pp_get_comparison_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_get_dashboard_summary_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-dash-sum").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -1345,7 +1322,6 @@ async fn pp_get_dashboard_cash_flow_trend_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_create_alert_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-create-alert").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -1400,7 +1376,6 @@ async fn pp_list_alerts_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_mark_alert_read_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-alert-read").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;
@@ -1426,7 +1401,6 @@ async fn pp_mark_alert_read_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pp_resolve_alert_succeeds(pool: PgPool) {
     let f = setup(pool.clone(), "pp-alert-resolve").await;
     let pf_id = seed_perf_portfolio(&pool, f.org_id, f.user_id).await;

--- a/backend/servers/api-server/tests/announcements_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/announcements_happy_path_tests.rs
@@ -122,7 +122,6 @@ async fn seed_critical_notification(pool: &PgPool, org_id: Uuid, created_by: Uui
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_announcement_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -151,7 +150,6 @@ async fn create_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_announcements_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -208,7 +206,6 @@ async fn list_published_announcements_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_announcement_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -234,7 +231,6 @@ async fn get_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_announcement_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -259,7 +255,6 @@ async fn update_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn publish_announcement_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -284,7 +279,6 @@ async fn publish_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn schedule_announcement_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -311,7 +305,6 @@ async fn schedule_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn archive_announcement_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -336,7 +329,6 @@ async fn archive_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pin_announcement_post_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -361,7 +353,6 @@ async fn pin_announcement_post_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pin_announcement_patch_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -410,7 +401,6 @@ async fn list_attachments_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_attachment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -440,7 +430,6 @@ async fn add_attachment_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_attachment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -520,7 +509,6 @@ async fn acknowledge_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_acknowledgments_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -544,7 +532,6 @@ async fn get_acknowledgments_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_statistics_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -587,7 +574,6 @@ async fn get_unread_count_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_announcement_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -616,7 +602,6 @@ async fn delete_announcement_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_critical_notification_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -646,7 +631,6 @@ async fn create_critical_notification_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_critical_notifications_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -672,7 +656,6 @@ async fn list_critical_notifications_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_unacknowledged_critical_notifications_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -698,7 +681,6 @@ async fn get_unacknowledged_critical_notifications_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn acknowledge_critical_notification_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -725,7 +707,6 @@ async fn acknowledge_critical_notification_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_critical_notification_stats_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/auth_partial_backfill_batch1_tests.rs
+++ b/backend/servers/api-server/tests/auth_partial_backfill_batch1_tests.rs
@@ -28,7 +28,6 @@ use sqlx::PgPool;
 
 /// Verifying a fresh, non-expired token returns 200 and a success message.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn verify_email_with_valid_token_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -236,7 +235,6 @@ async fn forgot_password_for_existing_user_returns_200(pool: PgPool) {
 
 /// Reset-password with a valid token returns 200 and allows subsequent login.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn reset_password_with_valid_token_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/auth_partial_backfill_batch2_tests.rs
+++ b/backend/servers/api-server/tests/auth_partial_backfill_batch2_tests.rs
@@ -615,7 +615,6 @@ async fn get_privacy_settings_returns_200(pool: PgPool) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_privacy_settings_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/documents_core_crud_tests.rs
+++ b/backend/servers/api-server/tests/documents_core_crud_tests.rs
@@ -150,7 +150,6 @@ async fn list_documents_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_document_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -207,7 +206,6 @@ async fn delete_document_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_document_access_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -260,7 +258,6 @@ async fn get_version_history_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_version_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -322,7 +319,6 @@ async fn get_version_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn restore_version_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -350,7 +346,6 @@ async fn restore_version_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_shares_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/documents_intelligence_templates_tests.rs
+++ b/backend/servers/api-server/tests/documents_intelligence_templates_tests.rs
@@ -117,7 +117,6 @@ async fn get_classification_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn submit_classification_feedback_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -236,7 +235,6 @@ async fn create_template(app: &TestApp, token: &str, org_id: Uuid) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_template_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -267,7 +265,6 @@ async fn create_template_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_templates_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -286,7 +283,6 @@ async fn list_templates_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_template_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -308,7 +304,6 @@ async fn get_template_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_template_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -333,7 +328,6 @@ async fn update_template_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_template_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
@@ -358,7 +352,6 @@ async fn delete_template_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn generate_document_from_template_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();

--- a/backend/servers/api-server/tests/faults_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/faults_behaviour_tests.rs
@@ -77,7 +77,6 @@ async fn create_fault(app: &TestApp, token: &str, org_id: Uuid, building_id: Uui
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_fault_returns_detail(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -106,7 +105,6 @@ async fn test_get_fault_returns_detail(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_fault_title(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -135,7 +133,6 @@ async fn test_update_fault_title(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_fault_status_to_in_progress(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -163,7 +160,6 @@ async fn test_update_fault_status_to_in_progress(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_resolve_fault(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -191,7 +187,6 @@ async fn test_resolve_fault(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_confirm_fault_resolution(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -241,7 +236,6 @@ async fn test_confirm_fault_resolution(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_reopen_resolved_fault(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -286,7 +280,6 @@ async fn test_reopen_resolved_fault(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_my_faults(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -323,7 +316,6 @@ async fn test_list_my_faults(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_add_and_list_fault_comments(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -368,7 +360,6 @@ async fn test_add_and_list_fault_comments(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_add_work_note(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -398,7 +389,6 @@ async fn test_add_work_note(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_fault_statistics(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/financial_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/financial_happy_path_tests.rs
@@ -16,7 +16,6 @@ use wiremock::{matchers, Mock, MockServer, ResponseTemplate};
 use common::{create_authenticated_user_with_org, TestApp, TestUser};
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn financial_endpoints_happy_path(pool: PgPool) {
     // 1. Start wiremock server for Stripe Checkout mocking
     let stripe_server = MockServer::start().await;

--- a/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/financial_reports_happy_path_tests.rs
@@ -27,7 +27,6 @@ use sqlx::PgPool;
 use common::{create_authenticated_user_with_org, TestApp, TestUser};
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn financial_reports_happy_path(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/infra_ops_admin_authz_backfill_bit331_tests.rs
@@ -533,7 +533,6 @@ fn all_cases() -> Vec<(Method, String, Option<&'static str>)> {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_privileged_endpoints_require_auth(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -544,7 +543,6 @@ async fn platform_privileged_endpoints_require_auth(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_privileged_endpoints_reject_ordinary_user(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, _user) = create_authenticated_user(&app, &TestUser::new()).await;

--- a/backend/servers/api-server/tests/legal_insurance_wave1b_tests.rs
+++ b/backend/servers/api-server/tests/legal_insurance_wave1b_tests.rs
@@ -318,7 +318,6 @@ async fn legal_list_versions_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legal_create_requirement_returns_201(pool: PgPool) {
     let (app, token, org_id) = setup(&pool, "leg-req-c").await;
     let sess = app.session(token, org_id);
@@ -364,7 +363,6 @@ async fn legal_list_requirements_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legal_get_requirement_200_and_404(pool: PgPool) {
     let (app, token, org_id) = setup(&pool, "leg-req-g").await;
     let sess = app.session(token, org_id);
@@ -411,7 +409,6 @@ async fn legal_get_requirement_200_and_404(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legal_update_requirement_returns_200(pool: PgPool) {
     let (app, token, org_id) = setup(&pool, "leg-req-u").await;
     let sess = app.session(token, org_id);
@@ -441,7 +438,6 @@ async fn legal_update_requirement_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legal_delete_requirement_returns_200(pool: PgPool) {
     let (app, token, org_id) = setup(&pool, "leg-req-d").await;
     let sess = app.session(token, org_id);
@@ -470,7 +466,6 @@ async fn legal_delete_requirement_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legal_create_verification_returns_201(pool: PgPool) {
     let (app, token, org_id) = setup(&pool, "leg-ver-c").await;
     let sess = app.session(token, org_id);
@@ -508,7 +503,6 @@ async fn legal_create_verification_returns_201(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legal_list_verifications_returns_200(pool: PgPool) {
     let (app, token, org_id) = setup(&pool, "leg-ver-l").await;
     let sess = app.session(token, org_id);

--- a/backend/servers/api-server/tests/listings_core_backfill_batch3_tests.rs
+++ b/backend/servers/api-server/tests/listings_core_backfill_batch3_tests.rs
@@ -138,7 +138,6 @@ fn mint_manager_jwt(user_id: Uuid, org_id: Uuid) -> String {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_listing_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "crlt").await;
@@ -212,7 +211,6 @@ async fn test_list_listings_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_listing_from_unit_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "lfun").await;
@@ -645,7 +643,6 @@ async fn test_get_photos_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_add_photo_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "adph").await;

--- a/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
+++ b/backend/servers/api-server/tests/marketplace_provider_profile_tests.rs
@@ -918,7 +918,6 @@ async fn submit_verification_returns_201(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_verifications_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "lv").await;
@@ -947,7 +946,6 @@ async fn list_verifications_returns_200(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_verification_queue_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "gvq").await;
@@ -976,7 +974,6 @@ async fn get_verification_queue_returns_200(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_expiring_verifications_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "gev").await;

--- a/backend/servers/api-server/tests/messaging_behaviour_backfill_tests.rs
+++ b/backend/servers/api-server/tests/messaging_behaviour_backfill_tests.rs
@@ -88,7 +88,6 @@ fn mint_token(user_id: Uuid, email: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn messaging_happy_paths(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "beh").await;

--- a/backend/servers/api-server/tests/migration_db_tests.rs
+++ b/backend/servers/api-server/tests/migration_db_tests.rs
@@ -69,7 +69,6 @@ async fn create_platform_admin(app: &TestApp, user: &TestUser, slug: &str) -> (S
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_import_template_lifecycle(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -203,7 +202,6 @@ async fn test_import_template_lifecycle(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_import_job_execution_flow(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -318,7 +316,6 @@ async fn test_import_job_execution_flow(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_migration_exports(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/news_articles_tests.rs
+++ b/backend/servers/api-server/tests/news_articles_tests.rs
@@ -112,7 +112,6 @@ async fn seed_comment(pool: &PgPool, article_id: Uuid, user_id: Uuid, content: &
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -160,7 +159,6 @@ async fn create_article_requires_auth(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_articles_returns_articles(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -190,7 +188,6 @@ async fn list_articles_returns_articles(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -217,7 +214,6 @@ async fn get_article_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_article_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -240,7 +236,6 @@ async fn get_article_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -269,7 +264,6 @@ async fn update_article_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn publish_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -298,7 +292,6 @@ async fn publish_article_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn archive_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -327,7 +320,6 @@ async fn archive_article_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn restore_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -367,7 +359,6 @@ async fn restore_article_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pin_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -396,7 +387,6 @@ async fn pin_article_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_media_returns_media(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -461,7 +451,6 @@ async fn add_media_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_media_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -488,7 +477,6 @@ async fn delete_media_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn toggle_reaction_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -518,7 +506,6 @@ async fn toggle_reaction_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_reaction_counts_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -544,7 +531,6 @@ async fn get_reaction_counts_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_comments_returns_comments(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -574,7 +560,6 @@ async fn list_comments_returns_comments(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_comment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -604,7 +589,6 @@ async fn create_comment_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_comment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -634,7 +618,6 @@ async fn update_comment_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_comment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -661,7 +644,6 @@ async fn delete_comment_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn moderate_comment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -691,7 +673,6 @@ async fn moderate_comment_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_comment_replies_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -735,7 +716,6 @@ async fn list_comment_replies_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn record_view_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -762,7 +742,6 @@ async fn record_view_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_statistics_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -787,7 +766,6 @@ async fn get_statistics_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_article_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/notification_pipeline_dispatch_tests.rs
+++ b/backend/servers/api-server/tests/notification_pipeline_dispatch_tests.rs
@@ -79,7 +79,6 @@ fn status_of(
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn dispatch_respects_channel_preferences(pool: PgPool) {
     let user = seed_user(&pool).await;
     set_channel_pref(&pool, user, "email", false).await;
@@ -114,7 +113,6 @@ async fn dispatch_respects_channel_preferences(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn urgent_notification_bypasses_preferences(pool: PgPool) {
     let user = seed_user(&pool).await;
     // Disable EVERY channel — an urgent alert must still go out.
@@ -166,7 +164,6 @@ async fn urgent_notification_bypasses_preferences(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn dispatch_writes_in_app_delivery_record(pool: PgPool) {
     let user = seed_user(&pool).await;
     let entity_id = Uuid::new_v4();

--- a/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/notification_preference_realtime_sync_tests.rs
@@ -101,7 +101,6 @@ use sqlx::PgPool;
 /// coupled to the realtime sync leg. This is the core #480–#487 concern: a
 /// missing/broken pubsub must never break preference updates.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn preference_update_succeeds_without_redis(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -131,7 +130,6 @@ async fn preference_update_succeeds_without_redis(pool: PgPool) {
 /// the realtime event went out. We re-read via the public GET endpoint to prove
 /// the write landed (the sync leg is fire-and-forget and never gates this).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn preference_update_persists_independently_of_sync(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -179,7 +177,6 @@ async fn preference_update_persists_independently_of_sync(pool: PgPool) {
 /// spurious `preference.updated` being emitted for a change that never landed —
 /// a realtime-sync correctness concern from the #480–#487 cluster.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn disable_all_guard_blocks_before_publish(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -241,7 +238,6 @@ async fn disable_all_guard_blocks_before_publish(pool: PgPool) {
 /// same persisted state rather than erroring. push + in_app stay enabled, so the
 /// disable-all guard never enters the picture for either apply.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn repeated_disable_is_idempotent(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -298,7 +294,6 @@ async fn repeated_disable_is_idempotent(pool: PgPool) {
 /// return 200 both times and leave the channel enabled — the enable path has no
 /// state-dependent rejection, making it unconditionally idempotent.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn repeated_enable_is_idempotent_and_never_conflicts(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -356,7 +351,6 @@ async fn repeated_enable_is_idempotent_and_never_conflicts(pool: PgPool) {
 /// must still return 200 — a replayed disable of an off channel is a pure no-op
 /// and must not be mistaken for "disabling the last channel". in_app stays on.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn redisable_of_off_channel_never_conflicts(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -417,7 +411,6 @@ async fn redisable_of_off_channel_never_conflicts(pool: PgPool) {
 /// test pins the baseline — GET on an untouched user returns exactly the three
 /// channels (push, email, in_app), each enabled, with no all-disabled warning.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn fresh_user_has_all_channels_enabled_by_default(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -480,7 +473,6 @@ async fn fresh_user_has_all_channels_enabled_by_default(pool: PgPool) {
 /// publish leg can never emit an event for a channel the system doesn't model,
 /// and leaves the user's real preferences untouched.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unknown_channel_is_rejected_without_mutation(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -524,7 +516,6 @@ async fn unknown_channel_is_rejected_without_mutation(pool: PgPool) {
 /// and the persisted state must converge to enabled — proving the update leg
 /// the publish leg rides is a genuine state machine, not a one-way latch.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn disable_then_enable_restores_channel(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -590,7 +581,6 @@ async fn disable_then_enable_restores_channel(pool: PgPool) {
 /// response so a connected client can render the "you may miss updates" notice.
 /// This is the update-leg warning the publish leg notifies clients about.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn confirmed_disable_all_succeeds_with_warning(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -661,7 +651,6 @@ async fn confirmed_disable_all_succeeds_with_warning(pool: PgPool) {
 /// payload shape. A regression that drops the publish or changes the channel
 /// name / payload would now fail in CI rather than silently passing.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn patch_publishes_preference_updated_event(pool: PgPool) {
     let (app, recorder) = TestApp::with_recording_pubsub(pool.clone()).await;
     let user = TestUser::new();
@@ -723,7 +712,6 @@ async fn patch_publishes_preference_updated_event(pool: PgPool) {
 /// change can never emit a spurious realtime event — assertable in CI without
 /// Redis.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn rejected_disable_all_records_no_event(pool: PgPool) {
     let (app, recorder) = TestApp::with_recording_pubsub(pool.clone()).await;
     let user = TestUser::new();
@@ -789,7 +777,6 @@ async fn rejected_disable_all_records_no_event(pool: PgPool) {
 /// test will fail and force an explicit decision rather than a silent behaviour
 /// shift.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn replayed_disable_republishes_identical_event(pool: PgPool) {
     let (app, recorder) = TestApp::with_recording_pubsub(pool.clone()).await;
     let user = TestUser::new();
@@ -1000,7 +987,6 @@ async fn preference_update_publishes_realtime_event(pool: PgPool) {
 /// broker instead of a real Redis. Proves the event is published to the
 /// correct channel with the correct payload (Story 1376).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn preference_update_publishes_realtime_event_in_memory(pool: PgPool) {
     use integrations::{InMemoryBroker, PubSubService};
     use std::sync::Arc;

--- a/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
+++ b/backend/servers/api-server/tests/ocr_meter_reading_tests.rs
@@ -127,7 +127,6 @@ fn multipart_body(meter_id: Uuid, reading_value: &str) -> (Vec<u8>, String) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn process_meter_reading_creates_pending_reading(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -190,7 +189,6 @@ async fn process_meter_reading_creates_pending_reading(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn process_meter_reading_requires_auth(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -220,7 +218,6 @@ async fn process_meter_reading_requires_auth(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn process_meter_reading_cross_tenant_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -262,7 +259,6 @@ async fn process_meter_reading_cross_tenant_rejected(pool: PgPool) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn submit_correction_persists_record(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -332,7 +328,6 @@ async fn submit_correction_persists_record(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn submit_correction_requires_auth(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "corr-noauth").await;
@@ -366,7 +361,6 @@ async fn submit_correction_requires_auth(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn submit_correction_cross_tenant_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
+++ b/backend/servers/api-server/tests/org_property_authz_backfill_bit331_tests.rs
@@ -406,7 +406,6 @@ fn organizations_cases(org: &str) -> Vec<(Method, String, Option<&'static str>)>
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn org_property_endpoints_require_auth(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (_t, org_id) = create_authenticated_user_with_org(&app, &TestUser::new(), "org-anon").await;
@@ -422,7 +421,6 @@ async fn org_property_endpoints_require_auth(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn tenant_scoped_endpoints_reject_non_member(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     // org-alpha is owned by one user; the outsider is a member of nothing.
@@ -440,7 +438,6 @@ async fn tenant_scoped_endpoints_reject_non_member(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn organizations_endpoints_reject_non_member(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     // org-beta belongs to its owner; the outsider is not a member.

--- a/backend/servers/api-server/tests/org_property_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/org_property_happy_path_tests.rs
@@ -106,7 +106,6 @@ fn id_of(resp: &common::TestResponse) -> Uuid {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn buildings_units_owners_residents_happy_path(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, user_id, _role) = manager_with_org(&pool, &app, "bldg").await;
@@ -335,7 +334,6 @@ async fn buildings_units_owners_residents_happy_path(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn organizations_read_surface_happy_path(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, _user, _role) = manager_with_org(&pool, &app, "org-read").await;
@@ -365,7 +363,6 @@ async fn organizations_read_surface_happy_path(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn organizations_mutation_happy_path(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, _user, seeded_role) = manager_with_org(&pool, &app, "org-mut").await;

--- a/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/owner_analytics_cross_org_idor_tests.rs
@@ -152,7 +152,6 @@ fn mint_token(user_id: Uuid, email: &str, org_id: Uuid) -> String {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unit_valuation_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "valuation-a").await;
@@ -182,7 +181,6 @@ async fn unit_valuation_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn value_history_from_other_org_is_empty(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "hist-a").await;
@@ -223,7 +221,6 @@ async fn value_history_from_other_org_is_empty(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unit_valuation_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "legit-a").await;
@@ -256,7 +253,6 @@ async fn unit_valuation_same_org_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unit_valuation_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let uri = format!("/api/v1/owner-analytics/units/{}/valuation", Uuid::new_v4());

--- a/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
+++ b/backend/servers/api-server/tests/payment_webhook_settlement_tests.rs
@@ -115,7 +115,6 @@ async fn seed_invoice_with_session(
 /// Fail-closed: with NO secret configured the route rejects any webhook with
 /// `503` — it never silently accepts an unverified payload.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unconfigured_secret_fails_closed(pool: PgPool) {
     let _guard = ENV_LOCK.lock().await;
     std::env::remove_var(SECRET_ENV);
@@ -139,7 +138,6 @@ async fn unconfigured_secret_fails_closed(pool: PgPool) {
 
 /// A forged signature is rejected with `401`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn invalid_signature_rejected(pool: PgPool) {
     let _guard = ENV_LOCK.lock().await;
     std::env::set_var(SECRET_ENV, "whsec_test");
@@ -165,7 +163,6 @@ async fn invalid_signature_rejected(pool: PgPool) {
 /// Happy path: a valid `checkout.session.completed` settles the invoice and the
 /// session, and a duplicate delivery is idempotent (no double-settlement).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn valid_webhook_settles_invoice_and_is_idempotent(pool: PgPool) {
     let _guard = ENV_LOCK.lock().await;
     let secret = "whsec_settle";
@@ -278,7 +275,6 @@ async fn valid_webhook_settles_invoice_and_is_idempotent(pool: PgPool) {
 /// produce exactly ONE payment + allocation (no double-credit), and the loser
 /// must return `Ok(None)`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn concurrent_settlement_does_not_double_credit(pool: PgPool) {
     use db::repositories::FinancialRepository;
 

--- a/backend/servers/api-server/tests/platform_admin_authz_tests.rs
+++ b/backend/servers/api-server/tests/platform_admin_authz_tests.rs
@@ -203,7 +203,6 @@ fn all_cases() -> Vec<(Method, String, Option<&'static str>)> {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_admin_endpoints_require_auth(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -219,7 +218,6 @@ async fn platform_admin_endpoints_require_auth(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_admin_endpoints_reject_unprivileged_user(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, _user) = create_authenticated_user(&app, &TestUser::new()).await;

--- a/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
+++ b/backend/servers/api-server/tests/portal_webhook_signature_tests.rs
@@ -63,7 +63,6 @@ fn sign(secret: &str, body: &[u8]) -> String {
 /// Fail-closed: with NO secret configured the route rejects any webhook (even a
 /// well-formed body) with `401` — never silently accepts an unverified payload.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unconfigured_secret_rejects_webhook(pool: PgPool) {
     let _guard = ENV_LOCK.lock().await;
     std::env::remove_var(PORTAL_SECRET_ENV);
@@ -89,7 +88,6 @@ async fn unconfigured_secret_rejects_webhook(pool: PgPool) {
 /// Fail-closed: with a secret configured but an INVALID signature, the route
 /// rejects with `401` before parsing the body or touching the database.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn invalid_signature_is_rejected(pool: PgPool) {
     let _guard = ENV_LOCK.lock().await;
     std::env::set_var(PORTAL_SECRET_ENV, "super-secret-key");
@@ -117,7 +115,6 @@ async fn invalid_signature_is_rejected(pool: PgPool) {
 /// Fail-closed: with a secret configured but the signature header MISSING
 /// entirely, the route rejects with `401`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn missing_signature_header_is_rejected(pool: PgPool) {
     let _guard = ENV_LOCK.lock().await;
     std::env::set_var(PORTAL_SECRET_ENV, "super-secret-key");
@@ -147,7 +144,6 @@ async fn missing_signature_header_is_rejected(pool: PgPool) {
 /// The assertion that matters for this regression is "not 401": the valid
 /// signature was accepted rather than rejected as forged.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn valid_signature_is_accepted(pool: PgPool) {
     let _guard = ENV_LOCK.lock().await;
     let secret = "super-secret-key";

--- a/backend/servers/api-server/tests/predictive_maintenance_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/predictive_maintenance_happy_path_tests.rs
@@ -124,7 +124,6 @@ async fn seed_alert(pool: &PgPool, org_id: Uuid, equipment_id: Uuid) -> Uuid {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_equipment_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "eq-create").await;
     let id = create_equipment(&app, &token, org_id, building_id).await;
@@ -132,7 +131,6 @@ async fn create_equipment_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_equipment_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "eq-list").await;
     create_equipment(&app, &token, org_id, building_id).await;
@@ -153,7 +151,6 @@ async fn list_equipment_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "eq-get").await;
     let id = create_equipment(&app, &token, org_id, building_id).await;
@@ -177,7 +174,6 @@ async fn get_equipment_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_equipment_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "eq-update").await;
     let id = create_equipment(&app, &token, org_id, building_id).await;
@@ -202,7 +198,6 @@ async fn update_equipment_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_equipment_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "eq-delete").await;
     let id = create_equipment(&app, &token, org_id, building_id).await;
@@ -222,7 +217,6 @@ async fn delete_equipment_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_and_list_equipment_documents_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "eq-docs").await;
     let id = create_equipment(&app, &token, org_id, building_id).await;
@@ -265,7 +259,6 @@ async fn add_and_list_equipment_documents_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_maintenance_log_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "log-create").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -274,7 +267,6 @@ async fn create_maintenance_log_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_maintenance_log_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "log-get").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -294,7 +286,6 @@ async fn get_maintenance_log_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_maintenance_log_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "log-update").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -311,7 +302,6 @@ async fn update_maintenance_log_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_equipment_maintenance_logs_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "log-list").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -328,7 +318,6 @@ async fn list_equipment_maintenance_logs_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_and_list_maintenance_photos_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "log-photos").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -367,7 +356,6 @@ async fn add_and_list_maintenance_photos_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn run_prediction_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "pred-run").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -388,7 +376,6 @@ async fn run_prediction_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn run_batch_predictions_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "pred-batch").await;
     create_equipment(&app, &token, org_id, building_id).await;
@@ -409,7 +396,6 @@ async fn run_batch_predictions_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_predictions_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "pred-hist").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -433,7 +419,6 @@ async fn get_equipment_predictions_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_alerts_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "alert-list").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -450,7 +435,6 @@ async fn list_alerts_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn acknowledge_alert_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "alert-ack").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -468,7 +452,6 @@ async fn acknowledge_alert_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resolve_alert_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "alert-resolve").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -486,7 +469,6 @@ async fn resolve_alert_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn dismiss_alert_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "alert-dismiss").await;
     let equipment_id = create_equipment(&app, &token, org_id, building_id).await;
@@ -507,7 +489,6 @@ async fn dismiss_alert_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn set_and_list_health_thresholds_succeeds(pool: PgPool) {
     let (app, token, org_id, _building_id) = setup(pool, "thresholds").await;
 
@@ -549,7 +530,6 @@ async fn set_and_list_health_thresholds_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_dashboard_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "dash").await;
     create_equipment(&app, &token, org_id, building_id).await;
@@ -564,7 +544,6 @@ async fn get_dashboard_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_by_health_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "by-health").await;
     create_equipment(&app, &token, org_id, building_id).await;

--- a/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
+++ b/backend/servers/api-server/tests/predictive_maintenance_photos_idor_tests.rs
@@ -176,7 +176,6 @@ fn photos_uri(log_id: Uuid) -> String {
 
 /// A user whose JWT `tenant_id` matches the log's org can read its photos.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_photos_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -214,7 +213,6 @@ async fn list_photos_same_org_succeeds(pool: PgPool) {
 /// A user from Org B cannot read Org A's maintenance photos by log id — the
 /// org-scoped log lookup finds no row and the handler returns 404 (#848 IDOR).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_photos_cross_org_is_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -254,7 +252,6 @@ async fn list_photos_cross_org_is_not_found(pool: PgPool) {
 
 /// A cross-org POST must not attach a photo to another org's log.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_photo_cross_org_does_not_insert(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/principal_platform_host_tests.rs
+++ b/backend/servers/api-server/tests/principal_platform_host_tests.rs
@@ -128,7 +128,6 @@ fn ensure_jwt_secret() {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_host_allows_platform_principal(pool: PgPool) {
     ensure_jwt_secret();
 
@@ -156,7 +155,6 @@ async fn platform_host_allows_platform_principal(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_host_rejects_staff_principal(pool: PgPool) {
     ensure_jwt_secret();
 
@@ -176,7 +174,6 @@ async fn platform_host_rejects_staff_principal(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_host_rejects_public_principal(pool: PgPool) {
     ensure_jwt_secret();
 

--- a/backend/servers/api-server/tests/push_delivery_receipt_tests.rs
+++ b/backend/servers/api-server/tests/push_delivery_receipt_tests.rs
@@ -152,7 +152,6 @@ fn make_notification(user_id: Uuid) -> Notification {
 /// follow-up). This test verifies the happy path: the wiremock server
 /// asserts one HTTP POST was received and the adapter propagates `Ok(())`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn successful_fcm_delivery_receipt_returns_ok(pool: PgPool) {
     // Start wiremock server and register the FCM v1 success stub.
     let server = MockServer::start().await;
@@ -204,7 +203,6 @@ async fn successful_fcm_delivery_receipt_returns_ok(pool: PgPool) {
 /// The wiremock server has no stubs registered; if the adapter made an
 /// unexpected HTTP call the mock would panic and the test would fail.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn apns_only_path_no_fcm_attempted_returns_ok(pool: PgPool) {
     // No stubs registered — any unexpected HTTP call will cause an assertion
     // failure in wiremock.
@@ -250,7 +248,6 @@ async fn apns_only_path_no_fcm_attempted_returns_ok(pool: PgPool) {
 ///
 /// After `send` completes the token row must be absent from the DB.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn fcm_not_registered_deletes_stale_token(pool: PgPool) {
     let server = MockServer::start().await;
 
@@ -310,7 +307,6 @@ async fn fcm_not_registered_deletes_stale_token(pool: PgPool) {
 /// The APNs token must remain in the DB (it was not stale and no APNs send
 /// is attempted in the current placeholder implementation).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn fcm_failure_with_apns_token_returns_err_not_silent_ok(pool: PgPool) {
     let server = MockServer::start().await;
 
@@ -374,7 +370,6 @@ async fn fcm_failure_with_apns_token_returns_err_not_silent_ok(pool: PgPool) {
 /// which POSTs to `{base_url}/fcm/send`.  A legacy success response
 /// (`{"success":1,"failure":0,…}`) must be decoded as `(success=true, expired=false)`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legacy_fcm_successful_delivery_returns_ok(pool: PgPool) {
     let server = MockServer::start().await;
 
@@ -416,7 +411,6 @@ async fn legacy_fcm_successful_delivery_returns_ok(pool: PgPool) {
 /// The legacy FCM path must also trigger `delete_stale_token` when the
 /// response results contain `"error":"NotRegistered"`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legacy_fcm_not_registered_deletes_stale_token(pool: PgPool) {
     let server = MockServer::start().await;
 

--- a/backend/servers/api-server/tests/push_fanout_stale_token_isolation_tests.rs
+++ b/backend/servers/api-server/tests/push_fanout_stale_token_isolation_tests.rs
@@ -88,7 +88,6 @@ fn assert_rejected(status: StatusCode, ctx: &str) {
 /// Unauthenticated DELETE on `/api/v1/users/me/push-tokens/{token}` must
 /// be rejected before any DB mutation.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -117,7 +116,6 @@ async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
 /// A request carrying Org B's `X-Tenant-ID` while targeting a token owned by
 /// user A must be rejected by the auth gate (4xx).  The token must survive.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_cross_user_via_http_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -152,7 +150,6 @@ async fn delete_push_token_cross_user_via_http_rejected(pool: PgPool) {
 /// the token is preserved.  This is the exact cross-user IDOR boundary the
 /// `(user_id, token)` scope enforces.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn stale_token_delete_scoped_to_user_id(pool: PgPool) {
     let user_a = seed_user(&pool, "user-a-stale@fanout.test").await;
     let user_b = seed_user(&pool, "user-b-stale@fanout.test").await;

--- a/backend/servers/api-server/tests/push_token_tests.rs
+++ b/backend/servers/api-server/tests/push_token_tests.rs
@@ -142,7 +142,6 @@ async fn token_count(pool: &PgPool, token: &str) -> i64 {
 /// `RlsConnection` validates the JWT before any handler body runs, so
 /// unauthenticated callers can never register a token.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_push_token_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -170,7 +169,6 @@ async fn register_push_token_without_auth_is_rejected(pool: PgPool) {
 /// This test documents the layered defence: invalid tokens can never slip
 /// through regardless of auth state.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_push_token_empty_token_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -193,7 +191,6 @@ async fn register_push_token_empty_token_is_rejected(pool: PgPool) {
 
 /// A whitespace-only token must be rejected (the handler trims before checking).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_push_token_whitespace_token_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -215,7 +212,6 @@ async fn register_push_token_whitespace_token_is_rejected(pool: PgPool) {
 /// `DELETE /api/v1/users/me/push-tokens/{token}` with no Bearer token must be
 /// rejected. Verifies the delete endpoint is protected by the same auth gate.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -245,7 +241,6 @@ async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
 /// the DB itself and is covered by the migration's `FORCE ROW LEVEL
 /// SECURITY` + `app.current_user_id` policy.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_cross_user_is_rejected_and_token_survives(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/regional_compliance_tests.rs
+++ b/backend/servers/api-server/tests/regional_compliance_tests.rs
@@ -90,7 +90,6 @@ async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_jurisdiction_lifecycle(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -138,7 +137,6 @@ async fn test_jurisdiction_lifecycle(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_slovak_voting_config_lifecycle(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -201,7 +199,6 @@ async fn test_slovak_voting_config_lifecycle(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_gdpr_consent_lifecycle(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/registry_backfill_tests.rs
+++ b/backend/servers/api-server/tests/registry_backfill_tests.rs
@@ -148,7 +148,6 @@ async fn create_spot(session: &AuthenticatedSession<'_>, app: &TestApp, building
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_pet_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -176,7 +175,6 @@ async fn create_pet_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_pet_registrations_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -195,7 +193,6 @@ async fn list_pet_registrations_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_pet_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -218,7 +215,6 @@ async fn get_pet_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_pet_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -241,7 +237,6 @@ async fn update_pet_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn review_pet_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -264,7 +259,6 @@ async fn review_pet_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_pet_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -290,7 +284,6 @@ async fn delete_pet_registration_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_vehicle_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -319,7 +312,6 @@ async fn create_vehicle_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_vehicle_registrations_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -338,7 +330,6 @@ async fn list_vehicle_registrations_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vehicle_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -361,7 +352,6 @@ async fn get_vehicle_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_vehicle_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -384,7 +374,6 @@ async fn update_vehicle_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn review_vehicle_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -407,7 +396,6 @@ async fn review_vehicle_registration_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_vehicle_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -433,7 +421,6 @@ async fn delete_vehicle_registration_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_parking_spot_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -460,7 +447,6 @@ async fn create_parking_spot_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_parking_spots_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -478,7 +464,6 @@ async fn list_parking_spots_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_parking_spot_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -500,7 +485,6 @@ async fn get_parking_spot_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_parking_spot_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -522,7 +506,6 @@ async fn update_parking_spot_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_parking_spot_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -547,7 +530,6 @@ async fn delete_parking_spot_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_registry_rules_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -568,7 +550,6 @@ async fn get_registry_rules_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_registry_rules_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -594,7 +575,6 @@ async fn update_registry_rules_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_registry_statistics_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
+++ b/backend/servers/api-server/tests/rental_connection_token_leak_tests.rs
@@ -180,7 +180,6 @@ fn authed_get(uri: &str, token: &str, tenant: Uuid) -> Request<Body> {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_connection_from_other_org_is_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -218,7 +217,6 @@ async fn get_connection_from_other_org_is_not_found(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_connection_same_org_succeeds_without_leaking_tokens(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -280,7 +278,6 @@ async fn get_connection_same_org_succeeds_without_leaking_tokens(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_connection_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -341,7 +338,6 @@ async fn assert_route_removed(app: &TestApp, uri: &str) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legacy_rental_oauth_callback_routes_are_removed(pool: PgPool) {
     // The rentals router IS mounted here (the connection tests above hit
     // `/api/v1/rentals/connections/{id}`), so a 404 on the callback paths proves

--- a/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
+++ b/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
@@ -206,7 +206,6 @@ fn extract_request(guest_id: Uuid, token: &str, org: Uuid) -> Request<Body> {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn upload_succeeds_sets_url_and_records_row(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, guest) = seed_manager_with_guest(&pool, "upok").await;
@@ -256,7 +255,6 @@ async fn upload_succeeds_sets_url_and_records_row(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn extract_with_stub_returns_501(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, guest) = seed_manager_with_guest(&pool, "extract").await;
@@ -291,7 +289,6 @@ async fn extract_with_stub_returns_501(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn extract_without_document_is_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, guest) = seed_manager_with_guest(&pool, "nodoc").await;
@@ -311,7 +308,6 @@ async fn extract_without_document_is_404(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn upload_for_cross_org_guest_is_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -350,7 +346,6 @@ async fn upload_for_cross_org_guest_is_404(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn upload_unsupported_mime_is_400(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, guest) = seed_manager_with_guest(&pool, "badmime").await;
@@ -371,7 +366,6 @@ async fn upload_unsupported_mime_is_400(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn upload_oversize_is_413(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org, guest) = seed_manager_with_guest(&pool, "big").await;
@@ -393,7 +387,6 @@ async fn upload_oversize_is_413(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn non_manager_is_forbidden_on_both_endpoints(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
+++ b/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
@@ -197,7 +197,6 @@ fn mint_manager_jwt(user_id: Uuid, org_id: Uuid) -> String {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_rental_statistics_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "rstat").await;
@@ -226,7 +225,6 @@ async fn test_rental_statistics_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_rental_sync_status_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "rsync").await;
@@ -255,7 +253,6 @@ async fn test_rental_sync_status_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_connections_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "lscon").await;
@@ -284,7 +281,6 @@ async fn test_list_connections_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_connection_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "crcon").await;
@@ -321,7 +317,6 @@ async fn test_create_connection_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_connection_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "upcon").await;
@@ -356,7 +351,6 @@ async fn test_update_connection_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_connection_returns_204(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "dlcon").await;
@@ -388,7 +382,6 @@ async fn test_delete_connection_returns_204(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_unit_connections_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "uccon").await;
@@ -423,7 +416,6 @@ async fn test_get_unit_connections_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_bookings_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "lsbk").await;
@@ -452,7 +444,6 @@ async fn test_list_bookings_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_booking_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "crbk").await;
@@ -493,7 +484,6 @@ async fn test_create_booking_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_booking_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "gtbk").await;
@@ -525,7 +515,6 @@ async fn test_get_booking_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_booking_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "upbk").await;
@@ -560,7 +549,6 @@ async fn test_update_booking_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_booking_status_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "bkst").await;
@@ -595,7 +583,6 @@ async fn test_update_booking_status_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_booking_with_guests_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "bkgs").await;
@@ -631,7 +618,6 @@ async fn test_get_booking_with_guests_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_calendar_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "gcal").await;
@@ -664,7 +650,6 @@ async fn test_get_calendar_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_check_availability_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "avail").await;
@@ -697,7 +682,6 @@ async fn test_check_availability_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_calendar_block_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "crblk").await;
@@ -736,7 +720,6 @@ async fn test_create_calendar_block_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_calendar_block_returns_204(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "dlblk").await;
@@ -772,7 +755,6 @@ async fn test_delete_calendar_block_returns_204(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_guest_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "crgs").await;
@@ -811,7 +793,6 @@ async fn test_create_guest_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_guest_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "gtgs").await;
@@ -844,7 +825,6 @@ async fn test_get_guest_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_guest_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "upgs").await;
@@ -880,7 +860,6 @@ async fn test_update_guest_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_guest_returns_204(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "dlgs").await;
@@ -913,7 +892,6 @@ async fn test_delete_guest_returns_204(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_register_guest_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "rgst").await;
@@ -951,7 +929,6 @@ async fn test_register_guest_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_checkin_reminders_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "cirem").await;
@@ -984,7 +961,6 @@ async fn test_get_checkin_reminders_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_reports_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "lsrep").await;
@@ -1013,7 +989,6 @@ async fn test_list_reports_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_generate_report_preview_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "rprev").await;
@@ -1050,7 +1025,6 @@ async fn test_generate_report_preview_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_report_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "crrep").await;
@@ -1089,7 +1063,6 @@ async fn test_create_report_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_report_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "gtrep").await;
@@ -1120,7 +1093,6 @@ async fn test_get_report_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_submit_report_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "sbrep").await;
@@ -1156,7 +1128,6 @@ async fn test_submit_report_returns_200(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_create_ical_feed_returns_201(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "crif").await;
@@ -1193,7 +1164,6 @@ async fn test_create_ical_feed_returns_201(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_ical_feed_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "upif").await;
@@ -1228,7 +1198,6 @@ async fn test_update_ical_feed_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_ical_feed_returns_204(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "dlif").await;
@@ -1260,7 +1229,6 @@ async fn test_delete_ical_feed_returns_204(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_unit_ical_feeds_returns_200(pool: PgPool) {
     let app = common::TestApp::new(pool.clone()).await;
     let org_id = seed_org(&pool, "uif").await;

--- a/backend/servers/api-server/tests/report_execution_download_retry_e2e_tests.rs
+++ b/backend/servers/api-server/tests/report_execution_download_retry_e2e_tests.rs
@@ -156,7 +156,6 @@ async fn authed_member(app: &TestApp, pool: &PgPool, org_id: Uuid, role: &str) -
 /// completed, file-bearing execution must receive a populated `download_url`
 /// pointing at that execution's download endpoint.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_populates_download_url_for_completed(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -217,7 +216,6 @@ async fn list_executions_populates_download_url_for_completed(pool: PgPool) {
 /// completed, file-bearing execution must receive a 200 with a non-empty URL,
 /// the stored file name, and a content type derived from the file extension.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_returns_presigned_payload(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -301,7 +299,6 @@ async fn get_execution_download_url_returns_presigned_payload(pool: PgPool) {
 /// A dedicated integration test against a live S3 stub would be required to
 /// verify the downstream presigning step; that is out of scope here.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn download_url_can_be_repeatedly_represigned_after_expiry(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -402,7 +399,6 @@ async fn download_url_can_be_repeatedly_represigned_after_expiry(pool: PgPool) {
 /// download URL — the endpoint returns 422 `NO_FILE_YET` rather than leaking a
 /// bogus link. Pins the "file not ready" branch of the handler.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_without_file_returns_422(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -459,7 +455,6 @@ async fn get_execution_download_url_without_file_returns_422(pool: PgPool) {
 /// persisted row must reflect the reset (status `pending`, error fields
 /// cleared). This is the core of the retry contract.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_failed_execution_resets_to_pending(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -515,7 +510,6 @@ async fn retry_failed_execution_resets_to_pending(pool: PgPool) {
 /// be rejected with 400 `INVALID_STATE` and must not mutate the row. Pins the
 /// "only failed executions may be retried" guard end-to-end.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_non_failed_execution_returns_400(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -573,7 +567,6 @@ async fn retry_non_failed_execution_returns_400(pool: PgPool) {
 /// and the failed execution stays failed. Proves the retry endpoint's
 /// manager-tier gate end-to-end (complements the cross-tenant IDOR tests).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_as_resident_returns_403(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/report_schedule_cron_roundtrip_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_cron_roundtrip_tests.rs
@@ -119,7 +119,6 @@ fn put_schedule_req(
 /// land in the dedicated `cron_expression` column, be returned in the response
 /// body, and leave the legacy `time` HH:MM value untouched.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_cron_expression_roundtrips_through_dedicated_column(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -193,7 +192,6 @@ async fn update_cron_expression_roundtrips_through_dedicated_column(pool: PgPool
 /// guards the `COALESCE($cron, cron_expression)` partial-update in
 /// `update_schedule()` from regressing into an unconditional overwrite.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn recipients_only_update_preserves_cron_and_time(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -265,7 +263,6 @@ async fn recipients_only_update_preserves_cron_and_time(pool: PgPool) {
 /// - the validator rejects an expression it previously accepted (PUT → 400), or
 /// - the SELECT projection drops / transforms `cron_expression` (read ≠ write).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn cron_validator_round_trip_stable(pool: PgPool) {
     // Canonical set taken from the validate_cron_expression unit tests in
     // reports.rs.  If the validator is tightened so that any of these become

--- a/backend/servers/api-server/tests/report_schedule_org_scope_jwt_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_org_scope_jwt_tests.rs
@@ -137,7 +137,6 @@ fn cross_tenant_req(
 /// that drops the org clause and starts mutating the Org A row would be
 /// caught (the response would become `200` or a different 4xx).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -204,7 +203,6 @@ async fn pause_schedule_from_other_org_returns_404(pool: PgPool) {
 /// the cross-tenant resume from Org B must return `404` and leave the row
 /// paused.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -269,7 +267,6 @@ async fn resume_schedule_from_other_org_returns_404(pool: PgPool) {
 /// Org B for an Org A schedule must therefore return `404` (schedule not
 /// found in caller's org), not `200` with an empty list and not `401`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_for_other_org_schedule_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -313,7 +310,6 @@ async fn list_executions_for_other_org_schedule_returns_404(pool: PgPool) {
 /// an attacker cannot distinguish "exists in another org" from "does not
 /// exist" by status code or response body.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_unknown_schedule_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_rbac_tests.rs
@@ -133,7 +133,6 @@ fn put_schedule_req_auth(
 /// proved the outer auth gate worked. This rewrite exercises the actual
 /// RBAC predicate.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_without_manager_role_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -207,7 +206,6 @@ async fn update_schedule_without_manager_role_is_rejected(pool: PgPool) {
 /// repository UPDATE was never executed. This rewrite forces the org-scoped
 /// WHERE clause to actually fire.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -276,7 +274,6 @@ async fn update_schedule_from_other_org_is_rejected(pool: PgPool) {
 /// be rejected with 4xx by `AuthUser` before any DB access. This is the
 /// legitimate outer-gate test and is intentionally kept as-is.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_without_any_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_sibling_scope_tests.rs
@@ -172,7 +172,6 @@ fn assert_rejected(status: StatusCode, label: &str) {
 
 /// Unauthenticated request to pause a schedule must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "pause-noauth").await;
@@ -193,7 +192,6 @@ async fn pause_schedule_without_auth_is_rejected(pool: PgPool) {
 /// In TestApp (no JWT) the auth gate fires first → 401.
 /// Either way the cross-tenant mutation is never applied.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -235,7 +233,6 @@ async fn pause_schedule_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to resume a schedule must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "resume-noauth").await;
@@ -265,7 +262,6 @@ async fn resume_schedule_without_auth_is_rejected(pool: PgPool) {
 
 /// A cross-tenant request to resume another org's schedule must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -320,7 +316,6 @@ async fn resume_schedule_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to list executions must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "list-exec-noauth").await;
@@ -339,7 +334,6 @@ async fn list_executions_without_auth_is_rejected(pool: PgPool) {
 
 /// A cross-tenant request to list another org's execution history must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -370,7 +364,6 @@ async fn list_executions_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to get an execution must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "get-exec-noauth").await;
@@ -390,7 +383,6 @@ async fn get_execution_without_auth_is_rejected(pool: PgPool) {
 
 /// A cross-tenant request to read another org's execution must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -420,7 +412,6 @@ async fn get_execution_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to get a download URL must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "dl-url-noauth").await;
@@ -441,7 +432,6 @@ async fn get_execution_download_url_without_auth_is_rejected(pool: PgPool) {
 /// A cross-tenant request to get a download URL for another org's execution
 /// must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -471,7 +461,6 @@ async fn get_execution_download_url_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to retry an execution must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "retry-noauth").await;
@@ -492,7 +481,6 @@ async fn retry_execution_without_auth_is_rejected(pool: PgPool) {
 /// A cross-tenant request to retry another org's failed execution must be rejected,
 /// and the execution must remain in its original 'failed' state.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -555,7 +543,6 @@ async fn retry_execution_cross_tenant_is_rejected(pool: PgPool) {
 /// row, and the handler maps `AppError::NotFound` to `404 SCHEDULE_NOT_FOUND`.
 /// The Org A schedule must remain active.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -619,7 +606,6 @@ async fn pause_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// schedule owned by `org_a`. Must hit the org-scoped WHERE and return 404.
 /// Org A's schedule must remain paused.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -696,7 +682,6 @@ async fn resume_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// lives in `org_a`), and returns 404 `SCHEDULE_NOT_FOUND` before any
 /// executions are listed.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -750,7 +735,6 @@ async fn list_executions_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// `report_schedules.organization_id`, finds no row, and returns 404
 /// `EXECUTION_NOT_FOUND`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -800,7 +784,6 @@ async fn get_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// `get_execution_scoped(id, org_b)` before generating any URL, finds no row,
 /// and returns 404 `EXECUTION_NOT_FOUND` — no download URL is leaked.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -855,7 +838,6 @@ async fn get_execution_download_url_cross_tenant_authenticated_returns_404(pool:
 /// `AppError::NotFound` → `404 EXECUTION_NOT_FOUND`. The execution must
 /// remain in `failed` state (not reset to `pending`).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -927,7 +909,6 @@ async fn retry_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// no row, and returns `AppError::NotFound` → `404 SCHEDULE_NOT_FOUND`.
 /// Org A's schedule recipients must be unchanged.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     use serde_json::json;
 

--- a/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
+++ b/backend/servers/api-server/tests/reports_export_org_scope_tests.rs
@@ -78,7 +78,6 @@ async fn setup(pool: &PgPool, app: &TestApp) -> (String, Uuid, Uuid) {
 /// not match the caller's tenant (Org B). On dev it trusts the body and
 /// proceeds; the fix returns 403.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn export_report_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org_a, org_b) = setup(&pool, &app).await;
@@ -110,7 +109,6 @@ async fn export_report_for_other_org_is_rejected(pool: PgPool) {
 /// owned by Org A; the caller is in Org B. On dev it returns the status; the
 /// fix returns 404.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_export_job_status_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org_a, org_b) = setup(&pool, &app).await;
@@ -135,7 +133,6 @@ async fn get_export_job_status_for_other_org_is_rejected(pool: PgPool) {
 
 /// Same-tenant export job status is readable (the guard must not over-reject).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_export_job_status_for_own_org_is_allowed(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, _org_a, org_b) = setup(&pool, &app).await;

--- a/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/reserve_funds_cross_org_idor_tests.rs
@@ -131,7 +131,6 @@ async fn seed_fund(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
 
 /// A user whose JWT `tenant_id` matches the fund's organization can read it.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_fund_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -164,7 +163,6 @@ async fn get_fund_same_org_succeeds(pool: PgPool) {
 /// A user from Org B cannot read Org A's fund by id — the org-scoped query
 /// finds no row and the handler returns 404 (the core #810 IDOR).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_fund_cross_org_is_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -201,7 +199,6 @@ async fn get_fund_cross_org_is_not_found(pool: PgPool) {
 
 /// A cross-org `PUT` must not rename another org's fund.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_fund_cross_org_does_not_mutate(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/service_history_cross_org_idor_tests.rs
@@ -112,7 +112,6 @@ async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
 /// Org B user requests service history for Org A equipment. Must be rejected
 /// with 403; Org A's work-order data must not be disclosed.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -163,7 +162,6 @@ async fn get_equipment_service_history_cross_org_is_rejected(pool: PgPool) {
 /// Org B user requests service history for Org A building. Must be rejected
 /// with 403; Org A's work-order data must not be disclosed.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_building_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -214,7 +212,6 @@ async fn get_building_service_history_cross_org_is_rejected(pool: PgPool) {
 /// A member of Org A reads service history for Org A equipment. Should succeed
 /// with 200 — the fix must not over-block legitimate callers.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_service_history_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -265,7 +262,6 @@ async fn get_equipment_service_history_same_org_succeeds(pool: PgPool) {
 /// A member of Org A reads service history for Org A building. Should succeed
 /// with 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_building_service_history_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -317,7 +313,6 @@ async fn get_building_service_history_same_org_succeeds(pool: PgPool) {
 /// so callers cannot distinguish "exists but forbidden" from "does not exist"
 /// via timing or error codes.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_service_history_unknown_id_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/tenant_config_tests.rs
+++ b/backend/servers/api-server/tests/tenant_config_tests.rs
@@ -83,7 +83,6 @@ async fn build_state(pool: PgPool) -> api_server::state::AppState {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_host_returns_defaults(pool: PgPool) {
     let state = build_state(pool).await;
     let resp = api_server::routes::tenant_config::tenant_config_inner(state, None).await;
@@ -108,7 +107,6 @@ async fn platform_host_returns_defaults(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn agency_a_returns_a_branding(pool: PgPool) {
     let org_a = common_phase3::seed_org(&pool, "Agency A").await;
     common_phase3::seed_branding(
@@ -143,7 +141,6 @@ async fn agency_a_returns_a_branding(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn agency_b_returns_b_branding_and_does_not_leak_a(pool: PgPool) {
     let org_a = common_phase3::seed_org(&pool, "Agency A").await;
     common_phase3::seed_branding(&pool, org_a, "#FF0000", "FontA", "https://a.example/logo").await;
@@ -170,7 +167,6 @@ async fn agency_b_returns_b_branding_and_does_not_leak_a(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn cache_headers_set_for_resolved_response(pool: PgPool) {
     let org = common_phase3::seed_org(&pool, "Agency C").await;
     let state = build_state(pool).await;

--- a/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/vendor_cross_org_idor_tests.rs
@@ -104,7 +104,6 @@ fn assert_rejected(status: StatusCode, ctx: &str) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vendor_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "noauth-a").await;
@@ -121,7 +120,6 @@ async fn get_vendor_without_auth_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_vendors_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "lst-a").await;
@@ -155,7 +153,6 @@ async fn list_vendors_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vendor_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "get-a").await;
@@ -191,7 +188,6 @@ async fn get_vendor_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_vendor_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "del-a").await;
@@ -232,7 +228,6 @@ async fn delete_vendor_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_vendor_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "upd-a").await;
@@ -273,7 +268,6 @@ async fn update_vendor_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_vendor_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "crt-a").await;
@@ -318,7 +312,6 @@ async fn create_vendor_for_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vendor_for_own_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "own-a").await;

--- a/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
+++ b/backend/servers/api-server/tests/vendor_portal_stub_removal_tests.rs
@@ -134,7 +134,6 @@ fn mint_token(user_id: Uuid, email: &str) -> String {
 /// unmounted (ROADMAP(PAP-24)/PAP-33), so the fabricating handler is not
 /// routable at all: every caller — authenticated or not — gets `404`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn job_details_never_returns_fabricated_pii(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "pii-a").await;
@@ -174,7 +173,6 @@ async fn job_details_never_returns_fabricated_pii(pool: PgPool) {
 /// `list_jobs` and `list_invoices` previously returned `200` with a fabricated
 /// array. Neither may return a `200` body anymore.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_endpoints_never_return_fabricated_arrays(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "lst-a").await;
@@ -213,7 +211,6 @@ async fn list_endpoints_never_return_fabricated_arrays(pool: PgPool) {
 /// will sit on. Without it, the portal would have no correct way to keep one
 /// party's jobs from another's.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn work_orders_are_org_scoped(pool: PgPool) {
     let org_a = seed_org(&pool, "scope-a").await;
     let org_b = seed_org(&pool, "scope-b").await;

--- a/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/violations_cross_org_idor_tests.rs
@@ -128,7 +128,6 @@ async fn seed_violation(pool: &PgPool, org_id: Uuid, number: &str) -> Uuid {
 /// A user whose JWT `tenant_id` matches the violation's organization can read
 /// it.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_violation_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -159,7 +158,6 @@ async fn get_violation_same_org_succeeds(pool: PgPool) {
 /// A user from Org B cannot read Org A's violation by id — the org-scoped
 /// query finds no row and the handler returns 404 (the core #850 IDOR).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_violation_cross_org_is_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
+++ b/backend/servers/api-server/tests/voice_oauth_exchange_auth_tests.rs
@@ -88,7 +88,6 @@ fn exchange_body() -> serde_json::Value {
 // Test 1: no Authorization header -> 401, no device created.
 // ---------------------------------------------------------------------------
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn oauth_exchange_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -114,7 +113,6 @@ async fn oauth_exchange_without_auth_is_rejected(pool: PgPool) {
 // Test 2: garbage bearer token -> 401.
 // ---------------------------------------------------------------------------
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn oauth_exchange_invalid_token_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -141,7 +139,6 @@ async fn oauth_exchange_invalid_token_is_rejected(pool: PgPool) {
 // Test 3: authenticated but no org context (no tenant_id claim) -> 403.
 // ---------------------------------------------------------------------------
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn oauth_exchange_without_org_context_is_forbidden(pool: PgPool) {
     let config = TestConfig::default();
     let secret = config.jwt_secret.clone();
@@ -177,7 +174,6 @@ async fn oauth_exchange_without_org_context_is_forbidden(pool: PgPool) {
 // that is well past the security boundary this fix establishes.)
 // ---------------------------------------------------------------------------
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn oauth_exchange_with_valid_auth_passes_auth_gate(pool: PgPool) {
     let config = TestConfig::default();
     let secret = config.jwt_secret.clone();

--- a/backend/servers/api-server/tests/voting_behaviour_tests.rs
+++ b/backend/servers/api-server/tests/voting_behaviour_tests.rs
@@ -145,7 +145,6 @@ async fn publish_vote(app: &TestApp, token: &str, org_id: Uuid, vote_id: Uuid) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_vote_title_succeeds(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -165,7 +164,6 @@ async fn test_update_vote_title_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_draft_vote_succeeds(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -188,7 +186,6 @@ async fn test_delete_draft_vote_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_cancel_active_vote_succeeds(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -218,7 +215,6 @@ async fn test_cancel_active_vote_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_close_active_vote_succeeds(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -247,7 +243,6 @@ async fn test_close_active_vote_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_questions_for_vote(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -276,7 +271,6 @@ async fn test_list_questions_for_vote(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_update_question_text(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -302,7 +296,6 @@ async fn test_update_question_text(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_delete_question_from_draft_vote(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -329,7 +322,6 @@ async fn test_delete_question_from_draft_vote(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_check_eligibility_returns_result(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -367,7 +359,6 @@ async fn test_check_eligibility_returns_result(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_my_response_after_cast(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -417,7 +408,6 @@ async fn test_get_my_response_after_cast(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_add_and_list_comments(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -475,7 +465,6 @@ async fn test_add_and_list_comments(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_hide_comment(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -508,7 +497,6 @@ async fn test_hide_comment(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_audit_log(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();
@@ -531,7 +519,6 @@ async fn test_get_audit_log(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_list_active_by_building(pool: PgPool) {
     let app = TestApp::new(pool).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/voting_report_tests.rs
+++ b/backend/servers/api-server/tests/voting_report_tests.rs
@@ -67,7 +67,6 @@ async fn seed_vote(pool: &PgPool, org_id: Uuid, building_id: Uuid, created_by: U
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool: PgPool) {
     db::run_migrations(&pool)
         .await
@@ -124,7 +123,6 @@ async fn test_get_report_pdf_returns_application_pdf_and_archives_document(pool:
 }
 
 #[sqlx::test]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn test_get_report_json_with_format_pdf_returns_application_pdf(pool: PgPool) {
     db::run_migrations(&pool)
         .await

--- a/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/work_order_cross_org_idor_tests.rs
@@ -135,7 +135,6 @@ async fn work_order_title(pool: &PgPool, id: Uuid) -> String {
 /// handler reads the row, sees it belongs to Org A, and rejects the caller
 /// (403) because they are not a member of Org A.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_work_order_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -182,7 +181,6 @@ async fn get_work_order_from_other_org_is_rejected(pool: PgPool) {
 /// A member of Org B attempts to update an Org A work order. The request is
 /// rejected (403) and the Org A row's title is unchanged.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_work_order_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -242,7 +240,6 @@ async fn update_work_order_from_other_org_is_rejected(pool: PgPool) {
 /// A member of Org B attempts to delete an Org A work order. Rejected (403)
 /// and the row still exists.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_work_order_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -298,7 +295,6 @@ async fn delete_work_order_from_other_org_is_rejected(pool: PgPool) {
 /// owner. `verify_org_access` rejects it (403) and no work order is inserted
 /// into Org A.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_work_order_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -359,7 +355,6 @@ async fn create_work_order_for_other_org_is_rejected(pool: PgPool) {
 /// passes and the handler returns 200 with the row — proving the fix does not
 /// over-block legitimate same-org access.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_work_order_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -454,7 +449,6 @@ async fn seed_completed_work_order(
 /// retained `verify_org_access` defense-in-depth gate rejects with 403. The
 /// test therefore asserts 403 — the floor guaranteed even if RLS were disabled.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn equipment_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -501,7 +495,6 @@ async fn equipment_service_history_cross_org_is_rejected(pool: PgPool) {
 /// lookup; this superuser test pool bypasses RLS, so `verify_org_access` is the
 /// gate that fires and the assertion is 403.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn building_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -543,7 +536,6 @@ async fn building_service_history_cross_org_is_rejected(pool: PgPool) {
 /// A member of Org A reading Org A equipment service history succeeds — proves
 /// the fix does not over-block legitimate same-org access.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn equipment_service_history_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/work_orders_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/work_orders_happy_path_tests.rs
@@ -126,7 +126,6 @@ async fn create_schedule(app: &TestApp, token: &str, org_id: Uuid, building_id: 
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_work_order_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-create").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -134,7 +133,6 @@ async fn create_work_order_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_work_orders_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-list").await;
     create_work_order(&app, &token, org_id, building_id).await;
@@ -153,7 +151,6 @@ async fn list_work_orders_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_work_orders_with_details_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-details").await;
     create_work_order(&app, &token, org_id, building_id).await;
@@ -168,7 +165,6 @@ async fn list_work_orders_with_details_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_statistics_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-stats").await;
     create_work_order(&app, &token, org_id, building_id).await;
@@ -183,7 +179,6 @@ async fn get_statistics_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_overdue_succeeds(pool: PgPool) {
     let (app, token, org_id, _building_id) = setup(pool, "wo-overdue").await;
 
@@ -197,7 +192,6 @@ async fn list_overdue_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_work_order_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-get").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -216,7 +210,6 @@ async fn get_work_order_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_work_order_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-update").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -233,7 +226,6 @@ async fn update_work_order_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn assign_work_order_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-assign").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -256,7 +248,6 @@ async fn assign_work_order_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn start_work_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-start").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -271,7 +262,6 @@ async fn start_work_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn complete_work_order_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-complete").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -287,7 +277,6 @@ async fn complete_work_order_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn put_on_hold_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-hold").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -303,7 +292,6 @@ async fn put_on_hold_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_and_list_comments_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-comments").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -341,7 +329,6 @@ async fn add_and_list_comments_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_work_order_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "wo-delete").await;
     let id = create_work_order(&app, &token, org_id, building_id).await;
@@ -372,7 +359,6 @@ async fn delete_work_order_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_schedule_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-create").await;
     let id = create_schedule(&app, &token, org_id, building_id).await;
@@ -380,7 +366,6 @@ async fn create_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_schedules_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-list").await;
     create_schedule(&app, &token, org_id, building_id).await;
@@ -401,7 +386,6 @@ async fn list_schedules_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_upcoming_schedules_succeeds(pool: PgPool) {
     let (app, token, org_id, _building_id) = setup(pool, "sch-upcoming").await;
 
@@ -417,7 +401,6 @@ async fn get_upcoming_schedules_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn process_due_schedules_succeeds(pool: PgPool) {
     let (app, token, org_id, _building_id) = setup(pool, "sch-process").await;
 
@@ -433,7 +416,6 @@ async fn process_due_schedules_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_schedule_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-get").await;
     let id = create_schedule(&app, &token, org_id, building_id).await;
@@ -452,7 +434,6 @@ async fn get_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-update").await;
     let id = create_schedule(&app, &token, org_id, building_id).await;
@@ -474,7 +455,6 @@ async fn update_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn activate_deactivate_schedule_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-toggle").await;
     let id = create_schedule(&app, &token, org_id, building_id).await;
@@ -499,7 +479,6 @@ async fn activate_deactivate_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn skip_schedule_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-skip").await;
     let id = create_schedule(&app, &token, org_id, building_id).await;
@@ -515,7 +494,6 @@ async fn skip_schedule_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-exec").await;
     let id = create_schedule(&app, &token, org_id, building_id).await;
@@ -530,7 +508,6 @@ async fn list_executions_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_schedule_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "sch-delete").await;
     let id = create_schedule(&app, &token, org_id, building_id).await;
@@ -554,7 +531,6 @@ async fn delete_schedule_succeeds(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn equipment_service_history_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "svc-eq").await;
     let equipment_id = seed_equipment(&app.pool, org_id, building_id).await;
@@ -574,7 +550,6 @@ async fn equipment_service_history_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn building_service_history_succeeds(pool: PgPool) {
     let (app, token, org_id, building_id) = setup(pool, "svc-bld").await;
 
@@ -593,7 +568,6 @@ async fn building_service_history_succeeds(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_cost_summary_succeeds(pool: PgPool) {
     let (app, token, org_id, _building_id) = setup(pool, "cost").await;
 

--- a/backend/servers/api-server/tests/workflow_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/workflow_cross_tenant_idor_tests.rs
@@ -156,7 +156,6 @@ fn assert_rejected(status: StatusCode, ctx: &str) {
 /// can only assert "rejected" (4xx) because `host_tenant_middleware`
 /// isn't wired.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn trigger_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -219,7 +218,6 @@ async fn trigger_workflow_from_owning_org_does_not_404(pool: PgPool) {
 
 /// GET /workflows/{id} from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "get-a").await;
@@ -236,7 +234,6 @@ async fn get_workflow_from_other_org_returns_404(pool: PgPool) {
 
 /// PUT /workflows/{id} from another org → rejected and no row mutation.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "upd-a").await;
@@ -264,7 +261,6 @@ async fn update_workflow_from_other_org_returns_404(pool: PgPool) {
 
 /// DELETE /workflows/{id} from another org → rejected and the row survives.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "del-a").await;
@@ -291,7 +287,6 @@ async fn delete_workflow_from_other_org_returns_404(pool: PgPool) {
 
 /// GET /workflows/{id}/actions from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_actions_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "la-a").await;
@@ -308,7 +303,6 @@ async fn list_actions_from_other_org_returns_404(pool: PgPool) {
 
 /// POST /workflows/{id}/actions from another org → rejected and no row inserted.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_action_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "aa-a").await;
@@ -345,7 +339,6 @@ async fn add_action_from_other_org_returns_404(pool: PgPool) {
 /// DELETE /workflows/actions/{action_id} from another org → rejected and
 /// the action survives.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_action_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "da-a").await;
@@ -382,7 +375,6 @@ async fn delete_action_from_other_org_returns_404(pool: PgPool) {
 
 /// GET /workflows/executions/{id} from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "ge-a").await;
@@ -411,7 +403,6 @@ async fn get_execution_from_other_org_returns_404(pool: PgPool) {
 
 /// GET /workflows/executions/{id}/steps from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_execution_steps_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "les-a").await;

--- a/backend/servers/api-server/tests/ws_integration_tests.rs
+++ b/backend/servers/api-server/tests/ws_integration_tests.rs
@@ -137,7 +137,6 @@ async fn build_ws_test_server(pool: PgPool) -> TestServer {
 /// Switching Protocols), and the session must accept and echo a heartbeat
 /// text frame without closing immediately.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ws_upgrade_with_valid_token_succeeds(pool: PgPool) {
     let server = build_ws_test_server(pool).await;
     let user_id = Uuid::new_v4();
@@ -170,7 +169,6 @@ async fn ws_upgrade_with_valid_token_succeeds(pool: PgPool) {
 /// the HTTP phase (before `on_upgrade`), so the client sees a 401 response
 /// body — not a successful 101 upgrade.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ws_upgrade_with_expired_token_returns_401(pool: PgPool) {
     let server = build_ws_test_server(pool).await;
     let user_id = Uuid::new_v4();
@@ -213,7 +211,6 @@ async fn ws_upgrade_with_expired_token_returns_401(pool: PgPool) {
 /// A refresh token supplied as the `token` query parameter must be rejected
 /// with 401 because `validate_ws_token_with_exp` checks `token_type == "access"`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ws_upgrade_with_refresh_token_returns_401(pool: PgPool) {
     let server = build_ws_test_server(pool).await;
     let user_id = Uuid::new_v4();
@@ -256,7 +253,6 @@ async fn ws_upgrade_with_refresh_token_returns_401(pool: PgPool) {
 /// Requesting the WS endpoint without a `token` query parameter must not
 /// complete the upgrade — the server rejects the request before upgrading.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ws_upgrade_without_token_is_rejected(pool: PgPool) {
     let server = build_ws_test_server(pool).await;
 
@@ -296,7 +292,6 @@ async fn ws_upgrade_without_token_is_rejected(pool: PgPool) {
 /// exits cleanly on client-close and does not leave stale state that would
 /// prevent re-connection.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ws_reconnect_after_client_close(pool: PgPool) {
     let server = build_ws_test_server(pool).await;
     let user_id = Uuid::new_v4();
@@ -343,7 +338,6 @@ async fn ws_reconnect_after_client_close(pool: PgPool) {
 /// it verifies the per-user channel name scheme (`notifications:{user_id}`)
 /// does not cause cross-user interference at the session level.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ws_two_users_simultaneous_sessions(pool: PgPool) {
     let server = build_ws_test_server(pool).await;
     let user_a = Uuid::new_v4();
@@ -585,7 +579,6 @@ async fn ws_pubsub_fanout_delivers_to_correct_subscriber(pool: PgPool) {
 
 /// A completely malformed (non-JWT) token must be rejected with 401.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn ws_upgrade_with_garbage_token_returns_401(pool: PgPool) {
     let server = build_ws_test_server(pool).await;
 

--- a/backend/servers/reality-server/tests/buyer_inquiries_tests.rs
+++ b/backend/servers/reality-server/tests/buyer_inquiries_tests.rs
@@ -112,7 +112,6 @@ async fn seed_buyer_inquiry(
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn buyer_sees_only_own_inquiries(pool: PgPool) {
     let org = seed_org(&pool, "b1").await;
     let realtor = seed_user(&pool, "realtor-b1@buyer.test").await;
@@ -148,7 +147,6 @@ async fn buyer_sees_only_own_inquiries(pool: PgPool) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn other_buyers_inquiries_hidden(pool: PgPool) {
     let org = seed_org(&pool, "b2").await;
     let realtor = seed_user(&pool, "realtor-b2@buyer.test").await;
@@ -182,7 +180,6 @@ async fn other_buyers_inquiries_hidden(pool: PgPool) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pagination_total_is_full_count(pool: PgPool) {
     let org = seed_org(&pool, "b3").await;
     let realtor = seed_user(&pool, "realtor-b3@buyer.test").await;

--- a/backend/servers/reality-server/tests/favorite_alert_worker_tests.rs
+++ b/backend/servers/reality-server/tests/favorite_alert_worker_tests.rs
@@ -65,7 +65,6 @@ async fn seed_listing(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &str
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn worker_queues_price_and_back_on_market_alerts(pool: PgPool) {
     let repo = RealityPortalRepository::new(pool.clone());
     let worker = FavoriteAlertWorker::new(

--- a/backend/servers/reality-server/tests/favorites_authz_tests.rs
+++ b/backend/servers/reality-server/tests/favorites_authz_tests.rs
@@ -43,7 +43,6 @@ async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
 // ── list_favorites ──────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_favorites_unauthenticated_returns_401(pool: PgPool) {
     let app = favorites_router(pool);
     let status = send(&app, Method::GET, "/api/v1/favorites", None).await;
@@ -54,7 +53,6 @@ async fn list_favorites_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_favorites_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "list-fav").await;
     let token = mint_token(user);
@@ -69,7 +67,6 @@ async fn list_favorites_authenticated_returns_non_401(pool: PgPool) {
 // ── list_favorite_alerts ────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_favorite_alerts_unauthenticated_returns_401(pool: PgPool) {
     let app = favorites_router(pool);
     let status = send(&app, Method::GET, "/api/v1/favorites/alerts", None).await;
@@ -80,7 +77,6 @@ async fn list_favorite_alerts_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_favorite_alerts_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "list-fav-alerts").await;
     let token = mint_token(user);
@@ -95,7 +91,6 @@ async fn list_favorite_alerts_authenticated_returns_non_401(pool: PgPool) {
 // ── mark_all_favorite_alerts_read ──────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_all_favorite_alerts_read_unauthenticated_returns_401(pool: PgPool) {
     let app = favorites_router(pool);
     let status = send(
@@ -112,7 +107,6 @@ async fn mark_all_favorite_alerts_read_unauthenticated_returns_401(pool: PgPool)
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_all_favorite_alerts_read_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "mark-all-fav-alerts").await;
     let token = mint_token(user);
@@ -133,7 +127,6 @@ async fn mark_all_favorite_alerts_read_authenticated_returns_non_401(pool: PgPoo
 // ── mark_favorite_alert_read ────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_favorite_alert_read_unauthenticated_returns_401(pool: PgPool) {
     let alert_id = Uuid::new_v4();
     let app = favorites_router(pool);
@@ -151,7 +144,6 @@ async fn mark_favorite_alert_read_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_favorite_alert_read_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "mark-fav-alert").await;
     let token = mint_token(user);
@@ -173,7 +165,6 @@ async fn mark_favorite_alert_read_authenticated_unknown_returns_non_401(pool: Pg
 // ── list_favorite_ids (SSR-anonymous) ──────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_favorite_ids_unauthenticated_returns_200(pool: PgPool) {
     let app = favorites_router(pool);
     let status = send(&app, Method::GET, "/api/v1/favorites/ids", None).await;
@@ -184,7 +175,6 @@ async fn list_favorite_ids_unauthenticated_returns_200(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_favorite_ids_authenticated_returns_200(pool: PgPool) {
     let user = seed_user(&pool, "list-fav-ids").await;
     let token = mint_token(user);
@@ -199,7 +189,6 @@ async fn list_favorite_ids_authenticated_returns_200(pool: PgPool) {
 // ── add_favorite ────────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_favorite_unauthenticated_returns_401(pool: PgPool) {
     let listing_id = Uuid::new_v4();
     let app = favorites_router(pool);
@@ -214,7 +203,6 @@ async fn add_favorite_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_favorite_authenticated_unknown_listing_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "add-fav").await;
     let token = mint_token(user);
@@ -236,7 +224,6 @@ async fn add_favorite_authenticated_unknown_listing_returns_non_401(pool: PgPool
 // ── remove_favorite ─────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn remove_favorite_unauthenticated_returns_401(pool: PgPool) {
     let listing_id = Uuid::new_v4();
     let app = favorites_router(pool);
@@ -254,7 +241,6 @@ async fn remove_favorite_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn remove_favorite_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "remove-fav").await;
     let token = mint_token(user);
@@ -276,7 +262,6 @@ async fn remove_favorite_authenticated_unknown_returns_non_401(pool: PgPool) {
 // ── check_favorite ──────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn check_favorite_unauthenticated_returns_401(pool: PgPool) {
     let listing_id = Uuid::new_v4();
     let app = favorites_router(pool);
@@ -294,7 +279,6 @@ async fn check_favorite_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn check_favorite_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "check-fav").await;
     let token = mint_token(user);

--- a/backend/servers/reality-server/tests/imports_idor_tests.rs
+++ b/backend/servers/reality-server/tests/imports_idor_tests.rs
@@ -195,7 +195,6 @@ async fn seed_membership(pool: &PgPool, agency_id: Uuid, user_id: Uuid) {
 
 /// Cross-tenant probe: user B requests user A's job → 404.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn import_job_cross_user_returns_404(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "job-user-a").await;
     let user_b = seed_portal_user(&pool, "job-user-b").await;
@@ -222,7 +221,6 @@ async fn import_job_cross_user_returns_404(pool: PgPool) {
 
 /// Happy path: user A requests their own job → 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn import_job_owner_returns_200(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "job-owner-a").await;
     let job_id = seed_import_job(&pool, user_a).await;
@@ -254,7 +252,6 @@ async fn import_job_owner_returns_200(pool: PgPool) {
 /// `user_id`, so it gets 404 — not 200 — on another user's import job. There is
 /// no admin bypass at this layer.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn import_job_platform_kind_caller_is_still_user_scoped_404(pool: PgPool) {
     let owner = seed_portal_user(&pool, "job-plat-owner").await;
     let platform_caller = seed_portal_user_with_kind(&pool, "job-plat-admin", "platform").await;
@@ -281,7 +278,6 @@ async fn import_job_platform_kind_caller_is_still_user_scoped_404(pool: PgPool) 
 
 /// Unauthenticated request → 401.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn import_job_unauthenticated_returns_401(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "job-unauth-a").await;
     let job_id = seed_import_job(&pool, user_a).await;
@@ -309,7 +305,6 @@ async fn import_job_unauthenticated_returns_401(pool: PgPool) {
 /// feed created for agency A is readable by every active member of A — not just
 /// the user who happened to create it. Two distinct members both get 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn feed_is_shared_across_agency_members(pool: PgPool) {
     let agency_a = seed_agency(&pool, "feed-shared-a").await;
     let member_1 = seed_portal_user(&pool, "feed-member-1").await;
@@ -342,7 +337,6 @@ async fn feed_is_shared_across_agency_members(pool: PgPool) {
 /// feed — the handler resolves the caller's own agency, so the by-id lookup is
 /// scoped away → 404.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn feed_non_member_returns_404(pool: PgPool) {
     let agency_a = seed_agency(&pool, "feed-idor-a").await;
     let agency_b = seed_agency(&pool, "feed-idor-b").await;
@@ -372,7 +366,6 @@ async fn feed_non_member_returns_404(pool: PgPool) {
 /// A caller who is a member of no agency cannot own/list feeds → 403 (rather than
 /// silently operating on a bogus user-id-as-agency-id scope).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn feed_caller_without_agency_returns_403(pool: PgPool) {
     let orphan = seed_portal_user(&pool, "feed-orphan").await; // no membership
 

--- a/backend/servers/reality-server/tests/inquiries_authz_tests.rs
+++ b/backend/servers/reality-server/tests/inquiries_authz_tests.rs
@@ -43,7 +43,6 @@ async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
 // ── send_contact_message (public) ───────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn send_contact_message_unauthenticated_does_not_return_401(pool: PgPool) {
     let listing_id = Uuid::new_v4();
     let app = inquiries_router(pool);
@@ -68,7 +67,6 @@ async fn send_contact_message_unauthenticated_does_not_return_401(pool: PgPool) 
 // ── request_viewing (public) ────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn request_viewing_unauthenticated_does_not_return_401(pool: PgPool) {
     let listing_id = Uuid::new_v4();
     let app = inquiries_router(pool);
@@ -90,7 +88,6 @@ async fn request_viewing_unauthenticated_does_not_return_401(pool: PgPool) {
 // ── list_my_inquiries ───────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_my_inquiries_unauthenticated_returns_401(pool: PgPool) {
     let app = inquiries_router(pool);
     let status = send(&app, Method::GET, "/api/v1/inquiries", None).await;
@@ -101,7 +98,6 @@ async fn list_my_inquiries_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_my_inquiries_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "list-inq").await;
     let token = mint_token(user);
@@ -116,7 +112,6 @@ async fn list_my_inquiries_authenticated_returns_non_401(pool: PgPool) {
 // ── list_buyer_inquiries ────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_buyer_inquiries_unauthenticated_returns_401(pool: PgPool) {
     let app = inquiries_router(pool);
     let status = send(&app, Method::GET, "/api/v1/inquiries/mine", None).await;
@@ -127,7 +122,6 @@ async fn list_buyer_inquiries_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_buyer_inquiries_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "buyer-inq").await;
     let token = mint_token(user);
@@ -142,7 +136,6 @@ async fn list_buyer_inquiries_authenticated_returns_non_401(pool: PgPool) {
 // ── get_inquiry ─────────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_inquiry_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = inquiries_router(pool);
@@ -151,7 +144,6 @@ async fn get_inquiry_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_inquiry_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "get-inq").await;
     let token = mint_token(user);
@@ -170,7 +162,6 @@ async fn get_inquiry_authenticated_unknown_returns_non_401(pool: PgPool) {
 // ── mark_as_read ────────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_as_read_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = inquiries_router(pool);
@@ -185,7 +176,6 @@ async fn mark_as_read_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_as_read_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "mark-read").await;
     let token = mint_token(user);
@@ -207,7 +197,6 @@ async fn mark_as_read_authenticated_unknown_returns_non_401(pool: PgPool) {
 // ── respond_to_inquiry ──────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn respond_to_inquiry_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = inquiries_router(pool);
@@ -226,7 +215,6 @@ async fn respond_to_inquiry_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn respond_to_inquiry_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "respond-inq").await;
     let token = mint_token(user);

--- a/backend/servers/reality-server/tests/inquiry_idor_tests.rs
+++ b/backend/servers/reality-server/tests/inquiry_idor_tests.rs
@@ -149,7 +149,6 @@ async fn get_read_at(pool: &PgPool, inquiry_id: Uuid) -> Option<chrono::DateTime
 /// `realtor_id = b_id`, so the function short-circuits and returns `false`
 /// without touching the row.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn realtor_b_cannot_mark_realtor_a_inquiry_read(pool: PgPool) {
     let org = seed_org(&pool, "idor-c1").await;
     let realtor_a = seed_user(&pool, "realtor-a-c1@idor.test").await;
@@ -191,7 +190,6 @@ async fn realtor_b_cannot_mark_realtor_a_inquiry_read(pool: PgPool) {
 /// This is the happy-path: the legitimate owner can mark their own inquiry read.
 /// The handler maps `true` → HTTP 204.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn realtor_a_can_mark_own_inquiry_read(pool: PgPool) {
     let org = seed_org(&pool, "idor-c2").await;
     let realtor_a = seed_user(&pool, "realtor-a-c2@idor.test").await;
@@ -233,7 +231,6 @@ async fn realtor_a_can_mark_own_inquiry_read(pool: PgPool) {
 /// succeeds — the function must therefore return `true` (owned) rather than
 /// `false` (not-found/not-owned).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn idempotent_re_mark_returns_true(pool: PgPool) {
     let org = seed_org(&pool, "idor-c3").await;
     let realtor_a = seed_user(&pool, "realtor-a-c3@idor.test").await;

--- a/backend/servers/reality-server/tests/inquiry_pagination_tests.rs
+++ b/backend/servers/reality-server/tests/inquiry_pagination_tests.rs
@@ -114,7 +114,6 @@ async fn seed_inquiries(
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn count_returns_full_total_not_page_len(pool: PgPool) {
     let org = seed_org(&pool, "pag-c1").await;
     let realtor = seed_user(&pool, "realtor-c1@pag.test").await;
@@ -146,7 +145,6 @@ async fn count_returns_full_total_not_page_len(pool: PgPool) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn count_respects_status_filter(pool: PgPool) {
     let org = seed_org(&pool, "pag-c2").await;
     let realtor = seed_user(&pool, "realtor-c2@pag.test").await;

--- a/backend/servers/reality-server/tests/portal_listings_idor_tests.rs
+++ b/backend/servers/reality-server/tests/portal_listings_idor_tests.rs
@@ -166,7 +166,6 @@ fn patch_req(id: Uuid, token: &str, body: serde_json::Value) -> Request<Body> {
 
 /// User B `GET`-ing user A's listing must return 404 (not 200, not 401).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_cross_user_returns_404(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "get-a").await;
     let user_b = seed_portal_user(&pool, "get-b").await;
@@ -183,7 +182,6 @@ async fn get_cross_user_returns_404(pool: PgPool) {
 
 /// User A reading their own listing → 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_owner_returns_200(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "get-own-a").await;
     let listing_id = seed_listing(&pool, user_a).await;
@@ -200,7 +198,6 @@ async fn get_owner_returns_200(pool: PgPool) {
 /// User B `PATCH`-ing user A's listing must return 404 (the SECURITY DEFINER
 /// update matches 0 rows → `fetch_optional` is `None` → handler maps to 404).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn patch_cross_user_returns_404(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "patch-a").await;
     let user_b = seed_portal_user(&pool, "patch-b").await;
@@ -229,7 +226,6 @@ async fn patch_cross_user_returns_404(pool: PgPool) {
 
 /// User A patching their own listing with valid data → 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn patch_owner_returns_200(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "patch-own-a").await;
     let listing_id = seed_listing(&pool, user_a).await;
@@ -246,7 +242,6 @@ async fn patch_owner_returns_200(pool: PgPool) {
 
 /// Unauthenticated GET → 401.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_unauthenticated_returns_401(pool: PgPool) {
     let user_a = seed_portal_user(&pool, "unauth-a").await;
     let listing_id = seed_listing(&pool, user_a).await;
@@ -271,7 +266,6 @@ async fn get_unauthenticated_returns_401(pool: PgPool) {
 
 /// Create with an unknown `propertyType` → 400.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_invalid_property_type_returns_400(pool: PgPool) {
     let user = seed_portal_user(&pool, "cv-pt").await;
     let app = listings_router(pool);
@@ -299,7 +293,6 @@ async fn create_invalid_property_type_returns_400(pool: PgPool) {
 
 /// Create with an unknown `transactionType` → 400.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_invalid_transaction_type_returns_400(pool: PgPool) {
     let user = seed_portal_user(&pool, "cv-tt").await;
     let app = listings_router(pool);
@@ -327,7 +320,6 @@ async fn create_invalid_transaction_type_returns_400(pool: PgPool) {
 
 /// Create with an unknown `currency` → 400.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_invalid_currency_returns_400(pool: PgPool) {
     let user = seed_portal_user(&pool, "cv-cur").await;
     let app = listings_router(pool);
@@ -357,7 +349,6 @@ async fn create_invalid_currency_returns_400(pool: PgPool) {
 /// Owner attempting the privileged transition `status = active` (publicly
 /// visible) must be rejected with 400 — publishing is moderation-only.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn patch_status_active_is_rejected_400(pool: PgPool) {
     let user = seed_portal_user(&pool, "ps-active").await;
     let listing_id = seed_listing(&pool, user).await;
@@ -385,7 +376,6 @@ async fn patch_status_active_is_rejected_400(pool: PgPool) {
 
 /// An entirely unknown `status` value → 400.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn patch_unknown_status_is_rejected_400(pool: PgPool) {
     let user = seed_portal_user(&pool, "ps-unknown").await;
     let listing_id = seed_listing(&pool, user).await;
@@ -402,7 +392,6 @@ async fn patch_unknown_status_is_rejected_400(pool: PgPool) {
 
 /// A permitted owner lifecycle status (`paused`) → 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn patch_status_paused_is_accepted_200(pool: PgPool) {
     let user = seed_portal_user(&pool, "ps-paused").await;
     let listing_id = seed_listing(&pool, user).await;

--- a/backend/servers/reality-server/tests/raw_pool_audit_tests.rs
+++ b/backend/servers/reality-server/tests/raw_pool_audit_tests.rs
@@ -120,7 +120,6 @@ fn get_req_unknown_host(uri: &str, host: &str) -> Request<Body> {
 /// `DbPool` and bypass the middleware entirely, a similar request would return
 /// 200 with data from *all* tenants — a cross-tenant data leak.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn listing_route_without_host_header_is_rejected(pool: PgPool) {
     let app = build_test_router(pool);
 
@@ -151,7 +150,6 @@ async fn listing_route_without_host_header_is_rejected(pool: PgPool) {
 /// attacker supplies an arbitrary Host value hoping to fall through to global
 /// data.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn listing_route_with_unknown_host_is_rejected(pool: PgPool) {
     let app = build_test_router(pool);
 
@@ -178,7 +176,6 @@ async fn listing_route_with_unknown_host_is_rejected(pool: PgPool) {
 /// without a resolved tenant the request must be rejected, not silently served
 /// with cross-tenant data.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn listing_search_without_host_is_rejected(pool: PgPool) {
     let app = build_test_router(pool);
 
@@ -204,7 +201,6 @@ async fn listing_search_without_host_is_rejected(pool: PgPool) {
 /// `Host: localhost`. The middleware resolves this to `TenantSource::PlatformHost`
 /// and lets it through; the stub handler returns 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn listing_route_reachable_with_platform_host(pool: PgPool) {
     // Build a router where "localhost" is a known platform host.
     let cfg = HostTenantConfig::with_parts(

--- a/backend/servers/reality-server/tests/saved_searches_authz_tests.rs
+++ b/backend/servers/reality-server/tests/saved_searches_authz_tests.rs
@@ -41,7 +41,6 @@ async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
 // ── list_saved_searches ─────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_saved_searches_unauthenticated_returns_401(pool: PgPool) {
     let app = saved_searches_router(pool);
     let status = send(&app, Method::GET, "/api/v1/saved-searches", None).await;
@@ -52,7 +51,6 @@ async fn list_saved_searches_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_saved_searches_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "list-ss").await;
     let token = mint_token(user);
@@ -67,7 +65,6 @@ async fn list_saved_searches_authenticated_returns_non_401(pool: PgPool) {
 // ── create_saved_search ─────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_saved_search_unauthenticated_returns_401(pool: PgPool) {
     let app = saved_searches_router(pool);
     let status = send_json(
@@ -85,7 +82,6 @@ async fn create_saved_search_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_saved_search_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "create-ss").await;
     let token = mint_token(user);
@@ -107,7 +103,6 @@ async fn create_saved_search_authenticated_returns_non_401(pool: PgPool) {
 // ── list_search_alerts ──────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_search_alerts_unauthenticated_returns_401(pool: PgPool) {
     let app = saved_searches_router(pool);
     let status = send(&app, Method::GET, "/api/v1/saved-searches/alerts", None).await;
@@ -118,7 +113,6 @@ async fn list_search_alerts_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_search_alerts_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "list-alerts").await;
     let token = mint_token(user);
@@ -139,7 +133,6 @@ async fn list_search_alerts_authenticated_returns_non_401(pool: PgPool) {
 // ── mark_all_alerts_read ────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_all_alerts_read_unauthenticated_returns_401(pool: PgPool) {
     let app = saved_searches_router(pool);
     let status = send(
@@ -156,7 +149,6 @@ async fn mark_all_alerts_read_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_all_alerts_read_authenticated_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "mark-all-alerts").await;
     let token = mint_token(user);
@@ -177,7 +169,6 @@ async fn mark_all_alerts_read_authenticated_returns_non_401(pool: PgPool) {
 // ── mark_alert_read ─────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_alert_read_unauthenticated_returns_401(pool: PgPool) {
     let alert_id = Uuid::new_v4();
     let app = saved_searches_router(pool);
@@ -195,7 +186,6 @@ async fn mark_alert_read_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_alert_read_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "mark-alert").await;
     let token = mint_token(user);
@@ -217,7 +207,6 @@ async fn mark_alert_read_authenticated_unknown_returns_non_401(pool: PgPool) {
 // ── get_saved_search ────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_saved_search_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = saved_searches_router(pool);
@@ -235,7 +224,6 @@ async fn get_saved_search_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_saved_search_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "get-ss").await;
     let token = mint_token(user);
@@ -257,7 +245,6 @@ async fn get_saved_search_authenticated_unknown_returns_non_401(pool: PgPool) {
 // ── update_saved_search ─────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_saved_search_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = saved_searches_router(pool);
@@ -276,7 +263,6 @@ async fn update_saved_search_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_saved_search_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "update-ss").await;
     let token = mint_token(user);
@@ -299,7 +285,6 @@ async fn update_saved_search_authenticated_unknown_returns_non_401(pool: PgPool)
 // ── delete_saved_search ─────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_saved_search_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = saved_searches_router(pool);
@@ -317,7 +302,6 @@ async fn delete_saved_search_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_saved_search_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "delete-ss").await;
     let token = mint_token(user);
@@ -339,7 +323,6 @@ async fn delete_saved_search_authenticated_unknown_returns_non_401(pool: PgPool)
 // ── run_saved_search ────────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn run_saved_search_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = saved_searches_router(pool);
@@ -357,7 +340,6 @@ async fn run_saved_search_unauthenticated_returns_401(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn run_saved_search_authenticated_unknown_returns_non_401(pool: PgPool) {
     let user = seed_user(&pool, "run-ss").await;
     let token = mint_token(user);

--- a/backend/servers/reality-server/tests/search_alert_drainer_tests.rs
+++ b/backend/servers/reality-server/tests/search_alert_drainer_tests.rs
@@ -169,7 +169,6 @@ fn worker(pool: &PgPool, email: RecordingEmail, push: RecordingPush) -> SearchAl
 /// C1–C4: happy path — email once, push to each owner token, `notified_at` set,
 /// `status` untouched, idempotent re-run, and a foreign user's token untouched.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn drains_alert_to_email_and_owner_push_tokens(pool: PgPool) {
     let repo = RealityPortalRepository::new(pool.clone());
 
@@ -245,7 +244,6 @@ async fn drains_alert_to_email_and_owner_push_tokens(pool: PgPool) {
 /// Failure path: when every channel fails, the row is not marked notified, its
 /// attempt counter climbs, and it drops out once it exhausts the budget.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn failed_delivery_increments_attempts_until_budget_exhausted(pool: PgPool) {
     let repo = RealityPortalRepository::new(pool.clone());
     let owner = seed_portal_user(&pool, "fail@test.sk").await;


### PR DESCRIPTION
## Summary

Optimistic bulk re-enablement of all remaining `#[ignore = "BIT-351 ..."]` annotations — 718 tests across 146 files (api-server, reality-server, db crates).

**Strategy:** strip all quarantine annotations, let CI flag any still-failing tests, re-quarantine only confirmed failures in a follow-up PR.

Batch 1 (PR #1957) already landed 4 hand-repaired files. This PR covers everything else.

## Test plan

- [ ] `check` gate passes (fmt + clippy)
- [ ] `test` gate passes — any failures get diagnosed and re-quarantined in a follow-up PR

Related: BIT-360, BIT-354, BIT-355