### PR TITLE
test-gap-hotfix-no-test-pr-959-reality-listings-pagination: route-level pagination clamp regression test

### DIFF
--- a/backend/servers/reality-server/tests/listings_pagination_clamp_tests.rs
+++ b/backend/servers/reality-server/tests/listings_pagination_clamp_tests.rs
@@ -1,0 +1,133 @@
+//! Route-level pagination-clamp regression tests for
+//! `GET /api/v1/listings` (`reality-server/src/routes/listings.rs`).
+//!
+//! # Background
+//!
+//! PR #959 (issue #953) added handler-side clamping of the `page`/`limit`
+//! query params so a negative `limit` can never reach SQL (Postgres rejects
+//! `LIMIT -1` with a raw "LIMIT must not be negative" error, which surfaced as
+//! a 500) and an unbounded `limit`/`page` can't become a resource-exhaustion
+//! vector. That PR shipped with *unit* tests on the private `clamp_pagination`
+//! helper only — there was no route/integration test proving the wired
+//! endpoint actually clamps. This file closes that gap.
+//!
+//! The `search` handler echoes the *effective* (post-clamp) `page` and `limit`
+//! back in `ListingSearchResponse`, so these tests drive the real production
+//! router end-to-end via `oneshot` and assert on the echoed values:
+//!
+//! | Case | Query                 | Expected echoed |
+//! |------|-----------------------|-----------------|
+//! | C1   | (none)                | page 1, limit 20 (defaults) |
+//! | C2   | `?limit=-1`           | limit 1 (negative floored)  |
+//! | C3   | `?limit=0`            | limit 1 (zero floored)      |
+//! | C4   | `?limit=100000`       | limit 100 (capped at max)   |
+//! | C5   | `?page=-5`            | page 1 (negative floored)   |
+//! | C6   | `?page=2&limit=50`    | page 2, limit 50 (untouched)|
+//!
+//! The search endpoint returns 200 on an empty database (see the sibling
+//! `listings_tests.rs`), so no seeding is required — the clamp is observable
+//! purely from the response metadata.
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    Router,
+};
+use reality_server::routes;
+use serde_json::Value;
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+fn listings_router(pool: PgPool) -> Router {
+    common::ensure_test_env();
+    let state = common::make_app_state(pool);
+    Router::new()
+        .nest("/api/v1/listings", routes::listings::router())
+        .with_state(state)
+}
+
+/// Drive `GET /api/v1/listings{query}` through the real router and return the
+/// status plus the decoded JSON body.
+async fn search(router: &Router, query: &str) -> (StatusCode, Value) {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/api/v1/listings{query}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    let json: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|e| panic!("body was not JSON ({e}): {:?}", String::from_utf8_lossy(&bytes)));
+    (status, json)
+}
+
+// C1 — no params: the endpoint echoes the documented defaults.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn defaults_when_no_pagination_params(pool: PgPool) {
+    let router = listings_router(pool);
+    let (status, body) = search(&router, "").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["page"], 1, "default page must be 1");
+    assert_eq!(body["limit"], 20, "default limit must be 20");
+}
+
+// C2 — a negative limit must never reach SQL; it is floored to 1 and the
+// request still succeeds (no raw "LIMIT must not be negative" 500).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn negative_limit_is_clamped_to_one(pool: PgPool) {
+    let router = listings_router(pool);
+    let (status, body) = search(&router, "?limit=-1").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "negative limit must be clamped, not 500"
+    );
+    assert_eq!(body["limit"], 1, "limit=-1 must be floored to 1");
+}
+
+// C3 — a zero limit is raised to the minimum of 1.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn zero_limit_is_clamped_to_one(pool: PgPool) {
+    let router = listings_router(pool);
+    let (status, body) = search(&router, "?limit=0").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["limit"], 1, "limit=0 must be raised to 1");
+}
+
+// C4 — an oversized limit is capped at MAX_LISTINGS_LIMIT (100).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oversized_limit_is_capped_at_max(pool: PgPool) {
+    let router = listings_router(pool);
+    let (status, body) = search(&router, "?limit=100000").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["limit"], 100, "oversized limit must be capped at 100");
+}
+
+// C5 — a negative page is floored to 1.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn negative_page_is_clamped_to_one(pool: PgPool) {
+    let router = listings_router(pool);
+    let (status, body) = search(&router, "?page=-5").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["page"], 1, "page=-5 must be floored to 1");
+}
+
+// C6 — in-range values pass through unchanged.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn valid_pagination_passes_through(pool: PgPool) {
+    let router = listings_router(pool);
+    let (status, body) = search(&router, "?page=2&limit=50").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["page"], 2, "valid page must pass through");
+    assert_eq!(body["limit"], 50, "valid limit must pass through");
+}

--- a/backend/servers/reality-server/tests/listings_pagination_clamp_tests.rs
+++ b/backend/servers/reality-server/tests/listings_pagination_clamp_tests.rs
@@ -66,8 +66,12 @@ async fn search(router: &Router, query: &str) -> (StatusCode, Value) {
     let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("read response body");
-    let json: Value = serde_json::from_slice(&bytes)
-        .unwrap_or_else(|e| panic!("body was not JSON ({e}): {:?}", String::from_utf8_lossy(&bytes)));
+    let json: Value = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+        panic!(
+            "body was not JSON ({e}): {:?}",
+            String::from_utf8_lossy(&bytes)
+        )
+    });
     (status, json)
 }
 


### PR DESCRIPTION
## Task
Reality-server listings pagination clamp (PR #959) shipped without a regression test for limit=-1. Add an integration/route test asserting the reality-server listings endpoint clamps a negative/zero/oversized limit correctly.

## Owner
pm-qa

## What changed
New integration test `backend/servers/reality-server/tests/listings_pagination_clamp_tests.rs`.

PR #959 (issue #953) added handler-side clamping of `page`/`limit` for `GET /api/v1/listings`, but shipped with **unit** tests on the private `clamp_pagination` helper only — there was no route/integration test proving the wired endpoint clamps. The `search` handler echoes the effective (post-clamp) `page`/`limit` in `ListingSearchResponse`, so the new test drives the real production router via `oneshot` and asserts on the echoed values:

| Case | Query | Expected echoed |
|------|-------|-----------------|
| C1 | (none) | page 1, limit 20 (defaults) |
| C2 | `?limit=-1` | 200 + limit 1 (negative floored — never reaches SQL) |
| C3 | `?limit=0` | limit 1 (zero floored) |
| C4 | `?limit=100000` | limit 100 (capped at `MAX_LISTINGS_LIMIT`) |
| C5 | `?page=-5` | page 1 (negative floored) |
| C6 | `?page=2&limit=50` | page 2, limit 50 (pass-through) |

Mirrors the sibling `listings_tests.rs` harness (`#[sqlx::test(migrator = "db::MIGRATOR")]`, same router construction, non-ignored). Adds a standard `axum::body::to_bytes` body-reading helper (deps `axum`, `serde_json`, `tower`/util all already used by the existing test suite).

## Tested (Band A — fast check)
`cd backend && cargo test -p reality-server --test listings_pagination_clamp_tests --no-run`
- FAILED to complete locally — **not** a test-code failure. The `utoipa-swagger-ui v9.0.2` build script panics downloading the Swagger UI zip through the sandbox proxy (`InvalidArchive("Could not find EOCD")`). The build aborts on this transitive build-dependency before compiling the test crate. This is the known cloud-sandbox limitation (proxy-blocked github.com download + no Postgres for `sqlx::test`).
- **`backend.yml` CI is the compile/test gate** — it has the vendored Swagger UI asset and a Postgres service, and runs the full reality-server test suite.

## Built (Band B — full build)
skipped: test-only change, no product/public-API/config surface.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only, no security/auth/billing/data-integrity change).

## Remote-tested
skipped: ppt-bridge MCP not connected.

## Scope drift
none — single file under `backend/servers/reality-server/tests/**`, matches pm-qa owner area (`scope-check.sh` exit 0).

## Notes
- Draft pending `backend.yml` green (local compile/test blocked by the swagger-ui proxy download, not by the added code).
- The added test is self-contained and follows the established reality-server integration-test pattern; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KEPa2z9ze4ixZMGFMgTFeK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEPa2z9ze4ixZMGFMgTFeK)_