### PR TITLE
gh-issue-1995: retarget migration data-movement checklist rows to #1995 (partial)

### DIFF
--- a/docs/endpoint-checklist/groups/integrations-ecosystem.md
+++ b/docs/endpoint-checklist/groups/integrations-ecosystem.md
@@ -154,20 +154,20 @@ _Deleted in [BIT-257](/BIT/issues/BIT-257): 43 unmounted `/api/v1/developer/*` R
 | GET | /api/v1/migration/templates/{template_id}/download | download_template | done | migration_db_tests.rs | db-backed and tested |
 | POST | /api/v1/migration/templates/{template_id}/duplicate | duplicate_template | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/categories/import | get_import_categories | done | migration_db_tests.rs | static metadata |
-| POST | /api/v1/migration/import/upload | upload_import_file | partial | migration_db_tests.rs | metadata row persisted; multipart bytes NOT uploaded to S3 (synthetic file_path) — #1905 |
+| POST | /api/v1/migration/import/upload | upload_import_file | partial | migration_db_tests.rs | metadata row persisted; multipart bytes NOT uploaded to S3 (synthetic file_path) — #1995 |
 | GET | /api/v1/migration/import/jobs | list_import_jobs | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/import/jobs/{job_id} | get_import_job_status | done | migration_db_tests.rs | db-backed and tested |
 | POST | /api/v1/migration/import/jobs/{job_id}/cancel | cancel_import_job | done | migration_db_tests.rs | db-backed and tested |
 | POST | /api/v1/migration/import/jobs/{job_id}/retry | retry_import_job | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/import/jobs/{job_id}/errors | get_import_job_errors | done | migration_db_tests.rs | db-backed and tested |
-| POST | /api/v1/migration/export | request_migration_export | partial | migration_db_tests.rs | persists export request row; no export is ever generated — #1905 |
-| GET | /api/v1/migration/export/{export_id} | get_export_status | partial | migration_db_tests.rs | fabricates Ready status + storage.example.com URL + fixed size/counts; no real export — #1905 |
-| GET | /api/v1/migration/export/{export_id}/download | download_export | partial | migration_db_tests.rs | returns placeholder storage.example.com URL; no real object — #1905 |
+| POST | /api/v1/migration/export | request_migration_export | partial | migration_db_tests.rs | persists export request row; no export is ever generated — #1995 |
+| GET | /api/v1/migration/export/{export_id} | get_export_status | partial | migration_db_tests.rs | fabricates Ready status + storage.example.com URL + fixed size/counts; no real export — #1995 |
+| GET | /api/v1/migration/export/{export_id}/download | download_export | partial | migration_db_tests.rs | returns placeholder storage.example.com URL; no real object — #1995 |
 | GET | /api/v1/migration/export/history | get_export_history | done | migration_db_tests.rs | db-backed and tested |
 | GET | /api/v1/migration/categories/export | get_export_categories | done | migration_db_tests.rs | static metadata |
-| GET | /api/v1/migration/import/jobs/{job_id}/preview | get_import_preview | partial | migration_db_tests.rs | returns the mock validate output (hardcoded issues); no real parse — #1905 |
-| POST | /api/v1/migration/import/jobs/{job_id}/approve | approve_import | partial | migration_db_tests.rs | flips status to Importing but queues no execution; nothing moves the job past it — #1905 |
-| POST | /api/v1/migration/import/jobs/{job_id}/validate | validate_import | partial | migration_db_tests.rs | inserts hardcoded errors + counts (total=100/ok=98/fail=2); file never read — #1905 |
+| GET | /api/v1/migration/import/jobs/{job_id}/preview | get_import_preview | partial | migration_db_tests.rs | returns the mock validate output (hardcoded issues); no real parse — #1995 |
+| POST | /api/v1/migration/import/jobs/{job_id}/approve | approve_import | partial | migration_db_tests.rs | flips status to Importing but queues no execution; nothing moves the job past it — #1995 |
+| POST | /api/v1/migration/import/jobs/{job_id}/validate | validate_import | partial | migration_db_tests.rs | inserts hardcoded errors + counts (total=100/ok=98/fail=2); file never read — #1995 |
 
 ## feature_packages.rs  (mount: /api/v1/feature-packages; public_router nested at /public)
 | Method | Path | Handler | Status | Tests | Notes |


### PR DESCRIPTION
## Task
Wire tenant-migration import/export data-movement (S3 upload, parse/validate, async execution, export gen) — split from #1905 (Closes #1995)

## Owner
pm-backend

## Scope of THIS PR (partial toward #1995)
This is a **deliberately narrow, verifiable slice**. The full functional
work in #1995 (real S3 byte upload, real file parse/validate, async import
execution, real export artifact + presigned URL, plus the `migration_db_tests.rs`
real-I/O + cross-tenant RLS asserts) is **DB-backed and S3-backed** and can
only be verified end-to-end against live Postgres + S3.

This implementer runs in a **cloud cron environment with no Docker, no
Postgres, and no S3**. None of #1995's acceptance criteria (bytes in S3,
real parse, async terminal-state, real presigned URL, DB integration tests)
can be exercised or honestly verified here. Per the skill's verify gate,
opening a "green" PR for unexercisable hot-path data-integrity/security
code would be fabricating verification. So this PR lands only the one
change that IS safe and verifiable in this environment: a checklist
reconciliation.

### Change
The 7 `partial` migration import/export rows in
`docs/endpoint-checklist/groups/integrations-ecosystem.md` pointed their
"remaining work" notes at **#1905**, whose constructive-review scope is
closing. #1995 is now the live tracker for exactly this data-movement work.
Retargeted the 7 row notes `#1905 → #1995` so a future implementer lands on
the correct tracking issue. No handler/code/behavior change; the notes
themselves already accurately describe the current mock behavior.

Rows retargeted: `upload_import_file`, `request_migration_export`,
`get_export_status`, `download_export`, `get_import_preview`,
`approve_import`, `validate_import`.

### Deferred (still open in #1995 — NOT done here)
- [ ] Real S3 upload of import bytes (`upload_import_file`, synthetic `file_path`)
- [ ] Real parse + validation (`validate_import` / `get_import_preview` — hardcoded errors/counts)
- [ ] Async import execution (`approve_import` — no worker queued)
- [ ] Real export artifact + presigned URL (`get_export_status` / `download_export` — `storage.example.com` placeholders)
- [ ] `migration_db_tests.rs` real-I/O asserts + cross-tenant RLS negatives

These require a live stack; recommend a DB/S3-capable runner (or the
`ppt-bridge` MCP against mefistos/hetzner) to implement + verify.

## Tested (Band A — fast check)
Docs-only change; no compilable surface touched.
- `git diff --check` → exit 0 (no whitespace/conflict errors)
- `git diff --stat` → 1 file changed, 7 insertions(+), 7 deletions(-)

## Built (Band B — full build)
skipped: docs-only change, no code/public-API/config touched.

## CI parity (Band C — hot-path only)
skipped: no code path changed. The underlying feature IS hot-path
(data-integrity + RLS), which is precisely why the functional work is
deferred rather than shipped unverified here.

## Remote-tested
skipped: ppt-bridge MCP not used.

## Scope drift
`scope-check.sh --owner pm-backend` → exit 2. The changed file
`docs/endpoint-checklist/groups/integrations-ecosystem.md` sits outside
pm-backend's code scope (`backend/**`, `docs/api/typespec/**`, `.sqlx/**`);
docs live under pm-tech-lead/pm-scrum-master areas. This is an intentional,
honest docs reconciliation for a pm-backend task — flagged for reviewer
awareness, not a code-area violation.

## Notes
Draft: partial toward #1995. Functional data-movement + tests intentionally
deferred as un-verifiable in a no-Docker/no-Postgres/no-S3 environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6dwaVVWB2rD1xurqN69jX)_