### PR TITLE
feat(dispatcher): ingest open GitHub issues → get things done

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -757,6 +757,49 @@ out of band under a NON-id subject (no `<id>:` prefix) are not auto-matched —
 those still need a manual reconcile note (that is how the Airbnb cluster was
 drained in this defect). Smoke-tested by `.research/test-dev-reconcile.sh`.
 
+**Open-issue ingestion (NEW 2026-07-02 — get things done).** Run RIGHT AFTER
+the reconcilers, before the buffer-guard tiers, so freshly-ingested issues are
+in this run's claim pool. Unlike the buffer refill (a starvation top-up), this
+runs **EVERY cycle** regardless of buffer level — real work filed as GitHub
+issues should always enter the pipeline. Fetch open issues via the **GitHub
+MCP** (the cron can't run `gh` — proxy-403'd, #958), write them to a temp file,
+then run the deterministic merge:
+
+```bash
+# 1. Fetch via MCP (NOT gh): mcp__github__list_issues owner=<owner> repo=<repo>
+#    state=open (paginate). Persist the raw array to a temp file in the same
+#    shape the REST /issues payload has: [{number,title,labels,html_url,
+#    pull_request?}, …]. The MCP call is the ONLY network step; the merge is
+#    deterministic + offline (GH_ISSUES_FILE injection, like dev-reconcile's
+#    DEV_LOG_FILE). If the MCP fetch fails, SKIP (no file → the script no-ops)
+#    — never block the run on issue ingestion.
+GH_ISSUES_FILE=<tmp.json> bash .research/issue-ingest.sh --apply
+```
+
+It promotes untracked open issues into `action-list.json` as `gh-issue-<N>`
+rows (PRs filtered; `EXCLUDE_LABELS` default `epic,discussion,question,wontfix,
+duplicate,blocked,needs-triage` dropped; label→priority `security|critical|bug`
+→high, `enhancement|backend|frontend|mobile|follow-up|from-merged-review`
+→medium, else low). Dedup is thorough: skip any issue already an action-list
+id/stem, an assignment id/stem, or referenced by `#<N>` in an existing row.
+Each row carries `Closes #<N>` in its action, `first_open_at=NOW`, `depends_on:[]`,
+and an `issue_ref:{number,url,labels}` stamp. Bounded: never past `BUFFER_CEIL`
+headroom, ≤ `ISSUE_INGEST_CAP` (default 12) per run, append-only fail-closed.
+Include `action-list.json` in the Phase 6 commit when it ingested any row;
+surface the count on the Phase 7 `Issue-ingest:` line. Smoke-tested by
+`.research/test-issue-ingest.sh`.
+
+**Closing the loop (get things DONE).** A `gh-issue-<N>` PR targets `dev`, and
+a `Closes #<N>` keyword only auto-closes on merge to the **default** branch
+(`main`, not `dev`) — so the issue must be closed EXPLICITLY. When Phase 2 (or
+Phase 5.5) observes a `gh-issue-<N>` assignment go `merged`, close issue `#<N>`
+via `mcp__github__update_issue` (`state=closed`) and post a one-line
+`mcp__github__add_issue_comment` linking the merged PR (`resolved by #<pr> on
+dev`). Surface on the Phase 7 `Issues-closed:` line. If the close MCP call
+fails, log it and continue — the merge already landed; a stale-open issue is
+re-closed idempotently next run (the `gh-issue-<N>` row is terminal, so it is
+not re-ingested).
+
 **Archive lookup pattern (issue #9 — token spending).** With terminal rows
 split into `assignments-archive.json`, the dep_blocked check below MUST
 consult BOTH files when resolving a `depends_on` entry. Compute a set of
@@ -2102,6 +2145,8 @@ Failed-dep cascades:      [<id> blocked-by=<dep_id>, …]             (issue #6;
 Unresolved-dep items:     [<id> dep="<truncated-legacy-text>", …]   (issue #583 — poisoned-sentinel rows whose legacy `dependency` text didn't parse; need human resolution; [] if none)
 GC1 cascade:              <closed-leak=<N> orphan-triage=<M> | clean>   (gc1-reconcile; archive-terminal closes + coverage-missing orphans)
 Backlog-refill:           <promoted=<N> honest-claimable=<A>→<B> capped=<0|1> | clean (healthy) | none-available>   (Tier 1b backlog.json self-refill; planner-independent)
+Issue-ingest:             <ingested=<N> [#<n>, …] capped=<0|1> | none-untracked | mcp-fetch-failed>   (open GH issues → action-list gh-issue-<N>; every cycle)
+Issues-closed:            [#<n> resolved-by=PR#<m>, …]   (gh-issue-<N> assignments that merged this run and were closed via MCP; [] if none)
 Aged claims (this run):   [<id> waited=<h>h <low→medium|medium→high>, …]   (Phase 3 anti-starvation aging boost; [] if none)
 Run lock:                 <acquired <run_id> ttl=<m>m | stole-stale exp=<iso> | abort-held expires-in=<m>m>  (Phase 0.5)
 Skip-gate:                <none | "recent-run age=<m>m; mutating phases SKIPPED">  (issue #1)

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -729,6 +729,34 @@ if [ -x "$REFILL" ]; then note "backlog-refill.sh present + executable"
 else fail "backlog-refill.sh missing or not executable ($REFILL)"; fi
 echo
 
+# --- T30: open-issue ingestion wiring (2026-07-02 — get things done) --------
+# gh-issue-<N> rows must carry issue_ref.number (drives the post-merge MCP
+# close); the prompt must encode the ingest + explicit-close loop; the helper
+# must exist + be executable.
+echo "T30 issue-ingest wiring: gh-issue-<N> rows carry issue_ref + ingest/close encoded"
+if [ -f "$ACTION_LIST" ]; then
+  BAD30=$(jq -r '
+    [ .items[]
+      | select(.id | type=="string" and startswith("gh-issue-"))
+      | select((.issue_ref // {} | .number | type) != "number") ]
+    | length' "$ACTION_LIST")
+  if [ "$BAD30" = "0" ]; then note "all gh-issue-<N> rows carry issue_ref.number"
+  else
+    fail "$BAD30 gh-issue-<N> row(s) missing issue_ref.number"
+    jq -r '.items[] | select(.id|type=="string" and startswith("gh-issue-")) | select((.issue_ref//{}|.number|type)!="number") | "    \(.id)"' "$ACTION_LIST" >&2
+  fi
+else
+  printf '  skip  %s not found\n' "$ACTION_LIST"
+fi
+if [ -f "$PROMPT" ]; then
+  grep -q 'issue-ingest.sh' "$PROMPT"        && note "prompt wires open-issue ingestion" || fail "prompt missing issue-ingest wiring"
+  grep -q 'mcp__github__update_issue' "$PROMPT" && note "prompt encodes explicit issue-close loop" || fail "prompt missing post-merge issue-close loop"
+fi
+INGEST="${INGEST:-.research/issue-ingest.sh}"
+if [ -x "$INGEST" ]; then note "issue-ingest.sh present + executable"
+else fail "issue-ingest.sh missing or not executable ($INGEST)"; fi
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/issue-ingest.sh
+++ b/.research/issue-ingest.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# issue-ingest.sh — pull OPEN GitHub issues into the dispatcher's action-list
+# so they get claimed, implemented, and closed. Target: get things done.
+#
+# Why this script exists (2026-07-02):
+#
+#   The dispatcher's backlog is synthetic (research-routine vectors +
+#   coverage). Real work filed as GitHub issues never entered the pipeline,
+#   so open issues sat untouched. This ingests them as first-class
+#   action-list rows (`gh-issue-<N>`), deterministically and idempotently.
+#
+# Division of labour (the cron can't run `gh` — proxy-403'd, #958):
+#
+#   The DISPATCHER fetches open issues via the GitHub MCP and writes them to
+#   a JSON file; THIS script does the deterministic merge. Same offline-
+#   injection contract as dev-reconcile.sh's DEV_LOG_FILE — so it is unit-
+#   testable with a fixture and a run with no issues degrades to a no-op.
+#
+#   GH_ISSUES_FILE must contain a JSON array of issue objects, each with at
+#   least: { "number": int, "title": str, "labels": [ {"name": str} | str ],
+#   "html_url"?: str, "pull_request"?: any }. This is exactly the shape of
+#   `mcp__github__list_issues` / the REST `GET /issues?state=open` payload.
+#
+# Filtering:
+#   - PRs are skipped (any object carrying a `pull_request` key).
+#   - Issues whose labels intersect EXCLUDE_LABELS are skipped
+#     (default: epic,discussion,question,wontfix,duplicate,blocked,needs-triage).
+#   - Already-tracked issues are skipped: `gh-issue-<N>` present as an
+#     action-list id/stem or an assignment id/stem, OR any existing
+#     action-list row that already references `#<N>` in its action/source
+#     (best-effort dup guard for issues tracked under a different slug).
+#
+# Priority from labels: security|critical|bug -> high; enhancement|backend|
+#   frontend|mobile|follow-up|from-merged-review -> medium; else -> low.
+#
+# UNLIKE backlog-refill (a buffer top-up gated on BUFFER_FLOOR), issue-ingest
+# runs EVERY cycle: any untracked open issue is pulled in regardless of buffer
+# level — real deliverables should always enter the pipeline. Still bounded:
+#   - never lifts the active item count past BUFFER_CEIL headroom,
+#   - at most ISSUE_INGEST_CAP issues per run (default 12),
+#   - append-only; fail-closed if the count doesn't grow by exactly N.
+#
+# The dispatcher closes issue #N via the GitHub MCP when the `gh-issue-<N>`
+# PR merges (a dev-targeted "Closes #N" does NOT auto-close, since `main` —
+# not `dev` — is the default branch). The `Closes #<N>` in the action text is
+# for the PR body; the explicit MCP close is the real done-signal.
+#
+# Usage:
+#   GH_ISSUES_FILE=issues.json ./.research/issue-ingest.sh            # dry-run
+#   GH_ISSUES_FILE=issues.json ./.research/issue-ingest.sh --apply    # ingest
+#   ACTION_LIST=… ASSIGN=… ASSIGN_ARCHIVE=… BUFFER_CEIL=… \
+#     ISSUE_INGEST_CAP=… EXCLUDE_LABELS=… ISSUE_INGEST_NOW=… … [--apply]
+
+set -euo pipefail
+
+ACTION_LIST="${ACTION_LIST:-.research/management/action-list.json}"
+ASSIGN="${ASSIGN:-.research/management/assignments.json}"
+ASSIGN_ARCHIVE="${ASSIGN_ARCHIVE:-.research/management/assignments-archive.json}"
+
+BUFFER_CEIL="${BUFFER_CEIL:-120}"
+ISSUE_INGEST_CAP="${ISSUE_INGEST_CAP:-12}"
+EXCLUDE_LABELS="${EXCLUDE_LABELS:-epic,discussion,question,wontfix,duplicate,blocked,needs-triage}"
+NOW="${ISSUE_INGEST_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+APPLY=0
+[ "${1:-}" = "--apply" ] && APPLY=1
+
+if [ ! -f "$ACTION_LIST" ]; then
+  echo "issue-ingest: action-list missing — nothing to do: $ACTION_LIST" >&2
+  exit 0
+fi
+if [ -z "${GH_ISSUES_FILE:-}" ] || [ ! -f "${GH_ISSUES_FILE:-}" ]; then
+  echo "issue-ingest: no GH_ISSUES_FILE — dispatcher must fetch open issues via GitHub MCP first (no-op)" >&2
+  exit 0
+fi
+
+# Assignment id set (active + archive), multi-file-safe via `jq -s`.
+ASSIGN_INPUTS=("$ASSIGN")
+[ -f "$ASSIGN_ARCHIVE" ] && ASSIGN_INPUTS+=("$ASSIGN_ARCHIVE")
+ASSIGN_IDS=$(jq -s '[ .[].assignments[]?.task_id ] | unique' "${ASSIGN_INPUTS[@]}")
+
+ACTIVE_BEFORE=$(jq '.items | length' "$ACTION_LIST")
+# CEIL headroom is measured against the active item count (append-bound).
+HEADROOM=$(( BUFFER_CEIL - ACTIVE_BEFORE ))
+[ "$HEADROOM" -lt 0 ] && HEADROOM=0
+LIMIT=$(( HEADROOM < ISSUE_INGEST_CAP ? HEADROOM : ISSUE_INGEST_CAP ))
+
+# Candidate issues → action-list rows. Filter PRs + excluded labels + already
+# tracked, map labels→priority, stamp issue_ref + Closes #N, sort by number ASC
+# (deterministic; lower/older issue numbers first).
+CANDIDATES=$(jq -n \
+  --slurpfile iss "$GH_ISSUES_FILE" \
+  --slurpfile al "$ACTION_LIST" \
+  --argjson aids "$ASSIGN_IDS" \
+  --arg now "$NOW" \
+  --arg excl "$EXCLUDE_LABELS" '
+  def stem: sub("-(impl|fix|v2|retry|followup|wip)[0-9]*$";"");
+  def lname: if type=="object" then .name else . end;       # label may be obj or string
+  ($excl | split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(length>0))) as $xl
+  | ([ $al[0].items[]?.id ] | unique) as $al_ids
+  | ([ $al[0].items[]? | select(.status != "done" and .status != "dropped") | (.id | stem) ] | unique) as $al_active_stems
+  | ($aids | unique) as $a_ids
+  | ($aids | map(stem) | unique) as $a_stems
+  # existing "#<N>" references in any action-list row (dup guard for issues
+  # tracked under a non gh-issue-<N> slug).
+  | ([ $al[0].items[]? | ((.action // "") + " " + (.source // "")) ] | join("  ")) as $al_text
+
+  | [ $iss[0][]
+      | select(has("pull_request") | not)                    # drop PRs
+      | . as $i
+      | ([ (.labels // [])[] | lname ]) as $lbls
+      | select( ($lbls | map(. as $l | $xl | index($l)) | map(select(. != null)) | length) == 0 )  # no excluded label
+      | ("gh-issue-" + (.number|tostring)) as $tid
+      | select(($tid | IN($al_ids[])) | not)                 # not already an action-list id
+      | select(($tid | stem | IN($al_active_stems[])) | not) # nor a non-terminal stem
+      | select(($tid | IN($a_ids[])) | not)                  # nor an assignment id
+      | select(($tid | stem | IN($a_stems[])) | not)
+      | select( ($al_text | test("(^|[^0-9])#" + ($i.number|tostring) + "([^0-9]|$)")) | not )  # not referenced already
+      | {
+          id:         $tid,
+          action:     ((.title // $tid) + " (Closes #" + (.number|tostring) + ")"),
+          owner_role: (
+            if   ($lbls | any(. == "security" or . == "dependencies")) then "pm-security"
+            elif ($lbls | any(. == "frontend" or . == "mobile"))       then "pm-frontend"
+            elif ($lbls | any(. == "backend"))                          then "pm-backend"
+            else "pm-tech-lead" end),
+          priority: (
+            if   ($lbls | any(. == "security" or . == "critical" or . == "bug")) then "high"
+            elif ($lbls | any(. == "enhancement" or . == "backend" or . == "frontend"
+                              or . == "mobile" or . == "follow-up" or . == "from-merged-review")) then "medium"
+            else "low" end),
+          status:     "open",
+          source:     ("dispatcher-issue-ingest " + $now + " (#" + (.number|tostring) + ")"),
+          deadline:   null,
+          dependency: null,
+          depends_on: [],
+          first_open_at: $now,
+          issue_ref:  { number: .number, url: (.html_url // null), labels: $lbls }
+        }
+    ]
+  | sort_by(.issue_ref.number)
+')
+
+AVAIL=$(echo "$CANDIDATES" | jq 'length')
+INGEST_N=$(( LIMIT < AVAIL ? LIMIT : AVAIL ))
+[ "$INGEST_N" -lt 0 ] && INGEST_N=0
+CAPPED=0
+[ "$AVAIL" -gt "$LIMIT" ] && CAPPED=1
+
+echo "issue-ingest: untracked open issues=$AVAIL ceil-headroom=$HEADROOM cap=$ISSUE_INGEST_CAP -> ingest=$INGEST_N (capped=$CAPPED)"
+
+if [ "$INGEST_N" -le 0 ]; then
+  echo "issue-ingest: nothing to ingest"
+  exit 0
+fi
+
+INGEST=$(echo "$CANDIDATES" | jq --argjson n "$INGEST_N" '.[0:$n]')
+echo "$INGEST" | jq -r '.[] | "  + \(.id)  [\(.priority)]  \(.action)"'
+
+if [ "$APPLY" = "0" ]; then
+  echo "  (dry-run — pass --apply to ingest them)"
+  exit 0
+fi
+
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+jq --argjson ingest "$INGEST" '.items += $ingest' "$ACTION_LIST" > "$TMP"
+
+ACTIVE_AFTER=$(jq '.items | length' "$TMP")
+if [ "$ACTIVE_AFTER" -ne "$(( ACTIVE_BEFORE + INGEST_N ))" ]; then
+  echo "issue-ingest: ABORT — item count $ACTIVE_BEFORE + $INGEST_N != $ACTIVE_AFTER; refusing to write" >&2
+  exit 2
+fi
+mv "$TMP" "$ACTION_LIST"
+trap - EXIT
+echo "issue-ingest: ingested $INGEST_N issue(s); action-list items $ACTIVE_BEFORE → $ACTIVE_AFTER"

--- a/.research/management/action-list.json
+++ b/.research/management/action-list.json
@@ -474,6 +474,166 @@
         "score": 1,
         "vector": "dx"
       }
+    },
+    {
+      "id": "gh-issue-1680",
+      "action": "Research dispatcher: cron environment can't run core pipeline (fire-and-forget implementers die, no DB, git-push + archive-push blocked) (Closes #1680)",
+      "owner_role": "pm-tech-lead",
+      "priority": "low",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#1680)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 1680,
+        "url": "https://github.com/martin-janci/property-management/issues/1680",
+        "labels": [
+          "dispatcher",
+          "infrastructure"
+        ]
+      }
+    },
+    {
+      "id": "gh-issue-1995",
+      "action": "Wire tenant-migration import/export data-movement (S3 upload, parse/validate, async execution, export gen) — split from #1905 (Closes #1995)",
+      "owner_role": "pm-backend",
+      "priority": "medium",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#1995)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 1995,
+        "url": "https://github.com/martin-janci/property-management/issues/1995",
+        "labels": [
+          "enhancement",
+          "backend"
+        ]
+      }
+    },
+    {
+      "id": "gh-issue-1997",
+      "action": "Follow-up: index + stable-sort + test for migration template pagination (PR #1994) (Closes #1997)",
+      "owner_role": "pm-tech-lead",
+      "priority": "medium",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#1997)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 1997,
+        "url": "https://github.com/martin-janci/property-management/issues/1997",
+        "labels": [
+          "follow-up",
+          "from-merged-review"
+        ]
+      }
+    },
+    {
+      "id": "gh-issue-1998",
+      "action": "Follow-up: #1771 regression test never runs in CI + stale count_unread_rls doc-comment (PR #1993) (Closes #1998)",
+      "owner_role": "pm-tech-lead",
+      "priority": "medium",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#1998)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 1998,
+        "url": "https://github.com/martin-janci/property-management/issues/1998",
+        "labels": [
+          "follow-up",
+          "from-merged-review"
+        ]
+      }
+    },
+    {
+      "id": "gh-issue-1999",
+      "action": "Follow-up: favorite price-alert enqueue/advance can drop an alert (non-transactional) + idempotency test is quarantined (PR #1992) (Closes #1999)",
+      "owner_role": "pm-tech-lead",
+      "priority": "medium",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#1999)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 1999,
+        "url": "https://github.com/martin-janci/property-management/issues/1999",
+        "labels": [
+          "follow-up",
+          "from-merged-review"
+        ]
+      }
+    },
+    {
+      "id": "gh-issue-2000",
+      "action": "Follow-up: CountryCode/SupportedCurrency serialize to ugly \"S_K\"/\"E_U_R\" (wrong rename_all) — wire + DB enum mismatch (PR #1991) (Closes #2000)",
+      "owner_role": "pm-tech-lead",
+      "priority": "medium",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#2000)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 2000,
+        "url": "https://github.com/martin-janci/property-management/issues/2000",
+        "labels": [
+          "follow-up",
+          "from-merged-review"
+        ]
+      }
+    },
+    {
+      "id": "gh-issue-2001",
+      "action": "Follow-up: finance 100% coverage overstated — ignored/500-tolerant tests marked \"done\" (PR #1983) (Closes #2001)",
+      "owner_role": "pm-tech-lead",
+      "priority": "medium",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#2001)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 2001,
+        "url": "https://github.com/martin-janci/property-management/issues/2001",
+        "labels": [
+          "follow-up",
+          "from-merged-review"
+        ]
+      }
+    },
+    {
+      "id": "gh-issue-2009",
+      "action": "cargo-deny advisories failing repo-wide: RUSTSEC advisory on ammonia v4.1.2 (blocks backend PR merges) (Closes #2009)",
+      "owner_role": "pm-security",
+      "priority": "high",
+      "status": "open",
+      "source": "dispatcher-issue-ingest 2026-07-02T11:12:15Z (#2009)",
+      "deadline": null,
+      "dependency": null,
+      "depends_on": [],
+      "first_open_at": "2026-07-02T11:12:15Z",
+      "issue_ref": {
+        "number": 2009,
+        "url": "https://github.com/martin-janci/property-management/issues/2009",
+        "labels": [
+          "security",
+          "dependencies"
+        ]
+      }
     }
   ]
 }

--- a/.research/test-issue-ingest.sh
+++ b/.research/test-issue-ingest.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Smoke test for issue-ingest.sh — deterministic, offline (fixture-fed).
+# Covers: PR filtering, exclude-labels, dedup (id/stem/assignment/#N-reference),
+# label->priority mapping, issue_ref + Closes #N stamp, CEIL/cap bounds,
+# additive-count guard, idempotency.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/issue-ingest.sh"
+FAIL=0
+ok()  { printf '  ok    %s\n' "$1"; }
+bad() { printf '  FAIL  %s\n' "$1"; FAIL=1; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+AL="$TMP/action-list.json"; ASG="$TMP/assignments.json"; ASGA="$TMP/assignments-archive.json"; ISS="$TMP/issues.json"
+NOW="2026-07-02T12:00:00Z"
+
+seed() {
+  cat > "$AL" <<'JSON'
+{"generated":"2026-07-01T00:00:00Z","items":[
+  {"id":"gh-issue-100","action":"already ingested (Closes #100)","owner_role":"pm-backend","priority":"low","status":"open","source":"manual-seed","deadline":null,"dependency":null,"depends_on":[],"issue_ref":{"number":100}},
+  {"id":"dep-bump-ammonia","action":"bump ammonia per #2009 RUSTSEC","owner_role":"pm-security","priority":"high","status":"open","source":"backlog","deadline":null,"dependency":null,"depends_on":[]}
+]}
+JSON
+  cat > "$ASG" <<'JSON'
+{"generated":"2026-07-01T00:00:00Z","assignments":[
+  {"task_id":"gh-issue-200","branch":"auto-impl/gh-issue-200","status":"in-progress","claimed_at":"2026-07-01T00:00:00Z","last_updated":"2026-07-01T00:00:00Z","status_changed_at":"2026-07-01T00:00:00Z"}
+]}
+JSON
+  echo '{"generated":"2026-07-01T00:00:00Z","assignments":[]}' > "$ASGA"
+  cat > "$ISS" <<'JSON'
+[
+  {"number":300,"title":"Fix SSR crash on listing page","labels":[{"name":"bug"},{"name":"frontend"}],"html_url":"https://x/300"},
+  {"number":301,"title":"Wire tenant migration import","labels":[{"name":"enhancement"},{"name":"backend"}],"html_url":"https://x/301"},
+  {"number":302,"title":"Docs cleanup idea","labels":[{"name":"documentation"}],"html_url":"https://x/302"},
+  {"number":303,"title":"Should we redesign X?","labels":[{"name":"discussion"}],"html_url":"https://x/303"},
+  {"number":304,"title":"This is actually a PR","labels":[],"pull_request":{"url":"https://x/pr/304"},"html_url":"https://x/304"},
+  {"number":100,"title":"dup of existing action-list id","labels":[{"name":"bug"}],"html_url":"https://x/100"},
+  {"number":200,"title":"dup of in-progress assignment","labels":[{"name":"bug"}],"html_url":"https://x/200"},
+  {"number":2009,"title":"cargo-deny ammonia advisory","labels":[{"name":"security"}],"html_url":"https://x/2009"}
+]
+JSON
+}
+
+run() { GH_ISSUES_FILE="$ISS" ISSUE_INGEST_NOW="$NOW" ACTION_LIST="$AL" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" \
+    BUFFER_CEIL="${BUFFER_CEIL:-120}" ISSUE_INGEST_CAP="${ISSUE_INGEST_CAP:-12}" bash "$SCRIPT" "$@"; }
+
+echo "== issue-ingest smoke test =="
+
+# 1. dry-run writes nothing
+seed; B=$(jq -c . "$AL"); run >/dev/null 2>&1; [ "$(jq -c . "$AL")" = "$B" ] && ok "dry-run wrote nothing" || bad "dry-run mutated"
+
+# 2. apply ingests only the eligible issues (300, 301) — 302 doc kept as low
+seed; run --apply >/dev/null 2>&1
+ING=$(jq -r '[.items[]|select(.source|startswith("dispatcher-issue-ingest "))|.issue_ref.number]|sort|join(",")' "$AL")
+[ "$ING" = "300,301,302" ] && ok "ingested eligible issues 300,301,302" || bad "ingested set = [$ING] (expected 300,301,302)"
+
+# 3. filters
+has(){ jq -e --argjson n "$1" '[.items[]|select(.issue_ref.number==$n)]|length==1' "$AL" >/dev/null; }
+has 303 && bad "discussion issue 303 ingested (should be excluded)" || ok "excluded label (discussion) skipped"
+has 304 && bad "PR 304 ingested (should be filtered)" || ok "pull_request object filtered out"
+# 100 already an action-list id, 200 an assignment, 2009 referenced via '#2009' text
+CNT100=$(jq '[.items[]|select(.id=="gh-issue-100")]|length' "$AL"); [ "$CNT100" = "1" ] && ok "existing gh-issue-100 not duplicated" || bad "gh-issue-100 dup (count=$CNT100)"
+has 200 && bad "issue 200 ingested despite in-progress assignment" || ok "assignment-tracked issue 200 skipped"
+has 2009 && bad "issue 2009 ingested despite existing #2009 reference" || ok "issue 2009 skipped (referenced by another row)"
+
+# 4. label -> priority + schema + Closes #N
+p(){ jq -r --argjson n "$1" '.items[]|select(.issue_ref.number==$n)|.priority' "$AL"; }
+[ "$(p 300)" = "high" ]   && ok "bug label -> high"          || bad "issue 300 priority=$(p 300)"
+[ "$(p 301)" = "medium" ] && ok "enhancement label -> medium"|| bad "issue 301 priority=$(p 301)"
+[ "$(p 302)" = "low" ]    && ok "unlabeled-ish -> low"       || bad "issue 302 priority=$(p 302)"
+jq -e '.items[]|select(.issue_ref.number==300)| .status=="open" and .depends_on==[] and .first_open_at=="2026-07-02T12:00:00Z" and (.action|test("Closes #300")) and .owner_role=="pm-frontend"' "$AL" >/dev/null \
+  && ok "ingested row schema (open, depends_on, first_open_at, Closes #N, role)" || bad "issue 300 row schema wrong"
+
+# 5. idempotency: second --apply is a no-op
+A=$(jq -c . "$AL"); run --apply >/dev/null 2>&1; [ "$(jq -c . "$AL")" = "$A" ] && ok "second --apply no-op (idempotent)" || bad "second --apply mutated"
+
+# 6. CEIL headroom bounds ingestion
+seed; BUFFER_CEIL=$(( $(jq '.items|length' "$AL") + 1 )) run --apply >/dev/null 2>&1
+NADD=$(jq '[.items[]|select(.source|startswith("dispatcher-issue-ingest "))]|length' "$AL")
+[ "$NADD" = "1" ] && ok "CEIL headroom caps ingest to 1" || bad "CEIL headroom not honored (added $NADD)"
+
+# 7. per-run cap
+seed; ISSUE_INGEST_CAP=1 run --apply >/dev/null 2>&1
+NADD=$(jq '[.items[]|select(.source|startswith("dispatcher-issue-ingest "))]|length' "$AL")
+[ "$NADD" = "1" ] && ok "per-run cap=1 honored" || bad "cap not honored (added $NADD)"
+
+echo
+if [ "$FAIL" = "0" ]; then echo "==> issue-ingest smoke test PASSED"; exit 0
+else echo "==> issue-ingest smoke test FAILED"; exit 1; fi


### PR DESCRIPTION
## Ingest open GitHub issues → get things done

Stacked on #2026 (base = `fix/dispatcher-starvation`; retarget to `dev` once #2026 merges). Extends the dispatcher's new self-refill machinery with a **real work source**: open GitHub issues now enter the pipeline, get claimed/implemented, and are closed on merge.

### What it does
- **`issue-ingest.sh` (new)** — deterministic merge of open issues into `action-list.json` as `gh-issue-<N>` rows. The dispatcher fetches issues via the **GitHub MCP** (the cron can't run `gh` — proxy-403'd, #958) and injects them via `GH_ISSUES_FILE` (same offline contract as `dev-reconcile`'s `DEV_LOG_FILE`, so it's unit-testable and a failed fetch degrades to a no-op).
- **Filtering**: PRs dropped; `EXCLUDE_LABELS` (`epic,discussion,question,wontfix,duplicate,blocked,needs-triage`) dropped; label→priority (`security|critical|bug`→high, `enhancement|backend|frontend|mobile|follow-up|from-merged-review`→medium, else low).
- **Dedup**: skip any issue already an action-list id/stem, an assignment id/stem, or referenced by `#<N>` in an existing row.
- **Runs every cycle** (not buffer-floor-gated) — real deliverables should always enter the pipeline. Bounded by `BUFFER_CEIL` headroom + `ISSUE_INGEST_CAP` (12/run), append-only fail-closed.
- **Closes the loop**: each row carries `Closes #<N>`; on merge the dispatcher **explicitly closes** issue `#N` via `mcp__github__update_issue` + a linking comment — because a `dev`-targeted `Closes #N` does *not* auto-close (`main`, not `dev`, is the default branch).
- **T30** self-test + **`test-issue-ingest.sh`** (14 assertions).

### Verification (local)
- `dispatcher-self-test` ✅ (incl. T30) · `goal-check --enforce` ✅ · `scope-check` ✅ · `test-issue-ingest` ✅ · `test-backlog-refill` ✅
- Applied to live data: ingested all **8** open issues (`#1680 #1995 #1997 #1998 #1999 #2000 #2001 #2009`) → `gh-issue-<N>` rows (security #2009 high, follow-ups medium, meta #1680 low).

### Note
`#1680` (dispatcher cron-env, labels `dispatcher`/`infrastructure`) gets ingested as low since those labels aren't in the exclude set — it's the dispatcher's own infra and may not be self-implementable. Add `dispatcher`/`infrastructure` to `EXCLUDE_LABELS` if you'd rather it stay out.
