### PR TITLE
perf(db): partial index + cross-org docs for payment-reminder sweeps

### DIFF
--- a/backend/crates/db/migrations/00209_invoices_due_status_partial_index.sql
+++ b/backend/crates/db/migrations/00209_invoices_due_status_partial_index.sql
@@ -1,0 +1,21 @@
+-- Migration: 00209_invoices_due_status_partial_index
+-- Partial composite index for the payment-reminder + overdue-transition sweeps
+-- (#1769 finding-5 / #1790 finding-4).
+--
+-- Both scheduler helpers in FinancialRepository filter on the same shape:
+--   find_invoices_due_for_reminder:  status IN ('sent','partial')
+--                                    AND due_date BETWEEN CURRENT_DATE .. +N
+--                                    AND balance_due > 0
+--   transition_invoices_to_overdue:  status IN ('sent','partial')
+--                                    AND due_date < CURRENT_DATE - N
+--                                    AND balance_due > 0
+--
+-- Only the single-column idx_invoices_status / idx_invoices_due_date existed
+-- (migration 00040), so these run as a status-or-date scan that grows with the
+-- whole invoices table. A partial composite index keyed on (due_date, status)
+-- and filtered to the open-balance rows the sweeps care about matches the hot
+-- predicate directly. Mirrors the existing partial-index precedent on the
+-- sibling invoice tables (idx_sub_invoices_due, idx_vendor_invoices_due_date).
+CREATE INDEX IF NOT EXISTS idx_invoices_due_status
+    ON invoices (due_date, status)
+    WHERE balance_due > 0;

--- a/backend/crates/db/src/repositories/financial.rs
+++ b/backend/crates/db/src/repositories/financial.rs
@@ -1555,6 +1555,17 @@ impl FinancialRepository {
     /// `days` days, across all organizations. Used by the scheduler reminder
     /// tick.
     ///
+    /// **Cross-org by design (#1769 finding-4 / #1790 finding-4):** this runs on
+    /// the raw `self.pool` with no `organization_id` predicate and no
+    /// `app.current_organization_id` GUC — a deliberate system-level sweep, since
+    /// the background scheduler has no single tenant context. The scheduler pool
+    /// is the FORCE-RLS-exempt path, so this returns every tenant's due invoices
+    /// rather than silently empty. No cross-tenant leak results: the caller fans
+    /// notifications out strictly by each invoice's own `unit_id`
+    /// (`unit_residents`), never by a client-supplied org. The
+    /// `(due_date, status) WHERE balance_due > 0` partial index (migration 00209)
+    /// backs the hot predicate.
+    ///
     /// The due/overdue boundary is computed with SQL `CURRENT_DATE`
     /// (`make_interval`) rather than `Utc::now()` in Rust so it agrees with the
     /// `update_invoice_payment_status` trigger (migration 00040), which also
@@ -1602,6 +1613,13 @@ impl FinancialRepository {
     /// status `overdue`. Returns the transitioned invoices so callers can
     /// fire escalation notifications. Safe to call repeatedly (idempotent on
     /// already-overdue rows).
+    ///
+    /// Like [`find_invoices_due_for_reminder`], this is a deliberate
+    /// **cross-org** sweep on the raw `self.pool` (no `organization_id` filter,
+    /// RLS-exempt scheduler path); the single `UPDATE ... RETURNING` is atomic
+    /// and self-idempotent (a flipped row leaves the `status IN ('sent','partial')`
+    /// predicate). Backed by the `(due_date, status) WHERE balance_due > 0`
+    /// partial index (migration 00209).
     pub async fn transition_invoices_to_overdue(
         &self,
         grace_period_days: i64,
@@ -1627,55 +1645,11 @@ impl FinancialRepository {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use chrono::{Duration, Utc};
-
-    /// Verify the reminder window predicate: invoices due strictly after today
-    /// and on or before today + N days qualify for a reminder.
-    #[test]
-    fn test_reminder_window_predicate() {
-        let today = Utc::now().date_naive();
-        let days_before = 7i64;
-        let cutoff = today + Duration::days(days_before);
-
-        // The reminder window predicate: due strictly after today, on or before cutoff.
-        let in_reminder_window = |due| due > today && due <= cutoff;
-
-        // Due tomorrow — inside window.
-        assert!(in_reminder_window(today + Duration::days(1)));
-
-        // Due exactly at cutoff — inside window.
-        assert!(in_reminder_window(cutoff));
-
-        // Due today — excluded (already due, not upcoming).
-        assert!(!in_reminder_window(today));
-
-        // Due 8 days out — outside window.
-        assert!(!in_reminder_window(today + Duration::days(8)));
-    }
-
-    /// Verify the overdue grace-period predicate: invoices with due_date
-    /// strictly before today - grace_period_days should be transitioned.
-    #[test]
-    fn test_overdue_grace_period_predicate() {
-        let today = Utc::now().date_naive();
-
-        // The overdue predicate: due strictly before the grace cutoff transitions.
-        let is_overdue = |due, grace_cutoff| due < grace_cutoff;
-
-        // Grace period = 0: any invoice past due (due_date < today) transitions.
-        let grace_cutoff_0 = today - Duration::days(0);
-        assert!(is_overdue(today - Duration::days(1), grace_cutoff_0));
-
-        // Due today is NOT included (strict less-than).
-        assert!(!is_overdue(today, grace_cutoff_0));
-
-        // Grace period = 3: invoice overdue by 2 days stays pending.
-        let grace_cutoff_3 = today - Duration::days(3);
-        assert!(!is_overdue(today - Duration::days(2), grace_cutoff_3));
-
-        // Invoice overdue by 4 days transitions.
-        assert!(is_overdue(today - Duration::days(4), grace_cutoff_3));
-    }
-}
+// Behavioural coverage for the scheduler reminder/overdue helpers lives in the
+// DB-backed `backend/crates/db/tests/payment_reminder_dedup_tests.rs`
+// (`#[sqlx::test]`): it seeds boundary-date invoices and runs the real repo
+// methods — no-double-send after `mark_payment_reminder_sent`, `partial`
+// invoices reminded, and both `CURRENT_DATE` boundaries. The earlier in-module
+// unit tests were removed (#1769 finding-3 / #1790 finding-5): they re-derived
+// the date inequality as local closures and asserted on those, so they passed
+// regardless of the shipped SQL and gave false confidence.


### PR DESCRIPTION
Closes **#1769** and **#1790** (same PR #1709, overlapping findings).

## Already resolved on `dev` (verified)
The HIGH dedup finding and the medium correctness findings have already landed:
- **Persistent dedup** — `invoices.last_payment_reminder_at` (migration **00206**), the 24h `last_payment_reminder_at` filter in `find_invoices_due_for_reminder`, `mark_payment_reminder_sent`, and the scheduler's stamp-after-send (`scheduler.rs:1219`). No more every-tick re-spam.
- **`partial` invoices included** in reminders (`status IN ('sent','partial')`).
- **`CURRENT_DATE` boundaries** in both helpers (matches the 00040 trigger; no UTC/TZ drift).
- **Real DB tests** — `payment_reminder_dedup_tests.rs` (no-double-send, partial, both boundaries) — all 4 green.

## This PR — the remaining LOW findings
- **Migration 00209**: partial composite index `idx_invoices_due_status` on `invoices (due_date, status)` filtered to `WHERE balance_due > 0` — backs the exact `status + due_date + balance_due` predicate both sweeps run; only single-column indexes existed before. Mirrors the `idx_sub_invoices_due` / `idx_vendor_invoices_due_date` precedent. (#1769 finding-5 / #1790 finding-4)
- **Docs**: `find_invoices_due_for_reminder` / `transition_invoices_to_overdue` are now documented as deliberate cross-org, RLS-exempt scheduler sweeps on the raw pool, with no cross-tenant leak (notification targeting is unit-scoped). (#1769 finding-4 / #1790 finding-4)
- **Removed the tautological unit tests** that re-derived the date inequality as local closures and asserted on those (false confidence) — real behaviour is covered by `payment_reminder_dedup_tests`. (#1769 finding-3 / #1790 finding-5)

## Verification
`cargo check -p db` clean; migration guard green; the full migrator **including 00209** applies and the 4 `payment_reminder_dedup_tests` pass against Postgres 16.

## Merge-order note
Migration numbered **00209** because my PR #1977 (#1773) adds **00208**; sqlx migrations are append-only by version, so this should merge after #1977 (or #1977 is renumbered) to keep the sequence increasing on existing DBs.

Closes #1769
Closes #1790
