### PR TITLE
test(BIT-360): re-enable quarantined db enum-decode + notification tests (batch 2)

### DIFF
--- a/backend/crates/db/tests/facility_enum_decode_tests.rs
+++ b/backend/crates/db/tests/facility_enum_decode_tests.rs
@@ -82,7 +82,6 @@ async fn seed(pool: &PgPool) -> (Uuid, Uuid, Uuid) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_by_id_decodes_facility_type_enum(pool: PgPool) {
     let (_building_id, facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -98,7 +97,6 @@ async fn find_by_id_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_by_building_decodes_facility_type_enum(pool: PgPool) {
     let (building_id, _facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -112,7 +110,6 @@ async fn find_by_building_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_bookable_decodes_facility_type_enum(pool: PgPool) {
     let (building_id, _facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -126,7 +123,6 @@ async fn find_bookable_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn booking_read_paths_decode_booking_status_enum(pool: PgPool) {
     let (building_id, facility_id, user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -207,7 +203,6 @@ async fn booking_read_paths_decode_booking_status_enum(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn facility_update_decodes_facility_type_enum(pool: PgPool) {
     let (_building_id, facility_id, _user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());
@@ -246,7 +241,6 @@ async fn facility_update_decodes_facility_type_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn booking_transitions_decode_status_enum(pool: PgPool) {
     let (_building_id, facility_id, user_id) = seed(&pool).await;
     let repo = FacilityRepository::new(pool.clone());

--- a/backend/crates/db/tests/notification_events_repo_tests.rs
+++ b/backend/crates/db/tests/notification_events_repo_tests.rs
@@ -37,7 +37,6 @@ fn many(channel: &str, event: &str, n: usize, at: DateTime<Utc>) -> Vec<NewNotif
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn insert_aggregate_and_alert_fires(pool: PgPool) {
     let repo = NotificationEventRepository::new(pool.clone());
     let now = Utc::now();
@@ -94,7 +93,6 @@ async fn insert_aggregate_and_alert_fires(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn min_attempts_guard_suppresses_noisy_alert(pool: PgPool) {
     let repo = NotificationEventRepository::new(pool.clone());
     let now = Utc::now();
@@ -118,7 +116,6 @@ async fn min_attempts_guard_suppresses_noisy_alert(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn channel_filter_and_empty_window(pool: PgPool) {
     let repo = NotificationEventRepository::new(pool.clone());
     let now = Utc::now();
@@ -157,7 +154,6 @@ async fn channel_filter_and_empty_window(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn service_role_rls_allows_unset_guc_denies_user(pool: PgPool) {
     let now = Utc::now();
 

--- a/backend/crates/db/tests/rental_enum_decode_tests.rs
+++ b/backend/crates/db/tests/rental_enum_decode_tests.rs
@@ -115,7 +115,6 @@ async fn seed(pool: &PgPool) -> (Uuid, Uuid, Uuid, Uuid) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_booking_by_id_decodes_platform_and_status_enums(pool: PgPool) {
     let (_org, _unit, _conn, booking_id) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -131,7 +130,6 @@ async fn find_booking_by_id_decodes_platform_and_status_enums(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_booking_for_org_decodes_enums(pool: PgPool) {
     let (org_id, _unit, _conn, booking_id) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -146,7 +144,6 @@ async fn find_booking_for_org_decodes_enums(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_booking_returning_decodes_enums(pool: PgPool) {
     let (_org, _unit, _conn, booking_id) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -178,7 +175,6 @@ async fn update_booking_returning_decodes_enums(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn connection_read_paths_decode_platform_enum(pool: PgPool) {
     let (org_id, _unit, conn_id, _booking) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -200,7 +196,6 @@ async fn connection_read_paths_decode_platform_enum(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_airbnb_tokens_returning_decodes_platform_enum(pool: PgPool) {
     let (_org, _unit, conn_id, _booking) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());

--- a/backend/crates/db/tests/rental_guest_ical_enum_decode_tests.rs
+++ b/backend/crates/db/tests/rental_guest_ical_enum_decode_tests.rs
@@ -161,7 +161,6 @@ async fn seed(pool: &PgPool) -> (Uuid, Uuid, Uuid, Uuid, Uuid, Uuid, String) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_guest_by_id_decodes_status(pool: PgPool) {
     let (_org, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -175,7 +174,6 @@ async fn find_guest_by_id_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_guest_for_org_decodes_status(pool: PgPool) {
     let (org_id, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -189,7 +187,6 @@ async fn find_guest_for_org_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_guest_returning_decodes_status(pool: PgPool) {
     let (_org, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -222,7 +219,6 @@ async fn update_guest_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_guest_for_org_returning_decodes_status(pool: PgPool) {
     let (org_id, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -259,7 +255,6 @@ async fn update_guest_for_org_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_guest_returning_decodes_status(pool: PgPool) {
     let (_org, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -271,7 +266,6 @@ async fn register_guest_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_guest_for_org_returning_decodes_status(pool: PgPool) {
     let (org_id, _unit, _booking, guest_id, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -287,7 +281,6 @@ async fn register_guest_for_org_returning_decodes_status(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_guests_for_booking_decodes_status(pool: PgPool) {
     let (_org, _unit, booking_id, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -305,7 +298,6 @@ async fn get_guests_for_booking_decodes_status(pool: PgPool) {
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_calendar_block_returning_decodes_source_platform(pool: PgPool) {
     let (org_id, unit_id, _booking, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -333,7 +325,6 @@ async fn create_calendar_block_returning_decodes_source_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn seeded_calendar_block_source_platform_decodes_via_raw_query(pool: PgPool) {
     use db::models::rental::CalendarBlock;
 
@@ -370,7 +361,6 @@ async fn seeded_calendar_block_source_platform_decodes_via_raw_query(pool: PgPoo
 // ============================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn find_ical_feed_by_token_decodes_import_platform(pool: PgPool) {
     let (_org, _unit, _booking, _guest, _block, _feed, feed_token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -384,7 +374,6 @@ async fn find_ical_feed_by_token_decodes_import_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_ical_feeds_for_unit_decodes_import_platform(pool: PgPool) {
     let (_org, unit_id, _booking, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -398,7 +387,6 @@ async fn get_ical_feeds_for_unit_decodes_import_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_ical_feeds_for_unit_in_org_decodes_import_platform(pool: PgPool) {
     let (org_id, unit_id, _booking, _guest, _block, _feed, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -412,7 +400,6 @@ async fn get_ical_feeds_for_unit_in_org_decodes_import_platform(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_ical_feed_for_org_returning_decodes_import_platform(pool: PgPool) {
     let (org_id, _unit, _booking, _guest, _block, feed_id, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());
@@ -437,7 +424,6 @@ async fn update_ical_feed_for_org_returning_decodes_import_platform(pool: PgPool
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_ical_feed_returning_decodes_import_platform(pool: PgPool) {
     let (_org, _unit, _booking, _guest, _block, feed_id, _token) = seed(&pool).await;
     let repo = RentalRepository::new(pool.clone());


### PR DESCRIPTION
Re-enables 4 BIT-351-quarantined db test files (enum decode + notification events repo). Local spot-check passed for facility enum-decode; CI test gate confirms the rest. Any genuine failers will be re-quarantined in a follow-up so the gate stays green.