### PR TITLE
gh-issue-2080: pin import_templates id-tiebreak on tied updated_at + scope 00212 no-sort claim

### DIFF
--- a/backend/crates/db/migrations/00212_import_templates_org_updated_id_index.sql
+++ b/backend/crates/db/migrations/00212_import_templates_org_updated_id_index.sql
@@ -14,13 +14,23 @@
 -- leading sort key, but NOT the `id DESC` tie-break: Postgres can range-scan
 -- the index for the first two keys, yet rows sharing an `updated_at` value
 -- still need an extra in-memory sort to resolve the `id DESC` order. Adding
--- `id DESC` as a third index key makes the entire ORDER BY (and therefore the
--- LIMIT/OFFSET slice) satisfiable directly from the index, so paginated reads
--- become a pure index range scan with a stable, deterministic order.
+-- `id DESC` as a third index key makes the whole ORDER BY (and therefore the
+-- LIMIT/OFFSET slice) index-satisfiable *on the strict-org leg*
+-- (`organization_id = $1`, i.e. include_system=false): that query is a single
+-- equality on the leading column, so the planner walks the index range in
+-- order and the read becomes a pure index range scan with a stable,
+-- deterministic order and no top-level sort.
 --
--- The system-template leg of the OR (organization_id IS NULL) is still served
--- by this index: NULLs are indexed by btree, and the leading key plus the two
--- sort keys match the query's ordering for that branch too.
+-- This does NOT eliminate the sort on the default include_system=true leg.
+-- `WHERE (organization_id = $1 OR organization_id IS NULL)
+--  ORDER BY updated_at DESC, id DESC` is an OR over two disjoint ranges of the
+-- leading index column; Postgres resolves it via BitmapOr -> Bitmap Heap Scan
+-- (which discards index order) and then a top-level Sort. Each individual leg
+-- (`organization_id = $1` and `organization_id IS NULL`, with NULLs indexed by
+-- btree) is an ordered index range this index can serve, but the union of the
+-- two still requires a sort unless the query is rewritten as a UNION ALL /
+-- MergeAppend of the ordered legs. The `id DESC` tie-break itself remains
+-- deterministic on both legs regardless of the access path.
 CREATE INDEX IF NOT EXISTS idx_import_templates_org_updated_id
     ON import_templates (organization_id, updated_at DESC, id DESC);
 

--- a/backend/servers/api-server/tests/migration_pagination_tests.rs
+++ b/backend/servers/api-server/tests/migration_pagination_tests.rs
@@ -167,6 +167,43 @@ async fn seed_buildings_templates(pool: &PgPool, org_id: Uuid, count: i32) -> Ve
     (0..count).rev().map(|i| format!("pg-tpl-{i}")).collect()
 }
 
+/// Insert `count` custom `buildings` templates for `org_id` that all share an
+/// identical `updated_at`, collapsing the leading `ORDER BY updated_at DESC`
+/// key into a single tie for every row. That makes the `id DESC` sub-sort the
+/// *only* thing that decides order — the exact instability the 00212 index +
+/// the `id DESC` ORDER BY key exist to pin (#2051 / #1997 / #2080).
+///
+/// Returns the inserted ids sorted DESC — the exact order
+/// `ORDER BY updated_at DESC, id DESC` must produce for a single tie group.
+/// Postgres compares `uuid` byte-wise big-endian, which matches the derived
+/// `Ord` on `uuid::Uuid`'s `[u8; 16]`, so a Rust descending sort is a faithful
+/// oracle for Postgres `id DESC`.
+async fn seed_tied_updated_at_templates(pool: &PgPool, org_id: Uuid, count: i32) -> Vec<Uuid> {
+    let mut ids = Vec::with_capacity(count as usize);
+    for i in 0..count {
+        // Pin one literal timestamp for every row so no two rows can differ on
+        // the leading sort key.
+        let id: Uuid = sqlx::query_scalar(
+            r#"INSERT INTO import_templates
+                   (organization_id, name, description, data_type,
+                    field_mappings, is_system_template, updated_at)
+               VALUES ($1, $2, NULL, 'buildings', '[]'::jsonb, false,
+                       TIMESTAMPTZ '2026-01-01 12:00:00+00')
+               RETURNING id"#,
+        )
+        .bind(org_id)
+        .bind(format!("tie-tpl-{i}"))
+        .fetch_one(pool)
+        .await
+        .expect("seed tied-updated_at template");
+        ids.push(id);
+    }
+
+    ids.sort_unstable();
+    ids.reverse();
+    ids
+}
+
 /// `per_page=0` and `per_page=-5` must both clamp up to 1.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn per_page_zero_and_negative_clamp_to_one(pool: PgPool) {
@@ -257,5 +294,52 @@ async fn page_two_returns_expected_offset_slice(pool: PgPool) {
         names,
         vec![&expected_order[2][..], &expected_order[3][..]],
         "page 2 must be the offset-2 slice of the DESC ordering"
+    );
+}
+
+/// The whole point of the `id DESC` tie-break (00212's third index column and
+/// the second ORDER BY key) is to make paging deterministic when rows share an
+/// `updated_at`. The clamp tests above give every row a distinct `updated_at`,
+/// so their slice assertions would pass even if the tiebreak regressed. This
+/// test pins the tiebreak directly (#2080): it seeds one tie group — several
+/// rows with an identical `updated_at` — and asserts both the full-list order
+/// and an offset slice straddling that group resolve to a strict `id DESC`
+/// order.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn identical_updated_at_falls_back_to_deterministic_id_desc(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgtie").await;
+
+    // Four rows, all with the same updated_at => a single 4-row tie group.
+    let ids_desc = seed_tied_updated_at_templates(&pool, org_id, 4).await;
+
+    // (1) Full list order must equal the seeded ids sorted DESC. Without the
+    // `id DESC` key this order would be unspecified across the tie group.
+    let uri = "/api/v1/migration/templates?include_system=false&per_page=100";
+    let resp = app.execute(get(&token, org_id, uri)).await;
+    assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
+    let body: ListTemplatesResponse = resp.json();
+    assert_eq!(body.total, 4, "all four tied rows are listed");
+    let full_order: Vec<Uuid> = body.templates.iter().map(|t| t.id).collect();
+    assert_eq!(
+        full_order, ids_desc,
+        "tied updated_at must resolve to a strict id DESC order"
+    );
+
+    // (2) Offset slice straddling the tie group: page=2&per_page=2 => offset
+    // (2-1)*2 = 2 => the 3rd and 4th ids of the DESC order. This slice is only
+    // stable because the id tiebreak fixes the intra-tie ordering.
+    let uri = "/api/v1/migration/templates?include_system=false&page=2&per_page=2";
+    let resp = app.execute(get(&token, org_id, uri)).await;
+    assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
+    let body: ListTemplatesResponse = resp.json();
+    assert_eq!(body.page, 2);
+    assert_eq!(body.per_page, 2);
+    assert_eq!(body.total, 4);
+    let slice: Vec<Uuid> = body.templates.iter().map(|t| t.id).collect();
+    assert_eq!(
+        slice,
+        vec![ids_desc[2], ids_desc[3]],
+        "page-2 slice of a single tie group must be the deterministic id DESC sub-slice"
     );
 }


### PR DESCRIPTION
## Task

Add a `#[sqlx::test]` in `backend/servers/api-server/tests/migration_pagination_tests.rs` that seeds >=3 rows sharing an identical `updated_at`, then asserts (1) full-list order equals those ids sorted DESC and (2) an offset slice straddling the tie group (`page=2&per_page=2`) returns the deterministic `id DESC` sub-slice — pinning the id-tiebreak the 00212 index + ORDER BY exist to provide (per GitHub issue #2080). Also soften the 00212 migration header comment to scope the "no sort" claim to the strict-org leg (the `include_system=true` OR path still requires a top sort).

Closes #2080

## Owner

pm-backend (specialist: `rust-backend`)

## Changes

- **New test `identical_updated_at_falls_back_to_deterministic_id_desc`** — seeds a single 4-row tie group (all rows pinned to one literal `updated_at`), so the `id DESC` sub-sort is the *only* thing deciding order. Asserts:
  1. full-list order equals the seeded ids sorted DESC, and
  2. the `page=2&per_page=2` slice straddling that tie group is the deterministic `id DESC` sub-slice (`ids_desc[2..4]`).
  - New helper `seed_tied_updated_at_templates` captures each `RETURNING id` and returns them DESC-sorted. Postgres compares `uuid` byte-wise big-endian, matching the derived `Ord` on `uuid::Uuid`'s `[u8; 16]`, so a Rust descending sort is a faithful oracle for `id DESC`. Existing clamp tests (distinct `updated_at` per row) are unchanged; they would have passed even with the tiebreak regressed — this new test is the one that actually pins it.
- **00212 header comment softened** — the "entire ORDER BY … satisfiable directly from the index, no top-level sort" claim is now scoped to the strict-org leg (`organization_id = $1`, `include_system=false`). Added a paragraph noting the default `include_system=true` OR path (`organization_id = $1 OR organization_id IS NULL`) resolves via BitmapOr → Bitmap Heap Scan → top-level Sort, so it still requires a sort unless rewritten as a UNION ALL / MergeAppend of the ordered legs. The `id DESC` tiebreak itself stays deterministic on both legs. No index DDL change.

## Tested (Band A — fast check)

- `rustfmt --edition 2021 --check backend/servers/api-server/tests/migration_pagination_tests.rs` → exit 0 (clean).
- `cargo check -p api-server --tests` → **could not complete** in this cloud sandbox: the `utoipa-swagger-ui` build script panics because it cannot download `swagger-ui` through the agent proxy (`InvalidArchive("Could not find EOCD")`). This is a known pre-existing environment limitation, unrelated to this change.

## Built (Band B — full build)

Skipped — same swagger-ui build-script limitation blocks a full `api-server` build in this sandbox.

## CI parity (Band C — hot-path only)

Not a hot-path change (test + migration-comment only, no runtime/security/auth/data-path code).

## Notes

**Test gate is CI.** The DB-backed `#[sqlx::test]` requires Postgres + the vendored swagger asset, both present in `backend.yml` but not in this cloud sandbox. No DB test run was executed locally — it is deferred to CI. Please keep as draft until `backend.yml` is green.

Scope-drift check (`scope-check.sh --owner pm-backend`): clean (exit 0) — both changed files are backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oejVXzjVPDw1B64Pr1Q4U

---
_Generated by [Claude Code](https://claude.ai/code/session_012oejVXzjVPDw1B64Pr1Q4U)_