### PR TITLE
test-gap-screen-map-drift-pr-922-ppt: reconcile ppt screen-map route mapping drift

### DIFF
--- a/docs/screens/ppt/ai-predictive-maintenance.md
+++ b/docs/screens/ppt/ai-predictive-maintenance.md
@@ -2,6 +2,8 @@
 id: ppt/ai-predictive-maintenance
 name: Predictive Maintenance Dashboard
 product: ppt
+sitemapRefs:
+  ppt-web: ppt-ai-predictive-maintenance
 implementations:
   ppt-web:
     route: "/ai/predictive-maintenance"

--- a/docs/screens/ppt/ai-sentiment.md
+++ b/docs/screens/ppt/ai-sentiment.md
@@ -2,6 +2,8 @@
 id: ppt/ai-sentiment
 name: Tenant Sentiment Dashboard
 product: ppt
+sitemapRefs:
+  ppt-web: ppt-ai-sentiment
 implementations:
   ppt-web:
     route: "/ai/sentiment"

--- a/docs/screens/ppt/notification-settings.md
+++ b/docs/screens/ppt/notification-settings.md
@@ -78,7 +78,7 @@ owner: pm-frontend
 
 Epic 8A, Story 8A.1 — channel-level notification toggles. The screen is the user-facing surface over `notification_preferences` (push / email / in_app), backed by `GET` + `PATCH /api/v1/users/me/notification-preferences`. Default preferences (all enabled) are auto-created per user by a DB trigger (migration `00021_create_notification_preferences.sql`). Story 8A.3 layers realtime sync on top so multiple sessions stay consistent.
 
-There is a sibling **Advanced** route (`/settings/notifications/advanced`, `AdvancedNotificationSettingsPage`, Epic 40) for per-category preferences, digests, quiet hours and grouping — catalogued in the sitemap as `ppt-settings-notifications-advanced` but intentionally out of scope for this 8A.1 screen-map.
+There is a sibling **Advanced** route (`/settings/notifications/advanced`, `AdvancedNotificationSettingsPage`, Epic 40) for per-category preferences, digests, quiet hours and grouping — catalogued in the sitemap as `ppt-settings-notifications-advanced` and out of scope for this 8A.1 screen-map. It now has its own screen-map at `ppt/settings-notifications-advanced` (child of this screen).
 
 ### Specific (recent)
 

--- a/docs/screens/ppt/settings-notifications-advanced.md
+++ b/docs/screens/ppt/settings-notifications-advanced.md
@@ -1,0 +1,97 @@
+---
+id: ppt/settings-notifications-advanced
+name: Advanced Notification Settings
+product: ppt
+sitemapRefs:
+  ppt-web: ppt-settings-notifications-advanced
+implementations:
+  ppt-web:
+    route: "/settings/notifications/advanced"
+    component: AdvancedNotificationSettingsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: partial
+  mobile:
+    buildStatus: n/a
+    redesignStatus: n/a
+    apiStatus: n/a
+epics:
+  - Epic-40
+relatedScreens:
+  - id: ppt/notification-settings
+    rel: parent
+  - id: ppt/accessibility-settings
+    rel: sibling
+  - id: ppt/privacy-settings
+    rel: sibling
+sharedComponents:
+  - switch
+  - section-card
+  - tabs
+useCases: []
+endpoints: []
+diagrams: []
+owner: pm-frontend
+---
+
+# Advanced Notification Settings
+
+Manager/tenant-web surface for Epic 40 — advanced notification preferences that
+layer on top of the channel-level toggles in `ppt/notification-settings`
+(`/settings/notifications`). Route `/settings/notifications/advanced` is wired in
+`routes/groups/core.tsx` behind `<ProtectedRoute>` to the lazy
+`AdvancedNotificationSettingsPage`
+(`features/settings/notifications/advanced/AdvancedNotificationSettingsPage.tsx`).
+
+The page is a tabbed surface (`categories` / `schedule` / `grouping`) backed by
+the `@ppt/api-client` hooks `useCategoryPreferences`, `useQuietHours`,
+`useDigestPreferences`, `useGroupingPreferences` and their matching
+`useUpdate*` mutations.
+
+- **Story 40.1 — Granular category preferences**: per-category channel toggles
+  (`CategoryPreferenceCard`).
+- **Story 40.2 — Quiet hours**: quiet-hours window configuration
+  (`QuietHoursConfig`).
+- **Story 40.3 — Digest preferences**: batched digest cadence
+  (`DigestPreferences`).
+- **Story 40.4 — Smart notification grouping**: grouping rules
+  (`GroupingSettings`).
+
+## States
+
+- **Loading**: combined `isLoading` across the four preference queries drives a
+  loading state before any tab renders.
+- **Loaded**: active tab (`categories` by default) renders its section from the
+  corresponding query data.
+- **Saving**: per-section update mutations disable their controls while pending.
+- **Error**: any of the four query errors surfaces an error state; per-update
+  failures set a dismissible `updateError` banner
+  ("Failed to update … preference. Please try again.").
+
+## Notes
+
+### Broader context
+
+Sitemap route `ppt-settings-notifications-advanced` (child of
+`ppt-settings-notifications`, `feature: Epic-40`). This screen-map was
+previously left unmapped — `ppt/notification-settings` catalogued the route in
+prose but scoped it out of the 8A.1 map, so the sitemap ID had no screen-map
+`sitemapRefs` owner. This map closes that route↔screen gap.
+
+### Specific (recent)
+
+- `apiStatus: partial` — the four advanced-preference endpoint families
+  (category / quiet-hours / digest / grouping) are consumed via `@ppt/api-client`
+  hooks; endpoints are left unlisted here until their sitemap `apiEndpoint` IDs
+  are catalogued, to avoid introducing unknown-endpoint drift.
+
+## Agent Log
+
+<!-- newest entries on top -->
+
+- 2026-07-04 — agent (test-gap-screen-map-drift-pr-922): created this screen-map
+  to reconcile screen-map drift after ppt-web route changes. Maps the
+  already-shipped `/settings/notifications/advanced` route
+  (`AdvancedNotificationSettingsPage`, Epic 40) to sitemap
+  `ppt-settings-notifications-advanced`, which no screen-map previously
+  referenced. Docs-only.


### PR DESCRIPTION
## Task

Screen-map drift: PR #922 modified ppt-web App.tsx (dev-review rounds 1-5 fixes) without a corresponding docs/screens/ppt update. Reconcile the screen-map: run /screens update to detect the drift, then create or update the relevant docs/screens/ppt/*.md so the sitemap/route↔screen mapping matches the current App.tsx routes. Run /screens validate. Docs-only change unless a genuine missing route mapping requires a small code touch.

## Owner

pm-qa

## What changed (docs-only)

`/screens update` reported **3 `unmapped-sitemap`** route↔screen mapping gaps — ppt-web sitemap route entries that no screen-map's `sitemapRefs` claimed. All three routes exist and are registered in the current router (post-App.tsx-refactor routes now live in `routes/groups/*.tsx`):

| Sitemap ID | Route / component (registered in) | Fix |
|---|---|---|
| `ppt-ai-sentiment` | `/ai/sentiment` · `SentimentDashboardPage` (`routes/groups/ai-dashboards.tsx`) | Added `sitemapRefs` to existing `ppt/ai-sentiment` map |
| `ppt-ai-predictive-maintenance` | `/ai/predictive-maintenance` · `PredictiveMaintenancePage` (`routes/groups/ai-dashboards.tsx`) | Added `sitemapRefs` to existing `ppt/ai-predictive-maintenance` map |
| `ppt-settings-notifications-advanced` | `/settings/notifications/advanced` · `AdvancedNotificationSettingsPage` (`routes/groups/core.tsx`) | Created new `ppt/settings-notifications-advanced` map (was prose-only OOS note in `notification-settings.md`) |

Also updated the OOS note in `notification-settings.md` to point at the new child screen-map.

No code touch required — every route already exists and is registered; the gap was purely in the screen-map docs.

## Tested (Band A — fast check)

- `pnpm --filter @ppt/screen-map cli validate` → `Validated 162 screen-maps: 0 errors, 0 warnings.` (exit 0)
- `pnpm --filter @ppt/screen-map cli update` (drift) → `unmapped-sitemap` count now **0** (was 3). Remaining drift is pre-existing systemic `unknown-component` / `unknown-epic` noise (the component/epic registries are unwired across all 162 screens) — not route-mapping drift and out of scope for this task.
- `pnpm --filter @ppt/screen-map test` → `18 test files passed, 76 passed | 1 skipped` (exit 0)

## Built (Band B — full build)

skipped: docs-only change (screen-map markdown), no build output affected.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (docs-only, no security/auth/billing/data-integrity change). The `screen-map.yml` workflow runs `/screens validate` on `docs/screens/**` changes — replicated locally above (green).

## Scope drift

`scope-check.sh --owner pm-qa` → exit 2 (`scope_drift=true`). The four changed paths are all under `docs/screens/ppt/`, which is outside the pm-qa owner-area globs. Justified: the task is explicitly a `docs/screens/ppt` screen-map reconciliation assigned to pm-qa. No non-doc code touched.

- docs/screens/ppt/ai-predictive-maintenance.md
- docs/screens/ppt/ai-sentiment.md
- docs/screens/ppt/notification-settings.md
- docs/screens/ppt/settings-notifications-advanced.md (new)

## Code-reuse review

none

## Remote-tested

skipped

## Notes

- IG1–IG8 goal-check reports IG1/IG2/IG3 fails — these are plan-file-workflow checks (`.research/plans` file, `impl/` branch name, TDD test commit) that do not apply to a dispatcher `auto-impl` docs-only screen-map task with no runtime surface to test. The task-relevant gate is the screen-map validator, which is green.
- Verified all three routes are live in the router before mapping (`routes/groups/ai-dashboards.tsx` lines 91-92; `routes/groups/core.tsx` line 201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXjQbidHCUkzLanQro9dG5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXjQbidHCUkzLanQro9dG5)_