### PR TITLE
gh-issue-2058: wire refill/ingest smoke tests into dispatcher-self-test CI

### DIFF
--- a/.github/workflows/dispatcher-self-test.yml
+++ b/.github/workflows/dispatcher-self-test.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - ".research/dispatcher-prompt.md"
       - ".research/dispatcher-self-test.sh"
+      - ".research/backlog-refill.sh"
+      - ".research/issue-ingest.sh"
+      - ".research/test-backlog-refill.sh"
+      - ".research/test-issue-ingest.sh"
       - ".research/management/assignments.json"
       - ".claude/skills/ppt-implement/**"
       - ".claude/skills/ppt-pr-merge/**"
@@ -29,6 +33,10 @@ jobs:
           fetch-depth: 0
       - name: dispatcher schema + invariant self-test
         run: bash .research/dispatcher-self-test.sh
+      - name: backlog-refill behavioral smoke test
+        run: bash .research/test-backlog-refill.sh
+      - name: issue-ingest behavioral smoke test
+        run: bash .research/test-issue-ingest.sh
       - name: goal-check (enforcing)
         env:
           GOAL_CHECK_ENFORCE: "1"


### PR DESCRIPTION
## Summary

Follow-up to #2058. The `dispatcher-self-test.yml` workflow previously only ran `dispatcher-self-test.sh`, and its `paths:` filter did not cover the refill/ingest scripts — so a logic regression to `backlog-refill.sh` or `issue-ingest.sh` could land with zero CI signal.

This PR closes that gap in the single workflow file `.github/workflows/dispatcher-self-test.yml`:

1. **Widen the `paths:` trigger** to include `.research/backlog-refill.sh`, `.research/issue-ingest.sh`, `.research/test-backlog-refill.sh`, `.research/test-issue-ingest.sh`.
2. **Run the two behavioral smoke tests** as CI steps alongside the existing self-test:
   - `bash .research/test-backlog-refill.sh`
   - `bash .research/test-issue-ingest.sh`

   This mirrors the offline-self-test pattern already used in `stale-pr-guard.yml` (`stale-pr-guard.test.sh`).

## Verification

Both smoke tests confirmed to exist and pass locally before wiring:

```
==> backlog-refill smoke test PASSED   (17 checks)
==> issue-ingest smoke test PASSED     (14 checks)
```

YAML validated well-formed (`yaml.safe_load`). Change is minimal and in-scope: 1 file, 8 insertions, no other files touched. No Rust build or Postgres needed.

Closes #2058

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TC142HhGJUAVy3DxQdTSvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01TC142HhGJUAVy3DxQdTSvS)_