### PR TITLE
gh-issue-2078: guard refill/ingest against missing assignments.json + smoke coverage

### DIFF
--- a/.research/backlog-refill.sh
+++ b/.research/backlog-refill.sh
@@ -90,14 +90,24 @@ fi
 # stem() mirrors dispatcher-prompt.md Phase 3 + dispatcher-self-test.sh T24:
 # strip a trailing -(impl|fix|v2|retry|followup|wip)<digits> suffix. Bare
 # action-list/backlog slugs carry no branch prefix, so no prefix strip.
-ASSIGN_INPUTS=("$ASSIGN")
+# Guard BOTH inputs symmetrically with `[ -f ]`: a missing PRIMARY
+# assignments.json makes `jq -s "$ASSIGN"` exit 2 ("Could not open file"),
+# which under `set -euo pipefail` aborts the whole refill — the `.assignments[]?`
+# optional operator only tolerates a missing *key*, not a missing *file* (#2078).
+# Default to an empty id set when neither file exists.
+ASSIGN_INPUTS=()
+[ -f "$ASSIGN" ]         && ASSIGN_INPUTS+=("$ASSIGN")
 [ -f "$ASSIGN_ARCHIVE" ] && ASSIGN_INPUTS+=("$ASSIGN_ARCHIVE")
 
 # Assignment id set (active + archive). `jq -s` slurps every input file into an
 # array of root docs; `.[].assignments[]?` then streams all rows regardless of
 # which file (or how many) held them — this is the multi-file-safe read that
 # --slurpfile (one file only) cannot do.
-ASSIGN_IDS=$(jq -s '[ .[].assignments[]?.task_id ] | unique' "${ASSIGN_INPUTS[@]}")
+if [ "${#ASSIGN_INPUTS[@]}" -eq 0 ]; then
+  ASSIGN_IDS='[]'
+else
+  ASSIGN_IDS=$(jq -s '[ .[].assignments[]?.task_id ] | unique' "${ASSIGN_INPUTS[@]}")
+fi
 
 # Honest effective-claimable count: open action-list items whose id AND stem
 # are absent from assignments (active+archive) and whose deps are empty

--- a/.research/issue-ingest.sh
+++ b/.research/issue-ingest.sh
@@ -75,9 +75,19 @@ if [ -z "${GH_ISSUES_FILE:-}" ] || [ ! -f "${GH_ISSUES_FILE:-}" ]; then
 fi
 
 # Assignment id set (active + archive), multi-file-safe via `jq -s`.
-ASSIGN_INPUTS=("$ASSIGN")
+# Guard BOTH inputs symmetrically with `[ -f ]`: a missing PRIMARY
+# assignments.json makes `jq -s "$ASSIGN"` exit 2 ("Could not open file"),
+# which under `set -euo pipefail` aborts the whole ingest — the `.assignments[]?`
+# optional operator only tolerates a missing *key*, not a missing *file* (#2078).
+# Default to an empty id set when neither file exists.
+ASSIGN_INPUTS=()
+[ -f "$ASSIGN" ]         && ASSIGN_INPUTS+=("$ASSIGN")
 [ -f "$ASSIGN_ARCHIVE" ] && ASSIGN_INPUTS+=("$ASSIGN_ARCHIVE")
-ASSIGN_IDS=$(jq -s '[ .[].assignments[]?.task_id ] | unique' "${ASSIGN_INPUTS[@]}")
+if [ "${#ASSIGN_INPUTS[@]}" -eq 0 ]; then
+  ASSIGN_IDS='[]'
+else
+  ASSIGN_IDS=$(jq -s '[ .[].assignments[]?.task_id ] | unique' "${ASSIGN_INPUTS[@]}")
+fi
 
 ACTIVE_BEFORE=$(jq '.items | length' "$ACTION_LIST")
 # CEIL headroom is measured against the active item count (append-bound).

--- a/.research/test-backlog-refill.sh
+++ b/.research/test-backlog-refill.sh
@@ -124,6 +124,26 @@ N=$(jq '[.items[]|select(.source|startswith("dispatcher-backlog-refill"))]|lengt
 jq -e '[.items[]|select(.source|startswith("dispatcher-backlog-refill"))|.id]|sort==["bl-sec-high","bl-test-med"]' "$AL" >/dev/null \
   && ok "cap picks top-2 by score" || bad "cap picked wrong items"
 
+# --- 8. missing assignments.json: clean exit, empty assignment set (#2078) ---
+# A primary $ASSIGN that does not exist must NOT abort jq under `set -e`; the
+# refill should proceed treating the assignment set as empty. With no
+# assignments, the two ghost rows become honest-claimable (honest 3 >= floor 2),
+# so the buffer is healthy and --apply is a no-op — but critically it exits 0.
+seed
+rm -f "$ASG" "$ASGA"          # neither primary ($ASSIGN) nor archive exists
+BEFORE=$(jq -c . "$AL")
+if OUT=$(run --apply 2>&1); then
+  ok "missing assignments.json exits cleanly (no jq abort)"
+else
+  bad "missing assignments.json aborted (exit $?): $OUT"
+fi
+# ghosts are no longer excluded (empty assignment set) -> honest_claimable=3
+echo "$OUT" | grep -q "honest_claimable=3" \
+  && ok "empty assignment set: both ghosts now claimable (honest=3)" \
+  || bad "expected honest_claimable=3 with empty assignments: $(echo "$OUT" | grep -o 'honest_claimable=[0-9]*')"
+[ "$(jq -c . "$AL")" = "$BEFORE" ] \
+  && ok "healthy buffer under empty assignments -> no-op" || bad "mutated action-list under empty assignments"
+
 echo
 if [ "$FAIL" = "0" ]; then echo "==> backlog-refill smoke test PASSED"; exit 0
 else echo "==> backlog-refill smoke test FAILED"; exit 1; fi

--- a/.research/test-issue-ingest.sh
+++ b/.research/test-issue-ingest.sh
@@ -85,6 +85,21 @@ seed; ISSUE_INGEST_CAP=1 run --apply >/dev/null 2>&1
 NADD=$(jq '[.items[]|select(.source|startswith("dispatcher-issue-ingest "))]|length' "$AL")
 [ "$NADD" = "1" ] && ok "per-run cap=1 honored" || bad "cap not honored (added $NADD)"
 
+# 8. missing assignments.json: clean exit, empty assignment set (#2078)
+# A primary $ASSIGN that does not exist must NOT abort jq under `set -e`; ingest
+# should proceed treating the assignment set as empty. With no assignments,
+# issue 200 (previously skipped *only* because it matched an in-progress
+# assignment) becomes eligible and is ingested — proving the set is empty.
+seed; rm -f "$ASG" "$ASGA"     # neither primary ($ASSIGN) nor archive exists
+if OUT=$(run --apply 2>&1); then
+  ok "missing assignments.json exits cleanly (no jq abort)"
+else
+  bad "missing assignments.json aborted (exit $?): $OUT"
+fi
+has 200 \
+  && ok "empty assignment set: issue 200 now ingested (no assignment dedup)" \
+  || bad "issue 200 not ingested under empty assignment set"
+
 echo
 if [ "$FAIL" = "0" ]; then echo "==> issue-ingest smoke test PASSED"; exit 0
 else echo "==> issue-ingest smoke test FAILED"; exit 1; fi


### PR DESCRIPTION
## Task
Guard refill/ingest against a missing `assignments.json` + add smoke-test coverage. In `.research/backlog-refill.sh` (~line 93) and `.research/issue-ingest.sh` (~line 78), guard the PRIMARY `assignments.json` input symmetrically with `[ -f ]` (build `ASSIGN_INPUTS` from only existing files; default `ASSIGN_IDS='[]'` when neither the primary nor archive file exists), exactly as GitHub issue #2078 describes. Then add one missing-assignments case to `.research/test-backlog-refill.sh` and `.research/test-issue-ingest.sh` asserting a clean exit with the assignment set treated as empty.

Closes #2078

## Owner
pm-tech-lead

## Root cause
Both scripts added the PRIMARY `$ASSIGN` to `ASSIGN_INPUTS` unconditionally while guarding only `$ASSIGN_ARCHIVE` with `[ -f ]`. When `assignments.json` is absent, `jq -s "$ASSIGN"` exits 2 (`Could not open file … No such file or directory`), which under `set -euo pipefail` aborts the whole refill/ingest run. The `.assignments[]?` optional operator tolerates a missing *key*, not a missing *file*.

## Fix
```bash
ASSIGN_INPUTS=()
[ -f "$ASSIGN" ]         && ASSIGN_INPUTS+=("$ASSIGN")
[ -f "$ASSIGN_ARCHIVE" ] && ASSIGN_INPUTS+=("$ASSIGN_ARCHIVE")
if [ "${#ASSIGN_INPUTS[@]}" -eq 0 ]; then
  ASSIGN_IDS='[]'
else
  ASSIGN_IDS=$(jq -s '[ .[].assignments[]?.task_id ] | unique' "${ASSIGN_INPUTS[@]}")
fi
```
Applied symmetrically to `.research/backlog-refill.sh` and `.research/issue-ingest.sh`.

## Test coverage (IG3 — fails on `dev`, passes with the fix)
Added case 8 to each smoke test. Each seeds fixtures, `rm`s both `assignments.json` and the archive, runs `--apply`, and asserts a clean exit with the assignment set treated as empty:
- `test-backlog-refill.sh`: missing files -> exit 0, both former ghosts become claimable (`honest_claimable=3`), healthy buffer -> no-op.
- `test-issue-ingest.sh`: missing files -> exit 0, issue 200 (previously skipped only because it matched an in-progress assignment) is now ingested — proving the set is empty.

Confirmed on the **unfixed** scripts both new cases fail with the exact `jq: error: Could not open file …/assignments.json` from #2078; with the fix both suites pass.

## Tested (Band A — fast check)
```
bash .research/test-backlog-refill.sh   -> exit 0 (20/20 ok, PASSED)
bash .research/test-issue-ingest.sh     -> exit 0 (16/16 ok, PASSED)
```

## Built (Band B — full build)
skipped: shell-script change, no compiled artifact / public API / config surface.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change). These `.research/test-*.sh` are the same scripts gated by `dispatcher-self-test.yml` (wired by PR #2061); both pass locally.

## Scope drift
None. `scope-check.sh --owner pm-tech-lead --base origin/dev` exits 0. Diff is confined to four `.research/*.sh` files. (Against a *stale local* `dev` ref the script flagged an unrelated reality-server test already on `origin/dev`; re-run against `origin/dev` is clean.)

## Code-reuse review
None. `reuse-grep.sh --specialist generic` emitted no warnings.

## Remote-tested
skipped.

## Notes
Fix + regression tests only; no behavior change when `assignments.json` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oejVXzjVPDw1B64Pr1Q4U

---
_Generated by [Claude Code](https://claude.ai/code/session_012oejVXzjVPDw1B64Pr1Q4U)_