### PR TITLE
fix(reality-server): transactional favorite alert enqueue/advance (Closes #1999)

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal.rs
+++ b/backend/crates/db/src/repositories/reality_portal.rs
@@ -563,8 +563,18 @@ impl RealityPortalRepository {
     //
     // Ordering matters: the enqueue reads the pre-update watermark state, so the
     // worker MUST call `enqueue_*` before `advance_*_watermarks` for the same
-    // path. `ON CONFLICT DO NOTHING` keeps re-runs idempotent if the worker dies
-    // between the two statements.
+    // path. `ON CONFLICT DO NOTHING` keeps *crash re-runs* idempotent if the
+    // worker dies between the two statements.
+    //
+    // Snapshot consistency is NOT optional (#1999 finding-1): the advance
+    // re-derives its working set (`MAX(changed_at)` / current status) over the
+    // live tables, independently of what the enqueue actually inserted. A row
+    // committed by a concurrent writer *between* the two statements would be
+    // missed by the enqueue yet swept past the watermark by the advance, and
+    // its alert would be dropped forever. The caller MUST therefore run each
+    // enqueue+advance pair in a single `REPEATABLE READ` (or stricter)
+    // transaction so both statements read one MVCC snapshot — see
+    // `FavoriteAlertWorker::run_price_path` / `run_status_path`.
     //
     // (Runtime `sqlx::query`, not the compile-time macros — see the module-level
     // note on the repo-wide convention.)
@@ -645,6 +655,14 @@ impl RealityPortalRepository {
     /// a favorite still gets the (rarer, higher-signal) "it's available again"
     /// notice. Add a `status_alert_enabled` column + filter here if that should
     /// change.
+    ///
+    /// Flap dedupe (#1999 finding-3, accepted): `idx_favorite_alert_queue_status_dedupe`
+    /// (migration 00194) is unique on
+    /// `(favorite_id, alert_type, previous_status, new_status)` for
+    /// `back_on_market`. A listing that flaps active→inactive→active with the
+    /// *same* before/after status tuple has its second genuine back-on-market
+    /// event deduped away. This is intentional for an hourly poll — repeated
+    /// identical flaps shouldn't spam the user — not a bug.
     pub async fn enqueue_pending_favorite_status_alerts<'e, E>(
         &self,
         executor: E,

--- a/backend/servers/reality-server/src/routes/favorites.rs
+++ b/backend/servers/reality-server/src/routes/favorites.rs
@@ -270,16 +270,31 @@ pub async fn mark_favorite_alert_read(
         .await
         .map_err(|e| crate::util::errors::db_error("mark favorite alert read", e))?;
 
+    mark_read_outcome_status(outcome)
+}
+
+/// Map a [`db::repositories::FavoriteAlertReadOutcome`] to the HTTP result the
+/// `mark_favorite_alert_read` route returns.
+///
+/// Extracted as a pure, DB-free function so the idempotency contract (#1852
+/// finding-4) has a fast regression guard that actually runs on the PR gate
+/// (#1999 finding-2) while the DB-backed
+/// `mark_favorite_alert_read_is_idempotent` integration test stays quarantined
+/// under BIT-351.
+///
+/// Idempotent: a freshly-flipped alert AND one already read both succeed with
+/// 204 — a client polling read-state shouldn't get a surprising 404 for an
+/// alert it already marked. Genuinely absent / not-owned still 404s (no
+/// existence leak).
+fn mark_read_outcome_status(
+    outcome: db::repositories::FavoriteAlertReadOutcome,
+) -> Result<axum::http::StatusCode, (axum::http::StatusCode, String)> {
+    use db::repositories::FavoriteAlertReadOutcome;
     match outcome {
-        // Idempotent (#1852 finding-4): a freshly-flipped alert AND one already
-        // read both succeed — a client polling read-state shouldn't get a
-        // surprising 404 for an alert it already marked. Genuinely absent /
-        // not-owned still 404s (no existence leak).
-        db::repositories::FavoriteAlertReadOutcome::Flipped
-        | db::repositories::FavoriteAlertReadOutcome::AlreadyRead => {
+        FavoriteAlertReadOutcome::Flipped | FavoriteAlertReadOutcome::AlreadyRead => {
             Ok(axum::http::StatusCode::NO_CONTENT)
         }
-        db::repositories::FavoriteAlertReadOutcome::NotFound => Err((
+        FavoriteAlertReadOutcome::NotFound => Err((
             axum::http::StatusCode::NOT_FOUND,
             "Alert not found".to_string(),
         )),
@@ -351,4 +366,41 @@ pub async fn list_favorite_ids(
         })?;
 
     Ok(Json(favorites.into_iter().map(|f| f.listing_id).collect()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mark_read_outcome_status;
+    use axum::http::StatusCode;
+    use db::repositories::FavoriteAlertReadOutcome;
+
+    // #1852 finding-4 / #1999 finding-2: the mark-read route is idempotent.
+    // These assert the outcome→status mapping directly, without a database, so
+    // the contract is guarded on every PR even while the DB-backed
+    // `mark_favorite_alert_read_is_idempotent` test stays quarantined (BIT-351).
+
+    #[test]
+    fn flipped_maps_to_204() {
+        assert_eq!(
+            mark_read_outcome_status(FavoriteAlertReadOutcome::Flipped),
+            Ok(StatusCode::NO_CONTENT)
+        );
+    }
+
+    #[test]
+    fn already_read_maps_to_204_not_404() {
+        // The core of finding-4: a second mark on an already-read alert is a
+        // success, not a surprising 404.
+        assert_eq!(
+            mark_read_outcome_status(FavoriteAlertReadOutcome::AlreadyRead),
+            Ok(StatusCode::NO_CONTENT)
+        );
+    }
+
+    #[test]
+    fn not_found_maps_to_404() {
+        let err = mark_read_outcome_status(FavoriteAlertReadOutcome::NotFound)
+            .expect_err("NotFound must map to an error status");
+        assert_eq!(err.0, StatusCode::NOT_FOUND);
+    }
 }

--- a/backend/servers/reality-server/src/services/favorite_alerts.rs
+++ b/backend/servers/reality-server/src/services/favorite_alerts.rs
@@ -8,6 +8,7 @@
 use std::time::Duration;
 
 use db::{repositories::RealityPortalRepository, DbPool};
+use sqlx::{pool::PoolConnection, Connection, Error as SqlxError, Postgres};
 use tokio::time::interval;
 use tracing::Instrument;
 
@@ -111,49 +112,25 @@ impl FavoriteAlertWorker {
                 continue;
             }
 
-            // Price path: one set-based enqueue, then advance the watermarks.
+            // Price path: enqueue + advance run as ONE REPEATABLE READ
+            // transaction so both statements observe a single MVCC snapshot.
             // The enqueue MUST run first — it reads the pre-update watermark.
-            match self
-                .repo
-                .enqueue_pending_favorite_price_alerts(&mut *conn)
-                .await
-            {
-                Ok(n) => {
-                    queued_price += n as usize;
-                    if let Err(e) = self
-                        .repo
-                        .advance_favorite_price_watermarks(&mut *conn)
-                        .await
-                    {
-                        tracing::warn!(org_id = %org_id, error = %e, "[BIT-138] failed to advance favorite price watermarks");
-                    }
-                }
+            match self.run_price_path(&mut conn).await {
+                Ok(n) => queued_price += n as usize,
                 Err(e) => {
-                    tracing::warn!(org_id = %org_id, error = %e, "[BIT-138] failed to enqueue favorite price alerts");
+                    tracing::warn!(org_id = %org_id, error = %e, "[BIT-138] favorite price-alert pass failed");
                 }
             }
 
             // Back-on-market path: one set-based enqueue (favorites whose listing
-            // just became active), then snapshot ALL changed favorites' status.
-            // back_on_market alerts are intentionally not opt-out-able — see
+            // just became active), then snapshot ALL changed favorites' status —
+            // also under one REPEATABLE READ transaction. back_on_market alerts
+            // are intentionally not opt-out-able — see
             // `enqueue_pending_favorite_status_alerts` (#1852 finding-3).
-            match self
-                .repo
-                .enqueue_pending_favorite_status_alerts(&mut *conn)
-                .await
-            {
-                Ok(n) => {
-                    queued_status += n as usize;
-                    if let Err(e) = self
-                        .repo
-                        .advance_favorite_status_watermarks(&mut *conn)
-                        .await
-                    {
-                        tracing::warn!(org_id = %org_id, error = %e, "[BIT-138] failed to advance favorite status snapshots");
-                    }
-                }
+            match self.run_status_path(&mut conn).await {
+                Ok(n) => queued_status += n as usize,
                 Err(e) => {
-                    tracing::warn!(org_id = %org_id, error = %e, "[BIT-138] failed to enqueue favorite back-on-market alerts");
+                    tracing::warn!(org_id = %org_id, error = %e, "[BIT-138] favorite back-on-market pass failed");
                 }
             }
         }
@@ -165,5 +142,56 @@ impl FavoriteAlertWorker {
                 "[BIT-138] favorite alerts queued"
             );
         }
+    }
+
+    /// Enqueue price-change alerts and advance the price watermarks inside a
+    /// single `REPEATABLE READ` transaction (#1999 finding-1).
+    ///
+    /// The enqueue and the advance compute their working set independently:
+    /// the enqueue inserts rows for `changed_at > watermark`, and the advance
+    /// re-derives `MAX(changed_at)` over the *same* predicate. Run as separate
+    /// autocommitted statements, a `listing_price_history` row committed by a
+    /// concurrent writer *between* them would be missed by the enqueue yet
+    /// swept past the watermark by the advance's re-evaluated `MAX` — the alert
+    /// for that price change would then be silently dropped forever. Binding
+    /// both statements to one MVCC snapshot closes that race. The org RLS
+    /// context set on `conn` is session-scoped (`set_config(..., FALSE)`), so
+    /// it remains in force inside the transaction.
+    async fn run_price_path(&self, conn: &mut PoolConnection<Postgres>) -> Result<u64, SqlxError> {
+        let mut tx = conn.begin().await?;
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+            .execute(&mut *tx)
+            .await?;
+        let queued = self
+            .repo
+            .enqueue_pending_favorite_price_alerts(&mut *tx)
+            .await?;
+        self.repo
+            .advance_favorite_price_watermarks(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(queued)
+    }
+
+    /// Enqueue back-on-market alerts and advance the status snapshots inside a
+    /// single `REPEATABLE READ` transaction (#1999 finding-1), for the same
+    /// snapshot-consistency reason as [`Self::run_price_path`]: the advance
+    /// snapshots `last_seen_listing_status` for every changed favorite, so a
+    /// status transition committed between the two statements must not let the
+    /// advance move a favorite past a transition the enqueue never saw.
+    async fn run_status_path(&self, conn: &mut PoolConnection<Postgres>) -> Result<u64, SqlxError> {
+        let mut tx = conn.begin().await?;
+        sqlx::query("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+            .execute(&mut *tx)
+            .await?;
+        let queued = self
+            .repo
+            .enqueue_pending_favorite_status_alerts(&mut *tx)
+            .await?;
+        self.repo
+            .advance_favorite_status_watermarks(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(queued)
     }
 }


### PR DESCRIPTION
## Task

Follow-up: favorite price-alert enqueue/advance can drop an alert (non-transactional) + idempotency test is quarantined (PR #1992). Closes #1999.

## Owner

`rust-backend` (reality-server + `db` repositories).

## What changed

**Finding-1 (correctness/race, medium) — the fix.**
`FavoriteAlertWorker::run_once` previously ran `enqueue_*` then `advance_*` as two separate autocommitted `execute` calls on one connection. Because the advance re-derives its working set (`MAX(changed_at)` / current status) over the *live* tables independently of what the enqueue inserted, a `listing_price_history` (or status) row committed by a concurrent writer **between** the two statements would be missed by the enqueue yet swept past the watermark by the advance — dropping that alert forever.

Both the price path and the status path now run their enqueue+advance pair inside a single **`REPEATABLE READ`** transaction (`run_price_path` / `run_status_path`), so the two statements read one MVCC snapshot. This matches the existing `audit_log.rs` precedent (`begin()` + `SET TRANSACTION ISOLATION LEVEL …`). The org RLS context is set with `set_config(..., FALSE)` (session-scoped, migration 00006), so it stays in force inside the transaction. The stale "`ON CONFLICT DO NOTHING` keeps re-runs idempotent" module comment in `reality_portal.rs` is corrected to state that snapshot consistency (a transaction) is **required**, not optional.

**Finding-2 (test gap, medium) — a guard that actually runs.**
The DB-backed `mark_favorite_alert_read_is_idempotent` integration test is `#[ignore]`d under BIT-351 (the whole `favorite_alert_worker_tests.rs` file is quarantined for a pre-existing blind-CI seed/schema-drift failure, tracked for repair in BIT-352), so the `Flipped → AlreadyRead → NotFound` behavior had zero enforced coverage. I extracted the route's outcome→status mapping into a pure, DB-free `mark_read_outcome_status` function and added three `#[cfg(test)]` unit tests asserting `Flipped`/`AlreadyRead → 204` and `NotFound → 404`. These run on every PR gate (no DB needed). The durable DB-backed drop-race regression test the issue also asks for should land green once BIT-352 un-quarantines this file — adding it now would just be a fourth `#[ignore]`d test (never-green), which would violate "never ship red"; noted for the BIT-352 follow-up.

**Finding-3 (low, accepted) — documentation only.**
Documented the status-flap dedupe behavior of `idx_favorite_alert_queue_status_dedupe` in the `enqueue_pending_favorite_status_alerts` doc comment. (The comment lives in the repo method, **not** in migration 00194 — editing an already-applied migration would break its sqlx checksum.)

## Tested (Band A — fast check)

Sandbox has **no Postgres/Docker**, so `#[sqlx::test]` DB-backed tests cannot run here — CI (which has Postgres) runs them. Verification here is **compile-only "honest partial"** (same posture as PR #2038/#2039). All commands run with `SQLX_OFFLINE=true`:

- `cargo fmt -p db -p reality-server --check` → exit 0 (clean)
- `cargo check -p db` → exit 0
- `cargo clippy -p db` → exit 0, no warnings
- `cargo check -p reality-server` → exit 0
- `cargo clippy -p reality-server` → exit 0, no warnings
- `cargo test -p reality-server --no-run` → exit 0 (all test binaries, incl. `favorite_alert_worker_tests` and the new `favorites` unit tests, compiled)

**Sandbox caveat (honest):** `reality-server`'s `utoipa-swagger-ui` build script downloads the Swagger UI zip from `github.com`, which this session's egress policy blocks (HTTP 403). To type-check the reality-server code I temporarily enabled the crate's offline `vendored` feature (fetched from crates.io), confirmed a clean check/clippy/test-compile, then **reverted** it — the pushed diff contains **only** the three source files below, no `Cargo.toml`/`Cargo.lock` change. CI is unaffected (it can reach GitHub).

## Built (Band B — full build)

Skipped: no full release build possible in-sandbox (swagger-ui download wall above). CI covers it.

## CI parity (Band C — hot-path only)

This is a data-integrity change, but CI parity can't be replicated locally (no DB, no swagger download). Relying on CI: the DB-backed `#[sqlx::test]` suite + `backend.yml` (`fmt`/`clippy`/`test`) will exercise the transactional paths.

## Remote-tested

skipped (no ppt-bridge in session).

## Files

- `backend/servers/reality-server/src/services/favorite_alerts.rs` — `run_price_path` / `run_status_path` REPEATABLE READ transactions.
- `backend/servers/reality-server/src/routes/favorites.rs` — extracted `mark_read_outcome_status` + 3 unit tests.
- `backend/crates/db/src/repositories/reality_portal.rs` — corrected ordering/idempotency comment + finding-3 dedupe note.

## Notes

Verification is compile-only; the DB-backed drop-race regression test is deferred to the BIT-352 un-quarantine (see finding-2 above). Reviewer should confirm the REPEATABLE READ isolation is acceptable for the worker (serialization retries are unlikely — this worker is the only writer to the watermarks and runs single-threaded per connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCvyzEXfnsXzXKbLchaeqz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCvyzEXfnsXzXKbLchaeqz)_