### PR TITLE
gh-issue-2049: fix units u.name schema drift in lease.rs

### DIFF
--- a/backend/crates/db/src/repositories/lease.rs
+++ b/backend/crates/db/src/repositories/lease.rs
@@ -296,7 +296,7 @@ impl LeaseRepository {
         let apps = sqlx::query_as::<_, (Uuid, Uuid, String, String, String, String, String, Option<chrono::DateTime<Utc>>, Option<Decimal>, Option<NaiveDate>, i64, bool)>(
             r#"
             SELECT
-                a.id, a.unit_id, u.name, b.name,
+                a.id, a.unit_id, u.designation, b.name,
                 a.applicant_name, a.applicant_email, a.status,
                 a.submitted_at, a.monthly_income, a.desired_move_in,
                 (SELECT COUNT(*) FROM tenant_screenings WHERE application_id = a.id) as screening_count,
@@ -1039,7 +1039,7 @@ impl LeaseRepository {
         >(
             r#"
             SELECT
-                l.id, l.unit_id, u.name, b.name,
+                l.id, l.unit_id, u.designation, b.name,
                 l.tenant_name, l.tenant_email,
                 l.start_date, l.end_date, l.monthly_rent, l.status,
                 (l.end_date - $6::date)::int8 as days_until_expiry
@@ -1489,7 +1489,7 @@ impl LeaseRepository {
         >(
             r#"
             SELECT
-                l.id, l.unit_id, u.name, b.name,
+                l.id, l.unit_id, u.designation, b.name,
                 l.tenant_name, l.tenant_email,
                 l.start_date, l.end_date, l.monthly_rent, l.status,
                 (l.end_date - $2::date)::int8 as days_until_expiry
@@ -1998,7 +1998,7 @@ impl LeaseRepository {
 
         // Get unit and building names
         let (unit_name, building_name): (String, String) = sqlx::query_as(
-            r#"SELECT u.name, b.name FROM units u JOIN buildings b ON b.id = u.building_id WHERE u.id = $1"#,
+            r#"SELECT u.designation, b.name FROM units u JOIN buildings b ON b.id = u.building_id WHERE u.id = $1"#,
         )
         .bind(lease.unit_id)
         .fetch_one(&self.pool)


### PR DESCRIPTION
## Task
Follow-up: units u.name schema-drift 500 still live in lease.rs (PR #2042) — change the drifted u.name projections to u.designation. Closes #2049

## Owner
pm-tech-lead (change is rust-backend; rust-backend specialist selected)

## Change
`backend/crates/db/src/repositories/lease.rs` had FOUR runtime `sqlx::query_as::<_, ...>` (string, not compile-checked macro) queries that JOIN `units u` and projected `u.name`. The `units` identity column is `designation` (`00008_create_units.sql`: `designation VARCHAR(50) NOT NULL`; there is no `name` column), so each query 500s at fetch time with Postgres 42703 (undefined column). Fixed all four:

- `lease.rs:299` — tenant-applications list (`JOIN units u ON u.id = a.unit_id`)
- `lease.rs:1042` — leases list (`JOIN units u ON u.id = l.unit_id`)
- `lease.rs:1492` — expiring-leases list (`JOIN units u ON u.id = l.unit_id`)
- `lease.rs:2001` — `get_lease_with_details` (`SELECT u.designation, b.name FROM units u JOIN buildings b ...`)

Each `u.name` (alias `u` = `units`) → `u.designation`. All are positional tuple-mapped SELECTs; column position/order is unchanged so row→struct field bindings still resolve. `b.name` on `buildings b` is correct (buildings has a `name` column) and was left untouched. This mirrors the sibling fix already landed in `rental.rs` (PR #2042), which projects `u.designation` throughout — the sweep had stopped there.

Diff: 1 file, 4 insertions / 4 deletions.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p db` → exit 0
- `cargo fmt -p db --check` → exit 0

## Built (Band B — full build)
- `SQLX_OFFLINE=true cargo clippy -p db -- -D warnings` → exit 0

## CI parity (Band C — hot-path only)
skipped: targeted 4-line column-name correctness fix, no security/auth/billing change. Data-integrity impact is the fix itself (restores broken reads).

## Remote-tested
skipped: no ppt-bridge MCP in this session.

## Scope drift
`scope-check.sh --owner pm-tech-lead` flags `backend/crates/db/src/repositories/lease.rs` (exit 2) because the `pm-tech-lead` owner-role maps only to `docs/**`, `.research/**`, `_bmad-output/**`. This is an expected owner_role-hint vs actual-stack mismatch: the task itself states owner is pm-tech-lead "but the change is rust-backend; select the rust specialist". The single changed file is squarely inside rust-backend / db-repository scope. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. No new helpers/symbols added.

## Regression guard (test-coverage note — limitation)
No DB-backed regression test was added. Root cause is that these are runtime `sqlx::query_as::<_, ...>` string queries, which are deliberately excluded from `.sqlx` offline metadata and are NOT compile-time verified — so `cargo sqlx prepare --check` cannot catch this class of drift. A meaningful guard requires a live-Postgres round-trip test (execute each list/detail query and assert no 42703), which is not feasible in this cloud env (no Postgres). Documented honestly rather than adding a brittle source-grep test.

Recommended follow-ups (out of scope here):
1. Add DB-round-trip regression tests for these four lease queries under `backend/crates/db/tests/` (run where Postgres is available).
2. Consider migrating these hot-path list queries from runtime `query_as::<_, tuple>` to compile-checked `sqlx::query_as!` so schema drift is caught at build time — the durable fix for this whole bug class.

## Notes
Closes #2049

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke4tPELkxX9BzdFfCXL14r)_