### PR TITLE
fix(messaging): unread soft-delete leak + set-based block check (#1771, #1776, #1789)

### DIFF
--- a/backend/crates/db/src/repositories/messaging.rs
+++ b/backend/crates/db/src/repositories/messaging.rs
@@ -618,6 +618,10 @@ impl MessagingRepository {
               AND t.organization_id = $2
               AND m.sender_id != $1
               AND m.deleted_at IS NULL
+              -- exclude threads this user soft-deleted ("delete for me"); they
+              -- vanish from the inbox list, so their unread messages must not
+              -- keep the global unread badge stuck non-zero (#1771).
+              AND tps.deleted_at IS NULL
               AND (tps.last_read_at IS NULL OR m.created_at > tps.last_read_at)
             "#,
         )
@@ -761,6 +765,39 @@ impl MessagingRepository {
         .await?;
 
         Ok(exists)
+    }
+
+    /// Set-based block check for N-party thread creation (#1776).
+    ///
+    /// Returns the subset of `candidates` that have either blocked `caller` or
+    /// been blocked by `caller`, in a single query. Replaces the per-recipient
+    /// `is_blocked_rls` loop in `start_thread`, keeping that handler at a
+    /// constant number of round-trips regardless of participant count (matching
+    /// the already-set-based existence and org-membership checks alongside it).
+    pub async fn blocked_among_rls<'e, E>(
+        &self,
+        executor: E,
+        caller: Uuid,
+        candidates: &[Uuid],
+    ) -> Result<Vec<Uuid>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            r#"
+            SELECT blocked_id AS other_id FROM user_blocks
+              WHERE blocker_id = $1 AND blocked_id = ANY($2)
+            UNION
+            SELECT blocker_id AS other_id FROM user_blocks
+              WHERE blocked_id = $1 AND blocker_id = ANY($2)
+            "#,
+        )
+        .bind(caller)
+        .bind(candidates)
+        .fetch_all(executor)
+        .await?;
+
+        Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
     /// List blocked users with their info with RLS context.

--- a/backend/crates/db/tests/thread_participant_state_tests.rs
+++ b/backend/crates/db/tests/thread_participant_state_tests.rs
@@ -16,6 +16,7 @@
 //! catalog-metadata checks at the bottom of this file, mirroring
 //! `messaging_rls_cross_tenant_tests.rs`.)
 
+use db::models::CreateMessage;
 use db::repositories::MessagingRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -240,5 +241,78 @@ async fn thread_participant_state_has_force_rls_and_policy(pool: PgPool) {
     assert!(
         policy_count > 0,
         "thread_participant_state must carry at least one RLS policy; found {policy_count}"
+    );
+}
+
+/// A thread the user soft-deleted ("delete for me") must not keep contributing
+/// to that user's global unread badge (#1771). Before the fix, `count_unread_rls`
+/// joined `thread_participant_state` only for the read watermark and ignored
+/// `deleted_at`, so a hidden thread with unread messages left the badge stuck
+/// non-zero with no thread visible in the inbox to clear it. The other
+/// participant's count must be unaffected.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
+async fn soft_deleted_thread_excluded_from_unread_count(pool: PgPool) {
+    let repo = MessagingRepository::new(pool.clone());
+    let org = seed_org(&pool, "tps-unread-del").await;
+    let alice = seed_user(&pool, "alice").await;
+    let bob = seed_user(&pool, "bob").await;
+    let thread = seed_thread(&pool, org, alice, bob).await;
+
+    // Bob sends a message → unread for alice (the recipient), not for bob.
+    repo.create_message_rls(
+        &pool,
+        CreateMessage {
+            thread_id: thread,
+            sender_id: bob,
+            content: "ping".to_string(),
+        },
+    )
+    .await
+    .expect("bob sends");
+
+    assert_eq!(
+        repo.count_unread_rls(&pool, alice, org).await.unwrap(),
+        1,
+        "alice has 1 unread before deleting"
+    );
+
+    // Alice deletes the thread for herself. It leaves her inbox; its unread
+    // message must leave her badge too — otherwise the badge is stuck.
+    repo.hide_thread_for_user(&pool, thread, alice)
+        .await
+        .expect("hide for alice");
+
+    assert_eq!(
+        repo.count_unread_rls(&pool, alice, org).await.unwrap(),
+        0,
+        "soft-deleted thread must not contribute to alice's unread badge (#1771)"
+    );
+    assert_eq!(
+        repo.count_unread_rls(&pool, bob, org).await.unwrap(),
+        0,
+        "bob (the sender) was never unread; unaffected by alice's delete"
+    );
+
+    // A new inbound message un-hides the thread (existing best-effort path), so
+    // the unread naturally returns and is actionable again.
+    repo.unhide_thread_for_user(&pool, thread, alice)
+        .await
+        .expect("unhide for alice");
+    repo.create_message_rls(
+        &pool,
+        CreateMessage {
+            thread_id: thread,
+            sender_id: bob,
+            content: "ping again".to_string(),
+        },
+    )
+    .await
+    .expect("bob sends again");
+
+    assert_eq!(
+        repo.count_unread_rls(&pool, alice, org).await.unwrap(),
+        2,
+        "after un-hide both messages count again for alice (thread is back in her inbox)"
     );
 }

--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -415,29 +415,29 @@ async fn start_thread(
 
     let repo = MessagingRepository::new(state.db.clone());
 
-    // No participant may have blocked (or be blocked by) the caller.
-    for &rid in &recipients {
-        let is_blocked = repo
-            .is_blocked_rls(&mut **rls.conn(), user_id, rid)
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to check block status: {:?}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new("DB_ERROR", e.to_string())),
-                )
-            })?;
+    // No participant may have blocked (or be blocked by) the caller. One
+    // set-based query instead of a per-recipient loop (#1776), matching the
+    // existence and org-membership checks above.
+    let blocked = repo
+        .blocked_among_rls(&mut **rls.conn(), user_id, &recipients)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to check block status: {:?}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", e.to_string())),
+            )
+        })?;
 
-        if is_blocked {
-            rls.release().await;
-            return Err((
-                StatusCode::FORBIDDEN,
-                Json(ErrorResponse::new(
-                    "USER_BLOCKED",
-                    "Cannot message this user",
-                )),
-            ));
-        }
+    if !blocked.is_empty() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "USER_BLOCKED",
+                "Cannot message this user",
+            )),
+        ));
     }
 
     // Build the full participant list (caller + recipients). The repository


### PR DESCRIPTION
## Summary

Addresses the post-merge review follow-ups for the messaging stack (PRs #1689 / #1696). Resolves **#1771**, **#1776**, and **#1789**.

Two of #1789's findings (snake_case test wire-contract, lossy 2-party `other_participant` response) were already resolved on `dev` (tests now read `participantIds`; `ThreadDetailResponse` already carries `participants: Vec<ParticipantInfo>` via BIT-206). The remaining work is below.

## Changes

### #1771 — unread-count leaked soft-deleted threads (HIGH)
`count_unread_rls` joined `thread_participant_state` only for the read watermark and ignored `deleted_at`. A user who "deleted for me" a thread with unread messages had it vanish from their inbox but its messages kept the global unread badge stuck non-zero, with no thread visible to clear them. Added `AND tps.deleted_at IS NULL` to mirror the list/count read paths.

- `backend/crates/db/src/repositories/messaging.rs` — `count_unread_rls` filter.
- Regression test in `thread_participant_state_tests.rs`: after `hide_thread_for_user`, the deleting user's `count_unread_rls` excludes that thread's unread; un-hide (new inbound message) restores it. (Marked `#[ignore]` to match the BIT-351-quarantined sqlx::test siblings in that file; un-ignores when the DB test harness is repaired.)

### #1776 / #1789 finding-3 — N+1 block check in `start_thread`
`start_thread` looped `is_blocked_rls` once per recipient. Replaced with a single set-based `blocked_among_rls(caller, candidates)` query (UNION of both block directions), matching the already-set-based existence and org-membership checks in the same handler. Keeps the handler at a constant number of round-trips regardless of participant count.

- `backend/crates/db/src/repositories/messaging.rs` — new `blocked_among_rls`.
- `backend/servers/api-server/src/routes/messaging.rs` — replace the loop. Behavior preserved: any blocked party ⇒ `403 USER_BLOCKED`.

## Verification
- `cargo check -p api-server` ✅
- `cargo test -p db --test thread_participant_state_tests --no-run` ✅
- `cargo fmt --check` ✅

Closes #1771
Closes #1776
Closes #1789
