### PR TITLE
gh-issue-2001: don't green-light a 500 in person_months calculate_from_residents; finance.md already reconciled

### DIFF
--- a/backend/servers/api-server/tests/person_months_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/person_months_happy_path_tests.rs
@@ -117,11 +117,13 @@ async fn person_months_endpoints_happy_path(pool: PgPool) {
                 .build(),
         )
         .await;
-    // 200 OK, 400 if no residents, or 500 pre-existing endpoint bug (BIT-440)
+    // 200 OK, or 400 if the unit has no residents to calculate from.
+    // The pre-existing BIT-440 500 was fixed in PR #1991 (the
+    // count_residents_for_month result is now decoded via a `::bigint` cast),
+    // so a 500 here is a real regression and must fail loudly — do NOT
+    // green-light INTERNAL_SERVER_ERROR.
     assert!(
-        resp.status == StatusCode::OK
-            || resp.status == StatusCode::BAD_REQUEST
-            || resp.status == StatusCode::INTERNAL_SERVER_ERROR,
+        resp.status == StatusCode::OK || resp.status == StatusCode::BAD_REQUEST,
         "calculate_from_residents: unexpected {}",
         resp.status
     );


### PR DESCRIPTION
## Task
Follow-up: finance 100% coverage overstated — ignored/500-tolerant tests marked "done" (PR #1983) (Closes #2001)

Two findings from the post-merge review of PR #1983:
1. ~59 endpoints (market_pricing 31, multi_currency 28) marked `done` in `finance.md` while their sole cited happy-path suites were `#[ignore]`d.
2. `person_months` `calculate_from_residents` happy-path assertion widened to accept `INTERNAL_SERVER_ERROR` (500).

## Owner
rust-backend (pm-tech-lead hint)

## What changed
**Finding #2 (fixed here):** `backend/servers/api-server/tests/person_months_happy_path_tests.rs` — dropped `INTERNAL_SERVER_ERROR` from the `calculate_from_residents` accepted-status set. The assertion now only passes on `OK || BAD_REQUEST`. A happy-path test that green-lights a 500 does not verify the endpoint. The underlying 500 was a decode bug (`count_residents_for_month` returns `int4` but was decoded into `i64`) that **PR #1991 (BIT-479) already repaired** with a `::bigint` cast, so tolerating a 500 is no longer warranted — it would only mask a future regression. The finance.md row stays `done` and is now genuinely verified.

**Finding #1 (already resolved on `dev` — no change needed):** The premise ("sole cited test is `#[ignore]`d") is stale. **PR #1991 (`c3af308`, merged 2026-07-01T00:40Z)** — landed ~9.5h *before* issue #2001 was filed, and reviewed against the older #1983 — already:
- removed the `#[ignore]` from all five finance happy-path suites (multi_currency, market_pricing, person_months, financial, financial_reports) so they run on the real PR test gate, and
- fixed the underlying endpoint 500s (market_pricing `pricing_source`/`pricing_recommendation_status` enum casts, person_months `::bigint` cast, ar-aging `designation`).

Verified against current `dev` (`fdab888`): neither `market_pricing_happy_path_tests.rs` nor `multi_currency_happy_path_tests.rs` contains `#[ignore]`. Their cited tests execute on the gate and pass, so `finance.md`'s `done: 234` is **accurate**. Reverting those rows to `partial` would introduce a regression in the doc (falsely down-marking working, tested, un-ignored endpoints), so `finance.md` is intentionally left unchanged.

## Tested (Band A — fast check)
- `cargo fmt -p api-server -- --check .../person_months_happy_path_tests.rs` → exit 0 (clean)
- `SQLX_OFFLINE=true cargo test -p api-server --test person_months_happy_path_tests --no-run` → **blocked** at exit 101 by a network-gated build dependency: `utoipa-swagger-ui` build script attempts to download the Swagger UI zip from github.com and fails under the proxy (`InvalidArchive("Could not find EOCD")`). This is unrelated to the change. The edit is a pure deletion of one `||` disjunct in an `assert!` macro and cannot introduce a compile error. Honest-partial verification per the cloud-cron constraints (same as PR #2038 / #2039); PR CI is the authoritative build/test host.

## Built (Band B — full build)
skipped: change is a 1-clause test assertion edit (<50 LOC, no public API/config/migration touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path change (test-assertion tightening; no security/auth/billing/data-integrity surface).

## Remote-tested
skipped: ppt-bridge MCP not used.

## Scope drift
none — only `backend/servers/api-server/tests/person_months_happy_path_tests.rs` touched (rust-backend area).

## Code-reuse review
none — no new helpers added.

## Notes
- Base for the local compile attempt was a stale worktree (`ac3fc2c`); the pushed content is built from current `dev` (`fdab888`) via the GitHub API, so the branch is coherent against dev.
- On merge this satisfies both findings: #2 by the code change, #1 by confirming the doc is already in sync (courtesy of #1991).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCvyzEXfnsXzXKbLchaeqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCvyzEXfnsXzXKbLchaeqz)_