### PR TITLE
gh-issue-2028: fix latent u.name schema-drift 500 in list_bookings

### DIFF
--- a/backend/crates/db/src/repositories/rental.rs
+++ b/backend/crates/db/src/repositories/rental.rs
@@ -459,12 +459,12 @@ impl RentalRepository {
         let connections = sqlx::query_as::<_, PlatformConnectionSummary>(
             r#"
             SELECT
-                c.id, c.unit_id, u.name as unit_name,
+                c.id, c.unit_id, u.designation as unit_name,
                 c.platform::text, c.is_active, c.last_sync_at, c.sync_error
             FROM rental_platform_connections c
             JOIN units u ON u.id = c.unit_id
             WHERE c.organization_id = $1
-            ORDER BY u.name, c.platform
+            ORDER BY u.designation, c.platform
             "#,
         )
         .bind(org_id)
@@ -947,7 +947,7 @@ impl RentalRepository {
         let bookings = sqlx::query_as::<_, (Uuid, Uuid, String, String, String, Option<String>, String, i32, NaiveDate, NaiveDate, Option<Decimal>, Option<String>, String, Option<String>)>(
             r#"
             SELECT
-                b.id, b.unit_id, u.name, bld.name,
+                b.id, b.unit_id, u.designation, bld.name,
                 b.platform::text, b.external_booking_id, b.guest_name, b.guest_count,
                 b.check_in, b.check_out, b.total_amount, b.currency,
                 b.status,
@@ -1021,7 +1021,7 @@ impl RentalRepository {
         let reminders = sqlx::query_as::<_, (Uuid, String, String, NaiveDate, i64)>(
             r#"
             SELECT
-                b.id, u.name, b.guest_name, b.check_in,
+                b.id, u.designation, b.guest_name, b.check_in,
                 (SELECT COUNT(*) FROM rental_guests WHERE booking_id = b.id AND status = 'pending')
             FROM rental_bookings b
             JOIN units u ON u.id = b.unit_id

--- a/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
+++ b/backend/servers/api-server/tests/rental_guest_id_document_tests.rs
@@ -668,17 +668,17 @@ async fn guest_booking_pii_reads_are_manager_gated(pool: PgPool) {
             res.text()
         );
 
-        // Manager → passes the role gate (i.e. NOT 403). We assert "not
-        // forbidden" rather than a strict 2xx because the manager path's job is
-        // to prove the rejection above is the *role* gate and not a
-        // no-context/no-member pass — the underlying repo query is out of scope.
-        // (`list_bookings` currently 500s on a separate latent `u.name`
-        // schema-drift bug; the role gate it now sits behind is still exercised.)
+        // Manager → passes the role gate AND the endpoint's happy path. We now
+        // assert a strict 2xx: the underlying repo query for each of the four
+        // PII read paths must actually succeed for a manager in the org. The
+        // latent `u.name` schema-drift 500 in `list_bookings` (and its sibling
+        // rental queries) is fixed — the `units` identity column is
+        // `designation`, not `name` — so this pins the real happy path rather
+        // than merely "not 403" (issue #2028).
         let mgr = app.execute(get_request(uri, &mgr_token, org)).await;
-        assert_ne!(
-            mgr.status,
-            StatusCode::FORBIDDEN,
-            "manager read of {uri} must pass the role gate (not 403), got {}: {}",
+        assert!(
+            mgr.status.is_success(),
+            "manager read of {uri} must succeed (2xx), got {}: {}",
             mgr.status,
             mgr.text()
         );


### PR DESCRIPTION
## Task
Follow-up: latent `u.name` schema-drift 500 in `list_bookings` (PR #1973) (Closes #2028)

Trace the `list_bookings` repo query's `u.name` projection against the current
`users`/`units` schema and correct it; then tighten the manager-path assertion in
`guest_booking_pii_reads_are_manager_gated` from `assert_ne!(FORBIDDEN)` to a strict 2xx.

Closes #2028

## Root cause
The three rental repo queries that `JOIN units u` projected a non-existent
`u.name` column. The `units` table (migration `00008_create_units.sql`) has **no
`name` column** — the unit identity column is `designation VARCHAR(50) NOT NULL`.
Every such read therefore 500s with `column "name" does not exist` at runtime.
On the PII-gated `list_bookings` path (PR #1973 / #1766) this was masked by the
regression test asserting only "not 403" for the manager path.

## Fix
`backend/crates/db/src/repositories/rental.rs` — replace `u.name` → `u.designation` in:
- `list_bookings` (the issue's primary target)
- `get_connections_for_org` (`SELECT ... u.name as unit_name` + `ORDER BY u.name`)
- `get_upcoming_checkins_needing_registration`

All three are the identical `units`-join drift (same root cause, same file); the
column rename does not change tuple arity/types so the positional `query_as`
mappings are unaffected.

`backend/servers/api-server/tests/rental_guest_id_document_tests.rs` —
`guest_booking_pii_reads_are_manager_gated`: manager path tightened from
`assert_ne!(mgr.status, FORBIDDEN)` to `assert!(mgr.status.is_success())` (strict
2xx) so the happy path is now actually pinned. The stale "list_bookings currently
500s" comment is removed. (The `#[ignore]` BIT-351 quarantine on the harness is a
separate concern tracked in BIT-352 and is left as-is.)

## Owner
pm-tech-lead (hint). Actual specialist: **rust-backend** (per issue Suggested specialist).

## Tested (Band A — fast check)
Runtime `sqlx::query_as` (string queries, not the `query!` macro) → no `.sqlx`
offline regen needed. DB-backed integration tests run in CI.
- `cargo fmt -p db -p api-server -- --check` → exit 0
- `SQLX_OFFLINE=true cargo check -p db` → exit 0 (crate carrying the fix)
- `SQLX_OFFLINE=true cargo clippy -p db` → exit 0

## Built (Band B — full build)
Honest-partial (cloud-cron, no DB / no network egress to GitHub archives), same
posture as PR #2038 / #2039:
- `SQLX_OFFLINE=true cargo test -p api-server --test rental_guest_id_document_tests --no-run`
  → **could not link**: transitive build dep `utoipa-swagger-ui` panics fetching
  `swagger-ui v5.17.14.zip` from github.com (egress-blocked → 195-byte stub →
  `InvalidArchive("Could not find EOCD")`). This is an environment limitation,
  not a code error — the test-file change is a one-line assertion swap. CI (with
  network + DB) compiles and runs this target.

## CI parity (Band C — hot-path only)
Endpoint returns guest identity PII (issue's secondary specialist pm-security).
The change is a correctness fix to an existing gated read; no authz surface
changed. DB-backed manager/resident gate + happy-path assertions run in
`backend.yml`.

## Remote-tested
skipped (ppt-bridge not connected)

## Notes
- Verify the real column: `units.designation` (migration `00008_create_units.sql`);
  there is no `units.name` and no later migration adds one.
- `scope_drift`: `pm-tech-lead` owner hint maps to architecture/docs, so
  scope-check.sh flags the two backend files (exit 2) — but under the correct
  `rust-backend`/`pm-backend` owner the diff is fully in-scope (exit 0). Reported
  as `scope_drift=false` (hint mismatch, not real drift).
- No new helpers/symbols added → `code_reuse_warn=none`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KCvyzEXfnsXzXKbLchaeqz)_