### PR TITLE
test(db): pin #1771 unread soft-delete fix with non-DB guard (Closes #1998)

### DIFF
--- a/backend/crates/db/src/repositories/messaging.rs
+++ b/backend/crates/db/src/repositories/messaging.rs
@@ -39,6 +39,28 @@ pub struct MessagingRepository {
     pool: DbPool,
 }
 
+/// SQL for [`MessagingRepository::count_unread_rls`].
+///
+/// Hoisted into a `const` so a non-DB unit test can pin the #1771 soft-delete
+/// exclusion (`tps.deleted_at IS NULL`) on the normal CI gate without a live
+/// Postgres pool (the DB-backed regression test is quarantined under BIT-351).
+const COUNT_UNREAD_SQL: &str = r#"
+            SELECT COUNT(*)
+            FROM messages m
+            JOIN message_threads t ON t.id = m.thread_id
+            LEFT JOIN thread_participant_state tps
+                ON tps.thread_id = t.id AND tps.user_id = $1
+            WHERE $1 = ANY(t.participant_ids)
+              AND t.organization_id = $2
+              AND m.sender_id != $1
+              AND m.deleted_at IS NULL
+              -- exclude threads this user soft-deleted ("delete for me"); they
+              -- vanish from the inbox list, so their unread messages must not
+              -- keep the global unread badge stuck non-zero (#1771).
+              AND tps.deleted_at IS NULL
+              AND (tps.last_read_at IS NULL OR m.created_at > tps.last_read_at)
+            "#;
+
 impl MessagingRepository {
     /// Create a new MessagingRepository.
     pub fn new(pool: DbPool) -> Self {
@@ -594,10 +616,12 @@ impl MessagingRepository {
     /// — one member reading no longer clears everyone's badge.
     ///
     /// Note (#1771): this LEFT JOIN to `thread_participant_state` is also where
-    /// the per-participant soft-delete exclusion lives; see PR #1968 which adds
-    /// `tps.deleted_at IS NULL` on the same join. The two changes touch the same
-    /// query and should be reconciled at merge (combine both predicates on the
-    /// one join).
+    /// the per-participant soft-delete exclusion lives — `tps.deleted_at IS NULL`
+    /// is inline in the query below, so threads a user soft-deleted ("delete for
+    /// me") no longer keep their global unread badge stuck non-zero. The query
+    /// SQL is hoisted into [`COUNT_UNREAD_SQL`] so a non-DB unit test can pin that
+    /// predicate on the normal CI gate (the DB-backed regression test is
+    /// quarantined under BIT-351).
     pub async fn count_unread_rls<'e, E>(
         &self,
         executor: E,
@@ -607,28 +631,11 @@ impl MessagingRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let (count,): (i64,) = sqlx::query_as(
-            r#"
-            SELECT COUNT(*)
-            FROM messages m
-            JOIN message_threads t ON t.id = m.thread_id
-            LEFT JOIN thread_participant_state tps
-                ON tps.thread_id = t.id AND tps.user_id = $1
-            WHERE $1 = ANY(t.participant_ids)
-              AND t.organization_id = $2
-              AND m.sender_id != $1
-              AND m.deleted_at IS NULL
-              -- exclude threads this user soft-deleted ("delete for me"); they
-              -- vanish from the inbox list, so their unread messages must not
-              -- keep the global unread badge stuck non-zero (#1771).
-              AND tps.deleted_at IS NULL
-              AND (tps.last_read_at IS NULL OR m.created_at > tps.last_read_at)
-            "#,
-        )
-        .bind(user_id)
-        .bind(organization_id)
-        .fetch_one(executor)
-        .await?;
+        let (count,): (i64,) = sqlx::query_as(COUNT_UNREAD_SQL)
+            .bind(user_id)
+            .bind(organization_id)
+            .fetch_one(executor)
+            .await?;
 
         Ok(count)
     }
@@ -1293,5 +1300,29 @@ impl MessagingRepository {
                 )
             },
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::COUNT_UNREAD_SQL;
+
+    /// Non-DB guard for the #1771 fix (PR #1993): the unread-count query must
+    /// exclude threads a user soft-deleted ("delete for me") via the
+    /// per-participant `tps.deleted_at IS NULL` predicate on the
+    /// `thread_participant_state` join. The DB-backed regression test
+    /// (`soft_deleted_thread_excluded_from_unread_count`) is `#[ignore]`d under
+    /// the BIT-351 quarantine, so this plain `#[test]` — mirroring the
+    /// catalog-metadata guard style — is the executing guard on the normal CI
+    /// gate. It runs without a live Postgres pool.
+    #[test]
+    fn count_unread_sql_excludes_soft_deleted_threads() {
+        assert!(
+            COUNT_UNREAD_SQL.contains("tps.deleted_at IS NULL"),
+            "count_unread_rls SQL must keep the per-participant soft-delete \
+             exclusion `tps.deleted_at IS NULL` (#1771 / PR #1993); without it a \
+             thread a user hid from their inbox leaves its unread messages stuck \
+             on the global unread badge with no thread visible to clear them"
+        );
     }
 }


### PR DESCRIPTION
## Task
Follow-up: #1771 regression test never runs in CI + stale `count_unread_rls` doc-comment (PR #1993) (Closes #1998)

PR #1993 fixed the `count_unread_rls` unread-count soft-delete leak (#1771), but its regression test `soft_deleted_thread_excluded_from_unread_count` in `backend/crates/db/tests/thread_participant_state_tests.rs` is `#[ignore]`d under the BIT-351 quarantine — so there was **no executing guard** for the fix on the normal CI gate.

## What changed (backend/crates/db/ only)
1. **Non-DB guard.** Hoisted the `count_unread_rls` query SQL into a testable module-level `const COUNT_UNREAD_SQL` in `backend/crates/db/src/repositories/messaging.rs`, and added a plain `#[test]` (`count_unread_sql_excludes_soft_deleted_threads`, no `#[sqlx::test]`, no live pool) asserting the SQL still contains `tps.deleted_at IS NULL`. Mirrors the catalog-metadata guard style referenced in the tps test file's header. This runs on the normal CI gate even without Docker/Postgres.
2. **Stale doc-comment fixed.** The `count_unread_rls` doc-comment still said the `tps.deleted_at IS NULL` predicate from PR #1968/#1993 "should be reconciled at merge". That reconciliation already happened in #1993 and the predicate is inline — the comment now states that plainly and points at `COUNT_UNREAD_SQL` / the BIT-351 quarantine.

Single file touched: `backend/crates/db/src/repositories/messaging.rs` (+57/-26). No behavior change to the query itself.

## Owner
pm-tech-lead (hint) — actual work: rust-backend, all under `backend/crates/db/`

## Tested (Band A — fast check)
- `cargo fmt -p db -- --check` → exit 0
- `SQLX_OFFLINE=true cargo test -p db --lib count_unread_sql_excludes_soft_deleted_threads` → exit 0 (`1 passed; 0 failed`)
- `SQLX_OFFLINE=true cargo clippy -p db --tests -- -D warnings` → exit 0

## Built (Band B — full build)
Skipped: change is a single-file test/doc addition (<50 LOC substantive, no public API/migration/config touch). The new non-DB `#[test]` compiles and runs green via the Band A `cargo test` above.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path change (test guard + doc-comment only; no security/auth/billing/data-integrity behavior change). Query SQL is byte-identical to the merged #1993 version.

## Remote-tested
Skipped (cloud sandbox: no Docker/Postgres/S3). The DB-backed `#[sqlx::test]` regression test remains `#[ignore]`d under BIT-351; this PR intentionally adds the compile-and-run non-DB guard instead. Compile-only verification per the "honest partial" pattern.

## Notes
- The quarantined DB test `soft_deleted_thread_excluded_from_unread_count` is left as-is (BIT-351/BIT-352 track its repair) — this PR only adds the always-running guard alongside it.
- Scope check clean (`scope-check.sh --owner pm-tech-lead`): all changes inside `backend/crates/db/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016UBNNyN7GsBVTQNQAe5rrL

---
_Generated by [Claude Code](https://claude.ai/code/session_016UBNNyN7GsBVTQNQAe5rrL)_