### PR TITLE
gh-issue-2030: surface Slovak accounting export un-computed totals honestly (not misleading 0)

### DIFF
--- a/backend/crates/db/src/models/regional_compliance.rs
+++ b/backend/crates/db/src/models/regional_compliance.rs
@@ -379,9 +379,24 @@ pub struct SlovakAccountingExport {
     pub payment_count: i32,
     pub journal_entry_count: i32,
     pub total_revenue: Decimal,
-    pub total_expenses: Decimal,
+    /// Total expenses for the period. `None` = **not available**, not zero.
+    /// There is no expense source wired for this export yet (#1906 finding-3,
+    /// tracked by #2030); a `null` here means "not computed" and a consumer
+    /// MUST NOT treat it as genuine zero expenses. See `unsupported_fields`.
+    pub total_expenses: Option<Decimal>,
     pub total_receivables: Decimal,
-    pub total_payables: Decimal,
+    /// Total accounts-payable for the period. `None` = **not available**, not
+    /// zero. No vendor/accounts-payable source is wired yet (#1906 finding-3,
+    /// tracked by #2030). See `unsupported_fields`.
+    pub total_payables: Option<Decimal>,
+    /// `true` when one or more monetary fields could not be computed and are
+    /// returned as `null`. A partial export is NOT a complete accounting
+    /// statement — see `unsupported_fields` for which figures are missing.
+    pub partial: bool,
+    /// Names of the fields that are not yet computed and are returned as
+    /// `null` (e.g. `["total_expenses", "total_payables"]`). Empty when the
+    /// export is complete.
+    pub unsupported_fields: Vec<String>,
     pub download_url: Option<String>,
     pub export_data: Option<serde_json::Value>,
     pub generated_at: DateTime<Utc>,
@@ -626,4 +641,51 @@ pub struct RegionalComplianceStatus {
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct SetJurisdiction {
     pub jurisdiction: Jurisdiction,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression for #2030: an un-computed monetary field must serialize as
+    /// JSON `null`, not a misleading `0`, so a consumer can distinguish
+    /// "not available" from a genuine zero. A real zero (`Some(0)`) must still
+    /// serialize as a number.
+    #[test]
+    fn uncomputed_totals_serialize_as_null_not_zero() {
+        let export = SlovakAccountingExport {
+            export_id: Uuid::nil(),
+            organization_id: Uuid::nil(),
+            from_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            to_date: NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            format: SlovakAccountingFormat::Pohoda,
+            invoice_count: 3,
+            payment_count: 2,
+            journal_entry_count: 5,
+            total_revenue: Decimal::new(12345, 2),
+            total_expenses: None,
+            total_receivables: Decimal::ZERO,
+            total_payables: None,
+            partial: true,
+            unsupported_fields: vec!["total_expenses".into(), "total_payables".into()],
+            download_url: None,
+            export_data: None,
+            generated_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        };
+
+        let json = serde_json::to_value(&export).expect("serialize export");
+
+        // Un-computed fields are explicit null — NOT the number 0.
+        assert!(json["total_expenses"].is_null());
+        assert!(json["total_payables"].is_null());
+        // A genuinely-zero figure still renders as a number, proving the two
+        // cases are distinguishable on the wire.
+        assert!(!json["total_receivables"].is_null());
+        // Partial signalling is honest and enumerates the missing fields.
+        assert_eq!(json["partial"], serde_json::json!(true));
+        assert_eq!(
+            json["unsupported_fields"],
+            serde_json::json!(["total_expenses", "total_payables"])
+        );
+    }
 }

--- a/backend/crates/db/src/repositories/regional_compliance.rs
+++ b/backend/crates/db/src/repositories/regional_compliance.rs
@@ -480,23 +480,23 @@ impl RegionalComplianceRepository {
     /// Returns `(invoice_count, payment_count, total_revenue, total_expenses,
     /// total_receivables, total_payables)` for the accounting export.
     ///
-    /// **Not yet computed (#1906 finding-3):** `total_expenses` and
-    /// `total_payables` (the 4th and 6th tuple fields) are returned as
-    /// `Decimal::ZERO` *by design, not as a calculation* — this export only has
-    /// the receivables side (`invoices` / `payments`) wired; there is no
-    /// expense / accounts-payable source in scope here. They are deliberate
-    /// placeholders, NOT an accidental zero. Surfacing this to API clients (e.g.
-    /// `Option<Decimal>` / an `unsupported` flag on `SlovakAccountingExport`) and
-    /// computing real figures from an expense / vendor-payables model is a
-    /// tracked follow-up; until then a caller must treat these two fields as
-    /// "not available", not "zero".
+    /// **Not yet computed (#1906 finding-3, tracked by #2030):**
+    /// `total_expenses` and `total_payables` (the 4th and 6th tuple fields) are
+    /// returned as `None` — this export only has the receivables side
+    /// (`invoices` / `payments`) wired; there is no expense / accounts-payable
+    /// source in scope here. `None` is a deliberate "not available" signal, NOT
+    /// an accidental zero, and it is surfaced honestly to API clients via
+    /// `Option<Decimal>` + the `partial` / `unsupported_fields` flags on
+    /// [`SlovakAccountingExport`]. Computing real figures from an expense /
+    /// vendor-payables model is the tracked follow-up; until then a caller must
+    /// treat these two fields as "not available", not "zero".
     pub async fn get_accounting_metrics(
         &self,
         conn: &mut PgConnection,
         organization_id: Uuid,
         from_date: NaiveDate,
         to_date: NaiveDate,
-    ) -> Result<(i32, i32, Decimal, Decimal, Decimal, Decimal), SqlxError> {
+    ) -> Result<(i32, i32, Decimal, Option<Decimal>, Decimal, Option<Decimal>), SqlxError> {
         let (invoice_count, total_revenue): (i64, Option<Decimal>) = sqlx::query_as(
             r#"
             SELECT COUNT(*), SUM(total)
@@ -543,9 +543,12 @@ impl RegionalComplianceRepository {
             invoice_count as i32,
             payment_count as i32,
             total_revenue,
-            Decimal::ZERO,
+            // Not computed — no expense source wired. `None` means "not
+            // available", surfaced to clients as a null field, never 0.
+            None,
             total_receivables,
-            Decimal::ZERO,
+            // Not computed — no accounts-payable source wired.
+            None,
         ))
     }
 }

--- a/backend/servers/api-server/src/routes/regional_compliance.rs
+++ b/backend/servers/api-server/src/routes/regional_compliance.rs
@@ -448,6 +448,18 @@ async fn export_slovak_accounting(
 
     let journal_entry_count = invoice_count + payment_count;
 
+    // Surface un-computed monetary fields honestly (#2030): a `null` +
+    // `unsupported_fields` entry so consumers can distinguish "not available"
+    // from a genuine zero, rather than the previous misleading hardcoded 0.
+    let mut unsupported_fields = Vec::new();
+    if total_expenses.is_none() {
+        unsupported_fields.push("total_expenses".to_string());
+    }
+    if total_payables.is_none() {
+        unsupported_fields.push("total_payables".to_string());
+    }
+    let partial = !unsupported_fields.is_empty();
+
     let result = Ok(Json(SlovakAccountingExport {
         export_id: Uuid::new_v4(),
         organization_id: org_id,
@@ -461,6 +473,8 @@ async fn export_slovak_accounting(
         total_expenses,
         total_receivables,
         total_payables,
+        partial,
+        unsupported_fields,
         download_url: Some(format!(
             "/api/v1/regional-compliance/slovak/accounting/download/{}",
             Uuid::new_v4()


### PR DESCRIPTION
## Task
Follow-up to PR #1976: `RegionalComplianceRepository::get_accounting_metrics` returned `total_expenses` / `total_payables` as hardcoded `Decimal::ZERO` placeholders (no expense / accounts-payable source is modeled) that flowed into `SlovakAccountingExport` as if they were real computed figures. For a legal/financial export a silent `0` is worse than an explicit "not available" — a consumer cannot distinguish "genuinely zero" from "not computed". Surface them honestly on the API boundary.

Closes #2030

## Owner
rust-backend

## Changes
- `SlovakAccountingExport.total_expenses` and `.total_payables` are now `Option<Decimal>` — the repo returns `None` (JSON `null`), never a fabricated `0`.
- Added `partial: bool` and `unsupported_fields: Vec<String>` to `SlovakAccountingExport`; the handler populates them (`["total_expenses", "total_payables"]`, `partial: true`) so clients can detect and enumerate the missing figures.
- `get_accounting_metrics` return type changed `(.., Decimal, .., Decimal)` → `(.., Option<Decimal>, .., Option<Decimal>)`; doc updated to state `None` = "not available", real computation is a tracked follow-up.
- Added a serialization regression test (`uncomputed_totals_serialize_as_null_not_zero`) proving un-computed totals render as `null` — distinguishable from a genuine zero (`total_receivables` still a number) — and that `partial` / `unsupported_fields` are honest.

Out of scope (per issue + task): the §1209-vs-§1210 legal-citation finding (severity low) is left for legal review, not touched here.

## Wire change
Contained to the utoipa code-first schema. Verified this endpoint/struct has **no** TypeSpec source, **no** generated frontend-client reference, and **no** entry in the committed `docs/api/generated/*` OpenAPI snapshots — so no client regeneration is required. Change is additive (two new fields) plus two fields becoming nullable.

## Tested (Band A — fast check)
```
cd backend && SQLX_OFFLINE=true cargo check -p db      # exit 0
cd backend && SQLX_OFFLINE=true cargo test -p db --lib regional_compliance::tests  # 1 passed
```
`test models::regional_compliance::tests::uncomputed_totals_serialize_as_null_not_zero ... ok`

## Built (Band B — full build)
`cargo check -p api-server` could **not** complete in this cloud-cron environment: the `utoipa-swagger-ui v9.0.2` build script panics fetching the Swagger UI zip (`build.rs:219 get_zip_archive`) — a network/offline sandbox limitation, unrelated to this diff and reproducible before any change. The api-server edit is a mechanically type-correct struct-literal change: the two tuple `Option<Decimal>` values map directly to the now-`Option<Decimal>` fields, and `partial` / `unsupported_fields` match the added field types. The `db` crate (which owns the model, repo, and test) builds clean. Honest-partial verification per the cloud-mode contract — CI (`backend.yml`) will run the full api-server build with network access.

## CI parity (Band C — hot-path only)
Not run locally (same swagger-ui build-script constraint). This touches financial/legal export correctness — reviewer should confirm `backend.yml` is green before merge.

## Notes
- No migration, no schema change.
- Follow-up still open: model an expense / vendor-payables source and compute the real figures (then drop the fields from `unsupported_fields`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcAWqmrSrbkVM32UUECEY6)_