### PR TITLE
test(accounting-web): a11y + login TODO + SEO nit + vitest suite

### DIFF
--- a/frontend/apps/accounting-web/package.json
+++ b/frontend/apps/accounting-web/package.json
@@ -6,8 +6,9 @@
     "dev": "next dev -p 3002",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
     "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui"
   },
@@ -27,10 +28,16 @@
     "@ppt/dev-panel": "workspace:*",
     "@ppt/e2e": "workspace:*",
     "@ppt/vite-plugin-worktree": "workspace:*",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^25.0.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "typescript": "^5.3.0"
+    "@vitejs/plugin-react": "^6.0.2",
+    "jsdom": "^29.1.1",
+    "typescript": "^5.3.0",
+    "vitest": "^4.1.9"
   },
   "version": "0.1.0"
 }

--- a/frontend/apps/accounting-web/src/app/[locale]/signup/page.tsx
+++ b/frontend/apps/accounting-web/src/app/[locale]/signup/page.tsx
@@ -39,6 +39,8 @@ function SignupContent() {
             <SignupForm />
             <p className={styles.altAuth}>
               {t('haveAccount')}{' '}
+              {/* TODO(PAP-303 #3): point at /login once the login route lands;
+                  currently the only public route is /signup. */}
               <Link href="/signup" className={styles.altAuthLink}>
                 {t('login')}
               </Link>
@@ -46,8 +48,13 @@ function SignupContent() {
           </div>
         </section>
 
-        <aside className={styles.asideCol} aria-hidden="true">
-          <div className={styles.asideBrand}>{BRAND_NAME}</div>
+        <aside className={styles.asideCol}>
+          {/* Only the decorative brand mark is hidden from assistive tech; the
+              benefits heading + list below are real value-prop content and must
+              stay announced (#1828 finding-1). */}
+          <div className={styles.asideBrand} aria-hidden="true">
+            {BRAND_NAME}
+          </div>
           <h2 className={styles.asideHeading}>{t('benefitsTitle')}</h2>
           <ul className={styles.benefitList}>
             {[0, 1, 2, 3].map((i) => (

--- a/frontend/apps/accounting-web/src/app/robots.ts
+++ b/frontend/apps/accounting-web/src/app/robots.ts
@@ -18,6 +18,8 @@ export default function robots(): MetadataRoute.Robots {
       },
     ],
     sitemap: `${base}/sitemap.xml`,
-    host: base,
+    // `host` intentionally omitted (#1828 finding-5): a Yandex-only extension,
+    // ignored by Google/Bing and not part of MetadataRoute.Robots' indexing
+    // contract; the sitemap URL already conveys the canonical origin.
   };
 }

--- a/frontend/apps/accounting-web/src/app/sitemap.test.ts
+++ b/frontend/apps/accounting-web/src/app/sitemap.test.ts
@@ -1,0 +1,48 @@
+/**
+ * sitemap() output contract — accounting-web (#1828 finding-3).
+ *
+ * The PR headlined SEO (sitemap/hreflang) but shipped no tests. This pins the
+ * per-locale URL shape and the hreflang `alternates.languages` map that search
+ * engines consume.
+ */
+import { describe, expect, it } from 'vitest';
+import { locales } from '@/i18n/config';
+import sitemap from './sitemap';
+
+const DEFAULT_BASE = 'https://eko.dev.rlt.sk'; // NEXT_PUBLIC_SITE_URL fallback
+
+describe('accounting-web sitemap', () => {
+  const entries = sitemap();
+
+  it('emits one entry per (public path × locale)', () => {
+    // 2 public paths ('', '/signup') × 2 locales (cs, sk).
+    expect(entries).toHaveLength(2 * locales.length);
+  });
+
+  it('serves cs at the bare path and sk under /sk (as-needed prefixing)', () => {
+    const urls = entries.map((e) => e.url);
+    expect(urls).toContain(`${DEFAULT_BASE}`); // cs home
+    expect(urls).toContain(`${DEFAULT_BASE}/sk`); // sk home
+    expect(urls).toContain(`${DEFAULT_BASE}/signup`); // cs signup
+    expect(urls).toContain(`${DEFAULT_BASE}/sk/signup`); // sk signup
+  });
+
+  it('gives the home path the highest priority and a weekly change frequency', () => {
+    const csHome = entries.find((e) => e.url === DEFAULT_BASE);
+    expect(csHome?.priority).toBe(1);
+    expect(csHome?.changeFrequency).toBe('weekly');
+  });
+
+  it('every entry carries an hreflang alternates map covering all locales', () => {
+    for (const entry of entries) {
+      const langs = entry.alternates?.languages ?? {};
+      // Each entry advertises a URL for every supported locale.
+      for (const locale of locales) {
+        expect(langs).toHaveProperty(locale);
+      }
+      // The sk alternate of any entry is /sk-prefixed; the cs alternate is bare.
+      expect(String(langs.sk)).toContain('/sk');
+      expect(String(langs.cs)).not.toContain('/sk');
+    }
+  });
+});

--- a/frontend/apps/accounting-web/src/components/invoices/totals.test.ts
+++ b/frontend/apps/accounting-web/src/components/invoices/totals.test.ts
@@ -1,90 +1,86 @@
 /**
  * Unit tests for the live invoice totals helper (UC-ACC-05.2, .19, .20).
  *
- * Runnable with the Node built-in test runner (no extra dependency):
- *   node --test --import tsx src/components/invoices/totals.test.ts
- * (or via whatever runner Phase 2 wires up — the assertions are runner-agnostic
- * `node:assert` calls). Uses `node:test` + `node:assert`, both covered by the
- * existing `@types/node` devDependency, so this file typechecks under
- * `tsc --noEmit` without adding a test framework.
+ * Converted from the original `node:test` + `node:assert` form to vitest
+ * (#1828) so accounting-web has a single test runner — the new `vitest` glob
+ * picked this file up and `node:test` registrations are invisible to vitest's
+ * collector. Behaviour and assertions are unchanged.
  */
 
-import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { describe, expect, it } from 'vitest';
 import { computeDocumentTotals, computeLine, roundHalfUp } from './totals';
 
-test('roundHalfUp rounds to 2 decimals half-up', () => {
-  assert.equal(roundHalfUp(1.005, 2), 1.01);
-  assert.equal(roundHalfUp(2.675, 2), 2.68);
-  assert.equal(roundHalfUp(10, 2), 10);
-  assert.equal(roundHalfUp(0.1 + 0.2, 2), 0.3);
-});
+describe('invoice totals helper', () => {
+  it('roundHalfUp rounds to 2 decimals half-up', () => {
+    expect(roundHalfUp(1.005, 2)).toBe(1.01);
+    expect(roundHalfUp(2.675, 2)).toBe(2.68);
+    expect(roundHalfUp(10, 2)).toBe(10);
+    expect(roundHalfUp(0.1 + 0.2, 2)).toBe(0.3);
+  });
 
-test('computeLine: net, VAT and gross for a single line', () => {
-  // 3 × 100.00 @ 20% → net 300.00, VAT 60.00, gross 360.00
-  const lt = computeLine({ qty: '3', unit_price: '100', vat_rate: '20' });
-  assert.equal(lt.base, 300);
-  assert.equal(lt.vat, 60);
-  assert.equal(lt.gross, 360);
-});
+  it('computeLine: net, VAT and gross for a single line', () => {
+    // 3 × 100.00 @ 20% → net 300.00, VAT 60.00, gross 360.00
+    const lt = computeLine({ qty: '3', unit_price: '100', vat_rate: '20' });
+    expect(lt.base).toBe(300);
+    expect(lt.vat).toBe(60);
+    expect(lt.gross).toBe(360);
+  });
 
-test('computeLine: 4-dp precision on inputs retained before rounding', () => {
-  // 1.5 × 33.3333 = 49.99995 → base rounds to 50.00; VAT @ 21% = 10.50
-  const lt = computeLine({ qty: '1.5', unit_price: '33.3333', vat_rate: '21' });
-  assert.equal(lt.base, 50);
-  assert.equal(lt.vat, 10.5);
-  assert.equal(lt.gross, 60.5);
-});
+  it('computeLine: 4-dp precision on inputs retained before rounding', () => {
+    // 1.5 × 33.3333 = 49.99995 → base rounds to 50.00; VAT @ 21% = 10.50
+    const lt = computeLine({ qty: '1.5', unit_price: '33.3333', vat_rate: '21' });
+    expect(lt.base).toBe(50);
+    expect(lt.vat).toBe(10.5);
+    expect(lt.gross).toBe(60.5);
+  });
 
-test('computeDocumentTotals: groups VAT per rate (mixed rates)', () => {
-  const totals = computeDocumentTotals([
-    { qty: '1', unit_price: '100', vat_rate: '20' }, // base 100, vat 20
-    { qty: '2', unit_price: '50', vat_rate: '20' }, //  base 100, vat 20
-    { qty: '1', unit_price: '200', vat_rate: '10' }, // base 200, vat 20
-    { qty: '1', unit_price: '300', vat_rate: '0' }, //  base 300, vat 0
-  ]);
+  it('computeDocumentTotals: groups VAT per rate (mixed rates)', () => {
+    const totals = computeDocumentTotals([
+      { qty: '1', unit_price: '100', vat_rate: '20' }, // base 100, vat 20
+      { qty: '2', unit_price: '50', vat_rate: '20' }, //  base 100, vat 20
+      { qty: '1', unit_price: '200', vat_rate: '10' }, // base 200, vat 20
+      { qty: '1', unit_price: '300', vat_rate: '0' }, //  base 300, vat 0
+    ]);
 
-  // Three rate groups, ascending by rate
-  assert.equal(totals.groups.length, 3);
-  assert.deepEqual(
-    totals.groups.map((g) => g.rate),
-    [0, 10, 20]
-  );
+    // Three rate groups, ascending by rate
+    expect(totals.groups.length).toBe(3);
+    expect(totals.groups.map((g) => g.rate)).toEqual([0, 10, 20]);
 
-  const g20 = totals.groups.find((g) => g.rate === 20);
-  assert.ok(g20);
-  assert.equal(g20?.base, 200); // 100 + 100
-  assert.equal(g20?.vat, 40);
+    const g20 = totals.groups.find((g) => g.rate === 20);
+    expect(g20).toBeTruthy();
+    expect(g20?.base).toBe(200); // 100 + 100
+    expect(g20?.vat).toBe(40);
 
-  const g10 = totals.groups.find((g) => g.rate === 10);
-  assert.equal(g10?.base, 200);
-  assert.equal(g10?.vat, 20);
+    const g10 = totals.groups.find((g) => g.rate === 10);
+    expect(g10?.base).toBe(200);
+    expect(g10?.vat).toBe(20);
 
-  const g0 = totals.groups.find((g) => g.rate === 0);
-  assert.equal(g0?.base, 300);
-  assert.equal(g0?.vat, 0);
+    const g0 = totals.groups.find((g) => g.rate === 0);
+    expect(g0?.base).toBe(300);
+    expect(g0?.vat).toBe(0);
 
-  // Document totals
-  assert.equal(totals.base, 700); // 200 + 200 + 300
-  assert.equal(totals.vat, 60); //  40 + 20 + 0
-  assert.equal(totals.gross, 760);
-});
+    // Document totals
+    expect(totals.base).toBe(700); // 200 + 200 + 300
+    expect(totals.vat).toBe(60); //  40 + 20 + 0
+    expect(totals.gross).toBe(760);
+  });
 
-test('computeDocumentTotals: ignores blank/zero lines', () => {
-  const totals = computeDocumentTotals([
-    { qty: '0', unit_price: '0', vat_rate: '20' },
-    { qty: '1', unit_price: '100', vat_rate: '20' },
-  ]);
-  assert.equal(totals.groups.length, 1);
-  assert.equal(totals.base, 100);
-  assert.equal(totals.vat, 20);
-  assert.equal(totals.gross, 120);
-});
+  it('computeDocumentTotals: ignores blank/zero lines', () => {
+    const totals = computeDocumentTotals([
+      { qty: '0', unit_price: '0', vat_rate: '20' },
+      { qty: '1', unit_price: '100', vat_rate: '20' },
+    ]);
+    expect(totals.groups.length).toBe(1);
+    expect(totals.base).toBe(100);
+    expect(totals.vat).toBe(20);
+    expect(totals.gross).toBe(120);
+  });
 
-test('computeDocumentTotals: empty document is all zero', () => {
-  const totals = computeDocumentTotals([]);
-  assert.equal(totals.base, 0);
-  assert.equal(totals.vat, 0);
-  assert.equal(totals.gross, 0);
-  assert.equal(totals.groups.length, 0);
+  it('computeDocumentTotals: empty document is all zero', () => {
+    const totals = computeDocumentTotals([]);
+    expect(totals.base).toBe(0);
+    expect(totals.vat).toBe(0);
+    expect(totals.gross).toBe(0);
+    expect(totals.groups.length).toBe(0);
+  });
 });

--- a/frontend/apps/accounting-web/src/components/marketing/SiteHeader.tsx
+++ b/frontend/apps/accounting-web/src/components/marketing/SiteHeader.tsx
@@ -28,6 +28,8 @@ export function SiteHeader() {
 
         <div className={styles.navActions}>
           <LocaleSwitcher />
+          {/* TODO(PAP-303 #3): point at /login once the login route lands; for
+              now the only public route is /signup. */}
           <Link href="/signup" className={`${styles.navLink} ${styles.navLinks}`}>
             {t('login')}
           </Link>

--- a/frontend/apps/accounting-web/src/components/signup/SignupForm.test.tsx
+++ b/frontend/apps/accounting-web/src/components/signup/SignupForm.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * SignupForm client-side validation — accounting-web (#1828 finding-3).
+ *
+ * The signup POST is a deliberate no-op for now, but the client-side validation
+ * (required fields, email shape, password length) is real behaviour and was
+ * untested. The next-intl mock returns message keys verbatim, so the assertions
+ * pin the validation branches by their stable keys.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SignupForm } from './SignupForm';
+
+function fill(container: HTMLElement, name: string, value: string) {
+  const input = container.querySelector<HTMLInputElement>(`input[name="${name}"]`);
+  if (!input) throw new Error(`input[name="${name}"] not found`);
+  fireEvent.change(input, { target: { value } });
+}
+
+function submit(container: HTMLElement) {
+  const form = container.querySelector('form');
+  if (!form) throw new Error('form not found');
+  fireEvent.submit(form);
+}
+
+describe('SignupForm validation', () => {
+  it('reports required fields when submitted empty', () => {
+    const { container } = render(<SignupForm />);
+    submit(container);
+
+    expect(screen.getByText('validation.companyRequired')).toBeInTheDocument();
+    expect(screen.getByText('validation.emailRequired')).toBeInTheDocument();
+    expect(screen.getByText('validation.passwordShort')).toBeInTheDocument();
+    // No "coming soon" success notice on a failed validation.
+    expect(screen.queryByText('comingSoon')).not.toBeInTheDocument();
+  });
+
+  it('rejects a malformed email', () => {
+    const { container } = render(<SignupForm />);
+    fill(container, 'company', 'Acme s.r.o.');
+    fill(container, 'email', 'not-an-email');
+    fill(container, 'password', 'supersecret');
+    submit(container);
+
+    expect(screen.getByText('validation.emailInvalid')).toBeInTheDocument();
+    expect(screen.queryByText('comingSoon')).not.toBeInTheDocument();
+  });
+
+  it('rejects a short password', () => {
+    const { container } = render(<SignupForm />);
+    fill(container, 'company', 'Acme s.r.o.');
+    fill(container, 'email', 'owner@acme.test');
+    fill(container, 'password', 'short');
+    submit(container);
+
+    expect(screen.getByText('validation.passwordShort')).toBeInTheDocument();
+    expect(screen.queryByText('comingSoon')).not.toBeInTheDocument();
+  });
+
+  it('shows the coming-soon notice when all fields are valid', () => {
+    const { container } = render(<SignupForm />);
+    fill(container, 'company', 'Acme s.r.o.');
+    fill(container, 'email', 'owner@acme.test');
+    fill(container, 'password', 'supersecret');
+    submit(container);
+
+    expect(screen.getByText('comingSoon')).toBeInTheDocument();
+    expect(screen.queryByText('validation.emailInvalid')).not.toBeInTheDocument();
+    expect(screen.queryByText('validation.passwordShort')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/accounting-web/src/test/setup.tsx
+++ b/frontend/apps/accounting-web/src/test/setup.tsx
@@ -1,0 +1,64 @@
+/**
+ * Vitest test setup for accounting-web.
+ *
+ * Mirrors reality-web's setup: Jest-DOM matchers, cleanup after each test, and
+ * mocks for the next-intl / next/navigation / next/link / next/image framework
+ * boundaries plus the browser APIs jsdom doesn't provide.
+ */
+
+import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+
+// next-intl: translation hooks return the key verbatim so tests can assert on
+// stable message keys without loading the cs/sk catalogs.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'cs',
+  useMessages: () => ({}),
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/',
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({ locale: 'cs' }),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, ...props }: { src: string; alt: string }) => (
+    <img src={src} alt={alt || ''} {...props} />
+  ),
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/frontend/apps/accounting-web/vitest.config.ts
+++ b/frontend/apps/accounting-web/vitest.config.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import react from '@vitejs/plugin-react';
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    // Mirror tsconfig's `@/*` -> `src/*` mapping so test files and the modules
+    // they import (e.g. `@/i18n/config`, `@/styles/...`) resolve under vitest.
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.tsx'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -65,6 +65,15 @@ importers:
       '@ppt/vite-plugin-worktree':
         specifier: workspace:*
         version: link:../../packages/vite-plugin-ppt-worktree
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3)(@types/react@19.2.14)(react-dom@19.2.0)(react@19.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.0.5
         version: 25.9.3
@@ -74,9 +83,18 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16)
 
   apps/admin-web:
     dependencies:
@@ -522,7 +540,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@25.9.3)(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16)
 
   packages/admin-ui:
     dependencies:
@@ -665,7 +683,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@25.9.3)(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16)
 
   packages/shared:
     dependencies:
@@ -690,7 +708,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@types/node@25.9.3)(vite@8.0.16)
+        version: 4.1.9(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16)
 
   packages/ui-kit:
     dependencies:
@@ -1820,6 +1838,7 @@ packages:
   /@babel/runtime@7.29.2:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
+    dev: false
 
   /@babel/runtime@7.29.7:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
@@ -4913,7 +4932,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
@@ -8076,7 +8095,7 @@ packages:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      lru-cache: 11.5.0
+      lru-cache: 11.5.1
       parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
@@ -8274,11 +8293,6 @@ packages:
 
   /lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  /lru-cache@11.5.0:
-    resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
-    engines: {node: 20 || >=22}
-    dev: true
 
   /lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
@@ -10614,7 +10628,7 @@ packages:
       - msw
     dev: true
 
-  /vitest@4.1.9(@types/node@25.9.3)(vite@8.0.16):
+  /vitest@4.1.9(@types/node@25.9.3)(jsdom@29.1.1)(vite@8.0.16):
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
@@ -10665,6 +10679,7 @@ packages:
       '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
+      jsdom: 29.1.1
       magic-string: 0.30.21
       obug: 2.1.3
       pathe: 2.0.3


### PR DESCRIPTION
Closes **#1828** — post-merge follow-ups for the accounting-web marketing/signup scaffold (PR #1808).

| Finding | Fix |
|---------|-----|
| **1 — a11y (medium)** | The signup benefits `<aside>` wrapped real value-prop content (`<h2>` + 4-item benefit list) in `aria-hidden="true"`, hiding the whole column from screen readers. Scoped `aria-hidden` to just the decorative `.asideBrand` mark. |
| **2 — UX (low)** | The "Log in" links (signup page + `SiteHeader`) point at `/signup` because `/login` doesn't exist yet (PAP-303 #3). Added `// TODO(PAP-303 #3)` at both sites so it isn't silently forgotten. |
| **3 — tests (medium)** | Added a vitest harness mirroring reality-web (`vitest.config.ts` + `src/test/setup.tsx` + `test`/`test:run` scripts + devDeps) and tests for **SignupForm** client-side validation (required/email-shape/password-length/coming-soon) and the **sitemap** hreflang output (per-locale URLs + `alternates.languages`). |
| **4 — convention (low)** | Dropped the deprecated `next lint` script; the workspace Biome pipeline is the lint authority. |
| **5 — SEO (low)** | Dropped the Yandex-only `host` directive from `robots.ts` (ignored by Google/Bing; the sitemap URL already conveys canonical origin). |

### Runner reconciliation
accounting-web already had `src/components/invoices/totals.test.ts` written for Node's built-in `node:test` runner (it never ran — there was no `test` script). Once the new vitest glob picks it up, vitest can't collect `node:test` registrations and fails the run. Converted it to vitest (behaviour/assertions unchanged) so accounting-web has **one** runner.

### Verification
- `vitest run` — **14 passed** (6 totals + 4 SignupForm + 4 sitemap).
- `biome check` clean on all changed files; `tsc --noEmit` clean.
- `pnpm-lock.yaml` updated for the new devDeps.

Closes #1828
