### PR TITLE
gh-issue-2029: share triage/confirm notification recipient logic with tests

### DIFF
--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -26,6 +26,61 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 // ============================================================================
+// Notification recipient policy (single source of truth — #2029)
+// ============================================================================
+//
+// The fault-lifecycle notification recipient rules are extracted into pure
+// functions so the production handlers below and the recipient tests in
+// `tests/fault_notification_recipient_tests.rs` assert against the *same*
+// logic. Previously the tests re-implemented the selection inline, so the
+// handler's real policy (self-exclusion, dedup, `assigned_to`/manager
+// handling) could drift while the tests stayed green (#1974 / #2029).
+
+/// Recipients for a `triage_fault` notification (#1793).
+///
+/// The reporter (unless they are the triaging manager) plus the assigned
+/// technician if triage set one (skipping the actor and any duplicate).
+pub fn triage_fault_recipients(
+    reporter_id: Uuid,
+    actor_id: Uuid,
+    assigned_to: Option<Uuid>,
+) -> Vec<Uuid> {
+    let mut recipients: Vec<Uuid> = Vec::new();
+    if reporter_id != actor_id {
+        recipients.push(reporter_id);
+    }
+    if let Some(assignee) = assigned_to {
+        if assignee != actor_id && !recipients.contains(&assignee) {
+            recipients.push(assignee);
+        }
+    }
+    recipients
+}
+
+/// Recipients for a `confirm_fault` notification (#1793).
+///
+/// The assignee who did the work (unless they are the confirming reporter)
+/// plus the org's managers, excluding the actor and any duplicate.
+pub fn confirm_fault_recipients(
+    assigned_to: Option<Uuid>,
+    actor_id: Uuid,
+    manager_ids: impl IntoIterator<Item = Uuid>,
+) -> Vec<Uuid> {
+    let mut recipients: Vec<Uuid> = Vec::new();
+    if let Some(assignee) = assigned_to {
+        if assignee != actor_id {
+            recipients.push(assignee);
+        }
+    }
+    for mid in manager_ids {
+        if mid != actor_id && !recipients.contains(&mid) {
+            recipients.push(mid);
+        }
+    }
+    recipients
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 //
@@ -826,16 +881,10 @@ async fn triage_fault(
     // #1793: notify the reporter (and the assigned technician, if triage set
     // one) that the fault has been triaged — the first manager touch on a fault.
     // Best-effort, mirroring the other transitions: a dispatch failure is logged
-    // and never fails the mutation.
-    let mut recipients: Vec<Uuid> = Vec::new();
-    if fault.reporter_id != principal.user_id {
-        recipients.push(fault.reporter_id);
-    }
-    if let Some(assignee) = fault.assigned_to {
-        if assignee != principal.user_id && !recipients.contains(&assignee) {
-            recipients.push(assignee);
-        }
-    }
+    // and never fails the mutation. Recipient policy lives in the shared
+    // `triage_fault_recipients` (#2029) so the tests exercise this exact logic.
+    let recipients =
+        triage_fault_recipients(fault.reporter_id, principal.user_id, fault.assigned_to);
     if !recipients.is_empty() {
         let notification = Notification::new(
             Uuid::nil(),
@@ -1182,31 +1231,24 @@ async fn confirm_fault(
     // #1793: the reporter has confirmed (and rated) the resolution — typically
     // the closing transition. Notify the assignee who did the work plus the
     // org's managers so the lifecycle gets a closure signal. Best-effort.
-    let mut recipients: Vec<Uuid> = Vec::new();
-    if let Some(assignee) = fault.assigned_to {
-        if assignee != principal.user_id {
-            recipients.push(assignee);
-        }
-    }
-    match MembershipRepository::new(state.db.clone())
+    let manager_ids = match MembershipRepository::new(state.db.clone())
         .list_manager_ids(tenant_id)
         .await
     {
-        Ok(manager_ids) => {
-            for mid in manager_ids {
-                if mid != principal.user_id && !recipients.contains(&mid) {
-                    recipients.push(mid);
-                }
-            }
-        }
+        Ok(manager_ids) => manager_ids,
         Err(e) => {
             tracing::error!(
                 fault_id = %fault.id,
                 error = %e,
                 "Failed to load manager ids for FaultConfirmed notification"
             );
+            Vec::new()
         }
-    }
+    };
+    // Recipient policy lives in the shared `confirm_fault_recipients` (#2029)
+    // so the tests exercise this exact selection (assignee + managers, minus
+    // the confirming reporter, deduplicated).
+    let recipients = confirm_fault_recipients(fault.assigned_to, principal.user_id, manager_ids);
     if !recipients.is_empty() {
         let notification = Notification::new(
             Uuid::nil(),

--- a/backend/servers/api-server/tests/fault_notification_recipient_tests.rs
+++ b/backend/servers/api-server/tests/fault_notification_recipient_tests.rs
@@ -391,18 +391,11 @@ async fn triage_fault_notifies_reporter_and_assignee_not_manager(pool: PgPool) {
     let fault_id = Uuid::new_v4();
     let pipeline = build_pipeline(&pool);
 
-    // Mirror triage_fault recipient logic (manager = principal.user_id):
-    // reporter + assignee (if triage set one), excluding the actor.
-    let assigned_to: Option<Uuid> = Some(assignee);
-    let mut recipients: Vec<Uuid> = Vec::new();
-    if reporter != manager {
-        recipients.push(reporter);
-    }
-    if let Some(a) = assigned_to {
-        if a != manager && !recipients.contains(&a) {
-            recipients.push(a);
-        }
-    }
+    // Exercise the *production* recipient policy (manager = principal.user_id):
+    // reporter + assignee (if triage set one), excluding the actor. Shared with
+    // the `triage_fault` handler so this asserts the real selection (#2029).
+    let recipients =
+        api_server::routes::faults::triage_fault_recipients(reporter, manager, Some(assignee));
 
     let notification = Notification::new(
         Uuid::nil(),
@@ -450,24 +443,16 @@ async fn confirm_fault_notifies_assignee_and_managers_not_reporter(pool: PgPool)
     let fault_id = Uuid::new_v4();
     let pipeline = build_pipeline(&pool);
 
-    // Mirror confirm_fault recipient logic (reporter = principal.user_id):
-    // assignee + org managers, excluding the actor.
-    let assigned_to: Option<Uuid> = Some(assignee);
-    let mut recipients: Vec<Uuid> = Vec::new();
-    if let Some(a) = assigned_to {
-        if a != reporter {
-            recipients.push(a);
-        }
-    }
+    // Exercise the *production* recipient policy (reporter = principal.user_id):
+    // assignee + org managers, excluding the actor. The manager lookup uses the
+    // real `MembershipRepository`; the merge/self-exclusion is the shared
+    // `confirm_fault` handler policy (#2029).
     let manager_ids = MembershipRepository::new(pool.clone())
         .list_manager_ids(org)
         .await
         .expect("list_manager_ids");
-    for mid in manager_ids {
-        if mid != reporter && !recipients.contains(&mid) {
-            recipients.push(mid);
-        }
-    }
+    let recipients =
+        api_server::routes::faults::confirm_fault_recipients(Some(assignee), reporter, manager_ids);
 
     assert!(
         recipients.contains(&assignee),


### PR DESCRIPTION
## Task
Follow-up: fault triage/confirm notification tests don't exercise the real handler (PR #1974). Drive the two tests in `backend/servers/api-server/tests/fault_notification_recipient_tests.rs` (`triage_fault_notifies_reporter_and_assignee_not_manager`, `confirm_fault_notifies_assignee_and_managers_not_reporter`) through the real `triage_fault`/`confirm_fault` handlers, OR factor the recipient computation into one shared pure function called by both the handler and the test.

Closes #2029

## Owner
rust-backend

## Approach
A full end-to-end HTTP call is impractical for these tests: `TestApp` mounts the fault routes without `host_tenant_middleware`, so `require_tenant_id` short-circuits every request at `403 TENANT_REQUIRED` before any recipient logic runs (documented in the test-file header — it's also why the "sibling" `reopen_fault_notifies_managers_not_reopener` operates at the repository+pipeline layer rather than through the handler).

So this takes the issue's second option: the recipient computation for the triage and confirm transitions is factored into two pure functions in `routes/faults.rs`, now the single source of truth:

- `triage_fault_recipients(reporter_id, actor_id, assigned_to)` — reporter (unless actor) + assignee if triage set one (skipping actor/dupes).
- `confirm_fault_recipients(assigned_to, actor_id, manager_ids)` — assignee (unless confirming reporter) + org managers (minus actor/dupes).

The `triage_fault` and `confirm_fault` handlers now call these functions instead of computing recipients inline, and tests R7/R8 assert against the *same* functions instead of re-implementing the selection. The confirm test still resolves managers via the real `MembershipRepository::list_manager_ids`, then feeds them to the shared function. Behaviour is identical to before — a pure refactor that closes the test-effectiveness gap: self-exclusion / dedup / `assigned_to` / manager-lookup drift can no longer pass silently.

## Tested (Band A — fast check)
Cloud-cron environment: no Docker/Postgres, so the DB-backed `#[sqlx::test]` cases cannot execute (honest partial — compile-only verification). All commands run with `SQLX_OFFLINE=true`.

- `cargo fmt -p api-server` — applied, clean.
- `cargo check -p api-server` — **exit 0** (`Finished dev profile ... in 5m05s`).
- `cargo clippy -p api-server --tests -- -D warnings` — **exit 0**. This compiles the full test suite (including both refactored tests) AND lints with warnings-as-errors, so it is the authoritative proof that the production code and the changed test file compile lint-clean.
- `cargo test -p api-server --no-run` — the `fault_notification_recipient_tests` binary compiled successfully; the overall run then hit `ENOSPC` while linking the remaining ~90 integration-test binaries (each ~46 MB; `target/debug` reached 19 GB and filled the sandbox disk). This is an infrastructure limit, not a code failure, and is fully covered by the clippy `--tests` compile above.

Build-dep note: `utoipa-swagger-ui` downloads the Swagger UI archive from `github.com/swagger-api/swagger-ui` at build time, which this session's egress policy blocks. The compile was unblocked by pointing `SWAGGER_UI_DOWNLOAD_URL` at a locally-constructed stub archive (build-time env var only — **no repo/Cargo change**).

## Built (Band B — full build)
skipped: pure refactor, ~27 substantive LOC net, no public API/schema/config change (the two new `pub fn`s are internal recipient helpers, not an external API surface).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-effectiveness refactor; no auth/billing/data-integrity behaviour change).

## Remote-tested
skipped.

## Scope drift
None — the diff is confined to `backend/servers/api-server/src/routes/faults.rs` and `.../tests/fault_notification_recipient_tests.rs`, both in the rust-backend owner area.

## Code-reuse review
None — `reuse-grep` reported no warnings; the two new helpers have no pre-existing equivalent.

## Notes
Recipient-selection behaviour is unchanged; only its location moved (inline → shared pure fn) so the handler and its tests share one implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TcAWqmrSrbkVM32UUECEY6

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcAWqmrSrbkVM32UUECEY6)_