### PR TITLE
perf(messaging): set-based block check in start_thread (N+1 fix)

### DIFF
--- a/backend/crates/db/src/repositories/messaging.rs
+++ b/backend/crates/db/src/repositories/messaging.rs
@@ -718,6 +718,42 @@ impl MessagingRepository {
         Ok(exists)
     }
 
+    /// Whether `caller` is blocked by — or has blocked — ANY of `candidates`,
+    /// in a single set-based query (#1776 / #1789).
+    ///
+    /// Replaces the per-recipient `is_blocked_rls` loop in `start_thread`: for an
+    /// N-party thread that loop issued N sequential round-trips (an N+1 pattern);
+    /// this keeps the block gate at one query regardless of N, matching the
+    /// set-based existence/membership checks already used in that handler. Same
+    /// bidirectional `user_blocks` predicate as [`is_blocked_rls`], with the
+    /// single peer replaced by `= ANY($2)`. `EXISTS` short-circuits — the caller
+    /// only needs "is anyone blocked", not the full set.
+    pub async fn any_blocked_among_rls<'e, E>(
+        &self,
+        executor: E,
+        caller: Uuid,
+        candidates: &[Uuid],
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let (exists,): (bool,) = sqlx::query_as(
+            r#"
+            SELECT EXISTS(
+                SELECT 1 FROM user_blocks
+                WHERE (blocker_id = $1 AND blocked_id = ANY($2))
+                   OR (blocked_id = $1 AND blocker_id = ANY($2))
+            )
+            "#,
+        )
+        .bind(caller)
+        .bind(candidates)
+        .fetch_one(executor)
+        .await?;
+
+        Ok(exists)
+    }
+
     /// List blocked users with their info with RLS context.
     pub async fn list_blocked_users_rls<'e, E>(
         &self,

--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -415,29 +415,30 @@ async fn start_thread(
 
     let repo = MessagingRepository::new(state.db.clone());
 
-    // No participant may have blocked (or be blocked by) the caller.
-    for &rid in &recipients {
-        let is_blocked = repo
-            .is_blocked_rls(&mut **rls.conn(), user_id, rid)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to check block status: {:?}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-                )
-            })?;
+    // No participant may have blocked (or be blocked by) the caller. One
+    // set-based query for all recipients (#1776 / #1789), keeping start_thread
+    // at a constant 3 round-trips regardless of N instead of the prior
+    // per-recipient N+1 loop.
+    let any_blocked = repo
+        .any_blocked_among_rls(&mut **rls.conn(), user_id, &recipients)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to check block status: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
 
-        if is_blocked {
-            rls.release().await;
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(ErrorResponse::new(
-                    "USER_BLOCKED",
-                    "Cannot message this user",
-                )),
-            ));
-        }
+    if any_blocked {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "USER_BLOCKED",
+                "Cannot message this user",
+            )),
+        ));
     }
 
     // Build the full participant list (caller + recipients). The repository


### PR DESCRIPTION
Closes **#1776** and **#1789** (both from PR #1689, N-party group conversations).

## The fix — set-based block check (#1776 = #1789 finding-3)
`start_thread` checked blocks with a **per-recipient loop** (`for &rid in &recipients { is_blocked_rls(...) }`) — an N+1 pattern: one sequential DB round-trip per recipient, diverging from the set-based existence/membership checks already in the same handler.

Added `MessagingRepository::any_blocked_among_rls(caller, candidates)` — **one** `EXISTS` query over `user_blocks` with the same bidirectional predicate as `is_blocked_rls` but `= ANY($2)` for the candidate set — and replaced the loop with a single call. `start_thread` is now a constant **3 queries** regardless of N. Behaviour is identical: reject with `USER_BLOCKED` if the caller has blocked, or is blocked by, **any** recipient.

## #1789's other findings — already resolved on `dev`
- **finding-1 (HIGH, tests)**: the group-conversation tests now assert `v["thread"]["participantIds"]` (camelCase), not the broken `participant_ids` — already fixed.
- **finding-2 (MEDIUM, lossy detail)**: `ThreadDetailResponse` now carries `participants: Vec<ParticipantInfo>` and `get_other_participant` was removed — already generalized.
- **finding-4 (LOW)**: index note, no action.

So the only outstanding item across both issues was the N+1, fixed here.

## Verification (Postgres 16)
All **8** `messaging_group_conversations_tests` pass, including **T4** (`start_group_thread_with_blocked_recipient_is_rejected`, which seeds a recipient who blocked the caller — the bidirectional case the set query must catch) and the participant-list/detail tests that confirm findings 1+2. `cargo check -p db -p api-server` clean; `fmt` applied.

Closes #1776
Closes #1789
