### PR TITLE
gh-issue-2050: repository-level guard for mark_favorite_alert_read idempotency

### DIFF
--- a/backend/crates/db/tests/favorite_alert_read_idempotent_tests.rs
+++ b/backend/crates/db/tests/favorite_alert_read_idempotent_tests.rs
@@ -1,0 +1,185 @@
+//! Repository round-trip guard for the `mark_favorite_alert_read` idempotency
+//! contract (#2050, follow-up to #1999 finding-2 / PR #2043).
+//!
+//! Why this test exists
+//! --------------------
+//! PR #2043 remediated #1999 finding-2 ("the idempotency test was `#[ignore]`d")
+//! by adding a *pure unit test* of `mark_read_outcome_status`
+//! (`reality-server/src/routes/favorites.rs`), which only exercises the
+//! `FavoriteAlertReadOutcome -> StatusCode` **mapping**. The behavior the finding
+//! was actually about — that the *repository* returns `AlreadyRead` (not
+//! `NotFound`) when a client re-marks an already-read alert — lives in the
+//! `exists_count` / `flipped_count` CTE split in `mark_favorite_alert_read`
+//! (`crates/db/src/repositories/reality_portal.rs`) and had **no running guard**:
+//! the only integration test that covered it,
+//! `mark_favorite_alert_read_is_idempotent` in reality-server, is still
+//! `#[ignore]`d under the BIT-351 quarantine and never runs on the PR gate.
+//!
+//! This test gives that CTE branch a guard that actually runs on `cargo test -p
+//! db` (i.e. the backend.yml gate, which has Postgres). It asserts the three-way
+//! outcome **directly against the DB**, independent of the route mapping and of
+//! the `FavoriteAlertWorker` — the pending alert is inserted straight into
+//! `favorite_alert_queue` rather than produced via a price-drop worker tick, so a
+//! regression in the CTE (e.g. dropping the `existing` branch so an already-read
+//! row collapses to `NotFound`) fails here even while the mapping unit test still
+//! passes.
+//!
+//! `#[sqlx::test]` connects as the Postgres SUPERUSER, which bypasses RLS
+//! entirely — so `favorite_alert_queue`'s FORCE RLS policy does not hide rows and
+//! no tenant context needs to be set for this behavioral (non-isolation) check.
+
+use db::repositories::{FavoriteAlertReadOutcome, RealityPortalRepository};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Org {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@fav-idem.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_portal_user(pool: &PgPool, email: &str) -> Uuid {
+    // portal_users was merged into `users` (migration 00132); portal users are
+    // rows with principal_kind='public'.
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Favorite User', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed portal user")
+}
+
+async fn seed_listing(pool: &PgPool, org_id: Uuid, created_by: Uuid, title: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO listings (
+            organization_id, created_by, transaction_type, title, property_type,
+            street, city, postal_code, country, price, status
+        )
+        VALUES (
+            $1, $2, 'sale', $3, 'apartment',
+            'Main St', 'Bratislava', '81101', 'SK', 100000, 'active'
+        )
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .bind(title)
+    .fetch_one(pool)
+    .await
+    .expect("seed listing")
+}
+
+/// Insert one `pending` price-change alert straight into the queue, bypassing the
+/// `FavoriteAlertWorker`, and return its id.
+async fn seed_pending_alert(
+    pool: &PgPool,
+    favorite_id: Uuid,
+    user_id: Uuid,
+    listing_id: Uuid,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO favorite_alert_queue (
+            favorite_id, user_id, listing_id, alert_type,
+            old_price, new_price, currency, change_percentage, status
+        )
+        VALUES ($1, $2, $3, 'price_change', 100000, 80000, 'EUR', -20.00, 'pending')
+        RETURNING id
+        "#,
+    )
+    .bind(favorite_id)
+    .bind(user_id)
+    .bind(listing_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed pending alert")
+}
+
+/// pending -> `Flipped`, second mark -> `AlreadyRead`, unknown id -> `NotFound`.
+///
+/// Guards the `exists_count` / `flipped_count` CTE split directly, so the
+/// AlreadyRead-vs-NotFound idempotency branch has a failing-on-regression guard
+/// independent of the route's `FavoriteAlertReadOutcome -> StatusCode` mapping.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn mark_favorite_alert_read_repo_round_trip_is_idempotent(pool: PgPool) {
+    let repo = RealityPortalRepository::new(pool.clone());
+
+    let org_id = seed_org(&pool, "fav-idem-org").await;
+    let user_id = seed_portal_user(&pool, "fav-idem@test.sk").await;
+    let listing_id = seed_listing(&pool, org_id, user_id, "Idempotency flat").await;
+
+    let favorite = repo
+        .add_favorite(user_id, listing_id, None)
+        .await
+        .expect("add favorite");
+    let alert_id = seed_pending_alert(&pool, favorite.id, user_id, listing_id).await;
+
+    // First mark flips pending -> sent.
+    assert_eq!(
+        repo.mark_favorite_alert_read(alert_id, user_id)
+            .await
+            .expect("first mark"),
+        FavoriteAlertReadOutcome::Flipped,
+        "a pending alert must flip to Flipped on first mark",
+    );
+
+    // Second mark is idempotent — the row still exists for the user but is
+    // already read, so it must be AlreadyRead (route -> 204), NOT NotFound.
+    assert_eq!(
+        repo.mark_favorite_alert_read(alert_id, user_id)
+            .await
+            .expect("second mark"),
+        FavoriteAlertReadOutcome::AlreadyRead,
+        "re-marking an already-read alert must be AlreadyRead, not NotFound",
+    );
+
+    // A genuinely-absent id is NotFound (route -> 404, no existence leak).
+    assert_eq!(
+        repo.mark_favorite_alert_read(Uuid::new_v4(), user_id)
+            .await
+            .expect("unknown id mark"),
+        FavoriteAlertReadOutcome::NotFound,
+        "an unknown alert id must be NotFound",
+    );
+
+    // An alert owned by a different user must also collapse to NotFound for the
+    // wrong caller (no existence leak), and must remain markable by its owner.
+    let other_user = seed_portal_user(&pool, "fav-idem-other@test.sk").await;
+    let other_favorite = repo
+        .add_favorite(other_user, listing_id, None)
+        .await
+        .expect("add favorite (other user)");
+    let other_alert = seed_pending_alert(&pool, other_favorite.id, other_user, listing_id).await;
+
+    assert_eq!(
+        repo.mark_favorite_alert_read(other_alert, user_id)
+            .await
+            .expect("cross-user mark"),
+        FavoriteAlertReadOutcome::NotFound,
+        "another user's alert must be NotFound for the wrong caller",
+    );
+    assert_eq!(
+        repo.mark_favorite_alert_read(other_alert, other_user)
+            .await
+            .expect("owner mark"),
+        FavoriteAlertReadOutcome::Flipped,
+        "the owning user must still be able to flip their own alert",
+    );
+}

--- a/backend/servers/reality-server/tests/favorite_alert_worker_tests.rs
+++ b/backend/servers/reality-server/tests/favorite_alert_worker_tests.rs
@@ -150,6 +150,14 @@ async fn worker_queues_price_and_back_on_market_alerts(pool: PgPool) {
 /// to read (Flipped); marking the same alert again returns AlreadyRead (the
 /// route maps both to 204, not a surprising 404); a non-existent alert id
 /// returns NotFound.
+///
+/// NOTE (#2050): this test remains under the BIT-351 quarantine (never green on
+/// the PR gate). The running guard for the AlreadyRead-vs-NotFound idempotency
+/// branch now lives in a non-ignored repository round-trip,
+/// `mark_favorite_alert_read_repo_round_trip_is_idempotent`
+/// (`crates/db/tests/favorite_alert_read_idempotent_tests.rs`), so the CTE has a
+/// failing-on-regression guard that actually runs. Repair + un-`#[ignore]` of
+/// this worker-driven test is still tracked under BIT-352.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn mark_favorite_alert_read_is_idempotent(pool: PgPool) {


### PR DESCRIPTION
## Task
Follow-up: idempotency remediation (#1999 finding-2) guards only the mapping, not the repo behavior (PR #2043). Give the AlreadyRead-vs-NotFound branch of `mark_favorite_alert_read` (`backend/crates/db/src/repositories/reality_portal.rs` ~L801) a guard that actually runs on the PR gate — independent of the route's `FavoriteAlertReadOutcome -> StatusCode` mapping.

Closes #2050

## Owner
pm-tech-lead (hint) — implemented as a `rust-backend` (db-crate test) change.

## What changed
- **New, non-ignored** `#[sqlx::test]` repository round-trip: `backend/crates/db/tests/favorite_alert_read_idempotent_tests.rs`. Seeds org+user+listing+favorite, inserts a `pending` row **directly** into `favorite_alert_queue` (bypassing `FavoriteAlertWorker`), then asserts the three-way outcome straight against the DB:
  - pending -> `Flipped`
  - second mark -> `AlreadyRead` (not a surprising `NotFound`)
  - unknown id -> `NotFound`
  - plus a cross-user case: another user's alert -> `NotFound` for the wrong caller (no existence leak), still `Flipped` for its owner.
  This guards the `exists_count`/`flipped_count` CTE split independently of the route mapping unit test that PR #2043 added.
- Breadcrumb comment on the still-`#[ignore]`d `mark_favorite_alert_read_is_idempotent` (reality-server) pointing at the new running guard, so finding-2 is no longer "documented-as-guarded-but-isn't". Repair/un-ignore of the worker-driven test stays tracked under BIT-352.

## Design notes
- `#[sqlx::test]` connects as the Postgres **superuser**, which bypasses RLS (even `FORCE`), so `favorite_alert_queue`'s tenant policy does not hide rows and no tenant context is needed for this behavioral (non-isolation) check. Matches the green-on-CI pattern already used by `notification_events_repo_tests.rs`.
- Lives in the **db crate** test binary (run by `backend.yml`, which has Postgres) rather than the reality-server binary that is under the BIT-351 blind-CI quarantine — so it actually runs on the gate.

## Tested (Band A — fast check)
`cd backend && cargo check -p db --test favorite_alert_read_idempotent_tests` — could not complete in the cloud CI sandbox (no Docker/Postgres; workspace dep build blocked by the `utoipa-swagger-ui` proxy 403). Not fabricating a green build. Verified by inspection against the established `#[sqlx::test]` patterns in `crates/db/tests/` (imports, `db::MIGRATOR`, `RealityPortalRepository`/`FavoriteAlertReadOutcome` exports, `PortalFavorite.id`, `favorite_alert_queue` columns from migration 00194). **CI (`backend.yml`, which provisions Postgres) is the gate.**

## Built (Band B — full build)
skipped: cloud sandbox cannot build the workspace (proxy 403 on `utoipa-swagger-ui`); test-only change (no product code touched). Deferred to CI.

## CI parity (Band C — hot-path only)
skipped: test-only change; no security/auth/billing/data-integrity code modified.

## Remote-tested
skipped.

## Scope drift
`scope-check.sh --owner pm-tech-lead` -> exit 2. The two changed files are backend test files (`backend/crates/db/tests/**`, `backend/servers/reality-server/tests/**`), which fall in the pm-qa area, not pm-tech-lead's `docs/**` + `.research/**` mapping. This is the mismatched owner hint, not real drift — the task explicitly asked for a backend `#[sqlx::test]`. No product/source code changed.

## Notes
Reviewer: the guard is intentionally worker-independent (direct queue insert) to isolate the CTE idempotency branch from the price-history/worker machinery that the BIT-351 quarantine is suspected to trip on.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa)_