### PR TITLE
gh-issue-2053: encapsulate + test SlovakAccountingExport partial derivation

### DIFF
--- a/backend/crates/db/src/models/regional_compliance.rs
+++ b/backend/crates/db/src/models/regional_compliance.rs
@@ -402,6 +402,31 @@ pub struct SlovakAccountingExport {
     pub generated_at: DateTime<Utc>,
 }
 
+impl SlovakAccountingExport {
+    /// Derive `partial` and `unsupported_fields` from the `Option` monetary
+    /// fields, keeping the honesty invariant (#2030) co-located with the fields
+    /// it depends on instead of being hand-rolled in the route handler.
+    ///
+    /// A monetary field that is `None` is **not available** (not a genuine
+    /// zero): it serializes as JSON `null` and its name is enumerated in
+    /// `unsupported_fields`. `partial` is `true` iff at least one such field is
+    /// missing. When a new `Option` monetary field is added to this struct,
+    /// extend the checks below so it is covered here in one place rather than
+    /// being silently omitted from the derivation (which would re-introduce the
+    /// "looks complete but isn't" dishonesty #2030 set out to kill).
+    pub fn compute_partial(&mut self) {
+        let mut unsupported_fields = Vec::new();
+        if self.total_expenses.is_none() {
+            unsupported_fields.push("total_expenses".to_string());
+        }
+        if self.total_payables.is_none() {
+            unsupported_fields.push("total_payables".to_string());
+        }
+        self.partial = !unsupported_fields.is_empty();
+        self.unsupported_fields = unsupported_fields;
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct PohodaExport {
     pub header: PohodaHeader,
@@ -687,5 +712,77 @@ mod tests {
             json["unsupported_fields"],
             serde_json::json!(["total_expenses", "total_payables"])
         );
+    }
+
+    /// Baseline export whose `partial`/`unsupported_fields` are deliberately
+    /// seeded with WRONG values, so a passing assertion proves
+    /// `compute_partial` actually (re)derived them rather than reading stale
+    /// hand-set state.
+    fn export_with(
+        total_expenses: Option<Decimal>,
+        total_payables: Option<Decimal>,
+    ) -> SlovakAccountingExport {
+        SlovakAccountingExport {
+            export_id: Uuid::nil(),
+            organization_id: Uuid::nil(),
+            from_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            to_date: NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            format: SlovakAccountingFormat::Pohoda,
+            invoice_count: 0,
+            payment_count: 0,
+            journal_entry_count: 0,
+            total_revenue: Decimal::ZERO,
+            total_expenses,
+            total_receivables: Decimal::ZERO,
+            total_payables,
+            // Intentionally inconsistent seed values — compute_partial must
+            // overwrite both.
+            partial: false,
+            unsupported_fields: vec!["stale".to_string()],
+            download_url: None,
+            export_data: None,
+            generated_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        }
+    }
+
+    /// #2053: exercise the derivation itself (not just serialization). Feeds
+    /// every combination of present/absent monetary fields through
+    /// `compute_partial` and asserts the exact `partial` + `unsupported_fields`
+    /// outcome, so a handler that forgets to set `partial` or mislabels a field
+    /// is caught.
+    #[test]
+    fn compute_partial_derives_from_option_fields() {
+        // Both monetary fields missing -> partial, both enumerated in order.
+        let mut both_missing = export_with(None, None);
+        both_missing.compute_partial();
+        assert!(both_missing.partial);
+        assert_eq!(
+            both_missing.unsupported_fields,
+            vec!["total_expenses".to_string(), "total_payables".to_string()]
+        );
+
+        // Only expenses missing -> partial, only expenses listed.
+        let mut expenses_missing = export_with(None, Some(Decimal::new(500, 2)));
+        expenses_missing.compute_partial();
+        assert!(expenses_missing.partial);
+        assert_eq!(
+            expenses_missing.unsupported_fields,
+            vec!["total_expenses".to_string()]
+        );
+
+        // Only payables missing -> partial, only payables listed.
+        let mut payables_missing = export_with(Some(Decimal::new(500, 2)), None);
+        payables_missing.compute_partial();
+        assert!(payables_missing.partial);
+        assert_eq!(
+            payables_missing.unsupported_fields,
+            vec!["total_payables".to_string()]
+        );
+
+        // Everything present (incl. genuine zero) -> complete, no unsupported.
+        let mut complete = export_with(Some(Decimal::ZERO), Some(Decimal::ZERO));
+        complete.compute_partial();
+        assert!(!complete.partial);
+        assert!(complete.unsupported_fields.is_empty());
     }
 }

--- a/backend/servers/api-server/src/routes/regional_compliance.rs
+++ b/backend/servers/api-server/src/routes/regional_compliance.rs
@@ -448,19 +448,7 @@ async fn export_slovak_accounting(
 
     let journal_entry_count = invoice_count + payment_count;
 
-    // Surface un-computed monetary fields honestly (#2030): a `null` +
-    // `unsupported_fields` entry so consumers can distinguish "not available"
-    // from a genuine zero, rather than the previous misleading hardcoded 0.
-    let mut unsupported_fields = Vec::new();
-    if total_expenses.is_none() {
-        unsupported_fields.push("total_expenses".to_string());
-    }
-    if total_payables.is_none() {
-        unsupported_fields.push("total_payables".to_string());
-    }
-    let partial = !unsupported_fields.is_empty();
-
-    let result = Ok(Json(SlovakAccountingExport {
+    let mut export = SlovakAccountingExport {
         export_id: Uuid::new_v4(),
         organization_id: org_id,
         from_date: payload.from_date,
@@ -473,15 +461,24 @@ async fn export_slovak_accounting(
         total_expenses,
         total_receivables,
         total_payables,
-        partial,
-        unsupported_fields,
+        // Derived below by `compute_partial` from the `Option` monetary fields.
+        partial: false,
+        unsupported_fields: Vec::new(),
         download_url: Some(format!(
             "/api/v1/regional-compliance/slovak/accounting/download/{}",
             Uuid::new_v4()
         )),
         export_data: None,
         generated_at: Utc::now(),
-    }));
+    };
+    // Surface un-computed monetary fields honestly (#2030): sets `partial` +
+    // `unsupported_fields` so consumers can distinguish "not available" from a
+    // genuine zero, rather than the previous misleading hardcoded 0. The
+    // derivation lives on the model (#2053) so the invariant stays co-located
+    // with the fields it depends on.
+    export.compute_partial();
+
+    let result = Ok(Json(export));
     rls.release().await;
     result
 }


### PR DESCRIPTION
## Task
Follow-up: encapsulate + test the `partial`/`unsupported_fields` derivation for `SlovakAccountingExport` (PR #2047). Move the honesty invariant (#2030) out of the `export_slovak_accounting` handler and onto the model, and add a unit test that exercises the derivation itself (not just serialization).

Closes #2053

## Owner
pm-tech-lead (specialist: rust-backend)

## What changed
- `backend/crates/db/src/models/regional_compliance.rs`
  - New `SlovakAccountingExport::compute_partial(&mut self)` that derives `partial` + `unsupported_fields` from the `Option` monetary fields (`total_expenses`, `total_payables`) in one place, co-located with the fields. Doc comment instructs future maintainers to extend it when adding a new `Option` monetary field, so the "looks complete but isn't" dishonesty (#2030) can't silently regress.
  - New unit test `compute_partial_derives_from_option_fields` feeds all four present/absent combinations (incl. `None`/`Some` mix and genuine-zero all-present) through `compute_partial` and asserts the exact `partial` + `unsupported_fields` outcome. The baseline builder seeds deliberately-wrong `partial`/`unsupported_fields` so a pass proves the method re-derived them rather than reading stale hand-set state.
  - Existing serialization regression test (`uncomputed_totals_serialize_as_null_not_zero`) left intact.
- `backend/servers/api-server/src/routes/regional_compliance.rs`
  - `export_slovak_accounting` now builds the struct with `partial: false` / `unsupported_fields: Vec::new()` and calls `export.compute_partial()` instead of hand-rolling the derivation inline. Behaviour is identical; the field-name string literals and the invariant now live in exactly one place.

## Tested (Band A — fast check)
Local compile is **environmentally blocked in this cloud runner** and was NOT completed:
- No Postgres and no tracked `.sqlx` offline data (`git ls-files | grep '^.sqlx/'` = 0) and `DATABASE_URL` unset, so `cargo test -p db` / `cargo check -p db` cannot expand the sqlx `query!` macros in sibling repository files.
- `api-server` additionally can't fully compile locally (utoipa-swagger-ui proxy 403).

No passing build is claimed. The change was verified **by inspection**: `compute_partial` is pure logic over the two `Option<Decimal>` fields; the route binding is `let mut export = …; export.compute_partial(); Ok(Json(export))` with all referenced imports (`Uuid`, `Utc`) already in scope; the test helper mirrors the struct field-for-field with `use super::*` bringing `Decimal`/`NaiveDate`/`DateTime` into scope.

**CI is the real gate** for compile + `cargo test -p db regional_compliance` on this PR.

## Built (Band B — full build)
Skipped — see Band A (local full build blocked by absent Postgres/sqlx data + swagger-ui proxy 403). Deferred to CI.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path change (pure refactor + test of an existing serialization invariant; no auth/billing/data-integrity change). The tenant-scoping/security fix from #1906/#2047 is untouched.

## Scope drift
`scope-check.sh --owner pm-tech-lead` reported exit 2 for:
- `backend/crates/db/src/models/regional_compliance.rs`
- `backend/servers/api-server/src/routes/regional_compliance.rs`

This is expected: `pm-tech-lead` is a cross-cutting owner role whose owner-areas map doesn't enumerate these specific backend paths. Both files are exactly the ones named in issue #2053; no unrelated files are touched. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no warnings (exit 0). `compute_partial` is a new, single-purpose method; no existing helper duplicates it.

## Notes
Pure maintainability/test-coverage follow-up (severity: low per the review). No API/OpenAPI/generated-client surface change — this is a code-first endpoint and the `SlovakAccountingExport` JSON shape is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuhgWDTPseg94M69E7FBRa)_