### PR TITLE
gh-issue-2056: exact-pin quick-xml (=0.41.0) and extend pin guard to Cargo.lock

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,4 +16,14 @@
 # that pin — so every change to this manifest must get an explicit
 # owner review rather than riding into an unrelated dep-bump merge
 # (the failure mode PR #2011 exhibited).
+#
+# Cargo.lock is owned too: because a version requirement can be an in-range
+# caret (or an exact `=` pin that still gets bumped), a `cargo update` or an
+# in-range Dependabot bump changes ONLY the lockfile. Without an owner on
+# Cargo.lock the resolved quick-xml version could move with no review request.
+#
+# NOTE: CODEOWNERS review is only *mandatory* when branch protection on `dev`
+# has "Require review from Code Owners" enabled. That setting is not
+# verifiable in-repo — confirm it is on, otherwise this guard is advisory.
 /backend/Cargo.toml    @martin-janci
+/backend/Cargo.lock    @martin-janci

--- a/.github/workflows/pinned-dependency-guard.yml
+++ b/.github/workflows/pinned-dependency-guard.yml
@@ -12,17 +12,24 @@ name: Pinned-dependency guard
 # comment asks for (GH #1519 / #1591 / #2033).
 #
 # This workflow is a lightweight, ADVISORY marker: whenever a PR touches
-# the `quick-xml` pin line in backend/Cargo.toml it emits a GitHub warning
-# annotation reminding the author + reviewers to treat it as an XXE-safety
-# change. It NEVER fails the build — the hard "requests explicit review"
-# guarantee is provided by .github/CODEOWNERS. This job only surfaces the
-# regression note so the pin cannot be crossed silently.
+# the `quick-xml` pin line in backend/Cargo.toml OR the resolved quick-xml
+# version in backend/Cargo.lock it emits a GitHub warning annotation
+# reminding the author + reviewers to treat it as an XXE-safety change. It
+# NEVER fails the build — the hard "requests explicit review" guarantee is
+# provided by .github/CODEOWNERS. This job only surfaces the regression note
+# so the pin cannot be crossed silently.
+#
+# Why Cargo.lock is watched too: the manifest requirement can be crossed with
+# a lockfile-only edit — a `cargo update -p quick-xml` or an in-range
+# Dependabot bump changes ONLY backend/Cargo.lock, so watching just
+# backend/Cargo.toml would miss the resolved-version move (GH #2056).
 
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'backend/Cargo.toml'
+      - 'backend/Cargo.lock'
 
 permissions:
   contents: read
@@ -41,22 +48,43 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Grab only the added/removed lines for backend/Cargo.toml and
-          # look for a change to the quick-xml dependency line.
-          DIFF=$(gh pr diff "$PR" --repo "$REPO" --patch -- backend/Cargo.toml || true)
-          TOUCHED=$(printf '%s\n' "$DIFF" | grep -E '^[+-][[:space:]]*quick-xml[[:space:]]*=' || true)
+          # (1) Manifest: grab the added/removed lines for backend/Cargo.toml and
+          #     look for a change to the quick-xml dependency requirement line.
+          TOML_DIFF=$(gh pr diff "$PR" --repo "$REPO" --patch -- backend/Cargo.toml || true)
+          TOML_TOUCHED=$(printf '%s\n' "$TOML_DIFF" | grep -E '^[+-][[:space:]]*quick-xml[[:space:]]*=' || true)
 
-          if [ -z "$TOUCHED" ]; then
-            echo "OK: this PR edits backend/Cargo.toml but does not change the quick-xml pin line."
+          # (2) Lockfile: an in-range bump (`cargo update` / Dependabot) moves the
+          #     resolved version with a Cargo.lock-only edit. Parse the lockfile
+          #     patch for a changed `version = ...` line inside the
+          #     `[[package]] name = "quick-xml"` block. In a unified diff the
+          #     `name = "quick-xml"` line rides along as context (or as a +/- line
+          #     when the whole package block is added/removed), so we track which
+          #     package block each changed version line belongs to.
+          LOCK_DIFF=$(gh pr diff "$PR" --repo "$REPO" --patch -- backend/Cargo.lock || true)
+          LOCK_TOUCHED=$(printf '%s\n' "$LOCK_DIFF" | awk '
+            /^[ +-][[:space:]]*name = "quick-xml"/ { inpkg=1; next }
+            /^[ +-][[:space:]]*name = /            { inpkg=0 }
+            inpkg && /^[+-][[:space:]]*version = / { print }
+          ')
+
+          if [ -z "$TOML_TOUCHED" ] && [ -z "$LOCK_TOUCHED" ]; then
+            echo "OK: this PR edits backend/Cargo.toml and/or backend/Cargo.lock but does not change the quick-xml pin line or its resolved version."
             exit 0
           fi
 
-          echo "::warning title=quick-xml is an XXE security pin::This PR changes the quick-xml dependency line in backend/Cargo.toml. quick-xml is pinned for XXE / billion-laughs safety and guarded by ota_xml::tests. Confirm 'cargo test -p integrations' entity-guard tests pass on the new version and that the change gets an explicit XXE-regression review (GH #1519/#1591/#2033)."
+          echo "::warning title=quick-xml is an XXE security pin::This PR changes the quick-xml dependency requirement in backend/Cargo.toml and/or its resolved version in backend/Cargo.lock. quick-xml is pinned for XXE / billion-laughs safety and guarded by ota_xml::tests. Confirm 'cargo test -p integrations' entity-guard tests pass on the new version and that the change gets an explicit XXE-regression review (GH #1519/#1591/#2033/#2056)."
 
           echo ""
-          echo "Changed quick-xml line(s):"
-          printf '%s\n' "$TOUCHED"
-          echo ""
+          if [ -n "$TOML_TOUCHED" ]; then
+            echo "Changed quick-xml manifest line(s) (backend/Cargo.toml):"
+            printf '%s\n' "$TOML_TOUCHED"
+            echo ""
+          fi
+          if [ -n "$LOCK_TOUCHED" ]; then
+            echo "Changed quick-xml resolved version (backend/Cargo.lock):"
+            printf '%s\n' "$LOCK_TOUCHED"
+            echo ""
+          fi
           echo "Reviewer checklist for a quick-xml bump:"
           echo "  - ota_xml::tests entity guards (XXE + billion-laughs) pass on the new version"
           echo "    (run: cd backend && cargo test -p integrations ota_xml)."

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -94,15 +94,22 @@ reqwest = { version = "0.13", features = ["json", "form", "query", "http2"] }
 # Regression note (GH #2033): PR #2011 folded a quick-xml 0.40->0.41 bump into an
 # unrelated ammonia RUSTSEC PR, crossing this pin without focused review. To
 # prevent a recurrence, changes to this manifest are gated by two markers:
-#   1. .github/CODEOWNERS routes every backend/Cargo.toml edit to an explicit
-#      owner review.
+#   1. .github/CODEOWNERS routes every backend/Cargo.toml AND backend/Cargo.lock
+#      edit to an explicit owner review.
 #   2. .github/workflows/pinned-dependency-guard.yml annotates any PR that
-#      touches this quick-xml line, reminding reviewers to confirm the
-#      `ota_xml::tests` entity guards stay green on the new version.
+#      touches this quick-xml line in either the manifest or the lockfile,
+#      reminding reviewers to confirm the `ota_xml::tests` entity guards stay
+#      green on the new version.
 # The entity-guard tests are live `#[test]`s in the `integrations` crate (they are
 # NOT among the BIT-440-quarantined suites), so `cargo test -p integrations` runs
 # them on every bump.
-quick-xml = { version = "0.41", features = ["serialize"] }
+# The requirement is an EXACT pin (`=0.41.0`), not a caret range: `"0.41"` would
+# mean `>=0.41.0, <0.42.0`, letting any future `0.41.x` publish (via
+# `cargo update` or an in-range Dependabot bump) cross the pin with only a
+# Cargo.lock edit. `=0.41.0` forces every move off 0.41.0 to be a manifest edit
+# the CODEOWNERS + workflow guards catch. Bump both the `=` requirement here and
+# the Cargo.lock entry together in a focused, reviewed PR.
+quick-xml = { version = "=0.41.0", features = ["serialize"] }
 
 # Observability (Epic 95)
 opentelemetry = { version = "0.32", features = ["metrics", "trace"] }


### PR DESCRIPTION
## Task
Follow-up: quick-xml pin is a caret range and the guard ignores Cargo.lock — silent in-range bumps slip past (PR #2044). Closes #2056.

Two mechanical holes in the #2044 guard:
1. `backend/Cargo.toml` declared `quick-xml = { version = "0.41", ... }` — a Cargo **caret** range (`>=0.41.0, <0.42.0`), not an exact pin, so any future `0.41.x` publish satisfied it.
2. Both guards (workflow `paths:` + grep, and CODEOWNERS) watched `backend/Cargo.toml` only. A `cargo update -p quick-xml` / in-range Dependabot bump moves the resolved version with a **Cargo.lock-only** edit — invisible to both layers.

## Changes
- `backend/Cargo.toml`: `version = "0.41"` → `version = "=0.41.0"` (exact pin) + expanded the pin comment. Cargo.lock already resolved `0.41.0`, so the lockfile is unchanged — no version move.
- `.github/workflows/pinned-dependency-guard.yml`: added `backend/Cargo.lock` to `paths:`, and now also parses the lockfile diff — an awk pass that tracks the `[[package]] name = "quick-xml"` block and flags any changed `version = ` line (handles context-line name, and whole-block add/remove).
- `.github/CODEOWNERS`: added `/backend/Cargo.lock @martin-janci`, plus a note that CODEOWNERS enforcement requires branch protection on `dev` with "Require review from Code Owners" enabled (not verifiable in-repo — confirm it is on, else the guard is advisory).

## Owner
pm-tech-lead

## Scope drift
`scope-check.sh --owner pm-tech-lead` exited 2 — the diff touches infra/config paths outside pm-tech-lead's mapped areas:
- `.github/CODEOWNERS`
- `.github/workflows/pinned-dependency-guard.yml`
- `backend/Cargo.toml`

Expected: this is a security-pin / CI-guard hardening task (issue suggested specialist `generic`), which inherently lives in `.github/` and the workspace manifest. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist generic` — no warnings. No new helpers added.

## Tested (Band A — fast check)
- `cd backend && cargo update -p quick-xml --precise 0.41.0` → exit 0 (manifest parses with the `=0.41.0` requirement; lockfile unchanged, still resolves `0.41.0`).
- `python3 yaml.safe_load(pinned-dependency-guard.yml)` → `YAML OK`.
- Lockfile awk parser tested against 3 synthetic diffs (quick-xml version bump → flagged; unrelated `quick-json` bump → not flagged; whole-block add → flagged).
- `git diff --check dev HEAD` → exit 0.

## Built (Band B — full build)
skipped: cloud-mode full compile blocked (utoipa-swagger-ui proxy 403, no Postgres). Change is a version-string pin + YAML/CODEOWNERS edits with no Rust code surface; Cargo.lock is unchanged. CI (`backend.yml` + `api-validation.yml`) is the build gate.

## CI parity (Band C — hot-path only)
The pin itself is security-load-bearing, but this PR changes no runtime code — only the requirement string (already-resolved version), the advisory guard workflow, and CODEOWNERS. The XXE entity-guard tests (`cargo test -p integrations ota_xml`) are unaffected. Left to CI.

## Remote-tested
skipped

## Notes
- Cargo.lock is intentionally NOT in this diff — `0.41.0` already satisfied the new `=0.41.0` requirement, so no resolution change. This keeps the PR minimal and low-risk.
- The `pinned-dependency-guard` workflow remains advisory (never fails the build); the hard "requires review" guarantee still depends on branch-protection "Require review from Code Owners" being enabled on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa)_