### PR TITLE
gh-issue-1997: index + stable-sort + tests for migration template pagination (Closes #1997)

### DIFF
--- a/backend/crates/db/migrations/00211_import_templates_org_updated_index.sql
+++ b/backend/crates/db/migrations/00211_import_templates_org_updated_index.sql
@@ -1,0 +1,27 @@
+-- Migration: 00211_import_templates_org_updated_index
+-- Composite index backing MigrationRepository::list_templates pagination
+-- (#1997 finding-1, follow-up to PR #1994).
+--
+-- PR #1994 moved list_templates pagination into SQL:
+--   SELECT * FROM import_templates
+--   WHERE (organization_id = $1 [OR organization_id IS NULL]) [AND data_type = $2]
+--   ORDER BY updated_at DESC, id DESC
+--   LIMIT $ OFFSET $
+--
+-- Migration 00198 only created idx_import_templates_organization_id
+-- (a single-column btree on organization_id). That index covers the equality
+-- predicate but not the ORDER BY, so every page runs an org-filtered scan
+-- followed by a sort — cost grows with the org's template count and the OFFSET.
+--
+-- A composite index keyed (organization_id, updated_at DESC) lets Postgres
+-- satisfy both the org filter and the descending sort from one index, so the
+-- paginated reads become an index range scan.
+--
+-- Note the (organization_id IS NULL) system-template leg of the OR: NULLs are
+-- indexed by btree, so the same index also serves the system-template branch
+-- (Postgres can OR two index scans or bitmap-OR them). The id DESC tiebreak
+-- added in the query is a within-key tiebreak the planner resolves after the
+-- index range; keeping the index on (organization_id, updated_at DESC) matches
+-- the leading sort keys, which is what drives the plan.
+CREATE INDEX IF NOT EXISTS idx_import_templates_org_updated
+    ON import_templates (organization_id, updated_at DESC);

--- a/backend/crates/db/src/repositories/migration.rs
+++ b/backend/crates/db/src/repositories/migration.rs
@@ -47,7 +47,7 @@ impl MigrationRepository {
         match (data_type, include_system) {
             (Some(dt), true) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) AND data_type = $2 ORDER BY updated_at DESC LIMIT $3 OFFSET $4",
+                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) AND data_type = $2 ORDER BY updated_at DESC, id DESC LIMIT $3 OFFSET $4",
                 )
                 .bind(org_id)
                 .bind(dt)
@@ -58,7 +58,7 @@ impl MigrationRepository {
             }
             (Some(dt), false) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE organization_id = $1 AND data_type = $2 ORDER BY updated_at DESC LIMIT $3 OFFSET $4",
+                    "SELECT * FROM import_templates WHERE organization_id = $1 AND data_type = $2 ORDER BY updated_at DESC, id DESC LIMIT $3 OFFSET $4",
                 )
                 .bind(org_id)
                 .bind(dt)
@@ -69,7 +69,7 @@ impl MigrationRepository {
             }
             (None, true) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) ORDER BY updated_at DESC LIMIT $2 OFFSET $3",
+                    "SELECT * FROM import_templates WHERE (organization_id = $1 OR organization_id IS NULL) ORDER BY updated_at DESC, id DESC LIMIT $2 OFFSET $3",
                 )
                 .bind(org_id)
                 .bind(limit)
@@ -79,7 +79,7 @@ impl MigrationRepository {
             }
             (None, false) => {
                 sqlx::query_as::<_, ImportTemplate>(
-                    "SELECT * FROM import_templates WHERE organization_id = $1 ORDER BY updated_at DESC LIMIT $2 OFFSET $3",
+                    "SELECT * FROM import_templates WHERE organization_id = $1 ORDER BY updated_at DESC, id DESC LIMIT $2 OFFSET $3",
                 )
                 .bind(org_id)
                 .bind(limit)

--- a/backend/crates/db/tests/migration_templates_pagination_tests.rs
+++ b/backend/crates/db/tests/migration_templates_pagination_tests.rs
@@ -1,0 +1,281 @@
+//! Round-trip coverage for `MigrationRepository::list_templates` /
+//! `count_templates` SQL pagination (#1997, follow-up to PR #1994).
+//!
+//! PR #1994 pushed the template listing pagination down into SQL
+//! (`ORDER BY updated_at DESC[, id DESC] LIMIT/OFFSET`) with a companion
+//! `count_templates`. Before this file there was no test exercising that path.
+//!
+//! What this locks in
+//! ------------------
+//! 1. `count_templates` returns the true total for the same filter
+//!    `list_templates` paginates (org-scoped, and org + system).
+//! 2. Successive pages are disjoint and together cover the full set exactly
+//!    once — i.e. `LIMIT/OFFSET` walks the ordering without gaps or overlap.
+//! 3. The ordering is *total*: with system templates seeded in a single INSERT
+//!    (identical `updated_at`), the `, id DESC` tiebreak added in #1997 makes
+//!    the order deterministic. Seeding a page's worth of rows with an identical
+//!    `updated_at` and asserting strict `id DESC` fails on `updated_at DESC`
+//!    alone (undefined tie order) — this is the regression guard.
+//! 4. A cross-tenant RLS negative: an org-A caller bound by FORCE RLS cannot
+//!    see org-B's templates even when the query's WHERE targets org-B's id.
+//!
+//! CI runs each `#[sqlx::test]` against its own freshly-migrated Postgres
+//! (see `.github/workflows/backend.yml`), connecting as the `postgres`
+//! superuser — which bypasses RLS. The pagination tests exercise the repo
+//! directly under that superuser; the RLS test drops to a dedicated
+//! `NOSUPERUSER NOBYPASSRLS` role so `FORCE ROW LEVEL SECURITY` actually binds.
+
+use db::models::ImportDataType;
+use db::repositories::MigrationRepository;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Org {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@migtmpl.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+/// Create `n` org-scoped templates, then flatten their `updated_at` to a single
+/// fixed instant so ordering within the page depends solely on the `id DESC`
+/// tiebreak. Returns the created ids.
+async fn seed_org_templates(
+    pool: &PgPool,
+    repo: &MigrationRepository,
+    org_id: Uuid,
+    n: usize,
+) -> Vec<Uuid> {
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let tmpl = repo
+            .create_template(
+                pool,
+                Some(org_id),
+                format!("Template {i}"),
+                Some(format!("desc {i}")),
+                ImportDataType::Buildings,
+                json!([]),
+                None,
+                false,
+            )
+            .await
+            .expect("create template");
+        ids.push(tmpl.id);
+    }
+    // Collapse updated_at to one instant so the only remaining sort key is id.
+    sqlx::query(
+        "UPDATE import_templates SET updated_at = TIMESTAMPTZ '2026-01-01 00:00:00+00' \
+         WHERE organization_id = $1",
+    )
+    .bind(org_id)
+    .execute(pool)
+    .await
+    .expect("flatten updated_at");
+    ids
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn count_and_pages_are_consistent_and_disjoint(pool: PgPool) {
+    // Superuser context — inserts bypass RLS; is_super_admin GUC harmless.
+    db::set_request_context(&pool, None, None, true)
+        .await
+        .expect("set super context");
+
+    let org = seed_org(&pool, "mig-pag-a").await;
+    let repo = MigrationRepository::new(pool.clone());
+
+    let total = 5usize;
+    let created = seed_org_templates(&pool, &repo, org, total).await;
+
+    // --- count_templates matches the org-scoped total (no system rows). ---
+    let org_count = repo
+        .count_templates(&pool, org, None, false)
+        .await
+        .expect("count org templates");
+    assert_eq!(
+        org_count, total as i64,
+        "count_templates must equal the number of org-scoped templates"
+    );
+
+    // count including system == org count + live system-template count (robust
+    // against changes to the exact number of seeded system templates).
+    let system_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM import_templates WHERE organization_id IS NULL")
+            .fetch_one(&pool)
+            .await
+            .expect("count system templates");
+    let with_system = repo
+        .count_templates(&pool, org, None, true)
+        .await
+        .expect("count incl system");
+    assert_eq!(
+        with_system,
+        total as i64 + system_count,
+        "include_system count must add the system (organization_id IS NULL) rows"
+    );
+
+    // --- Page 1 vs Page 2 (per_page = 2) are disjoint. ---
+    let per_page = 2i64;
+    let page1: Vec<Uuid> = repo
+        .list_templates(&pool, org, None, false, per_page, 0)
+        .await
+        .expect("page 1")
+        .into_iter()
+        .map(|t| t.id)
+        .collect();
+    let page2: Vec<Uuid> = repo
+        .list_templates(&pool, org, None, false, per_page, per_page)
+        .await
+        .expect("page 2")
+        .into_iter()
+        .map(|t| t.id)
+        .collect();
+    let page3: Vec<Uuid> = repo
+        .list_templates(&pool, org, None, false, per_page, per_page * 2)
+        .await
+        .expect("page 3")
+        .into_iter()
+        .map(|t| t.id)
+        .collect();
+
+    assert_eq!(page1.len(), 2, "page 1 must be full");
+    assert_eq!(page2.len(), 2, "page 2 must be full");
+    assert_eq!(page3.len(), 1, "page 3 holds the remainder");
+
+    for id in &page1 {
+        assert!(!page2.contains(id), "pages must be disjoint (p1 vs p2)");
+        assert!(!page3.contains(id), "pages must be disjoint (p1 vs p3)");
+    }
+    for id in &page2 {
+        assert!(!page3.contains(id), "pages must be disjoint (p2 vs p3)");
+    }
+
+    // Union of all pages == the full created set, each exactly once.
+    let mut walked: Vec<Uuid> = page1.iter().chain(&page2).chain(&page3).copied().collect();
+    walked.sort();
+    let mut expected = created.clone();
+    expected.sort();
+    assert_eq!(
+        walked, expected,
+        "paging must cover every template exactly once"
+    );
+
+    // --- Total order: identical updated_at ⇒ strict id DESC (the #1997 tiebreak).
+    //     On `ORDER BY updated_at DESC` alone this tie order is undefined. ---
+    let full: Vec<Uuid> = repo
+        .list_templates(&pool, org, None, false, 100, 0)
+        .await
+        .expect("full list")
+        .into_iter()
+        .map(|t| t.id)
+        .collect();
+    let mut sorted_desc = full.clone();
+    sorted_desc.sort_by(|a, b| b.cmp(a));
+    assert_eq!(
+        full, sorted_desc,
+        "with equal updated_at the order must be a stable, strict id DESC"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_templates_is_cross_tenant_isolated_under_force_rls(pool: PgPool) {
+    // Seed both orgs + an org-B template under superuser context.
+    db::set_request_context(&pool, None, None, true)
+        .await
+        .expect("set super context");
+
+    let org_a = seed_org(&pool, "mig-rls-a").await;
+    let org_b = seed_org(&pool, "mig-rls-b").await;
+    let repo = MigrationRepository::new(pool.clone());
+
+    let tmpl_b = repo
+        .create_template(
+            &pool,
+            Some(org_b),
+            "Org B Secret".to_string(),
+            None,
+            ImportDataType::Buildings,
+            json!([]),
+            None,
+            false,
+        )
+        .await
+        .expect("create org-B template");
+
+    // Dedicated NOSUPERUSER NOBYPASSRLS role so FORCE RLS actually binds.
+    let role = format!("ppt_mig_rls_test_{}", Uuid::new_v4().simple());
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create role");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON import_templates, organizations TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select");
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+         get_current_org_not_deleted() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute on rls helpers");
+
+    {
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // Org-A context, then drop to the FORCE-applicable role.
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(org_a)
+            .bind(Option::<Uuid>::None)
+            .bind(false)
+            .execute(&mut *conn)
+            .await
+            .expect("set org-A context");
+        sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+            .execute(&mut *conn)
+            .await
+            .expect("set role");
+
+        // Even though the query's WHERE targets org-B's id, FORCE RLS hides
+        // org-B's rows from an org-A caller.
+        let leaked = repo
+            .list_templates(&mut *conn, org_b, None, false, 100, 0)
+            .await
+            .expect("list under org-A");
+        assert!(
+            leaked.is_empty(),
+            "org-A caller must not see org-B templates (got {} rows incl {:?})",
+            leaked.len(),
+            tmpl_b.id,
+        );
+
+        let leaked_count = repo
+            .count_templates(&mut *conn, org_b, None, false)
+            .await
+            .expect("count under org-A");
+        assert_eq!(
+            leaked_count, 0,
+            "count_templates must not leak org-B's total to an org-A caller"
+        );
+
+        sqlx::query("RESET ROLE")
+            .execute(&mut *conn)
+            .await
+            .expect("reset role");
+    }
+}


### PR DESCRIPTION
## Task
Follow-up: index + stable-sort + test for migration template pagination (PR #1994) (Closes #1997).

Three constructive follow-ups to PR #1994 (which moved `MigrationRepository::list_templates` pagination into SQL with a companion `count_templates`):

1. **performance** — the query sorts on `updated_at DESC` but `import_templates` only had `idx_import_templates_organization_id` (migration 00198). Added a composite index via a **new forward-only migration** `00211_import_templates_org_updated_index.sql`:
   `CREATE INDEX IF NOT EXISTS idx_import_templates_org_updated ON import_templates (organization_id, updated_at DESC);`
   The migration header documents the `organization_id IS NULL` (system-template) OR-leg — btree indexes NULLs, so the same index serves that branch.
2. **correctness** — `ORDER BY updated_at DESC` had no tiebreak; system templates seeded in one INSERT share `updated_at`, so cross-page order was undefined. Appended `, id DESC` to **all four** `list_templates` branches in `backend/crates/db/src/repositories/migration.rs`, making the sort total.
3. **tests** — added `backend/crates/db/tests/migration_templates_pagination_tests.rs`:
   - `count_and_pages_are_consistent_and_disjoint`: seeds > per_page templates, asserts `count_templates == total` (org-scoped and org+system), page 1 / 2 / 3 are disjoint and jointly cover the set exactly once, and — with `updated_at` flattened to one instant — asserts strict `id DESC` (the #1997 tiebreak; undefined on `updated_at DESC` alone → regression guard).
   - `list_templates_is_cross_tenant_isolated_under_force_rls`: cross-tenant RLS negative — an org-A caller bound to a `NOSUPERUSER NOBYPASSRLS` role cannot see org-B templates even when the query WHERE targets org-B's id.

## Owner
pm-tech-lead (hint). Actual work is a **db-migration** specialist change (all files under `backend/crates/db/`).

## Tested (Band A — fast check)
Environment: cloud cron sandbox with **no Docker / Postgres / S3**, so DB-backed `#[sqlx::test]` tests **cannot be executed or verified here**. Verification is therefore **compile-only** (the honest partial pattern):

- `cargo fmt -p db -- --check` → exit 0 (clean)
- `SQLX_OFFLINE=true cargo test -p db --no-run --test migration_templates_pagination_tests` → exit 0 (test target + `, id DESC` repo change compile clean)
- `SQLX_OFFLINE=true cargo clippy -p db --tests` → exit 0 (no warnings)

The repo methods use runtime `sqlx::query_as::<_, T>(...)` (string queries, not the `query!` macro), so no `.sqlx` offline-data regeneration is required and `cargo sqlx prepare --check` is unaffected.

## Built (Band B — full build)
New migration present. Band B for db-migration normally applies the migration on an ephemeral DB (`dev-db reset && migrate`) — **deferred: no Postgres in this sandbox.** The migration is plain forward-only DDL (`CREATE INDEX IF NOT EXISTS`), mirroring the 00209 partial-index precedent.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path change (no auth/billing; adds an index + a sort tiebreak + tests). The two `#[sqlx::test]` cases **will run in CI**, which provisions a fresh migrated Postgres per test (`.github/workflows/backend.yml` runs `cargo test --workspace`).

## Remote-tested
Skipped (no ppt-bridge MCP in this session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 because `pm-tech-lead` maps to `docs/** / .research/** / _bmad-output/**` (an architecture-doc role), while this task's files are all under `backend/crates/db/`. This is the "owner_role hint is not authoritative" case — the task is db-migration work. All three changed files are exactly the intended target of issue #1997:
- `backend/crates/db/migrations/00211_import_templates_org_updated_index.sql`
- `backend/crates/db/src/repositories/migration.rs`
- `backend/crates/db/tests/migration_templates_pagination_tests.rs`

## Code-reuse review
`reuse-grep.sh` — no findings.

## Notes
- **Verification is compile-only in this sandbox (no DB).** The two DB-backed tests are added as source and were **not executed**; they are expected to run green under CI's per-test Postgres. Flagging for the reviewer to confirm on the real gate.
- The RLS negative test models the proven `document_shares_rls_cross_tenant_tests.rs` role-switch pattern (`NOSUPERUSER NOBYPASSRLS` + `SET ROLE`) so `FORCE ROW LEVEL SECURITY` actually binds under the CI superuser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JrWVJSUMyQ5WywRG9Ekpv

---
_Generated by [Claude Code](https://claude.ai/code/session_011JrWVJSUMyQ5WywRG9Ekpv)_