### PR TITLE
gh-issue-2000: fix CountryCode/SupportedCurrency rename_all (S_K/E_U_R -> ISO codes)

### DIFF
--- a/backend/crates/db/src/models/multi_currency.rs
+++ b/backend/crates/db/src/models/multi_currency.rs
@@ -16,8 +16,8 @@ use uuid::Uuid;
 
 /// Supported currencies for multi-currency operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema, sqlx::Type)]
-#[sqlx(type_name = "supported_currency", rename_all = "SCREAMING_SNAKE_CASE")]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[sqlx(type_name = "supported_currency", rename_all = "UPPERCASE")]
+#[serde(rename_all = "UPPERCASE")]
 #[derive(Default)]
 pub enum SupportedCurrency {
     #[default]
@@ -141,8 +141,8 @@ pub enum CrossBorderComplianceStatus {
 
 /// Country codes (ISO 3166-1 alpha-2)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema, sqlx::Type)]
-#[sqlx(type_name = "country_code", rename_all = "SCREAMING_SNAKE_CASE")]
-#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[sqlx(type_name = "country_code", rename_all = "UPPERCASE")]
+#[serde(rename_all = "UPPERCASE")]
 pub enum CountryCode {
     SK, // Slovakia
     CZ, // Czech Republic

--- a/backend/servers/api-server/tests/multi_currency_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/multi_currency_happy_path_tests.rs
@@ -111,9 +111,9 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
 
     // 1.1 POST /api/v1/multi-currency/config -> create_or_update_currency_config (200)
     let create_config_payload = json!({
-        "base_currency": "E_U_R",
-        "enabled_currencies": ["E_U_R", "U_S_D", "C_Z_K"],
-        "display_currency": "U_S_D",
+        "base_currency": "EUR",
+        "enabled_currencies": ["EUR", "USD", "CZK"],
+        "display_currency": "USD",
         "show_original_amount": true,
         "decimal_places": 2,
         "exchange_rate_source": "ecb",
@@ -162,8 +162,8 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
     // 2.1 POST /api/v1/multi-currency/properties -> create_property_currency_config (200)
     let create_prop_payload = json!({
         "building_id": building_id,
-        "default_currency": "U_S_D",
-        "country": "S_K",
+        "default_currency": "USD",
+        "country": "SK",
         "vat_rate": "20.00",
         "requires_local_reporting": true,
     });
@@ -179,7 +179,7 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
 
     // 2.2 PUT /api/v1/multi-currency/properties/{building_id} -> update_property_currency_config (200)
     let update_prop_payload = json!({
-        "default_currency": "E_U_R"
+        "default_currency": "EUR"
     });
     let resp = app
         .execute(
@@ -217,8 +217,8 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
 
     // 3.1 POST /api/v1/multi-currency/rates -> create_exchange_rate (200)
     let create_rate_payload = json!({
-        "from_currency": "E_U_R",
-        "to_currency": "U_S_D",
+        "from_currency": "EUR",
+        "to_currency": "USD",
         "rate": "1.10",
         "rate_date": "2026-06-27",
         "source": "ecb"
@@ -236,7 +236,7 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
     // 3.2 GET /api/v1/multi-currency/rates -> list_exchange_rates (200)
     let resp = app
         .execute(
-            app.get("/api/v1/multi-currency/rates?from_currency=E_U_R&to_currency=U_S_D")
+            app.get("/api/v1/multi-currency/rates?from_currency=EUR&to_currency=USD")
                 .bearer(&token)
                 .build(),
         )
@@ -246,7 +246,7 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
     // 3.3 GET /api/v1/multi-currency/rates/latest -> get_latest_exchange_rate (200)
     let resp = app
         .execute(
-            app.get("/api/v1/multi-currency/rates/latest?from_currency=E_U_R&to_currency=U_S_D")
+            app.get("/api/v1/multi-currency/rates/latest?from_currency=EUR&to_currency=USD")
                 .bearer(&token)
                 .build(),
         )
@@ -255,8 +255,8 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
 
     // 3.4 POST /api/v1/multi-currency/rates/override -> override_exchange_rate (200)
     let override_payload = json!({
-        "from_currency": "E_U_R",
-        "to_currency": "U_S_D",
+        "from_currency": "EUR",
+        "to_currency": "USD",
         "rate": "1.15",
         "rate_date": "2026-06-27",
         "reason": "Test Override"
@@ -300,7 +300,7 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
         "building_id": building_id,
         "source_type": "invoice",
         "source_id": source_id,
-        "original_currency": "U_S_D",
+        "original_currency": "USD",
         "original_amount": "100.00",
         "override_rate": "1.10",
         "override_reason": "Override Rate"
@@ -360,13 +360,13 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
     let lease_id = Uuid::new_v4();
     let create_lease_payload = json!({
         "lease_id": lease_id,
-        "property_country": "S_K",
-        "property_currency": "E_U_R",
-        "tenant_country": "C_Z",
+        "property_country": "SK",
+        "property_currency": "EUR",
+        "tenant_country": "CZ",
         "tenant_tax_id": "CZ12345678",
         "tenant_vat_number": "CZ12345678",
-        "lease_currency": "E_U_R",
-        "payment_currency": "C_Z_K",
+        "lease_currency": "EUR",
+        "payment_currency": "CZK",
         "convert_at_invoice_date": true,
         "convert_at_payment_date": false,
         "local_vat_applicable": true,
@@ -420,7 +420,7 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
     // 5.5 GET /api/v1/multi-currency/cross-border/compliance/{country} -> get_compliance_requirements (200)
     let resp = app
         .execute(
-            app.get("/api/v1/multi-currency/cross-border/compliance/S_K")
+            app.get("/api/v1/multi-currency/cross-border/compliance/SK")
                 .bearer(&token)
                 .build(),
         )
@@ -435,7 +435,7 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
     let create_report_config_payload = json!({
         "name": "Consolidated EU Report",
         "description": "Monthly consolidation in EUR",
-        "report_currency": "E_U_R",
+        "report_currency": "EUR",
         "show_original_currencies": true,
         "show_conversion_details": true,
         "rate_date_type": "end_of_period",
@@ -469,7 +469,7 @@ async fn multi_currency_endpoints_happy_path(pool: PgPool) {
     let generate_payload = json!({
         "period_start": "2026-06-01",
         "period_end": "2026-06-30",
-        "report_currency": "E_U_R",
+        "report_currency": "EUR",
         "config_id": report_config_id
     });
     let resp = app


### PR DESCRIPTION
## Task

Follow-up to PR #1991 (Closes #2000). `CountryCode` and `SupportedCurrency` used `rename_all = "SCREAMING_SNAKE_CASE"` on both `#[serde(...)]` and `#[sqlx(...)]`. serde's `SCREAMING_SNAKE_CASE` treats all-caps acronym variants as multiple words and inserts underscores: `SK` -> `"S_K"`, `EUR` -> `"E_U_R"`, `CZK` -> `"C_Z_K"`, `USD` -> `"U_S_D"`. This broke two contracts:

- **Wire (serde):** the public API required clients to send non-ISO `"S_K"`/`"E_U_R"` instead of ISO 3166-1 alpha-2 / ISO 4217 codes `"SK"`/`"EUR"`.
- **DB (sqlx):** the Postgres enum labels (`00101_create_multi_currency.sql`) are the real ISO codes `'SK'`/`'EUR'`; sqlx would try to encode/decode variant `SK` as non-existent label `'S_K'`.

## Fix

- `backend/crates/db/src/models/multi_currency.rs`: changed `rename_all` from `"SCREAMING_SNAKE_CASE"` to `"UPPERCASE"` on **both** `#[serde(...)]` and `#[sqlx(...)]` for `CountryCode` and `SupportedCurrency`. `UPPERCASE` maps `SK`->`"SK"`, `EUR`->`"EUR"`, matching the ISO wire convention and the existing Postgres enum labels.
- `backend/servers/api-server/tests/multi_currency_happy_path_tests.rs`: reverted the bent payloads (`S_K`/`C_Z`/`E_U_R`/`C_Z_K`/`U_S_D`) and the `/compliance/S_K` path back to their ISO forms (`SK`/`CZ`/`EUR`/`CZK`/`USD`, `/compliance/SK`). Removed the stale `#[ignore]` was not present on dev's version; the test remains un-quarantined as PR #1991 left it.

## Audit (other all-caps-acronym enums)

Swept `backend/` for `rename_all = "SCREAMING_SNAKE_CASE"`. The only other hit is `EnergyRating` (A-G) in `backend/crates/db/src/models/energy.rs`. Its variants are **single letters**, which have no internal word boundary, so `SCREAMING_SNAKE_CASE` and `UPPERCASE` serialize them identically (`A`->`"A"`). No change needed there.

## Owner

pm-tech-lead (specialist: rust-backend)

## Tested (Band A — fast check)

- `cargo fmt -p db --check` on the model file: exit 0
- `cargo fmt -p api-server --check` on the test file: exit 0
- `SQLX_OFFLINE=true cargo check -p db`: **exit 0** (compiles cleanly with the `UPPERCASE` change — this crate contains the actual fix)

## Built (Band B — full build)

Not fully runnable in this cloud-cron environment. `SQLX_OFFLINE=true cargo test -p api-server --test multi_currency_happy_path_tests --no-run` fails at a **network-gated build dependency**, not at this change: `utoipa-swagger-ui v9.0.2`'s build script downloads Swagger UI from GitHub at build time and the sandbox proxy corrupts the archive (`InvalidArchive("Could not find EOCD")`). This blocks any `api-server` compile in this environment regardless of the diff. The test-file change is limited to JSON string-literal values, which cannot introduce a compile error beyond what already builds.

## CI parity (Band C — hot-path only)

Deferred to CI. The DB-backed `#[sqlx::test]` (`multi_currency_endpoints_happy_path`) runs against a real Postgres in GitHub Actions, which is where the wire+DB round-trip (ISO codes encode/decode against the `country_code`/`supported_currency` enum labels) is actually exercised.

## Remote-tested

skipped (no ppt-bridge in this session)

## Notes

- Honest-partial verification (compile-only, no DB), consistent with PR #2038/#2039: the `db` crate — which carries the fix — compiles clean; the `api-server` test target can't link only because of the network-blocked `utoipa-swagger-ui` download build script.
- Finding #2 in the issue (TypeSpec modeling of these enums so generated clients enforce ISO values) is intentionally left as a separate `typespec` follow-on and is not addressed here.
- `scope-check.sh` reported `unknown owner_role 'rust-backend'` (exit 1); both changed files are backend and clearly in scope, so `scope_drift=false`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCvyzEXfnsXzXKbLchaeqz)_