### PR TITLE
fix(migration): SQL-side template pagination + honest import/export checklist (#1905)

### DIFF
--- a/backend/crates/db/src/repositories/migration.rs
+++ b/backend/crates/db/src/repositories/migration.rs
@@ -38,6 +38,8 @@ impl MigrationRepository {
         org_id: Uuid,
         data_type: Option<ImportDataType>,
         include_system: bool,
+        limit: i64,
+        offset: i64,
     ) -> Result<Vec<ImportTemplate>, SqlxError>
     where
         E: Executor<'e, Database = Postgres>,
@@ -45,39 +47,96 @@ impl MigrationRepository {
         match (data_type, include_system) {
             (Some(dt), true) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) AND data_type = $2",
+                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) AND data_type = $2 ORDER BY updated_at DESC LIMIT $3 OFFSET $4",
                 )
                 .bind(org_id)
                 .bind(dt)
+                .bind(limit)
+                .bind(offset)
                 .fetch_all(executor)
                 .await
             }
             (Some(dt), false) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE organization_id = $1 AND data_type = $2",
+                    "SELECT * FROM import_templates WHERE organization_id = $1 AND data_type = $2 ORDER BY updated_at DESC LIMIT $3 OFFSET $4",
                 )
                 .bind(org_id)
                 .bind(dt)
+                .bind(limit)
+                .bind(offset)
                 .fetch_all(executor)
                 .await
             }
             (None, true) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL)",
+                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) ORDER BY updated_at DESC LIMIT $2 OFFSET $3",
                 )
                 .bind(org_id)
+                .bind(limit)
+                .bind(offset)
                 .fetch_all(executor)
                 .await
             }
             (None, false) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE organization_id = $1",
+                    "SELECT * FROM import_templates WHERE organization_id = $1 ORDER BY updated_at DESC LIMIT $2 OFFSET $3",
                 )
                 .bind(org_id)
+                .bind(limit)
+                .bind(offset)
                 .fetch_all(executor)
                 .await
             }
         }
+    }
+
+    /// Count import templates matching the same filter as [`Self::list_templates`],
+    /// for accurate pagination totals (#1905).
+    pub async fn count_templates<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        data_type: Option<ImportDataType>,
+        include_system: bool,
+    ) -> Result<i64, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let (count,): (i64,) = match (data_type, include_system) {
+            (Some(dt), true) => {
+                sqlx::query_as(
+                    "SELECT COUNT(*) FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) AND data_type = $2",
+                )
+                .bind(org_id)
+                .bind(dt)
+                .fetch_one(executor)
+                .await?
+            }
+            (Some(dt), false) => {
+                sqlx::query_as(
+                    "SELECT COUNT(*) FROM import_templates WHERE organization_id = $1 AND data_type = $2",
+                )
+                .bind(org_id)
+                .bind(dt)
+                .fetch_one(executor)
+                .await?
+            }
+            (None, true) => {
+                sqlx::query_as(
+                    "SELECT COUNT(*) FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL)",
+                )
+                .bind(org_id)
+                .fetch_one(executor)
+                .await?
+            }
+            (None, false) => {
+                sqlx::query_as("SELECT COUNT(*) FROM import_templates WHERE organization_id = $1")
+                    .bind(org_id)
+                    .fetch_one(executor)
+                    .await?
+            }
+        };
+        Ok(count)
     }
 
     /// List system-provided templates.

--- a/backend/servers/api-server/src/routes/migration.rs
+++ b/backend/servers/api-server/src/routes/migration.rs
@@ -118,6 +118,23 @@ async fn list_templates(
         "Organization context required".to_string(),
     ))?;
 
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query.per_page.unwrap_or(20).clamp(1, 100);
+    let offset = (page - 1) as i64 * per_page as i64;
+
+    // Page in SQL (LIMIT/OFFSET) and take the total from a COUNT, rather than
+    // fetching every template and slicing in Rust (#1905).
+    let total = state
+        .migration_repo
+        .count_templates(
+            &mut **rls.conn(),
+            org_id,
+            query.data_type.clone(),
+            query.include_system,
+        )
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     let db_templates = state
         .migration_repo
         .list_templates(
@@ -125,6 +142,8 @@ async fn list_templates(
             org_id,
             query.data_type,
             query.include_system,
+            per_page as i64,
+            offset,
         )
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -150,19 +169,9 @@ async fn list_templates(
         })
         .collect();
 
-    let page = query.page.unwrap_or(1);
-    let per_page = query.per_page.unwrap_or(20);
-    let total = templates.len() as i64;
-    let offset = ((page - 1) * per_page).max(0) as usize;
-    let paginated = templates
-        .into_iter()
-        .skip(offset)
-        .take(per_page as usize)
-        .collect();
-
     Ok(Json(ListTemplatesResponse {
         total,
-        templates: paginated,
+        templates,
         page,
         per_page,
     }))
@@ -1427,7 +1436,17 @@ async fn get_export_history(
     let history = exports
         .into_iter()
         .map(|e| {
-            let categories: Vec<String> = serde_json::from_value(e.categories).unwrap_or_default();
+            let categories: Vec<String> =
+                serde_json::from_value(e.categories).unwrap_or_else(|err| {
+                    // Don't silently swallow a malformed `categories` blob (#1905):
+                    // surface it so a bad row is debuggable instead of just empty.
+                    tracing::warn!(
+                        export_id = %e.id,
+                        error = %err,
+                        "malformed export `categories` JSON; defaulting to empty list"
+                    );
+                    Vec::new()
+                });
             ExportHistoryEntry {
                 id: e.id,
                 status: e.status,

--- a/docs/endpoint-checklist/groups/integrations-ecosystem.md
+++ b/docs/endpoint-checklist/groups/integrations-ecosystem.md
@@ -154,20 +154,20 @@ _Deleted in [BIT-257](/BIT/issues/BIT-257): 43 unmounted `/api/v1/developer/*` R
 | GET | /api/v1/migration/templates/{template_id}/download | download_template | done | migration_db_tests.rs | db-backed and tested |
 | POST | /api/v1/migration/templates/{template_id}/duplicate | duplicate_template | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/categories/import | get_import_categories | done | migration_db_tests.rs | static metadata |
-| POST | /api/v1/migration/import/upload | upload_import_file | done | migration_db_tests.rs | db-backed and tested |
+| POST | /api/v1/migration/import/upload | upload_import_file | partial | migration_db_tests.rs | metadata row persisted; multipart bytes NOT uploaded to S3 (synthetic file_path) — #1905 |
 | GET | /api/v1/migration/import/jobs | list_import_jobs | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/import/jobs/{job_id} | get_import_job_status | done | migration_db_tests.rs | db-backed and tested |
 | POST | /api/v1/migration/import/jobs/{job_id}/cancel | cancel_import_job | done | migration_db_tests.rs | db-backed and tested |
 | POST | /api/v1/migration/import/jobs/{job_id}/retry | retry_import_job | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/import/jobs/{job_id}/errors | get_import_job_errors | done | migration_db_tests.rs | db-backed and tested |
-| POST | /api/v1/migration/export | request_migration_export | done | migration_db_tests.rs | db-backed and tested |
-| GET | /api/v1/migration/export/{export_id} | get_export_status | done | migration_db_tests.rs | db-backed and tested |
-| GET | /api/v1/migration/export/{export_id}/download | download_export | done | migration_db_tests.rs | db-backed and tested |
+| POST | /api/v1/migration/export | request_migration_export | partial | migration_db_tests.rs | persists export request row; no export is ever generated — #1905 |
+| GET | /api/v1/migration/export/{export_id} | get_export_status | partial | migration_db_tests.rs | fabricates Ready status + storage.example.com URL + fixed size/counts; no real export — #1905 |
+| GET | /api/v1/migration/export/{export_id}/download | download_export | partial | migration_db_tests.rs | returns placeholder storage.example.com URL; no real object — #1905 |
 | GET | /api/v1/migration/export/history | get_export_history | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/categories/export | get_export_categories | done | migration_db_tests.rs | static metadata |
-| GET | /api/v1/migration/import/jobs/{job_id}/preview | get_import_preview | done | migration_db_tests.rs | db-backed and tested |
-| POST | /api/v1/migration/import/jobs/{job_id}/approve | approve_import | done | migration_db_tests.rs | db-backed and tested |
-| POST | /api/v1/migration/import/jobs/{job_id}/validate | validate_import | done | migration_db_tests.rs | db-backed and tested |
+| GET | /api/v1/migration/import/jobs/{job_id}/preview | get_import_preview | partial | migration_db_tests.rs | returns the mock validate output (hardcoded issues); no real parse — #1905 |
+| POST | /api/v1/migration/import/jobs/{job_id}/approve | approve_import | partial | migration_db_tests.rs | flips status to Importing but queues no execution; nothing moves the job past it — #1905 |
+| POST | /api/v1/migration/import/jobs/{job_id}/validate | validate_import | partial | migration_db_tests.rs | inserts hardcoded errors + counts (total=100/ok=98/fail=2); file never read — #1905 |
 
 ## feature_packages.rs  (mount: /api/v1/feature-packages; public_router nested at /public)
 | Method | Path | Handler | Status | Tests | Notes |


### PR DESCRIPTION
## Summary

Partial follow-up for **#1905** (post-merge review of PR #1859, tenant-migration endpoints).

Two things first, verified against current `dev`:
- **Finding #1 (HIGH — duplicate migration `00196`) is already resolved.** The tenant-migration tables migration is now `00198_create_tenant_migration_tables.sql`; `00196` is solely `create_ocr_meter_corrections`, and there are no duplicate migration-number prefixes under `backend/crates/db/migrations/`.
- **Finding #2 (HIGH — import/export facade) is real and remains** large feature work (real S3 upload, file parsing/validation, async import execution, real export generation + presigned URLs). That is tracked as remaining work, not built here. This PR corrects the **overstated checklist** so the status is honest.

## Changes

### Finding #2 (documentation) — stop overstating completeness
`docs/endpoint-checklist/groups/integrations-ecosystem.md`: the import/export data-movement rows that are DB-backed facades are flipped from `done` → `partial` with a precise note (upload not written to S3, `validate`/`preview` return hardcoded mock errors+counts, `get_export_status`/`download_export` fabricate `storage.example.com` URLs, `approve_import` queues no execution, `request_migration_export` generates nothing). Template CRUD + list/get/cancel/retry/errors stay `done` — those are genuinely DB-backed.

### Finding #3 (MEDIUM) — push pagination into SQL
`list_templates` fetched **all** templates for the org then sliced in Rust. Now `MigrationRepository::list_templates` takes `limit`/`offset` (`ORDER BY updated_at DESC LIMIT/OFFSET`) and a new `count_templates` returns the real total, mirroring the existing `count_import_jobs`/`list_import_jobs` shape. Route clamps `per_page` to 1..=100 and `page` to ≥1.

### Finding #5 (LOW) — don't swallow malformed JSON
`get_export_history` mapped `serde_json::from_value(e.categories).unwrap_or_default()`, silently hiding a bad row. Now logs a `warn!` with the `export_id` + error before defaulting to an empty list.

## Not in this PR (tracked, remain on #1905)
- Finding #2 (functional): real S3 upload of import bytes; real file parse + validation; async import execution past `Importing`; real export generation + presigned URL.
- Finding #4: `migration_db_tests.rs` asserts the mock outputs, so they lock in the stub and there's no cross-tenant RLS negative test. These should be rewritten alongside the functional wiring above.

## Verification
- `cargo check -p db -p api-server` ✅
- `cargo fmt --check` ✅

Refs #1905
