### PR TITLE
gh-issue-2051: test per_page/page clamp + tighten import_templates pagination index

### DIFF
--- a/backend/crates/db/migrations/00212_import_templates_org_updated_id_index.sql
+++ b/backend/crates/db/migrations/00212_import_templates_org_updated_id_index.sql
@@ -1,0 +1,37 @@
+-- Migration: 00212_import_templates_org_updated_id_index
+-- Tighten the list_templates pagination index so the full ORDER BY tie-break
+-- is index-satisfiable, and drop the now-redundant single-column index
+-- (#2051, follow-up to PR #2038 / #1994).
+--
+-- MigrationRepository::list_templates pages with:
+--   SELECT * FROM import_templates
+--   WHERE (organization_id = $1 [OR organization_id IS NULL]) [AND data_type = $2]
+--   ORDER BY updated_at DESC, id DESC
+--   LIMIT $ OFFSET $
+--
+-- Migration 00211 added idx_import_templates_org_updated on
+-- (organization_id, updated_at DESC). That covers the org filter and the
+-- leading sort key, but NOT the `id DESC` tie-break: Postgres can range-scan
+-- the index for the first two keys, yet rows sharing an `updated_at` value
+-- still need an extra in-memory sort to resolve the `id DESC` order. Adding
+-- `id DESC` as a third index key makes the entire ORDER BY (and therefore the
+-- LIMIT/OFFSET slice) satisfiable directly from the index, so paginated reads
+-- become a pure index range scan with a stable, deterministic order.
+--
+-- The system-template leg of the OR (organization_id IS NULL) is still served
+-- by this index: NULLs are indexed by btree, and the leading key plus the two
+-- sort keys match the query's ordering for that branch too.
+CREATE INDEX IF NOT EXISTS idx_import_templates_org_updated_id
+    ON import_templates (organization_id, updated_at DESC, id DESC);
+
+-- Replace the (organization_id, updated_at DESC) index from 00211: the new
+-- three-column index is a strict superset (same leading keys), so keeping both
+-- only wastes write bandwidth and planner consideration.
+DROP INDEX IF EXISTS idx_import_templates_org_updated;
+
+-- Drop the original single-column index from 00198. The composite index above
+-- has organization_id as its leading column, so it already serves every
+-- equality lookup on organization_id that idx_import_templates_organization_id
+-- used to cover. Keeping it is pure redundancy (extra index maintenance on
+-- every insert/update/delete for no read benefit).
+DROP INDEX IF EXISTS idx_import_templates_organization_id;

--- a/backend/servers/api-server/tests/migration_pagination_tests.rs
+++ b/backend/servers/api-server/tests/migration_pagination_tests.rs
@@ -64,11 +64,68 @@ fn get(token: &str, tenant_id: Uuid, uri: &str) -> Request<Body> {
         .unwrap()
 }
 
-/// Register + verify + log in a user, then promote them to an active
-/// `platform_admin` member of a fresh org (mirrors the helper in
-/// `migration_db_tests.rs`). Returns `(access_token, org_id)`.
+/// Mint an access token that carries the `platform_admin` role and a
+/// `tenant_id` claim pinned to `org_id`.
+///
+/// The `list_templates` handler reads BOTH of these off the JWT *claims*:
+/// `require_platform_admin` gates on `AuthUser::is_platform_admin()` (the
+/// `role` claim) and the org scope comes from `user.tenant_id` (the
+/// `tenant_id` claim). The `/auth/login` flow used by `create_authenticated_user`
+/// mints a token with `role = None` / `tenant_id = None` ("roles are set when
+/// org context is selected", see `routes/auth.rs`), so a login token can never
+/// clear the platform-admin gate — it 403s before the query runs. We therefore
+/// mint the token directly, mirroring the green `accounting_happy_path` pattern.
+/// The signing secret matches `TestConfig::default().jwt_secret`, which
+/// `TestApp` installs into `JWT_SECRET`.
+///
+/// `role` serialises via `TenantRole`'s `rename_all = "snake_case"`, so the
+/// literal wire value is `"platform_admin"`.
+fn mint_platform_admin_token(user_id: Uuid, org_id: Uuid, email: &str) -> String {
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct Claims {
+        sub: String,
+        exp: i64,
+        iat: i64,
+        token_type: String,
+        tenant_id: String,
+        role: String,
+        email: String,
+        name: String,
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    encode(
+        &Header::default(),
+        &Claims {
+            sub: user_id.to_string(),
+            exp: now + 900,
+            iat: now,
+            token_type: "access".into(),
+            tenant_id: org_id.to_string(),
+            role: "platform_admin".into(),
+            email: email.into(),
+            name: "Migration Pagination Admin".into(),
+        },
+        &EncodingKey::from_secret(
+            b"test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes",
+        ),
+    )
+    .expect("mint platform-admin token")
+}
+
+/// Register + verify a user, seed a fresh org with an active `platform_admin`
+/// membership for that user, then return a directly-minted platform-admin
+/// access token scoped to the org (plus the org id).
+///
+/// The membership row is seeded to keep the fixture faithful to the real
+/// authorization model (an admin *is* a member); the token's `platform_admin`
+/// role claim is what actually clears `ValidatedTenantExtractor`'s membership
+/// bypass and the `require_platform_admin` gate.
 async fn create_platform_admin(app: &TestApp, user: &TestUser, slug: &str) -> (String, Uuid) {
-    let (access_token, _refresh) = create_authenticated_user(app, user).await;
+    let (_login_token, _refresh) = create_authenticated_user(app, user).await;
 
     let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
         .bind(&user.email)
@@ -79,7 +136,8 @@ async fn create_platform_admin(app: &TestApp, user: &TestUser, slug: &str) -> (S
     let org_id = seed_org(&app.pool, slug).await;
     seed_membership(&app.pool, org_id, user_id, "platform_admin").await;
 
-    (access_token, org_id)
+    let token = mint_platform_admin_token(user_id, org_id, &user.email);
+    (token, org_id)
 }
 
 /// Insert `count` custom `buildings` templates for `org_id` with strictly

--- a/backend/servers/api-server/tests/migration_pagination_tests.rs
+++ b/backend/servers/api-server/tests/migration_pagination_tests.rs
@@ -117,9 +117,7 @@ async fn per_page_zero_and_negative_clamp_to_one(pool: PgPool) {
     seed_buildings_templates(&pool, org_id, 3).await;
 
     for raw in ["0", "-5"] {
-        let uri = format!(
-            "/api/v1/migration/templates?include_system=false&per_page={raw}"
-        );
+        let uri = format!("/api/v1/migration/templates?include_system=false&per_page={raw}");
         let resp = app.execute(get(&token, org_id, &uri)).await;
         assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
         let body: ListTemplatesResponse = resp.json();
@@ -144,8 +142,7 @@ async fn per_page_above_max_clamps_to_hundred(pool: PgPool) {
     let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgclamp2").await;
     seed_buildings_templates(&pool, org_id, 5).await;
 
-    let uri =
-        "/api/v1/migration/templates?include_system=false&per_page=500";
+    let uri = "/api/v1/migration/templates?include_system=false&per_page=500";
     let resp = app.execute(get(&token, org_id, uri)).await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
     let body: ListTemplatesResponse = resp.json();
@@ -166,8 +163,7 @@ async fn page_zero_clamps_to_one(pool: PgPool) {
     let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgclamp3").await;
     let expected_order = seed_buildings_templates(&pool, org_id, 5).await;
 
-    let uri =
-        "/api/v1/migration/templates?include_system=false&page=0&per_page=2";
+    let uri = "/api/v1/migration/templates?include_system=false&page=0&per_page=2";
     let resp = app.execute(get(&token, org_id, uri)).await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
     let body: ListTemplatesResponse = resp.json();
@@ -188,8 +184,7 @@ async fn page_two_returns_expected_offset_slice(pool: PgPool) {
     let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgclamp4").await;
     let expected_order = seed_buildings_templates(&pool, org_id, 5).await;
 
-    let uri =
-        "/api/v1/migration/templates?include_system=false&page=2&per_page=2";
+    let uri = "/api/v1/migration/templates?include_system=false&page=2&per_page=2";
     let resp = app.execute(get(&token, org_id, uri)).await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
     let body: ListTemplatesResponse = resp.json();

--- a/backend/servers/api-server/tests/migration_pagination_tests.rs
+++ b/backend/servers/api-server/tests/migration_pagination_tests.rs
@@ -1,0 +1,208 @@
+//! Route-level pagination clamp tests for `GET /api/v1/migration/templates`
+//! (Epic 66, Story 66.1 — follow-up #2051 to PR #2038).
+//!
+//! The list handler (`routes/migration.rs::list_templates`) sanitises the
+//! caller-supplied paging params before touching the database:
+//!
+//! ```ignore
+//! let page = query.page.unwrap_or(1).max(1);
+//! let per_page = query.per_page.unwrap_or(20).clamp(1, 100);
+//! let offset = (page - 1) as i64 * per_page as i64;
+//! ```
+//!
+//! PR #2038 added this clamp but shipped without a test that actually drives
+//! the route with hostile paging input. These tests close that gap: they assert
+//! the clamp bounds (`per_page` -> `[1, 100]`, `page` -> `>= 1`) via the
+//! `per_page` / `page` values echoed back in [`ListTemplatesResponse`], and that
+//! the resulting `LIMIT`/`OFFSET` slice matches what the clamped values imply.
+//!
+//! These tests do NOT share the BIT-351 quarantine of `migration_db_tests.rs`:
+//! that quarantine is scoped to the create/validate/preview/approve lifecycle,
+//! whereas this file only seeds rows directly and reads them back through the
+//! list endpoint — the same happy-path listing surface that the un-ignored
+//! `infra_migration_platform_admin_tests.rs` already exercises.
+
+#![allow(dead_code)]
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use serde::Deserialize;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, seed_membership, seed_org, TestApp, TestUser};
+
+/// Subset of `routes::migration::ListTemplatesResponse` needed for assertions.
+/// (The route type is not exported, so mirror the wire shape here.)
+#[derive(Debug, Deserialize)]
+struct ListTemplatesResponse {
+    templates: Vec<TemplateSummary>,
+    total: i64,
+    page: i32,
+    per_page: i32,
+}
+
+#[derive(Debug, Deserialize)]
+struct TemplateSummary {
+    id: Uuid,
+    name: String,
+}
+
+/// Build a GET request carrying the platform-admin bearer token and the
+/// `X-Tenant-ID` header both required to reach the `list_templates` handler.
+fn get(token: &str, tenant_id: Uuid, uri: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(uri)
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .header("X-Tenant-ID", tenant_id.to_string())
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// Register + verify + log in a user, then promote them to an active
+/// `platform_admin` member of a fresh org (mirrors the helper in
+/// `migration_db_tests.rs`). Returns `(access_token, org_id)`.
+async fn create_platform_admin(app: &TestApp, user: &TestUser, slug: &str) -> (String, Uuid) {
+    let (access_token, _refresh) = create_authenticated_user(app, user).await;
+
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&app.pool)
+        .await
+        .expect("resolve user id");
+
+    let org_id = seed_org(&app.pool, slug).await;
+    seed_membership(&app.pool, org_id, user_id, "platform_admin").await;
+
+    (access_token, org_id)
+}
+
+/// Insert `count` custom `buildings` templates for `org_id` with strictly
+/// increasing `updated_at` (index `i` = `NOW() + i seconds`), so the
+/// `ORDER BY updated_at DESC, id DESC` list order is fully deterministic:
+/// `pg-tpl-{count-1}` (newest) down to `pg-tpl-0` (oldest).
+///
+/// Returns the template names in that expected descending list order.
+async fn seed_buildings_templates(pool: &PgPool, org_id: Uuid, count: i32) -> Vec<String> {
+    for i in 0..count {
+        sqlx::query(
+            r#"INSERT INTO import_templates
+                   (organization_id, name, description, data_type,
+                    field_mappings, is_system_template, updated_at)
+               VALUES ($1, $2, NULL, 'buildings', '[]'::jsonb, false,
+                       NOW() + make_interval(secs => $3))"#,
+        )
+        .bind(org_id)
+        .bind(format!("pg-tpl-{i}"))
+        .bind(i as f64)
+        .execute(pool)
+        .await
+        .expect("seed buildings template");
+    }
+
+    // Descending updated_at => highest index first.
+    (0..count).rev().map(|i| format!("pg-tpl-{i}")).collect()
+}
+
+/// `per_page=0` and `per_page=-5` must both clamp up to 1.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn per_page_zero_and_negative_clamp_to_one(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgclamp1").await;
+    seed_buildings_templates(&pool, org_id, 3).await;
+
+    for raw in ["0", "-5"] {
+        let uri = format!(
+            "/api/v1/migration/templates?include_system=false&per_page={raw}"
+        );
+        let resp = app.execute(get(&token, org_id, &uri)).await;
+        assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
+        let body: ListTemplatesResponse = resp.json();
+
+        assert_eq!(body.per_page, 1, "per_page={raw} must clamp to 1");
+        assert_eq!(body.page, 1, "page defaults to 1");
+        assert_eq!(body.total, 3, "total ignores paging window");
+        assert_eq!(
+            body.templates.len(),
+            1,
+            "per_page clamped to 1 => at most one row for per_page={raw}"
+        );
+    }
+}
+
+/// `per_page=500` must clamp down to 100. With only a handful of rows the
+/// returned slice equals the full set, and the echoed `per_page` reflects the
+/// clamp (not the requested 500).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn per_page_above_max_clamps_to_hundred(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgclamp2").await;
+    seed_buildings_templates(&pool, org_id, 5).await;
+
+    let uri =
+        "/api/v1/migration/templates?include_system=false&per_page=500";
+    let resp = app.execute(get(&token, org_id, uri)).await;
+    assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
+    let body: ListTemplatesResponse = resp.json();
+
+    assert_eq!(body.per_page, 100, "per_page=500 must clamp to 100");
+    assert_eq!(body.total, 5);
+    assert_eq!(
+        body.templates.len(),
+        5,
+        "clamp to 100 still returns all 5 seeded rows (5 < 100)"
+    );
+}
+
+/// `page=0` must clamp up to 1 (offset 0 => first page).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn page_zero_clamps_to_one(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgclamp3").await;
+    let expected_order = seed_buildings_templates(&pool, org_id, 5).await;
+
+    let uri =
+        "/api/v1/migration/templates?include_system=false&page=0&per_page=2";
+    let resp = app.execute(get(&token, org_id, uri)).await;
+    assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
+    let body: ListTemplatesResponse = resp.json();
+
+    assert_eq!(body.page, 1, "page=0 must clamp to 1");
+    assert_eq!(body.per_page, 2);
+    assert_eq!(body.total, 5);
+    // Offset 0 => the first two rows in updated_at DESC, id DESC order.
+    let names: Vec<&str> = body.templates.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(names, vec![&expected_order[0][..], &expected_order[1][..]]);
+}
+
+/// `page=2&per_page=2` selects offset `(2-1)*2 = 2` — the third and fourth
+/// rows in `updated_at DESC, id DESC` order.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn page_two_returns_expected_offset_slice(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgclamp4").await;
+    let expected_order = seed_buildings_templates(&pool, org_id, 5).await;
+
+    let uri =
+        "/api/v1/migration/templates?include_system=false&page=2&per_page=2";
+    let resp = app.execute(get(&token, org_id, uri)).await;
+    assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
+    let body: ListTemplatesResponse = resp.json();
+
+    assert_eq!(body.page, 2);
+    assert_eq!(body.per_page, 2);
+    assert_eq!(body.total, 5);
+
+    // offset = (page - 1) * per_page = 2 => rows at indices 2 and 3.
+    let names: Vec<&str> = body.templates.iter().map(|t| t.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![&expected_order[2][..], &expected_order[3][..]],
+        "page 2 must be the offset-2 slice of the DESC ordering"
+    );
+}


### PR DESCRIPTION
## Task
Follow-up: per_page clamp still untested + index tiebreak/redundancy polish (PR #2038). Closes #2051.

Two parts:
1. **test-coverage [medium]** — add an api-server integration test (alongside `backend/servers/api-server/tests/migration_db_tests.rs`) for the route-level `per_page` clamp at `backend/servers/api-server/src/routes/migration.rs:122` (`query.per_page.unwrap_or(20).clamp(1,100)` + `page.max(1)` / `offset=(page-1)*per_page`): assert `per_page=0` and `per_page=-5` clamp to 1; `per_page=500` clamps to 100 (assert echoed `per_page` in `ListTemplatesResponse` and returned row count); `page=0` clamps to 1; `page=2&per_page=2` returns the expected offset slice.
2. **efficiency [low]** — migration changing the index to `(organization_id, updated_at DESC, id DESC)` so the `updated_at DESC, id DESC` tie-break is fully index-satisfiable, and drop the now-redundant single-column `idx_import_templates_organization_id` (migration 00198).

## Owner
`pm-tech-lead` (implemented by the rust-backend + db-migration stacks — see Scope drift)

## What changed
- **`backend/servers/api-server/tests/migration_pagination_tests.rs`** (new) — 4 `#[sqlx::test]` cases that drive `GET /api/v1/migration/templates` with hostile paging input:
  - `per_page_zero_and_negative_clamp_to_one` — `per_page=0` and `per_page=-5` → echoed `per_page==1`, at most 1 row returned.
  - `per_page_above_max_clamps_to_hundred` — `per_page=500` → echoed `per_page==100`, all 5 seeded rows returned.
  - `page_zero_clamps_to_one` — `page=0` → echoed `page==1`, first-page slice.
  - `page_two_returns_expected_offset_slice` — `page=2&per_page=2` → offset-2 slice of the `updated_at DESC, id DESC` order.

  Rows are seeded directly via SQL with strictly increasing `updated_at`, so the ordering (and therefore the offset slice) is deterministic. Requests use `include_system=false` (no `data_type` filter) so the result set is exactly the fresh org's seeded rows — this deliberately avoids the `data_type` query param, since `ImportDataType` has `#[sqlx(rename_all="snake_case")]` but **no** `#[serde(rename_all)]`, so a `data_type=buildings` query param would not deserialize.

  These tests are **not** under the BIT-351 quarantine that covers `migration_db_tests.rs`: that quarantine is scoped to the create/validate/preview/approve lifecycle, whereas this file only seeds rows and reads them back through the list endpoint — the same happy-path listing surface that the already-un-ignored `infra_migration_platform_admin_tests.rs` exercises.

- **`backend/crates/db/migrations/00212_import_templates_org_updated_id_index.sql`** (new) —
  - `CREATE INDEX idx_import_templates_org_updated_id ON import_templates (organization_id, updated_at DESC, id DESC)` — makes the full `list_templates` `ORDER BY updated_at DESC, id DESC` + `LIMIT/OFFSET` index-satisfiable (00211 stopped at `(organization_id, updated_at DESC)`, leaving the `id DESC` tie-break to an extra sort).
  - `DROP INDEX idx_import_templates_org_updated` (from 00211 — strict subset of the new composite).
  - `DROP INDEX idx_import_templates_organization_id` (from 00198 — the composite's leading column already serves every equality lookup on `organization_id`).

## Tested (Band A — fast check)
**Could not run `cargo`/`sqlx` locally.** This cloud sandbox's egress proxy enforces an org policy that blocks GitHub archive downloads, so the `utoipa-swagger-ui` build script fails before any api-server code compiles:
```
utoipa-swagger-ui build.rs: failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
curl https://github.com/swagger-api/swagger-ui/.../v5.17.14.zip
  -> {"message":"GitHub access to this repository is not enabled for this session..."}  (HTTP 403)
```
`utoipa-swagger-ui` is an unconditional dependency of `api-server` (not feature-gated), so `cargo check -p api-server` / `cargo test -p api-server --no-run` cannot complete here. There is also no local Postgres, so the `#[sqlx::test]` cases cannot be executed in-sandbox. Per the dispatcher's cloud-mode guidance I did **not** fabricate a pass — the CI `backend.yml` job (which has GitHub archive access + Postgres) is the real gate for compile + test.

Verified locally by inspection instead:
- Migration is pure standard DDL (`CREATE INDEX IF NOT EXISTS` / `DROP INDEX IF EXISTS`); forward-only, matching repo convention (00211).
- No `sqlx::query!`/`query_as!` macro references any of the touched index names, so `cargo sqlx prepare` offline data is unaffected (no `.sqlx/*.json` change needed).
- The new test mirrors the request/seed/decode patterns of the compiling siblings `migration_db_tests.rs` and `infra_migration_platform_admin_tests.rs`.

## Built (Band B — full build)
Skipped — blocked by the same sandbox egress limitation described above. Runs on CI.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path change (no security/auth/billing/data-integrity behavior change — additive test + index-only migration).

## Remote-tested
Skipped: no ppt-bridge MCP session.

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports exit 2 for both files:
- `backend/servers/api-server/tests/migration_pagination_tests.rs` (rust-backend area)
- `backend/crates/db/migrations/00212_import_templates_org_updated_id_index.sql` (db-migration area)

This is expected: the owner hint `pm-tech-lead` is an architecture-review role that maps narrowly, while the task explicitly spans the rust-backend (test) and db-migration (index) stacks. No unrelated files are touched — the diff is exactly these two additive files.

## Notes
- Both parts are additive and low-risk; the migration only changes index coverage (no data/schema-shape change).
- Reviewer / CI should confirm the 4 `#[sqlx::test]` cases pass against Postgres, since they could not be executed in the cloud sandbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_018yTuwsPky7T4gmH1CVnqn6)_