### PR TITLE
7a-4-document-download-preview: verify-to-done — flip Story 7A.4 to done

### DIFF
--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -25,7 +25,7 @@ epics:
     name: "Basic Document Management"
     status: in-progress
     stories_total: 5
-    stories_completed: 0
+    stories_completed: 2  # 7a-1 (done 2026-06-17) + 7a-4 (verified done 2026-07-04)
   epic-8a:
     name: "Basic Notification Preferences"
     status: done
@@ -60,7 +60,7 @@ development_status:
   7a-1-document-upload-metadata: done  # Verified 2026-06-17 (verify-document-upload-metadata): POST /api/v1/documents/upload present in documents/core.rs (multipart parse of file/title/description/category/folder_id, title/desc length + size + MIME allow-list + category validation, S3 upload, RLS-aware create_rls). Metadata persistence + RLS isolation covered by document_upload_tests.rs (T1-T15): auth guard, missing-file/MIME/category rejects + orphan guards, DB-row persistence (T5/T6/T7), S3 happy (wiremock T14)/failure-no-orphan (T8), 50 MiB boundary (T12/T13), cross-tenant (T9) + non-member (T10) RLS reject, AC-2/AC-3 error bodies, and new end-to-end metadata round-trip through GET /{id} (T15). Stale 'upload route missing' verify report superseded — route + tests are on dev.
   7a-2-folder-organization: review  # CI test job red (document_folder_tests FK/isolation fix in PR #1316 round 1); reverted from done pending green CI
   7a-3-permission-based-access: ready-for-dev
-  7a-4-document-download-preview: ready-for-dev
+  7a-4-document-download-preview: done  # Verified 2026-07-04 (verify-7a-4-document-download-preview): download + preview slice complete on dev. Backend: GET /api/v1/documents/{id}/download + /{id}/preview (servers/api-server routes/documents/core.rs get_download_url/get_preview_url), router mounted at lib.rs:164 .nest("/api/v1/documents"). Both handlers: RLS find_by_id_rls lookup, defense-in-depth cross-tenant org guard (404 not existence-leak on BYPASSRLS pools), non-manager access gate via document_access_allowed (creator/organization/role/users scopes) OR scope_membership_allows (building/unit via user_scope_memberships_rls, GH #1413), then presigned S3 URL from state.storage_service — download uses generate_download_url (Content-Disposition: attachment, S3_PRESIGNED_URL_TTL_SECS/15-min TTL, gap-84-1), preview uses generate_preview_url (inline disposition, 1-hr) gated on Document::supports_preview() (400 PREVIEW_NOT_SUPPORTED for non-previewable MIME). Storage-not-configured → 503. Regression: document_download_preview_tests.rs (15 #[sqlx::test] cases: auth guard, unknown→404, cross-tenant→404, users/building/unit scope allow+deny, preview unsupported→400, text/plain supported, non-manager creator + accessible-document reach-presigner). Frontend ppt-web SHIPPED: DocumentDetail.tsx + DocumentPreviewModal (lazy) + DocumentsBrowse preview/download row; screen-map ppt/document-detail buildStatus=shipped (ppt-web). Follow-up (separate mobile story, NOT this backend slice): mobile document-detail preview frame (screen-map mobile buildStatus=planned, apiStatus=stub) — the "preview second frame" is a mobile UI gap, not a backend gap.
   7a-5-document-sharing: ready-for-dev
   # Epic 8A: Basic Notification Preferences
   8a-1-channel-level-notification-toggles: done


### PR DESCRIPTION
## Task
Coverage gap [mvp]: Document Download & Preview (Story 7A.4) — verify-to-done. Evidence: GET /{id}/download + /preview handlers, document-detail screen shipped. Gaps: sprint-status not flipped, preview second-frame planned. Confirm download/preview handlers are complete and flip sprint-status; if the preview second frame is a real gap, scope it.

## Owner
pm-backend

## Verify-to-done finding
The Story 7A.4 deliverable is **already implemented and merged on `dev`** — this PR only reconciles sprint-status to match reality (no product code change).

Backend (`backend/servers/api-server/src/routes/documents/core.rs`):
- `GET /api/v1/documents/{id}/download` → `get_download_url` and `GET /api/v1/documents/{id}/preview` → `get_preview_url`; router mounted at `lib.rs:164` `.nest("/api/v1/documents", routes::documents::router())`.
- Both handlers: RLS `find_by_id_rls` lookup → defense-in-depth cross-tenant org guard (returns 404, not an existence leak, even on BYPASSRLS pools) → non-manager access gate `document_access_allowed` (creator/organization/role/users) **OR** `scope_membership_allows` (building/unit via `user_scope_memberships_rls`, GH #1413) → presigned S3 URL from `state.storage_service`.
- Download: `generate_download_url` (Content-Disposition: attachment, TTL from `S3_PRESIGNED_URL_TTL_SECS`, default 15 min — gap-84-1).
- Preview: `generate_preview_url` (inline disposition, 1-hr) gated on `Document::supports_preview()` → 400 `PREVIEW_NOT_SUPPORTED` for non-previewable MIME. Storage-not-configured → 503.

Frontend ppt-web (shipped): `DocumentDetail.tsx` + lazy `DocumentPreviewModal` + `DocumentsBrowse` preview/download row; screen-map `ppt/document-detail` buildStatus=shipped (ppt-web).

## Preview "second frame" — scoped, not a backend gap
The "preview second-frame" is the **mobile** document-detail preview UI (screen-map `ppt/document-detail` mobile `buildStatus: planned`, `apiStatus: stub`). That is a separate mobile-frontend story, out of scope for this pm-backend verify-to-done. The backend `/preview` handler it will consume is already complete. Recorded as a follow-up in the sprint-status comment.

## Tested (Band A — fast check)
No product code changed — this PR edits only `_bmad-output/implementation-artifacts/sprint-status.yaml`. YAML validated:
```
python3 -c "import yaml; yaml.safe_load(open('.../sprint-status.yaml'))"  # OK
# 7a-4 = done ; epic-7a stories_completed = 2
```
Existing regression coverage for the verified handlers (not modified here): `backend/servers/api-server/tests/document_download_preview_tests.rs` — 15 `#[sqlx::test]` cases (auth guard, unknown→404, cross-tenant→404, users/building/unit scope allow+deny, preview unsupported→400, text/plain supported, non-manager creator + accessible-document reach-presigner). These are DB-backed; **CI `backend.yml` is the gate** (no local Postgres/Docker on this cloud runner).

## Built (Band B — full build)
Skipped: change is a 2-line YAML status edit, no Rust/public-API/config surface touched. `api-server` also can't build locally on this runner (utoipa-swagger-ui proxy-403) — deferred to CI.

## CI parity (Band C — hot-path only)
Skipped: not a code change (docs/status only).

## Scope drift
`scope-check.sh --owner pm-backend` exit 2 — flags `_bmad-output/implementation-artifacts/sprint-status.yaml` (that path maps to pm-tech-lead/pm-scrum-master, not pm-backend). Expected and intentional: a verify-to-done task's entire deliverable *is* the sprint-status flip. No product code outside pm-backend's area was touched.

## Code-reuse review
None — no new helpers added.

## Notes
- Reviewer: this is a reconciliation PR. Please confirm the 7A.4 handlers on `dev` match the evidence above before flipping. epic-7a `stories_completed` bumped 0 → 2 (7a-1 already `done` + 7a-4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZfDBc3VcdPMnKY7tLytnp

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZfDBc3VcdPMnKY7tLytnp)_