### PR TITLE
gh-issue-2052: harden #1771 unread soft-delete guard beyond a substring check

### DIFF
--- a/backend/crates/db/src/repositories/messaging.rs
+++ b/backend/crates/db/src/repositories/messaging.rs
@@ -1307,6 +1307,22 @@ impl MessagingRepository {
 mod tests {
     use super::COUNT_UNREAD_SQL;
 
+    /// Drop `--` line comments from a SQL string, keeping the code that precedes
+    /// them on each line. Used so a *commented-out* predicate
+    /// (`-- AND tps.deleted_at IS NULL`) is no longer mistaken for a live one by
+    /// a naive substring match (#2052). This is a deliberately simple textual
+    /// strip: it does not understand `--` inside string literals, which
+    /// `COUNT_UNREAD_SQL` does not contain.
+    fn strip_sql_line_comments(sql: &str) -> String {
+        sql.lines()
+            .map(|line| match line.find("--") {
+                Some(idx) => &line[..idx],
+                None => line,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     /// Non-DB guard for the #1771 fix (PR #1993): the unread-count query must
     /// exclude threads a user soft-deleted ("delete for me") via the
     /// per-participant `tps.deleted_at IS NULL` predicate on the
@@ -1315,14 +1331,44 @@ mod tests {
     /// the BIT-351 quarantine, so this plain `#[test]` — mirroring the
     /// catalog-metadata guard style — is the executing guard on the normal CI
     /// gate. It runs without a live Postgres pool.
+    ///
+    /// Hardened per #2052 beyond a raw substring match so two real regressions
+    /// no longer slip past green:
+    ///   1. **Comment-out.** The predicate is asserted against the SQL *with
+    ///      `--` line comments stripped*, so `-- AND tps.deleted_at IS NULL`
+    ///      (predicate disabled, #1771 bug back) now fails the test.
+    ///   2. **Wrong-join / alias drift.** The `tps` alias is pinned to the
+    ///      `thread_participant_state` join, so moving the predicate onto a
+    ///      different alias (where it no longer excludes soft-deleted threads)
+    ///      while keeping the literal text can't stay green.
     #[test]
     fn count_unread_sql_excludes_soft_deleted_threads() {
+        let effective_sql = strip_sql_line_comments(COUNT_UNREAD_SQL);
+
+        // (1) The soft-delete exclusion must be a *live* predicate, not a
+        //     commented-out one. `strip_sql_line_comments` removes `--` lines, so
+        //     a commented-out predicate no longer satisfies this `contains`.
         assert!(
-            COUNT_UNREAD_SQL.contains("tps.deleted_at IS NULL"),
+            effective_sql.contains("tps.deleted_at IS NULL"),
             "count_unread_rls SQL must keep the per-participant soft-delete \
-             exclusion `tps.deleted_at IS NULL` (#1771 / PR #1993); without it a \
-             thread a user hid from their inbox leaves its unread messages stuck \
-             on the global unread badge with no thread visible to clear them"
+             exclusion `tps.deleted_at IS NULL` as a live (non-commented) \
+             predicate (#1771 / PR #1993 / #2052); without it a thread a user hid \
+             from their inbox leaves its unread messages stuck on the global \
+             unread badge with no thread visible to clear them"
+        );
+
+        // (2) The `tps` alias the predicate references must be the
+        //     `thread_participant_state` join. This anchors the exclusion to the
+        //     correct table, so the predicate can't drift onto a different alias
+        //     (e.g. the messages or threads table) and silently stop excluding
+        //     soft-deleted threads while the literal substring survives.
+        assert!(
+            effective_sql.contains("thread_participant_state tps"),
+            "count_unread_rls SQL must bind the `tps` alias to \
+             `thread_participant_state` so the `tps.deleted_at IS NULL` exclusion \
+             stays on the per-participant soft-delete table (#2052); if the alias \
+             is rebound or the join is removed the predicate no longer excludes \
+             the threads it claims to"
         );
     }
 }


### PR DESCRIPTION
## Task
Follow-up: harden the #1771 unread soft-delete guard beyond a substring check (PR #2039). The `count_unread_sql_excludes_soft_deleted_threads` guard was a raw `COUNT_UNREAD_SQL.contains("tps.deleted_at IS NULL")`, which stays green if the predicate is commented out (`-- AND tps.deleted_at IS NULL`) or repositioned onto the wrong alias. This PR strips SQL line comments before the substring match and asserts the predicate co-occurs with the `thread_participant_state`/`tps` join.

Closes #2052

## Owner
pm-tech-lead (specialist: rust-backend)

## Changes
`backend/crates/db/src/repositories/messaging.rs` (test module only):
- Added `strip_sql_line_comments` helper — drops `--` line comments, keeping code before them.
- The guard now asserts against the comment-stripped SQL, so a commented-out `-- AND tps.deleted_at IS NULL` (predicate disabled, #1771 bug back) fails the test.
- Added a second assertion pinning the `tps` alias to `thread_participant_state tps`, so moving the predicate onto a different alias while keeping the literal text can't stay green.

Scoped exactly as the issue requested (both hardening options applied). Production SQL (`COUNT_UNREAD_SQL`) is unchanged — this is a test-coverage hardening only.

## Tested (Band A — fast check)
```
SQLX_OFFLINE=true cargo test -p db --lib count_unread_sql_excludes_soft_deleted_threads
```
Exit 0 — `test ... count_unread_sql_excludes_soft_deleted_threads ... ok` (1 passed).

## Built (Band B — full build)
skipped: change is test-only (~50 LOC, no production code / public API / migration / config touched). The `db` crate compiled clean as part of the Band A `cargo test` run (5m29s, `Finished test profile`).

## CI parity (Band C — hot-path only)
skipped: no production behavior change — production SQL is byte-identical; only the test's assertion strength changed. Backend CI (`backend.yml`: fmt/clippy/test) is the gate.

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports exit 2 for `backend/crates/db/src/repositories/messaging.rs` — the `pm-tech-lead` owner-area map doesn't cover `backend/crates/db/`. This is a mapping artifact, not real drift: the selected specialist is `rust-backend` and the file is exactly the one issue #2052 named. Reviewer to confirm.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no warnings (exit 0). `strip_sql_line_comments` is a test-local helper with no existing equivalent.

## Notes
- Cloud mode: Postgres/Docker absent; the DB-backed `soft_deleted_thread_excluded_from_unread_count` regression test remains `#[ignore]`d under BIT-351 (out of scope here — the issue explicitly frames lifting that quarantine as the "better, later" option). This PR takes the "at minimum" path from the issue.
- The UNION-vs-UNION-ALL nit and the `query_as` (non-macro) note from #1998/#2052 are left as-is; the issue frames the UNION as intentional dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa)_