### PR TITLE
fix(api-server): remove duplicate #[ignore] left by BIT-440 quarantine (unblocks dev test gate)

### DIFF
--- a/backend/servers/api-server/tests/community_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/community_happy_path_tests.rs
@@ -108,7 +108,6 @@ fn id_of(v: &Value) -> Uuid {
         .unwrap_or_else(|| panic!("expected id field in {v}"))
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn community_groups_posts_happy_path(pool: PgPool) {
@@ -186,7 +185,6 @@ async fn community_groups_posts_happy_path(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn community_events_happy_path(pool: PgPool) {
@@ -221,7 +219,6 @@ async fn community_events_happy_path(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn community_marketplace_happy_path(pool: PgPool) {

--- a/backend/servers/api-server/tests/disputes_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/disputes_happy_path_tests.rs
@@ -151,7 +151,6 @@ fn id_of(v: &Value) -> Uuid {
 // Filing, listing, parties, evidence, submissions, resolutions, status
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn dispute_lifecycle_happy_path(pool: PgPool) {
@@ -352,7 +351,6 @@ async fn dispute_lifecycle_happy_path(pool: PgPool) {
 // Action items + escalations + my/overdue dashboards
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn dispute_actions_escalations_happy_path(pool: PgPool) {
@@ -460,7 +458,6 @@ async fn dispute_actions_escalations_happy_path(pool: PgPool) {
 // Mediation sessions
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn dispute_sessions_happy_path(pool: PgPool) {
@@ -555,7 +552,6 @@ async fn dispute_sessions_happy_path(pool: PgPool) {
 // Withdraw (separate dispute so it doesn't collide with the lifecycle one)
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn dispute_withdraw_happy_path(pool: PgPool) {

--- a/backend/servers/api-server/tests/documents_forms_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/documents_forms_happy_path_tests.rs
@@ -489,7 +489,6 @@ async fn list_submissions_succeeds(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn get_submission_succeeds(pool: PgPool) {
@@ -514,7 +513,6 @@ async fn get_submission_succeeds(pool: PgPool) {
     res.assert_json_field("submission");
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn review_submission_succeeds(pool: PgPool) {

--- a/backend/servers/api-server/tests/faults_workflow_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/faults_workflow_happy_path_tests.rs
@@ -134,7 +134,6 @@ async fn add_attachment(app: &TestApp, token: &str, org_id: Uuid, fault_id: Uuid
 // Tests
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_list_faults_returns_created_fault(pool: PgPool) {
@@ -166,7 +165,6 @@ async fn test_list_faults_returns_created_fault(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_triage_new_fault(pool: PgPool) {
@@ -192,7 +190,6 @@ async fn test_triage_new_fault(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_assign_fault_to_self(pool: PgPool) {
@@ -218,7 +215,6 @@ async fn test_assign_fault_to_self(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_list_attachments_empty(pool: PgPool) {
@@ -246,7 +242,6 @@ async fn test_list_attachments_empty(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_add_attachment(pool: PgPool) {
@@ -274,7 +269,6 @@ async fn test_add_attachment(pool: PgPool) {
     assert!(found, "added attachment should appear in the list");
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_delete_attachment(pool: PgPool) {
@@ -302,7 +296,6 @@ async fn test_delete_attachment(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_get_ai_suggestion(pool: PgPool) {

--- a/backend/servers/api-server/tests/messaging_attachments_authz_tests.rs
+++ b/backend/servers/api-server/tests/messaging_attachments_authz_tests.rs
@@ -125,7 +125,6 @@ async fn link_then_list_attachment(pool: PgPool) {
 }
 
 /// Only the message sender may attach a file to it — another participant cannot.
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn non_sender_cannot_link_attachment(pool: PgPool) {
@@ -196,7 +195,6 @@ async fn non_participant_cannot_list_attachments(pool: PgPool) {
 /// Download authz: a participant passes the authz gate (reaching the storage
 /// layer — 503 in the no-S3 harness), while a non-participant in the SAME org
 /// and a user from a DIFFERENT org are both denied before any storage call.
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn download_url_authz_gate(pool: PgPool) {

--- a/backend/servers/api-server/tests/package_visitor_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/package_visitor_happy_path_tests.rs
@@ -202,7 +202,6 @@ fn nested_id(v: &Value, key: &str) -> Uuid {
 // Packages
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn packages_happy_path(pool: PgPool) {
@@ -273,7 +272,6 @@ async fn packages_happy_path(pool: PgPool) {
 // Visitors
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn visitors_happy_path(pool: PgPool) {

--- a/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
+++ b/backend/servers/api-server/tests/rentals_core_backfill_batch2_tests.rs
@@ -196,7 +196,6 @@ fn mint_manager_jwt(user_id: Uuid, org_id: Uuid) -> String {
 // Connections
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_rental_statistics_returns_200(pool: PgPool) {
@@ -255,7 +254,6 @@ async fn test_rental_sync_status_returns_200(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_list_connections_returns_200(pool: PgPool) {
@@ -285,7 +283,6 @@ async fn test_list_connections_returns_200(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_create_connection_returns_201(pool: PgPool) {
@@ -425,7 +422,6 @@ async fn test_get_unit_connections_returns_200(pool: PgPool) {
 // Bookings
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_list_bookings_returns_200(pool: PgPool) {
@@ -455,7 +451,6 @@ async fn test_list_bookings_returns_200(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_create_booking_returns_201(pool: PgPool) {
@@ -701,7 +696,6 @@ async fn test_check_availability_returns_200(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_create_calendar_block_returns_201(pool: PgPool) {
@@ -777,7 +771,6 @@ async fn test_delete_calendar_block_returns_204(pool: PgPool) {
 // Guests
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_create_guest_returns_201(pool: PgPool) {
@@ -957,7 +950,6 @@ async fn test_register_guest_returns_200(pool: PgPool) {
 // Check-in reminders
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_get_checkin_reminders_returns_200(pool: PgPool) {
@@ -1057,7 +1049,6 @@ async fn test_generate_report_preview_returns_200(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_create_report_returns_201(pool: PgPool) {
@@ -1097,7 +1088,6 @@ async fn test_create_report_returns_201(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_get_report_returns_200(pool: PgPool) {
@@ -1129,7 +1119,6 @@ async fn test_get_report_returns_200(pool: PgPool) {
     );
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_submit_report_returns_200(pool: PgPool) {
@@ -1166,7 +1155,6 @@ async fn test_submit_report_returns_200(pool: PgPool) {
 // iCal feeds
 // ---------------------------------------------------------------------------
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn test_create_ical_feed_returns_201(pool: PgPool) {

--- a/backend/servers/reality-server/tests/listings_happy_path_tests.rs
+++ b/backend/servers/reality-server/tests/listings_happy_path_tests.rs
@@ -92,7 +92,6 @@ async fn search_returns_2xx_on_empty_db(pool: PgPool) {
     assert!(status.is_success(), "expected 2xx, got {status}");
 }
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn search_returns_2xx_with_seeded_listing(pool: PgPool) {
@@ -134,7 +133,6 @@ async fn get_suggestions_returns_2xx(pool: PgPool) {
 
 // ── get_listing (GET /{id}) ──────────────────────────────────────────────────
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn get_listing_returns_2xx_for_active(pool: PgPool) {

--- a/backend/servers/reality-server/tests/users_happy_path_tests.rs
+++ b/backend/servers/reality-server/tests/users_happy_path_tests.rs
@@ -82,7 +82,6 @@ async fn request_password_reset_returns_2xx(pool: PgPool) {
 
 // ── get_me (GET /me) ─────────────────────────────────────────────────────────
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn get_me_returns_2xx(pool: PgPool) {
@@ -95,7 +94,6 @@ async fn get_me_returns_2xx(pool: PgPool) {
 
 // ── update_me (PUT /me) ──────────────────────────────────────────────────────
 
-#[ignore]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
 async fn update_me_returns_2xx(pool: PgPool) {


### PR DESCRIPTION
## Why
#1984 (BIT-440) quarantined 9 dev-hostage suites by adding `#[ignore = "BIT-440…"]`, but many of those test fns already carried a bare `#[ignore]`. Two `#[ignore]` attributes on one item ⇒ `error: unused attribute` under `-D warnings` ⇒ test targets fail to **compile** ⇒ dev `test` gate stays RED. The workspace-hostage that strands every backend PR was therefore **not** actually resolved by #1984.

Latest dev push-event `test` job (run 28421730513) failed to compile `rentals_core_backfill_batch2_tests` with 12 duplicate-attribute errors; 8 other suites carry the same pattern (36 sites / 9 files total).

## What
Drop the redundant bare `#[ignore]`, keeping the descriptive `#[ignore = "BIT-440…"]` so the tests remain quarantined. Pure deletion: 36 `-#[ignore]` lines, no additions, no behaviour change.

## Verify
- `check` (fmt+clippy) unaffected — only attribute lines removed.
- `test` should now compile + pass (quarantined tests stay ignored).

Found by the BIT-463 stale-PR guard: every open backend PR's `test` was red because dev itself doesn't compile its test targets. This is the true stranding cause.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)