### PR TITLE
83-2-booking-integration: document Booking.com dual-auth model (verify-to-done)

### DIFF
--- a/docs/phase2/oauth-integration.md
+++ b/docs/phase2/oauth-integration.md
@@ -37,7 +37,7 @@ External OAuth integrations are scaffolded but use placeholder tokens:
 | Google Calendar | Scaffolded | `integrations/calendar.rs` | Auth URL, token exchange implemented |
 | Microsoft Calendar | Scaffolded | `integrations/calendar.rs` | Parallel to Google |
 | Airbnb | Scaffolded | `integrations/airbnb.rs` | OAuth config defined |
-| Booking.com | Scaffolded | `integrations/booking.rs` | XML-based (OTA), no OAuth |
+| Booking.com | Implemented | `integrations/booking/` | Dual-auth: credential-connect + OTA-XML (primary), plus OAuth token-exchange (see below) |
 | Google Assistant | Stub | `routes/ai.rs:link_voice_device` | TODO comment for Phase 2 |
 | Amazon Alexa | Stub | Voice device model | Not started |
 
@@ -87,6 +87,40 @@ pub struct AirbnbOAuthConfig {
 - `GET /api/v1/integrations/airbnb/callback` - Handle redirect
 - `POST /api/v1/integrations/airbnb/disconnect` - Revoke access
 - `GET /api/v1/integrations/airbnb/status` - Check connection
+
+### 2b. Booking.com Channel Integration (Implemented)
+
+Unlike Airbnb, Booking.com is **not** connected through an Airbnb-style OAuth
+*connect* handshake. Booking.com's real API model exposes two authentication
+surfaces, and both are implemented in `backend/crates/integrations/src/booking/`:
+
+1. **Credential connect + OTA-XML (primary).** The legacy Supply XML /
+   Connectivity API authenticates each request with a per-hotel
+   `hotel_id + username + password` over HTTP Basic auth — Booking.com issues
+   long-lived machine credentials rather than running an authorization-code
+   flow. Handled by `BookingClient` / `BookingCredentials`. The api-server
+   `POST /booking/connect` route validates the credentials (by calling
+   `fetch_property`) and stores them encrypted at rest (`IntegrationCrypto`,
+   AES-256-GCM). Reservation pull/push and availability/rate sync ride this path
+   as OpenTravel Alliance (OTA) XML messages.
+2. **OAuth 2.0 token exchange (newer Connectivity APIs).** Booking.com's newer
+   endpoints additionally offer an authorization-code grant, handled by
+   `BookingOAuthClient` and the api-server `POST /booking/token/exchange` route
+   (mirrors the Airbnb OAuth client; fail-closed 503 when `client_id` is unset).
+
+**Existing endpoints:**
+- `POST /api/v1/integrations/organizations/{org_id}/booking/connect` — credential connect
+- `GET  /api/v1/integrations/organizations/{org_id}/booking/status` — connection status
+- `POST /api/v1/integrations/organizations/{org_id}/booking/sync` — pull + persist reservations
+- `POST /api/v1/integrations/organizations/{org_id}/booking/push-availability` / `.../push-rates`
+- `POST /api/v1/integrations/organizations/{org_id}/booking/listing-push` — OTA availability+rate push
+- `GET  /api/v1/integrations/organizations/{org_id}/booking/conflicts` — cross-platform overlap detection
+- `POST /api/v1/integrations/organizations/{org_id}/booking/token/exchange` — OAuth code exchange
+- `DELETE /api/v1/integrations/organizations/{org_id}/booking` — disconnect
+
+The absence of an OAuth *connect* handshake on the primary path is therefore
+intentional and correct — the credential-connect flow matches Booking.com's
+Supply XML contract (Story 83.2 / coverage gap 83-2).
 
 ### 3. Voice Assistant OAuth (Google Assistant/Alexa)
 


### PR DESCRIPTION
## Task
Coverage gap [phase4]: Booking.com OAuth and Sync — verify and finish to done. Gaps: Booking.com uses credential-based connect + OTA-XML rather than OAuth proper (matches Booking.com's real API model, not a true OAuth handshake like Airbnb).

## Owner
pm-backend

## Verdict: feature already complete + verified — this PR is the docs closeout

Investigation confirmed Story 83.2 (Booking.com integration) is implemented, wired, and heavily tested. The flagged "gap" (credential-connect instead of OAuth) is an **intentional, correct** design that matches Booking.com's real Supply XML API model. Notably, the repo actually supports **both** auth surfaces:

- **Credential connect + OTA-XML (primary)** — `BookingClient` / `BookingCredentials`; api-server `POST /booking/connect` validates + encrypts credentials at rest (AES-256-GCM). Reservation pull/push + availability/rate sync ride this path.
- **OAuth 2.0 token exchange (newer Connectivity APIs)** — `BookingOAuthClient` + api-server `POST /booking/token/exchange` (fail-closed 503 when unconfigured).

Verified present and complete:
- Routes wired in `routes/integrations/mod.rs` (`install`, `oauth`, `booking_channel`, `token_rotation`).
- Full pull-and-persist sync in `sync_booking` (fetch → unit mapping → dedup → conflict gate → `create_booking` → `update_connection_last_sync`).
- No `TODO`/`FIXME`/`unimplemented!()`/`todo!()`/`unreachable!()` anywhere under `crates/integrations/src/booking/` or the integration routes.
- Tests: 67 in-crate booking unit tests + 5 integration suites (`booking_connect_encryption`, `booking_credential_encryption`, `booking_cross_user_idor`, `booking_oauth_csrf`, `booking_oauth_routes`).

The only change here is a documentation correction: `docs/phase2/oauth-integration.md` still listed Booking.com as "Scaffolded … no OAuth" at the stale path `integrations/booking.rs`. Updated the status row and added a "Booking.com Channel Integration (Implemented)" section recording the dual-auth model, the existing endpoints, and why the primary path intentionally has no OAuth connect handshake.

## Tested (Band A — fast check)
Ran against the `integrations` crate (which compiles cleanly in this sandbox; api-server itself cannot fully build here — utoipa-swagger-ui build-script download is blocked by the proxy):
- `cargo check -p integrations` → exit 0
- `cargo test -p integrations booking` → `test result: ok. 67 passed; 0 failed`
- `cargo doc -p integrations --no-deps` → exit 0

## Built (Band B — full build)
skipped: docs-only change (no code/config/build-output touch). Underlying feature verified via Band A above.

## CI parity (Band C — hot-path only)
skipped: docs-only change; no security/auth/billing/data-integrity code touched. (The integration's encryption/auth code is unchanged and already covered by the existing test suites listed above.)

## Scope drift
`scope_drift=true`. The only changed file, `docs/phase2/oauth-integration.md`, is outside `pm-backend`'s owner-areas (`backend/**`, `docs/api/typespec/**`, `.sqlx/**`). The drift is justified: this doc records the design of the backend integration under review and corrects genuinely stale status. No code paths touched.

## Code-reuse review
`code_reuse_warn=none` — no new helpers/symbols added (docs-only).

## Remote-tested
skipped (ppt-bridge MCP not used).

## Notes
- Verify-to-done outcome: no code change was required; the feature was already complete and passing. This PR closes the coverage-gap loop with an accurate, durable design record.
- The branch was cut from a commit one behind current `dev`; the pushed commit is rebased onto current `dev` (only the doc file differs), so the diff is clean (1 file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUNyUwJNXHaJAryk4XGpfm

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUNyUwJNXHaJAryk4XGpfm)_