### PR TITLE
fix(reality-web): close SSO callback CSRF state-bypass

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/auth/callback/page.test.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/callback/page.test.tsx
@@ -54,9 +54,7 @@ vi.mock('next/navigation', () => ({
   useParams: () => ({ locale: 'en' }),
 }));
 
-import SsoCallbackPage from './page';
-
-const SSO_STATE_KEY = 'sso_state';
+import SsoCallbackPage, { SSO_STATE_KEY } from './page';
 
 function renderCallback(search: string) {
   currentParams = new URLSearchParams(search);
@@ -85,11 +83,28 @@ describe('SsoCallbackPage — reality-web SSO /auth/callback flow (Story 79.2)',
     expect(screen.queryByText('Login Failed')).not.toBeInTheDocument();
   });
 
-  it('redirects with no state token present (server already set the cookie)', async () => {
+  it('redirects when NO nonce was issued (server-cookie-only flow, nothing to verify)', async () => {
+    // No `sso_state` in sessionStorage → no nonce was issued, so there is
+    // nothing to validate and the server-set-cookie flow proceeds.
     renderCallback('');
 
     await waitFor(() => expect(replaceSpy).toHaveBeenCalledWith('/'));
     expect(screen.queryByText('Login Failed')).not.toBeInTheDocument();
+  });
+
+  it('FAILS when a nonce was issued but the callback carries no state (CSRF bypass closed, #1826)', async () => {
+    // A nonce was saved at flow start, but the callback arrives with no
+    // `state`. The pre-fix guard skipped validation here (state absent), letting
+    // an attacker-supplied callback through. It must now fail closed.
+    sessionStorage.setItem(SSO_STATE_KEY, 'nonce-1');
+
+    renderCallback('');
+
+    await waitFor(() => {
+      expect(screen.getByText('Login Failed')).toBeInTheDocument();
+    });
+    expect(screen.getByText(/invalid state token/i)).toBeInTheDocument();
+    expect(replaceSpy).not.toHaveBeenCalled();
   });
 
   it('honours a same-origin relative redirect_uri', async () => {

--- a/frontend/apps/reality-web/src/app/[locale]/auth/callback/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/auth/callback/page.tsx
@@ -8,6 +8,13 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { type CSSProperties, Suspense, useEffect, useState } from 'react';
 
+/**
+ * sessionStorage key holding the one-shot CSRF nonce issued when the SSO flow
+ * starts. Exported so the page and its tests single-source the contract (a
+ * rename here can't silently drift the test) — GH #1826 finding-3.
+ */
+export const SSO_STATE_KEY = 'sso_state';
+
 const styles: Record<string, CSSProperties> = {
   container: {
     minHeight: '100vh',
@@ -83,17 +90,25 @@ function SsoCallbackContent() {
       return;
     }
 
-    // Verify CSRF state token
+    // Verify CSRF state token.
+    //
+    // Whenever a nonce was issued at the start of the flow (`savedState`
+    // present), a matching `state` is REQUIRED: a missing or mismatched value
+    // is a failure, not a pass. The previous `state && savedState && …` form
+    // skipped the check entirely when `state` was absent/empty, so an
+    // attacker-supplied callback with no `state` bypassed the nonce check
+    // (GH #1826 finding-2). When no nonce was saved (server-cookie-only flow,
+    // nothing to verify) the check is correctly a no-op.
     const state = searchParams.get('state');
-    const savedState = sessionStorage.getItem('sso_state');
+    const savedState = sessionStorage.getItem(SSO_STATE_KEY);
 
-    if (state && savedState && state !== savedState) {
+    if (savedState && state !== savedState) {
       setError('Invalid state token. Please try logging in again.');
       return;
     }
 
     // Clear saved state
-    sessionStorage.removeItem('sso_state');
+    sessionStorage.removeItem(SSO_STATE_KEY);
 
     // Redirect to home - session cookie should already be set by the server.
     // Only accept same-origin relative paths to prevent open-redirect attacks:


### PR DESCRIPTION
Closes **#1826**.

## Security (finding-2) — the main fix
The SSO callback's CSRF guard was `if (state && savedState && state !== savedState)`. When the URL `state` was **absent/empty** but a `savedState` nonce existed, the check was skipped and the page treated the callback as success and redirected — an attacker-supplied callback with **no `state`** bypassed the nonce check entirely. The prior test even encoded this as *expected* ("redirects with no state token present"), locking the weakness in.

Tightened to:
```ts
if (savedState && state !== savedState) { /* fail */ }
```
Whenever a nonce was issued, a matching `state` is **required**. When no nonce was saved (server-cookie-only flow, nothing to verify) the check is a correct no-op — so the legitimate flow still works.

## finding-3 — single-source the key
Exported `SSO_STATE_KEY` from `page.tsx` and imported it in the test (was a duplicated string literal that could silently drift on rename).

## Tests
Split the old "no state token present" test into two:
- no nonce issued → still redirects (legitimate server-cookie flow);
- **nonce issued + no `state` → `Login Failed`** — the regression guard for the closed bypass (fails on the old guard, passes on the new).

All **9** reality-web auth-callback tests pass; **biome clean**.

## finding-1 (e2e vs unit) — scoping note
The page is **client-only**: it performs no token exchange and no `fetch` (reads query params + `sessionStorage`, calls `router.replace`). A render-based integration test is therefore the correct level for *this page*; a true browser e2e would exercise reality-server's cookie-session validation, which the page does not perform. Documented rather than adding a disproportionate Playwright harness for a page with no network round-trip.

Closes #1826