### PR TITLE
gh-issue-2033: mark quick-xml XXE pin with CODEOWNERS + CI review guard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS — explicit-review markers for load-bearing files.
+#
+# GitHub auto-requests a review from the listed owners whenever a PR
+# touches a matching path. When branch protection for `dev` has
+# "Require review from Code Owners" enabled, that review is mandatory.
+#
+# --------------------------------------------------------------------
+# Security-pinned dependency manifest
+# --------------------------------------------------------------------
+# backend/Cargo.toml carries dependency pins whose versions are
+# load-bearing for security posture, not just build reproducibility.
+# The most notable is `quick-xml`, pinned for XXE / billion-laughs
+# safety and guarded by `ota_xml::tests` in
+# backend/crates/integrations/src/booking/ota_xml.rs (see GH #1519 /
+# #1591 / #2033). A bump that changes entity normalization can cross
+# that pin — so every change to this manifest must get an explicit
+# owner review rather than riding into an unrelated dep-bump merge
+# (the failure mode PR #2011 exhibited).
+/backend/Cargo.toml    @martin-janci

--- a/.github/workflows/pinned-dependency-guard.yml
+++ b/.github/workflows/pinned-dependency-guard.yml
@@ -1,0 +1,67 @@
+name: Pinned-dependency guard
+
+# Why this exists
+# ---------------
+# PR #2011 ("bump ammonia to 4.1.3, RUSTSEC XSS-sanitizer bypass") also
+# carried an unrelated `quick-xml 0.40 -> 0.41` bump in backend/Cargo.toml.
+# `quick-xml` is a SECURITY PIN: the inbound OTA parsers depend on it NOT
+# resolving custom DTD entities (XXE / billion-laughs safety), guarded by
+# `ota_xml::tests` in backend/crates/integrations/src/booking/ota_xml.rs.
+# Folding that pin-crossing change into a differently-titled RUSTSEC PR
+# meant the entity-safety change got none of the focused review the pin
+# comment asks for (GH #1519 / #1591 / #2033).
+#
+# This workflow is a lightweight, ADVISORY marker: whenever a PR touches
+# the `quick-xml` pin line in backend/Cargo.toml it emits a GitHub warning
+# annotation reminding the author + reviewers to treat it as an XXE-safety
+# change. It NEVER fails the build — the hard "requests explicit review"
+# guarantee is provided by .github/CODEOWNERS. This job only surfaces the
+# regression note so the pin cannot be crossed silently.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'backend/Cargo.toml'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  quick-xml-pin-guard:
+    name: quick-xml XXE pin — advisory review marker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect diff for the quick-xml pin line
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Grab only the added/removed lines for backend/Cargo.toml and
+          # look for a change to the quick-xml dependency line.
+          DIFF=$(gh pr diff "$PR" --repo "$REPO" --patch -- backend/Cargo.toml || true)
+          TOUCHED=$(printf '%s\n' "$DIFF" | grep -E '^[+-][[:space:]]*quick-xml[[:space:]]*=' || true)
+
+          if [ -z "$TOUCHED" ]; then
+            echo "OK: this PR edits backend/Cargo.toml but does not change the quick-xml pin line."
+            exit 0
+          fi
+
+          echo "::warning title=quick-xml is an XXE security pin::This PR changes the quick-xml dependency line in backend/Cargo.toml. quick-xml is pinned for XXE / billion-laughs safety and guarded by ota_xml::tests. Confirm 'cargo test -p integrations' entity-guard tests pass on the new version and that the change gets an explicit XXE-regression review (GH #1519/#1591/#2033)."
+
+          echo ""
+          echo "Changed quick-xml line(s):"
+          printf '%s\n' "$TOUCHED"
+          echo ""
+          echo "Reviewer checklist for a quick-xml bump:"
+          echo "  - ota_xml::tests entity guards (XXE + billion-laughs) pass on the new version"
+          echo "    (run: cd backend && cargo test -p integrations ota_xml)."
+          echo "  - Those tests are live #[test]s, NOT BIT-440-quarantined, so CI runs them."
+          echo "  - The bump lands in its own PR (or is called out explicitly), not folded"
+          echo "    into an unrelated dep-bump."
+          echo ""
+          echo "This check is advisory and does not fail the build; CODEOWNERS enforces the review."

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -85,10 +85,23 @@ url = "2.5"
 reqwest = { version = "0.13", features = ["json", "form", "query", "http2"] }
 
 # XML parsing/generation (for OTA/Booking.com integration)
-# NOTE: the inbound OTA parsers rely on quick-xml NOT resolving custom DTD
-# entities (XXE / billion-laughs safety). That posture is load-bearing and pinned
-# by the entity guards in integrations `booking.rs` (`ota_xml::tests`) — a bump
-# that changes entity normalization will turn those tests red. See GH #1519/#1591.
+# SECURITY PIN — DO NOT bump casually. The inbound OTA parsers rely on quick-xml
+# NOT resolving custom DTD entities (XXE / billion-laughs safety). That posture is
+# load-bearing and pinned by the entity guards in integrations `ota_xml`
+# (`ota_xml::tests` in crates/integrations/src/booking/ota_xml.rs) — a bump that
+# changes entity normalization will turn those tests red. See GH #1519/#1591.
+#
+# Regression note (GH #2033): PR #2011 folded a quick-xml 0.40->0.41 bump into an
+# unrelated ammonia RUSTSEC PR, crossing this pin without focused review. To
+# prevent a recurrence, changes to this manifest are gated by two markers:
+#   1. .github/CODEOWNERS routes every backend/Cargo.toml edit to an explicit
+#      owner review.
+#   2. .github/workflows/pinned-dependency-guard.yml annotates any PR that
+#      touches this quick-xml line, reminding reviewers to confirm the
+#      `ota_xml::tests` entity guards stay green on the new version.
+# The entity-guard tests are live `#[test]`s in the `integrations` crate (they are
+# NOT among the BIT-440-quarantined suites), so `cargo test -p integrations` runs
+# them on every bump.
 quick-xml = { version = "0.41", features = ["serialize"] }
 
 # Observability (Epic 95)


### PR DESCRIPTION
## Task
Follow-up to #2033: the quick-xml 0.40→0.41 bump (an XXE security pin) rode into an ammonia-only RUSTSEC PR (#2011) without focused review. This adds a CODEOWNERS + CI marker so any future change to the XXE-pinned `quick-xml` line in `backend/Cargo.toml` always requests explicit review, and strengthens the inline pin comment with a regression note. No dependency version change (quick-xml already shipped at 0.41).

Closes #2033

## Owner
rust-backend (documentation/config-focused; touches `backend/Cargo.toml` + `.github/`)

## Changes
1. **`.github/CODEOWNERS`** (new) — routes every `backend/Cargo.toml` edit to an explicit owner review, with a header explaining the quick-xml XXE / billion-laughs pin. This is the hard "always requests explicit review" guarantee (enforced at merge when branch protection's "Require review from Code Owners" is on).
2. **`.github/workflows/pinned-dependency-guard.yml`** (new) — advisory, line-scoped CI marker. On any PR that touches the `quick-xml` line in `backend/Cargo.toml` it emits a GitHub warning annotation + reviewer checklist (confirm `ota_xml::tests` entity guards pass). Never fails the build — CODEOWNERS owns enforcement; this surfaces the regression note CODEOWNERS can't express at line granularity.
3. **`backend/Cargo.toml`** — strengthened the inline comment above the `quick-xml` line: relabeled it `SECURITY PIN — DO NOT bump casually`, corrected the guard reference (`ota_xml::tests` lives in `crates/integrations/src/booking/ota_xml.rs`, not `booking.rs`), and added a GH #2033 regression note documenting both markers. Comment-only; no version change.

## BIT-440 quarantine confirmation
**The `ota_xml::tests` entity-guard tests are NOT among the BIT-440-quarantined suites.** They are live `#[test]` unit tests inside `backend/crates/integrations/src/booking/ota_xml.rs` (crate `integrations`), with no `#[ignore]` attribute anywhere in that file. Verified guards present and active:
- `test_parse_avail_notif_rq_does_not_expand_internal_entity` (internal DTD entity dropped, not expanded)
- `test_parse_avail_notif_rq_does_not_disclose_external_entity` / `test_parse_rate_amount_notif_rq_does_not_disclose_external_entity` (external XXE file-disclosure probe yields nothing)
- `test_parse_avail_notif_rq_billion_laughs_does_not_amplify` (billion-laughs)
- prefixed-namespace parity guards

The BIT-440 `#[ignore = "BIT-440: quarantined …"]` markers appear only on integration-test files under `backend/servers/*/tests/*.rs`, never on `ota_xml.rs`. So `cargo test -p integrations` runs these guards on every bump — the pin in PR #2011 was verifiable via the crate's unit tests (not skipped).

## Tested (Band A — fast check)
No Rust source or logic changed (Cargo.toml edit is comment-only). Manifest + config validated:
- `cd backend && cargo verify-project` → `{"success":"true"}` (exit 0)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pinned-dependency-guard.yml'))"` → `workflow YAML ok` (exit 0)

## Built (Band B — full build)
Skipped: change is documentation/config-only (<50 LOC substantive, no public API/build-output change). No Rust code path altered.

## CI parity (Band C — hot-path only)
Skipped: no security/auth/billing/data-integrity code change — this PR only adds review-gating config around an existing pin. (Environment is cloud cron with no Docker/Postgres; compile-only honest-partial verification per dispatcher note.)

## Remote-tested
skipped

## Notes
- Deliberately does NOT downgrade or change quick-xml — it already shipped at 0.41.
- `scope-check.sh --owner rust-backend` returned exit 1 (owner_role `rust-backend` not in `owner-areas.json`), so scope drift could not be auto-adjudicated → treated as `scope_drift=false`. The `.github/` additions are the intended deliverable for this config-focused task.
- The CI guard is intentionally advisory (exit 0). If a hard block on the pin line is later wanted, it can be promoted to a required check like `security-test-gate.yml`'s conclusion-job pattern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcAWqmrSrbkVM32UUECEY6)_