### PR TITLE
docs(reality-server): correct migration number 00194 → 00195 in drainer comments

### DIFF
--- a/backend/crates/db/src/models/reality_portal.rs
+++ b/backend/crates/db/src/models/reality_portal.rs
@@ -148,7 +148,7 @@ pub struct SavedSearchAlert {
 /// a notification without a second round-trip.
 ///
 /// Delivery here is tracked by `search_alert_queue.notified_at` /
-/// `notify_attempts` (migration 00194), independently of the `status` column,
+/// `notify_attempts` (migration 00195), independently of the `status` column,
 /// which belongs to the in-app pull/read channel ([`SavedSearchAlert`]).
 #[derive(Debug, Clone, FromRow)]
 pub struct UndeliveredSearchAlert {

--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -271,7 +271,7 @@ impl RealityPortalRepository {
     // Saved-search alert transport drainer (BIT-139, Epic 16).
     //
     // The email/push drainer delivers alerts out-of-band and tracks its own
-    // progress via `notified_at` / `notify_attempts` (migration 00194), kept
+    // progress via `notified_at` / `notify_attempts` (migration 00195), kept
     // separate from the `status` column owned by the in-app read channel above.
     // It runs service-role (no `app.current_user_id`); `search_alert_queue`,
     // `portal_saved_searches`, and `users` are not RLS-gated, so it sees every

--- a/backend/servers/reality-server/src/services/search_alert_drainer.rs
+++ b/backend/servers/reality-server/src/services/search_alert_drainer.rs
@@ -9,7 +9,7 @@
 //! This background worker drains the same queue out-of-band: for each alert it
 //! has not yet delivered it dispatches an email to the owning user and a push
 //! notification to each of their registered devices (`device_push_tokens`), then
-//! records delivery in `notified_at` (migration 00194). That column is tracked
+//! records delivery in `notified_at` (migration 00195). That column is tracked
 //! independently of `status` — which belongs to the in-app read channel — so the
 //! drainer never re-sends on every poll and never clobbers the unread badge.
 //!


### PR DESCRIPTION
## Summary
Three doc comments attribute the `notified_at` / `notify_attempts` columns to migration `00194`, but those columns are actually added by `00195_search_alert_queue_transport_dispatch.sql`. `00194_favorite_alert_queue.sql` is the unrelated favorites-path table. A maintainer tracing the column source from these comments lands on the wrong migration.

Verified: `grep` confirms only `00195` adds `notify_attempts` to `search_alert_queue`.

Pure comment change, no behavior impact.

Fixes:
- `backend/servers/reality-server/src/services/search_alert_drainer.rs:12`
- `backend/crates/db/src/models/reality_portal.rs:151`
- `backend/crates/db/src/repositories/reality_portal.rs:274`

Closes #1854