### PR TITLE
gh-issue-2054: exercise triage/confirm recipient self-exclusion + dedup branches

### DIFF
--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -1906,8 +1906,7 @@ mod recipient_policy_tests {
         let assignee = Uuid::new_v4();
         let other_manager = Uuid::new_v4();
 
-        let recipients =
-            confirm_fault_recipients(Some(assignee), actor, [actor, other_manager]);
+        let recipients = confirm_fault_recipients(Some(assignee), actor, [actor, other_manager]);
 
         assert!(
             !recipients.contains(&actor),

--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -1828,3 +1828,108 @@ async fn get_statistics(
 
     Ok(Json(StatisticsResponse { statistics }))
 }
+
+// ============================================================================
+// Recipient-policy unit tests (#2054)
+// ============================================================================
+//
+// The DB-backed R7/R8 integration cases in
+// `tests/fault_notification_recipient_tests.rs` seed *distinct* actor /
+// reporter / assignee, so the actor is never in the candidate set and the
+// self-exclusion (`!= actor_id`) and dedup (`!recipients.contains(..)`)
+// branches never fire — a regression that deleted them would keep those
+// tests green (#2054). These pure-function cases put the actor *into* the
+// candidate set to exercise exactly those branches. They need no DB.
+#[cfg(test)]
+mod recipient_policy_tests {
+    use super::{confirm_fault_recipients, triage_fault_recipients};
+    use uuid::Uuid;
+
+    // --- triage_fault_recipients -------------------------------------------
+
+    /// Self-exclusion via the reporter path: the triaging manager IS the
+    /// reporter, so `reporter_id == actor_id` must drop them.
+    #[test]
+    fn triage_excludes_actor_when_reporter_is_the_triaging_manager() {
+        let actor = Uuid::new_v4(); // triaging manager == reporter
+        let assignee = Uuid::new_v4();
+
+        let recipients = triage_fault_recipients(actor, actor, Some(assignee));
+
+        assert!(
+            !recipients.contains(&actor),
+            "reporter == actor must be excluded (self-notify guard)"
+        );
+        assert_eq!(recipients, vec![assignee]);
+    }
+
+    /// Self-exclusion via the assignee path: the fault is self-assigned to the
+    /// actor, so `assignee != actor_id` must drop them.
+    #[test]
+    fn triage_excludes_actor_when_self_assigned() {
+        let actor = Uuid::new_v4();
+        let reporter = Uuid::new_v4();
+
+        let recipients = triage_fault_recipients(reporter, actor, Some(actor));
+
+        assert!(
+            !recipients.contains(&actor),
+            "self-assigned actor must be excluded"
+        );
+        assert_eq!(recipients, vec![reporter]);
+    }
+
+    /// Dedup: reporter and assignee are the same person, so
+    /// `!recipients.contains(&assignee)` must keep them to a single entry.
+    #[test]
+    fn triage_dedups_when_reporter_is_also_assignee() {
+        let actor = Uuid::new_v4();
+        let both = Uuid::new_v4();
+
+        let recipients = triage_fault_recipients(both, actor, Some(both));
+
+        assert_eq!(
+            recipients,
+            vec![both],
+            "reporter == assignee must appear exactly once"
+        );
+        assert_eq!(recipients.len(), 1);
+    }
+
+    // --- confirm_fault_recipients ------------------------------------------
+
+    /// Self-exclusion via `manager_ids`: the confirming reporter is also a
+    /// seeded manager, so `mid != actor_id` must drop the actor.
+    #[test]
+    fn confirm_excludes_actor_present_in_manager_ids() {
+        let actor = Uuid::new_v4(); // confirming reporter, also a manager
+        let assignee = Uuid::new_v4();
+        let other_manager = Uuid::new_v4();
+
+        let recipients =
+            confirm_fault_recipients(Some(assignee), actor, [actor, other_manager]);
+
+        assert!(
+            !recipients.contains(&actor),
+            "actor present in manager_ids must be excluded"
+        );
+        assert_eq!(recipients, vec![assignee, other_manager]);
+    }
+
+    /// Dedup: a manager id equals the assignee already collected, so
+    /// `!recipients.contains(&mid)` must keep them to a single entry.
+    #[test]
+    fn confirm_dedups_manager_equal_to_assignee() {
+        let actor = Uuid::new_v4();
+        let assignee = Uuid::new_v4(); // also listed in manager_ids
+
+        let recipients = confirm_fault_recipients(Some(assignee), actor, [assignee]);
+
+        assert_eq!(
+            recipients,
+            vec![assignee],
+            "assignee also listed as manager must appear exactly once"
+        );
+        assert_eq!(recipients.len(), 1);
+    }
+}


### PR DESCRIPTION
## Task
Follow-up: triage/confirm recipient tests don't exercise the self-exclusion/dedup branches (PR #2048). Add test cases in `backend/servers/api-server/src/routes/faults.rs` that put the actor INTO the candidate set to actually exercise the self-exclusion (`!= actor_id`) and dedup (`!recipients.contains(..)`) branches of `triage_fault_recipients` / `confirm_fault_recipients`.

Closes #2054

## Owner
pm-tech-lead (implemented by rust-backend specialist)

## What changed
Added a `#[cfg(test)] mod recipient_policy_tests` to `faults.rs` with 5 pure-function cases. The existing DB-backed R7/R8 cases in `tests/fault_notification_recipient_tests.rs` seed *distinct* actor/reporter/assignee, so the actor is never a candidate and the guard branches never fire — a regression removing them would stay green. The new cases put the actor into the candidate set:

- `triage_excludes_actor_when_reporter_is_the_triaging_manager` — reporter == actor (self-exclusion).
- `triage_excludes_actor_when_self_assigned` — assignee == actor (self-exclusion).
- `triage_dedups_when_reporter_is_also_assignee` — reporter == assignee (dedup, single entry).
- `confirm_excludes_actor_present_in_manager_ids` — confirming reporter also in `manager_ids` (self-exclusion).
- `confirm_dedups_manager_equal_to_assignee` — a manager id equals the assignee (dedup, single entry).

Pure-function assertions, no DB required — additive, no production code touched.

## Tested (Band A — fast check)
`cd backend && cargo test -p api-server --no-run recipient_policy`
BLOCKED in cloud mode: the build fails only at `utoipa-swagger-ui v9.0.2`'s build script, which downloads the Swagger UI zip over the proxy and gets an invalid archive (`InvalidArchive("Could not find EOCD")`, exit 101). This is a pre-existing environment limitation, not caused by this change — every dependency crate before it compiled cleanly. The added module is `#[cfg(test)]`-only, references the two `pub fn`s via `super::`, and uses the already-imported `uuid::Uuid`. Logic verified by inspection against each function body (all 5 expected recipient vectors traced). **CI is the gate.**

## Built (Band B — full build)
Skipped: test-only change, no production/public-API/config surface touched; compile blocked by the cloud-mode `utoipa-swagger-ui` download (see Band A).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path change (test-only; no security/auth/billing/data-integrity production code modified).

## Scope drift
`scope-check.sh --owner pm-tech-lead` flags `backend/servers/api-server/src/routes/faults.rs` as outside the `pm-tech-lead` owner area (exit 2). Justified: `owner_role` was a routing hint; this is a rust-backend test addition to a backend route file. No production code changed.

## Remote-tested
skipped

## Notes
Additive test-only change. The issue's second (low-severity) finding — extracting `assign_fault_recipients` etc. for the remaining fault transitions — is explicitly out of scope here and left for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa)_