### PR TITLE
81-2-report-execution-history: verify-to-done + pin apiStatus reason

### DIFF
--- a/docs/screens/ppt/reports.md
+++ b/docs/screens/ppt/reports.md
@@ -23,6 +23,7 @@ owner: pm-frontend
 
 ## Agent Log
 
+- 2026-07-01 — agent: gap-81-2 verify-to-done. Story 81.2 (Execution History) frontend is fully shipped and green: `ExecutionHistory`/`HistoryFilters` (status + date-range filter), offset/limit pagination, download and retry actions are wired end-to-end through the real api-client hooks (`useReportExecutionHistory`, `useDownloadReport`, `useRetryReportExecution`) in both `routes/groups/reports.tsx` route containers (`ReportsPageRoute`, `ScheduleDetailPageRoute`). The download hook guards empty presigned URLs and cleans up the temporary `<a>` in a `finally`; retry invalidates the executions query. The earlier download/retry test-gap follow-up (d1785e5fb) is closed: `routes/groups/reports.download-retry.route.test.tsx` now asserts the PRODUCTION route's `onError` download toast + retry-success toast (the sibling page Harness diverged there). Verified: `pnpm -F @ppt/web test --run reports` → 6 files / 70 tests pass; `pnpm -F @ppt/web typecheck` clean. `apiStatus` stays **partial** — pinned reason below — because the backend HTTP routes the hooks target do NOT exist yet (only DB models/repos in `crates/db`): the frontend is a `rust-backend` task away from live data. Frontend side of 81.2 is done; no frontend work remains.
 - 2026-06-28 — agent: gap-81-1 follow-up (#1368): reconciled frontend `isValidCron` (CronPicker) with the backend `validate_cron_expression` parse order — split each field on `,` first, then `/`, then `-`. Previously `1-5/2,10` was a frontend false-negative; because `scheduleToInitialCron` gates surfacing the persisted `cron_expression` on `isValidCron`, that silently flattened a backend-accepted cron back to the legacy time-derived form (silent #616 reintroduction). Flipped cron-validator-drift regression test to assert the validators now agree and the read path surfaces the persisted cron verbatim. apiStatus still partial (schedule create stub remains).
 - 2026-05-27 — agent: gap-81-1: EditScheduleModal rebuilt for cron-based PUT endpoint. CronPicker added (preset tabs + custom free-text with live validation). Pause/Resume props replaced by enabled toggle in modal (maps to `enabled` field in CronScheduleUpdateRequest). useUpdateScheduleCron hook wired. apiStatus remains partial (schedule create stub still absent).
 - 2026-05-25 — agent: Created screen-map. Route /reports wrapped in ProtectedRoute (PR #489 fix). Hooks pagination cache key fixed (executionOffset included). apiStatus=partial (schedule CRUD + execution history wired; download/retry stubs).
@@ -41,3 +42,13 @@ owner: pm-frontend
 - [x] [w] Pagination (offset/limit)
 - [x] [w] Retry failed execution
 - [x] [w] Download completed report
+
+> **apiStatus: partial — pinned reason (2026-07-01).** The Story 81.2 frontend is
+> complete and tested; `partial` reflects a *backend* gap, not frontend work.
+> The api-client hooks call `GET /api/v1/reports/schedules/{id}/executions`,
+> `GET /api/v1/reports/executions/{id}/download`, and
+> `POST /api/v1/reports/executions/{id}/retry`, but the backend only ships DB
+> models/repos for report executions (`crates/db/.../report_schedule.rs`,
+> migration `00162_create_report_schedules_executions.sql`) — no axum routes are
+> registered. Flipping `apiStatus` to `wired` is a `rust-backend` task (register
+> the three routes + presigned-download URL), out of scope for `pm-frontend`.

--- a/docs/screens/ppt/reports.md
+++ b/docs/screens/ppt/reports.md
@@ -23,7 +23,8 @@ owner: pm-frontend
 
 ## Agent Log
 
-- 2026-07-01 — agent: gap-81-2 verify-to-done. Story 81.2 (Execution History) frontend is fully shipped and green: `ExecutionHistory`/`HistoryFilters` (status + date-range filter), offset/limit pagination, download and retry actions are wired end-to-end through the real api-client hooks (`useReportExecutionHistory`, `useDownloadReport`, `useRetryReportExecution`) in both `routes/groups/reports.tsx` route containers (`ReportsPageRoute`, `ScheduleDetailPageRoute`). The download hook guards empty presigned URLs and cleans up the temporary `<a>` in a `finally`; retry invalidates the executions query. The earlier download/retry test-gap follow-up (d1785e5fb) is closed: `routes/groups/reports.download-retry.route.test.tsx` now asserts the PRODUCTION route's `onError` download toast + retry-success toast (the sibling page Harness diverged there). Verified: `pnpm -F @ppt/web test --run reports` → 6 files / 70 tests pass; `pnpm -F @ppt/web typecheck` clean. `apiStatus` stays **partial** — pinned reason below — because the backend HTTP routes the hooks target do NOT exist yet (only DB models/repos in `crates/db`): the frontend is a `rust-backend` task away from live data. Frontend side of 81.2 is done; no frontend work remains.
+- 2026-07-01 — agent: react-web PR #2004 follow-up (round 1). CORRECTION to the pinned reason below: the earlier claim that the backend axum routes for report executions are NOT registered was FALSE. All three routes ARE registered on `dev` in `backend/servers/api-server/src/routes/reports.rs::router()` — `GET /schedules/{id}/executions` → `list_schedule_executions` (line 222), `GET /executions/{id}/download` → `get_execution_download_url` (line 224, builds the presigned-download URL), `POST /executions/{id}/retry` → `retry_execution` (lines 225-228); the router is nested at `/api/v1/reports` in `backend/servers/api-server/src/lib.rs:293`. The Story 81.2 execution-history flow is therefore backend-wired end-to-end. `apiStatus` stays **partial** for a DIFFERENT, still-genuine reason: the Story 81.1 "Create new schedule" action (`POST /api/v1/reports/schedules`) has no backend route — `router()` only registers PUT `/schedules/{id}` plus pause/resume, no create handler. See corrected pinned reason below.
+- 2026-07-01 — agent: gap-81-2 verify-to-done. Story 81.2 (Execution History) frontend is fully shipped and green: `ExecutionHistory`/`HistoryFilters` (status + date-range filter), offset/limit pagination, download and retry actions are wired end-to-end through the real api-client hooks (`useReportExecutionHistory`, `useDownloadReport`, `useRetryReportExecution`) in both `routes/groups/reports.tsx` route containers (`ReportsPageRoute`, `ScheduleDetailPageRoute`). The download hook guards empty presigned URLs and cleans up the temporary `<a>` in a `finally`; retry invalidates the executions query. The earlier download/retry test-gap follow-up (d1785e5fb) is closed: `routes/groups/reports.download-retry.route.test.tsx` now asserts the PRODUCTION route's `onError` download toast + retry-success toast (the sibling page Harness diverged there). Verified: `pnpm -F @ppt/web test --run reports` → 6 files / 70 tests pass; `pnpm -F @ppt/web typecheck` clean. (NOTE: this entry's original claim that the 81.2 backend routes do not exist was later corrected — see the 2026-07-01 react-web follow-up entry above; the routes ARE registered.) Frontend side of 81.2 is done; no frontend work remains.
 - 2026-06-28 — agent: gap-81-1 follow-up (#1368): reconciled frontend `isValidCron` (CronPicker) with the backend `validate_cron_expression` parse order — split each field on `,` first, then `/`, then `-`. Previously `1-5/2,10` was a frontend false-negative; because `scheduleToInitialCron` gates surfacing the persisted `cron_expression` on `isValidCron`, that silently flattened a backend-accepted cron back to the legacy time-derived form (silent #616 reintroduction). Flipped cron-validator-drift regression test to assert the validators now agree and the read path surfaces the persisted cron verbatim. apiStatus still partial (schedule create stub remains).
 - 2026-05-27 — agent: gap-81-1: EditScheduleModal rebuilt for cron-based PUT endpoint. CronPicker added (preset tabs + custom free-text with live validation). Pause/Resume props replaced by enabled toggle in modal (maps to `enabled` field in CronScheduleUpdateRequest). useUpdateScheduleCron hook wired. apiStatus remains partial (schedule create stub still absent).
 - 2026-05-25 — agent: Created screen-map. Route /reports wrapped in ProtectedRoute (PR #489 fix). Hooks pagination cache key fixed (executionOffset included). apiStatus=partial (schedule CRUD + execution history wired; download/retry stubs).
@@ -43,12 +44,21 @@ owner: pm-frontend
 - [x] [w] Retry failed execution
 - [x] [w] Download completed report
 
-> **apiStatus: partial — pinned reason (2026-07-01).** The Story 81.2 frontend is
-> complete and tested; `partial` reflects a *backend* gap, not frontend work.
-> The api-client hooks call `GET /api/v1/reports/schedules/{id}/executions`,
+> **apiStatus: partial — pinned reason (2026-07-01, corrected).** Story 81.2
+> (Execution History) is fully wired on BOTH sides: the api-client hooks call
+> `GET /api/v1/reports/schedules/{id}/executions`,
 > `GET /api/v1/reports/executions/{id}/download`, and
-> `POST /api/v1/reports/executions/{id}/retry`, but the backend only ships DB
-> models/repos for report executions (`crates/db/.../report_schedule.rs`,
-> migration `00162_create_report_schedules_executions.sql`) — no axum routes are
-> registered. Flipping `apiStatus` to `wired` is a `rust-backend` task (register
-> the three routes + presigned-download URL), out of scope for `pm-frontend`.
+> `POST /api/v1/reports/executions/{id}/retry`, and all three routes are
+> registered on `dev` in `backend/servers/api-server/src/routes/reports.rs`
+> (`router()`, lines 222-228: `list_schedule_executions`, `get_execution_download_url`
+> which builds the presigned-download URL, and `retry_execution`), nested at
+> `/api/v1/reports` in `backend/servers/api-server/src/lib.rs:293`. (An earlier
+> version of this note incorrectly claimed those routes were missing — that was
+> false; corrected in PR #2004 round-1 follow-up.)
+>
+> `apiStatus` remains **partial** because of the Story 81.1 **"Create new
+> schedule"** action (see the unchecked checklist item above): there is no
+> backend create route — `router()` registers only `PUT /schedules/{id}` plus
+> `/schedules/{id}/pause` and `/schedules/{id}/resume`, no `POST /schedules`
+> handler. Flipping `apiStatus` to `wired` is a `rust-backend` task (add the
+> schedule-create route + handler), out of scope for `pm-frontend`.


### PR DESCRIPTION
## Task
Coverage gap [phase2]: Report Execution History — verify and finish to done. Gaps: sprint-status.yaml has no 81-2 key (only epic-80 keys present); classification driven by code+screen+PR consensus; Screen apiStatus: partial — download/retry flow had a test-gap follow-up (d1785e5fb).

## Owner
pm-frontend

## Finding (TL;DR)
Story 81.2 (Report Execution History) **frontend is already fully shipped and green** — this task is a verification, not new feature work. The `apiStatus: partial` is a **backend** gap (missing axum routes), not remaining frontend work. This PR is docs-only: it records the verify-to-done outcome in the screen-map Agent Log and pins the `partial` reason so future agents don't re-investigate.

### What was verified as shipped
- `ExecutionHistory` + `HistoryFilters`: list with status filter, date-range filter, offset/limit pagination.
- Download completed report + retry failed execution — wired end-to-end through the real api-client hooks (`useReportExecutionHistory`, `useDownloadReport`, `useRetryReportExecution`) in **both** `routes/groups/reports.tsx` route containers (`ReportsPageRoute`, `ScheduleDetailPageRoute`).
- Download hook guards empty presigned URLs and cleans up the temp `<a>` in a `finally`; retry invalidates the executions query.
- The d1785e5fb download/retry **test-gap is closed**: `routes/groups/reports.download-retry.route.test.tsx` asserts the PRODUCTION route's `onError` download toast + retry-success toast (the sibling page Harness had diverged there).

### Why apiStatus stays `partial`
The hooks call `GET /api/v1/reports/schedules/{id}/executions`, `GET /api/v1/reports/executions/{id}/download`, `POST /api/v1/reports/executions/{id}/retry`, but the backend ships only DB models/repos (`crates/db/.../report_schedule.rs`, migration `00162_create_report_schedules_executions.sql`) — **no axum routes are registered**. Registering those three routes (+ presigned download URL) is a `rust-backend` task, out of `pm-frontend` scope. Recommend spinning a follow-up backend task rather than merging a half-PR.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web test --run reports` → 6 files / 70 tests pass (exit 0)
- `pnpm -F @ppt/web typecheck` → clean (exit 0)
- `git diff --check` → no whitespace errors

## Built (Band B — full build)
skipped: docs-only change (<50 LOC, no public API/config/build-output touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; docs-only).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
none — single file under `docs/screens/**`, inside pm-frontend owner areas (scope-check exit 0).

## Code-reuse review
none.

## Notes
- Docs-only PR. No source code changed.
- Follow-up recommended: `rust-backend` task to register the report-execution HTTP routes so `apiStatus` can flip to `wired`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VJMVXctNYAs5ZEzj7YRZXy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJMVXctNYAs5ZEzj7YRZXy)_