### PR TITLE
gh-issue-2079: hoist ListingDetail state/side-effects into ListingDetailViewModel

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
@@ -14,14 +14,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
 import three.two.bit.ppt.reality.api.ApiConfig
 import three.two.bit.ppt.reality.auth.AuthState
 import three.two.bit.ppt.reality.auth.SsoService
-import three.two.bit.ppt.reality.favorites.FavoritesRepository
-import three.two.bit.ppt.reality.inquiry.CreateInquiryRequest
-import three.two.bit.ppt.reality.inquiry.InquiryRepository
 import three.two.bit.ppt.reality.listing.*
 import three.two.bit.ppt.reality.util.isNetworkError
 
@@ -66,104 +62,51 @@ fun ListingDetailScreen(
     val authState by ssoService.authState.collectAsState()
     val networkErrorMsg = stringResource(R.string.error_network)
     val genericErrorMsg = stringResource(R.string.error_generic)
-    fun friendlyError(e: Throwable) = if (e.isNetworkError()) networkErrorMsg else genericErrorMsg
-
-    var listing by remember { mutableStateOf<ListingDetail?>(null) }
-    var isLoading by remember { mutableStateOf(true) }
-    var errorMessage by remember { mutableStateOf<String?>(null) }
-    var isFavorite by remember { mutableStateOf(false) }
-    var isFavoriteLoading by remember { mutableStateOf(false) }
-    var showInquiryDialog by remember { mutableStateOf(false) }
-    var isInquirySubmitting by remember { mutableStateOf(false) }
-    var inquiryError by remember { mutableStateOf<String?>(null) }
-    var showShareSheet by remember { mutableStateOf(false) }
 
     val sessionToken = (authState as? AuthState.Authenticated)?.sessionToken
-    val favoritesRepository =
-        remember(sessionToken) {
-            FavoritesRepository(baseUrl = ApiConfig.requireBaseUrl(), sessionToken = sessionToken)
-        }
-    val inquiryRepository =
-        remember(sessionToken) {
-            InquiryRepository(baseUrl = ApiConfig.requireBaseUrl(), sessionToken = sessionToken)
-        }
-
-    LaunchedEffect(listingId, authState) {
-        if (authState is AuthState.Authenticated) {
-            favoritesRepository
-                .isFavorite(listingId)
-                .fold(onSuccess = { isFavorite = it }, onFailure = { /* non-critical */ })
-        }
-    }
-    LaunchedEffect(listingId) {
-        isLoading = true
-        repository
-            .getListingDetail(listingId)
-            .fold(
-                onSuccess = {
-                    listing = it
-                    isLoading = false
-                },
-                onFailure = {
-                    errorMessage = friendlyError(it)
-                    isLoading = false
-                },
+    // State + side-effects are hoisted into ListingDetailViewModel (commonMain). This composable
+    // is now a `collectAsState()` render + intent wiring — see issue #2079. The VM is re-created on
+    // session-token change so its repositories carry the current auth header.
+    val viewModel =
+        remember(sessionToken, listingId) {
+            ListingDetailViewModel.create(
+                listingId = listingId,
+                listingRepository = repository,
+                baseUrl = ApiConfig.requireBaseUrl(),
+                sessionToken = sessionToken,
+                scope = scope,
+                errorMapper = { e -> if (e.isNetworkError()) networkErrorMsg else genericErrorMsg },
             )
+        }
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(viewModel) { viewModel.start() }
+    LaunchedEffect(viewModel) {
+        viewModel.events.collect { event ->
+            when (event) {
+                ListingDetailEvent.InquirySubmitted -> onInquirySuccess()
+            }
+        }
     }
 
     Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         when {
-            isLoading ->
+            state.isLoading ->
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                     CircularProgressIndicator()
                 }
-            errorMessage != null ->
-                ErrorContent(
-                    message = errorMessage!!,
-                    onRetry = {
-                        scope.launch {
-                            isLoading = true
-                            errorMessage = null
-                            repository
-                                .getListingDetail(listingId)
-                                .fold(
-                                    onSuccess = { listing = it },
-                                    onFailure = { errorMessage = friendlyError(it) },
-                                )
-                            isLoading = false
-                        }
-                    },
-                )
-            listing != null ->
+            state.errorMessage != null ->
+                ErrorContent(message = state.errorMessage!!, onRetry = viewModel::retry)
+            state.listing != null ->
                 Box(modifier = Modifier.fillMaxSize()) {
                     ListingContent(
-                        listing = listing!!,
-                        isFavorite = isFavorite,
+                        listing = state.listing!!,
+                        isFavorite = state.isFavorite,
                         onBackClick = onBackClick,
-                        onShareClick = { showShareSheet = true },
-                        onFavoriteClick = {
-                            if (authState is AuthState.Authenticated && !isFavoriteLoading) {
-                                val previousFav = isFavorite
-                                val newFav = !isFavorite
-                                // Optimistic UI: flip the heart immediately, then reconcile with
-                                // the server response. On failure we roll the state back to
-                                // `previousFav` so the icon never lies about persisted state.
-                                isFavorite = newFav
-                                isFavoriteLoading = true
-                                scope.launch {
-                                    val result =
-                                        if (newFav) favoritesRepository.addFavorite(listingId)
-                                        else favoritesRepository.removeFavorite(listingId)
-                                    result.fold(
-                                        onSuccess = { /* optimistic value already applied */ },
-                                        onFailure = { isFavorite = previousFav },
-                                    )
-                                    isFavoriteLoading = false
-                                }
-                            }
-                        },
+                        onShareClick = viewModel::onShowShareSheet,
+                        onFavoriteClick = viewModel::onFavoriteToggle,
                         onCallClick = {
-                            listing!!.realtor?.phone?.let { phone ->
+                            state.listing!!.realtor?.phone?.let { phone ->
                                 context.startActivity(
                                     Intent(Intent.ACTION_DIAL).apply {
                                         data = Uri.parse("tel:$phone")
@@ -171,54 +114,27 @@ fun ListingDetailScreen(
                                 )
                             }
                         },
-                        onMessageClick = { showInquiryDialog = true },
-                        onInquiryClick = { showInquiryDialog = true },
+                        onMessageClick = viewModel::onShowInquiryDialog,
+                        onInquiryClick = viewModel::onShowInquiryDialog,
                     )
                 }
         }
     }
 
-    if (showInquiryDialog && listing != null) {
+    if (state.showInquiryDialog && state.listing != null) {
         InquiryDialog(
-            listing = listing!!,
+            listing = state.listing!!,
             isAuthenticated = authState is AuthState.Authenticated,
-            isSubmitting = isInquirySubmitting,
-            errorMessage = inquiryError,
-            onDismiss = {
-                showInquiryDialog = false
-                inquiryError = null
-            },
+            isSubmitting = state.isInquirySubmitting,
+            errorMessage = state.inquiryError,
+            onDismiss = viewModel::onDismissInquiryDialog,
             onSubmit = { message, name, email, phone ->
-                isInquirySubmitting = true
-                inquiryError = null
-                scope.launch {
-                    val request =
-                        CreateInquiryRequest(
-                            listingId = listingId,
-                            message = message,
-                            name = name,
-                            email = email,
-                            phone = phone,
-                        )
-                    inquiryRepository
-                        .createInquiry(request)
-                        .fold(
-                            onSuccess = {
-                                isInquirySubmitting = false
-                                showInquiryDialog = false
-                                onInquirySuccess()
-                            },
-                            onFailure = { error ->
-                                isInquirySubmitting = false
-                                inquiryError = friendlyError(error)
-                            },
-                        )
-                }
+                viewModel.onSubmitInquiry(message, name, email, phone)
             },
         )
     }
-    if (showShareSheet && listing != null) {
-        ShareListingSheet(listing = listing!!, onDismiss = { showShareSheet = false })
+    if (state.showShareSheet && state.listing != null) {
+        ShareListingSheet(listing = state.listing!!, onDismiss = viewModel::onDismissShareSheet)
     }
 }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
@@ -1,0 +1,208 @@
+package three.two.bit.ppt.reality.listing
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import three.two.bit.ppt.reality.favorites.FavoritesRepository
+import three.two.bit.ppt.reality.inquiry.CreateInquiryRequest
+import three.two.bit.ppt.reality.inquiry.InquiryRepository
+
+/**
+ * Immutable UI state for the Listing Detail screen.
+ *
+ * Every field the Compose (or, later, SwiftUI) surface needs is derived from this single value so
+ * the screen can be a pure `collectAsState()` render + intent wiring. See [ListingDetailViewModel].
+ */
+data class ListingDetailUiState(
+    val listing: ListingDetail? = null,
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+    val isFavorite: Boolean = false,
+    val isFavoriteLoading: Boolean = false,
+    val showInquiryDialog: Boolean = false,
+    val isInquirySubmitting: Boolean = false,
+    val inquiryError: String? = null,
+    val showShareSheet: Boolean = false,
+)
+
+/** One-shot side effects the UI must react to (navigation, etc.). */
+sealed interface ListingDetailEvent {
+    /** The inquiry was accepted by the server; the UI should navigate to the inquiries list. */
+    data object InquirySubmitted : ListingDetailEvent
+}
+
+/**
+ * State-holder / view-model for the Reality-portal Listing Detail screen.
+ *
+ * This hoists the state and side-effects that used to live inline in the `ListingDetailScreen`
+ * composable — the churn locus flagged in issue #2079 (PR #2059 follow-up). It owns the two data
+ * loads, the optimistic favorite toggle (+ rollback), inquiry submission, and share/dialog
+ * visibility, exposing them as an immutable [state] `StateFlow` plus intent methods
+ * ([onFavoriteToggle], [onSubmitInquiry], [retry], …). The composable shrinks to
+ * `collectAsState()` + intent wiring.
+ *
+ * It is a plain, framework-agnostic state-holder (no `androidx.lifecycle` / Android types) so it
+ * lives in `commonMain`, is unit-testable off a `TestScope`, and can be reused by the iOS target
+ * later — mirroring the existing [SearchState] convention. The app currently has no Koin container,
+ * so DI is done by constructor injection; [create] keeps repository construction out of the UI
+ * layer. Wiring a Koin single-module is left as a separate infra follow-up (tracked in #2079).
+ *
+ * @param scope the coroutine scope the loads/writes launch into. On Android this is a
+ *   `rememberCoroutineScope()`, so in-flight work is cancelled when the screen leaves composition;
+ *   in tests it is the `TestScope` from `runTest`.
+ * @param errorMapper maps a caught [Throwable] to a user-facing message — injected because the
+ *   Android strings come from `stringResource(...)`, which is not reachable from `commonMain`.
+ */
+class ListingDetailViewModel(
+    private val listingId: String,
+    private val listingRepository: ListingRepository,
+    private val favoritesRepository: FavoritesRepository,
+    private val inquiryRepository: InquiryRepository,
+    private val scope: CoroutineScope,
+    private val isAuthenticated: Boolean,
+    private val errorMapper: (Throwable) -> String,
+) {
+    private val _state = MutableStateFlow(ListingDetailUiState())
+    val state: StateFlow<ListingDetailUiState> = _state.asStateFlow()
+
+    private val _events = MutableSharedFlow<ListingDetailEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<ListingDetailEvent> = _events.asSharedFlow()
+
+    private var started = false
+
+    /**
+     * Kick off the initial listing load (and the favorite-state probe when authenticated).
+     * Idempotent per instance so it can be safely driven from a `LaunchedEffect(viewModel)`.
+     */
+    fun start() {
+        if (started) return
+        started = true
+        loadListing()
+        if (isAuthenticated) loadFavoriteState()
+    }
+
+    private fun loadFavoriteState() {
+        scope.launch {
+            favoritesRepository
+                .isFavorite(listingId)
+                .fold(
+                    onSuccess = { fav -> _state.update { it.copy(isFavorite = fav) } },
+                    onFailure = { /* non-critical: leave heart in its default state */ },
+                )
+        }
+    }
+
+    private fun loadListing() {
+        _state.update { it.copy(isLoading = true, errorMessage = null) }
+        scope.launch {
+            listingRepository
+                .getListingDetail(listingId)
+                .fold(
+                    onSuccess = { detail ->
+                        _state.update { it.copy(listing = detail, isLoading = false) }
+                    },
+                    onFailure = { e ->
+                        _state.update { it.copy(errorMessage = errorMapper(e), isLoading = false) }
+                    },
+                )
+        }
+    }
+
+    /** Retry the failed listing load. */
+    fun retry() = loadListing()
+
+    /**
+     * Optimistic favorite toggle: flip the heart immediately, then reconcile with the server. On
+     * failure the state rolls back to the previous value so the icon never lies about persisted
+     * state. No-op when unauthenticated or a toggle is already in flight.
+     */
+    fun onFavoriteToggle() {
+        if (!isAuthenticated) return
+        val current = _state.value
+        if (current.isFavoriteLoading) return
+        val previous = current.isFavorite
+        val next = !previous
+        _state.update { it.copy(isFavorite = next, isFavoriteLoading = true) }
+        scope.launch {
+            val result =
+                if (next) favoritesRepository.addFavorite(listingId)
+                else favoritesRepository.removeFavorite(listingId)
+            _state.update { s ->
+                if (result.isFailure) s.copy(isFavorite = previous, isFavoriteLoading = false)
+                else s.copy(isFavoriteLoading = false)
+            }
+        }
+    }
+
+    fun onShowInquiryDialog() = _state.update { it.copy(showInquiryDialog = true) }
+
+    fun onDismissInquiryDialog() =
+        _state.update { it.copy(showInquiryDialog = false, inquiryError = null) }
+
+    fun onShowShareSheet() = _state.update { it.copy(showShareSheet = true) }
+
+    fun onDismissShareSheet() = _state.update { it.copy(showShareSheet = false) }
+
+    /** Submit an inquiry for this listing; emits [ListingDetailEvent.InquirySubmitted] on success. */
+    fun onSubmitInquiry(message: String, name: String?, email: String?, phone: String?) {
+        _state.update { it.copy(isInquirySubmitting = true, inquiryError = null) }
+        scope.launch {
+            val request =
+                CreateInquiryRequest(
+                    listingId = listingId,
+                    message = message,
+                    name = name,
+                    email = email,
+                    phone = phone,
+                )
+            inquiryRepository
+                .createInquiry(request)
+                .fold(
+                    onSuccess = {
+                        _state.update {
+                            it.copy(isInquirySubmitting = false, showInquiryDialog = false)
+                        }
+                        _events.emit(ListingDetailEvent.InquirySubmitted)
+                    },
+                    onFailure = { e ->
+                        _state.update {
+                            it.copy(isInquirySubmitting = false, inquiryError = errorMapper(e))
+                        }
+                    },
+                )
+        }
+    }
+
+    companion object {
+        /**
+         * Builds the view-model together with its [FavoritesRepository] / [InquiryRepository],
+         * keeping repository construction out of the UI layer (previously `remember { … }` inside
+         * the composable). `sessionToken == null` is treated as unauthenticated.
+         */
+        fun create(
+            listingId: String,
+            listingRepository: ListingRepository,
+            baseUrl: String,
+            sessionToken: String?,
+            scope: CoroutineScope,
+            errorMapper: (Throwable) -> String,
+        ): ListingDetailViewModel =
+            ListingDetailViewModel(
+                listingId = listingId,
+                listingRepository = listingRepository,
+                favoritesRepository =
+                    FavoritesRepository(baseUrl = baseUrl, sessionToken = sessionToken),
+                inquiryRepository =
+                    InquiryRepository(baseUrl = baseUrl, sessionToken = sessionToken),
+                scope = scope,
+                isAuthenticated = sessionToken != null,
+                errorMapper = errorMapper,
+            )
+    }
+}

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
@@ -142,14 +142,17 @@ class ListingDetailViewModel(
 
     fun onShowInquiryDialog() = _state.update { it.copy(showInquiryDialog = true) }
 
-    fun onDismissInquiryDialog() =
-        _state.update { it.copy(showInquiryDialog = false, inquiryError = null) }
+    fun onDismissInquiryDialog() = _state.update {
+        it.copy(showInquiryDialog = false, inquiryError = null)
+    }
 
     fun onShowShareSheet() = _state.update { it.copy(showShareSheet = true) }
 
     fun onDismissShareSheet() = _state.update { it.copy(showShareSheet = false) }
 
-    /** Submit an inquiry for this listing; emits [ListingDetailEvent.InquirySubmitted] on success. */
+    /**
+     * Submit an inquiry for this listing; emits [ListingDetailEvent.InquirySubmitted] on success.
+     */
     fun onSubmitInquiry(message: String, name: String?, email: String?, phone: String?) {
         _state.update { it.copy(isInquirySubmitting = true, inquiryError = null) }
         scope.launch {

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
@@ -10,7 +10,6 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -30,8 +29,8 @@ import three.two.bit.ppt.reality.inquiry.InquiryRepository
  *
  * The favorites HTTP layer is driven through a real [FavoritesRepository] over a Ktor [MockEngine]
  * (same harness as `FavoritesToggleRepositoryTest`). The view-model runs on the `runTest`
- * [StandardTestDispatcher], so launched work is deferred until [advanceUntilIdle], letting us assert
- * the optimistic intermediate state before the server responds.
+ * [StandardTestDispatcher], so launched work is deferred until [advanceUntilIdle], letting us
+ * assert the optimistic intermediate state before the server responds.
  */
 class ListingDetailViewModelTest {
 
@@ -60,7 +59,9 @@ class ListingDetailViewModelTest {
 
     /** Repositories that are constructed but never exercised in these toggle tests. */
     private fun unusedListingRepo(): ListingRepository {
-        val engine = MockEngine { respond(content = ByteReadChannel(""), status = HttpStatusCode.OK) }
+        val engine = MockEngine {
+            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+        }
         return ListingRepository(
             baseUrl = "https://example.test",
             client = HttpClient(engine) { install(ContentNegotiation) { json(json) } },
@@ -68,7 +69,9 @@ class ListingDetailViewModelTest {
     }
 
     private fun unusedInquiryRepo(): InquiryRepository {
-        val engine = MockEngine { respond(content = ByteReadChannel(""), status = HttpStatusCode.OK) }
+        val engine = MockEngine {
+            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+        }
         return InquiryRepository(
             baseUrl = "https://example.test",
             client = HttpClient(engine) { install(ContentNegotiation) { json(json) } },
@@ -91,79 +94,83 @@ class ListingDetailViewModelTest {
         )
 
     @Test
-    fun favoriteToggle_success_keeps_optimistic_true() = runTest(StandardTestDispatcher()) {
-        val repo =
-            favoritesRepo(
-                HttpStatusCode.Created,
-                """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
-            )
-        val vm = viewModel(repo, scope = backgroundScope)
+    fun favoriteToggle_success_keeps_optimistic_true() =
+        runTest(StandardTestDispatcher()) {
+            val repo =
+                favoritesRepo(
+                    HttpStatusCode.Created,
+                    """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+                )
+            val vm = viewModel(repo, scope = backgroundScope)
 
-        vm.onFavoriteToggle()
+            vm.onFavoriteToggle()
 
-        // Optimistic: heart is already on and a write is in flight before the server answers.
-        assertTrue(vm.state.value.isFavorite, "heart should flip on immediately (optimistic)")
-        assertTrue(vm.state.value.isFavoriteLoading)
+            // Optimistic: heart is already on and a write is in flight before the server answers.
+            assertTrue(vm.state.value.isFavorite, "heart should flip on immediately (optimistic)")
+            assertTrue(vm.state.value.isFavoriteLoading)
 
-        advanceUntilIdle()
+            advanceUntilIdle()
 
-        // 201 → the optimistic value is confirmed, spinner cleared.
-        assertTrue(vm.state.value.isFavorite, "successful add keeps the heart on")
-        assertFalse(vm.state.value.isFavoriteLoading)
-    }
-
-    @Test
-    fun favoriteToggle_failure_rolls_back_to_previous() = runTest(StandardTestDispatcher()) {
-        // 500 → repository returns Result.failure, so the toggle must roll back.
-        val repo = favoritesRepo(HttpStatusCode.InternalServerError, """{"error":"boom"}""")
-        val vm = viewModel(repo, scope = backgroundScope)
-
-        vm.onFavoriteToggle()
-
-        // Optimistic flip applied first.
-        assertTrue(vm.state.value.isFavorite)
-        assertTrue(vm.state.value.isFavoriteLoading)
-
-        advanceUntilIdle()
-
-        // Rollback: heart returns to its previous (off) state and the spinner clears.
-        assertFalse(vm.state.value.isFavorite, "failed add must roll back to previous value")
-        assertFalse(vm.state.value.isFavoriteLoading)
-    }
+            // 201 → the optimistic value is confirmed, spinner cleared.
+            assertTrue(vm.state.value.isFavorite, "successful add keeps the heart on")
+            assertFalse(vm.state.value.isFavoriteLoading)
+        }
 
     @Test
-    fun favoriteToggle_ignored_when_not_authenticated() = runTest(StandardTestDispatcher()) {
-        val repo =
-            favoritesRepo(
-                HttpStatusCode.Created,
-                """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
-            )
-        val vm = viewModel(repo, scope = backgroundScope, isAuthenticated = false)
+    fun favoriteToggle_failure_rolls_back_to_previous() =
+        runTest(StandardTestDispatcher()) {
+            // 500 → repository returns Result.failure, so the toggle must roll back.
+            val repo = favoritesRepo(HttpStatusCode.InternalServerError, """{"error":"boom"}""")
+            val vm = viewModel(repo, scope = backgroundScope)
 
-        vm.onFavoriteToggle()
-        advanceUntilIdle()
+            vm.onFavoriteToggle()
 
-        assertFalse(vm.state.value.isFavorite, "unauthenticated toggle must be a no-op")
-        assertFalse(vm.state.value.isFavoriteLoading)
-    }
+            // Optimistic flip applied first.
+            assertTrue(vm.state.value.isFavorite)
+            assertTrue(vm.state.value.isFavoriteLoading)
+
+            advanceUntilIdle()
+
+            // Rollback: heart returns to its previous (off) state and the spinner clears.
+            assertFalse(vm.state.value.isFavorite, "failed add must roll back to previous value")
+            assertFalse(vm.state.value.isFavoriteLoading)
+        }
 
     @Test
-    fun favoriteToggle_is_reentrancy_guarded_while_in_flight() = runTest(StandardTestDispatcher()) {
-        val repo =
-            favoritesRepo(
-                HttpStatusCode.Created,
-                """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
-            )
-        val vm = viewModel(repo, scope = backgroundScope)
+    fun favoriteToggle_ignored_when_not_authenticated() =
+        runTest(StandardTestDispatcher()) {
+            val repo =
+                favoritesRepo(
+                    HttpStatusCode.Created,
+                    """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+                )
+            val vm = viewModel(repo, scope = backgroundScope, isAuthenticated = false)
 
-        vm.onFavoriteToggle() // starts add → optimistic true, loading
-        vm.onFavoriteToggle() // must be ignored while the first write is in flight
-        assertTrue(vm.state.value.isFavorite)
+            vm.onFavoriteToggle()
+            advanceUntilIdle()
 
-        advanceUntilIdle()
+            assertFalse(vm.state.value.isFavorite, "unauthenticated toggle must be a no-op")
+            assertFalse(vm.state.value.isFavoriteLoading)
+        }
 
-        // Only the first toggle took effect; state settled on favorited.
-        assertTrue(vm.state.value.isFavorite)
-        assertFalse(vm.state.value.isFavoriteLoading)
-    }
+    @Test
+    fun favoriteToggle_is_reentrancy_guarded_while_in_flight() =
+        runTest(StandardTestDispatcher()) {
+            val repo =
+                favoritesRepo(
+                    HttpStatusCode.Created,
+                    """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+                )
+            val vm = viewModel(repo, scope = backgroundScope)
+
+            vm.onFavoriteToggle() // starts add → optimistic true, loading
+            vm.onFavoriteToggle() // must be ignored while the first write is in flight
+            assertTrue(vm.state.value.isFavorite)
+
+            advanceUntilIdle()
+
+            // Only the first toggle took effect; state settled on favorited.
+            assertTrue(vm.state.value.isFavorite)
+            assertFalse(vm.state.value.isFavoriteLoading)
+        }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
@@ -1,0 +1,169 @@
+package three.two.bit.ppt.reality.listing
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import three.two.bit.ppt.reality.favorites.FavoritesRepository
+import three.two.bit.ppt.reality.inquiry.InquiryRepository
+
+/**
+ * Unit tests for [ListingDetailViewModel]'s optimistic favorite toggle.
+ *
+ * Pins the gap-82-4 behavior that made `ListingDetailScreen` a churn hotspot (issue #2079): the
+ * heart flips immediately (optimistic), then reconciles with the server — keeping the new value on
+ * success and rolling back to the previous value on failure. Previously this logic lived inline in
+ * the composable and was pinned only by a byte-identity script, not an executable test.
+ *
+ * The favorites HTTP layer is driven through a real [FavoritesRepository] over a Ktor [MockEngine]
+ * (same harness as `FavoritesToggleRepositoryTest`). The view-model runs on the `runTest`
+ * [StandardTestDispatcher], so launched work is deferred until [advanceUntilIdle], letting us assert
+ * the optimistic intermediate state before the server responds.
+ */
+class ListingDetailViewModelTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    /** A FavoritesRepository whose every request returns [status] with [body]. */
+    private fun favoritesRepo(status: HttpStatusCode, body: String): FavoritesRepository {
+        val engine = MockEngine {
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return FavoritesRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    /** Repositories that are constructed but never exercised in these toggle tests. */
+    private fun unusedListingRepo(): ListingRepository {
+        val engine = MockEngine { respond(content = ByteReadChannel(""), status = HttpStatusCode.OK) }
+        return ListingRepository(
+            baseUrl = "https://example.test",
+            client = HttpClient(engine) { install(ContentNegotiation) { json(json) } },
+        )
+    }
+
+    private fun unusedInquiryRepo(): InquiryRepository {
+        val engine = MockEngine { respond(content = ByteReadChannel(""), status = HttpStatusCode.OK) }
+        return InquiryRepository(
+            baseUrl = "https://example.test",
+            client = HttpClient(engine) { install(ContentNegotiation) { json(json) } },
+        )
+    }
+
+    private fun viewModel(
+        favorites: FavoritesRepository,
+        scope: kotlinx.coroutines.CoroutineScope,
+        isAuthenticated: Boolean = true,
+    ) =
+        ListingDetailViewModel(
+            listingId = "lst-1",
+            listingRepository = unusedListingRepo(),
+            favoritesRepository = favorites,
+            inquiryRepository = unusedInquiryRepo(),
+            scope = scope,
+            isAuthenticated = isAuthenticated,
+            errorMapper = { it.message ?: "error" },
+        )
+
+    @Test
+    fun favoriteToggle_success_keeps_optimistic_true() = runTest(StandardTestDispatcher()) {
+        val repo =
+            favoritesRepo(
+                HttpStatusCode.Created,
+                """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+            )
+        val vm = viewModel(repo, scope = backgroundScope)
+
+        vm.onFavoriteToggle()
+
+        // Optimistic: heart is already on and a write is in flight before the server answers.
+        assertTrue(vm.state.value.isFavorite, "heart should flip on immediately (optimistic)")
+        assertTrue(vm.state.value.isFavoriteLoading)
+
+        advanceUntilIdle()
+
+        // 201 → the optimistic value is confirmed, spinner cleared.
+        assertTrue(vm.state.value.isFavorite, "successful add keeps the heart on")
+        assertFalse(vm.state.value.isFavoriteLoading)
+    }
+
+    @Test
+    fun favoriteToggle_failure_rolls_back_to_previous() = runTest(StandardTestDispatcher()) {
+        // 500 → repository returns Result.failure, so the toggle must roll back.
+        val repo = favoritesRepo(HttpStatusCode.InternalServerError, """{"error":"boom"}""")
+        val vm = viewModel(repo, scope = backgroundScope)
+
+        vm.onFavoriteToggle()
+
+        // Optimistic flip applied first.
+        assertTrue(vm.state.value.isFavorite)
+        assertTrue(vm.state.value.isFavoriteLoading)
+
+        advanceUntilIdle()
+
+        // Rollback: heart returns to its previous (off) state and the spinner clears.
+        assertFalse(vm.state.value.isFavorite, "failed add must roll back to previous value")
+        assertFalse(vm.state.value.isFavoriteLoading)
+    }
+
+    @Test
+    fun favoriteToggle_ignored_when_not_authenticated() = runTest(StandardTestDispatcher()) {
+        val repo =
+            favoritesRepo(
+                HttpStatusCode.Created,
+                """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+            )
+        val vm = viewModel(repo, scope = backgroundScope, isAuthenticated = false)
+
+        vm.onFavoriteToggle()
+        advanceUntilIdle()
+
+        assertFalse(vm.state.value.isFavorite, "unauthenticated toggle must be a no-op")
+        assertFalse(vm.state.value.isFavoriteLoading)
+    }
+
+    @Test
+    fun favoriteToggle_is_reentrancy_guarded_while_in_flight() = runTest(StandardTestDispatcher()) {
+        val repo =
+            favoritesRepo(
+                HttpStatusCode.Created,
+                """{"id":"fav-1","listing_id":"lst-1","created_at":"2026-04-26T10:00:00Z"}""",
+            )
+        val vm = viewModel(repo, scope = backgroundScope)
+
+        vm.onFavoriteToggle() // starts add → optimistic true, loading
+        vm.onFavoriteToggle() // must be ignored while the first write is in flight
+        assertTrue(vm.state.value.isFavorite)
+
+        advanceUntilIdle()
+
+        // Only the first toggle took effect; state settled on favorited.
+        assertTrue(vm.state.value.isFavorite)
+        assertFalse(vm.state.value.isFavoriteLoading)
+    }
+}


### PR DESCRIPTION
## Task
Hoist ListingDetailScreen state + side-effects out of the composable into a `ListingDetailViewModel` (plain state-holder) per issue #2079 — the stateful entry composable in `ListingDetailScreen.kt` (~lines 55-223) was the churn locus. Expose an immutable `StateFlow` + intent methods (`onFavoriteToggle`/`onSubmitInquiry`/`retry`), move repository construction out of the composable, shrink `ListingDetailScreen` to `collectAsState()` + wiring, and add a ViewModel unit test for the optimistic favorite toggle + rollback-on-failure path. Closes #2079

## Owner
pm-frontend (hint) — actual specialist: **kotlin-mp** (`mobile-native/**` is owned by `pm-mobile`).

## What changed
- **New `ListingDetailViewModel`** (`mobile-native/shared/src/commonMain/.../listing/ListingDetailViewModel.kt`): a plain, framework-agnostic state-holder exposing an immutable `state: StateFlow<ListingDetailUiState>` + a `events: SharedFlow<ListingDetailEvent>` for one-shot navigation. Owns both data loads, the optimistic favorite toggle (+ rollback), inquiry submission, retry, and share/dialog visibility as intent methods.
- **Repository construction moved out of the composable** into `ListingDetailViewModel.create(...)` — previously `remember { FavoritesRepository(...) }` / `InquiryRepository(...)` inline in the composable body.
- **`ListingDetailScreen` shrunk** from ~170 lines of inline state/side-effects to `collectAsState()` + intent wiring against the byte-identical `ListingContent`/`InquiryDialog`/`ShareListingSheet` surfaces PR #2059 already produced.
- **New `ListingDetailViewModelTest`** (`shared/src/commonTest/...`): 4 tests over a real `FavoritesRepository` on a Ktor `MockEngine` (same harness as `FavoritesToggleRepositoryTest`) — optimistic flip, keep-on-success, rollback-on-failure, unauthenticated no-op, and in-flight reentrancy guard.

## Design decisions
- **`commonMain`, not `androidApp` (deviation from issue wording).** The issue proposed `androidApp/.../ui/listing/ListingDetailViewModel.kt`. Placing the state-holder in `shared/commonMain` instead (a) makes the unit test **executed by CI** — `mobile-native.yml`'s `build-android` job runs `:shared:build` (→ `commonTest`), whereas `:androidApp:assembleDebug` does not run app unit tests and no `androidApp` test source set exists; (b) matches the existing `SearchState` convention of pure, testable listing logic in `commonMain`; and (c) lets iOS reuse it later. It is a plain class (no `androidx.lifecycle`), so no Android types leak into `commonMain`.
- **DI by constructor injection, not Koin.** The issue suggested moving repo construction into Koin bindings, but the app currently has **no Koin container anywhere** (no dependency, no module, no bootstrap). Introducing Koin is a cross-cutting infra change touching every screen's wiring and is out of scope for this hotspot refactor. Construction is instead lifted out of the composable into `create(...)` (constructor injection = the DI principle). Full Koin adoption is noted as a follow-up.

## Scope drift
`scope-check.sh --owner pm-frontend` exits 2 (drift) because the `pm-frontend` owner hint maps to `frontend/apps/*-web` + `frontend/packages`, while every changed path is under `mobile-native/**` (owned by `pm-mobile`). This is a **hint/area mismatch, not real drift** — the task is explicitly a kotlin-mp `mobile-native` refactor and all 3 changed files are inside `mobile-native/`. `owner_role` is documented as a non-authoritative hint.

Changed paths (all `mobile-native/`):
- `mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt`
- `mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt`
- `mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt`

## Code-reuse review
`reuse-grep.sh --specialist kotlin-mp` → no warnings. The test harness deliberately reuses the `MockEngine` + `ContentNegotiation` pattern and the 201-favorite payload shape from the existing `FavoritesToggleRepositoryTest`.

## Tested (Band A — fast check)
**Could not run locally — env-limited cloud sandbox.** No Android SDK (`ANDROID_HOME` unset, no `local.properties`); the Gradle wrapper (9.6.0) distribution download is HTTP-403 blocked by the proxy; the system Gradle (8.14.3) cannot resolve the AGP 9.2.1 plugin offline. Per the implement skill's env-limited guidance, **CI (`mobile-native.yml`) is the verification gate** — `lint` (spotlessCheck), `build-android` (`:shared:build` incl. `commonTest`, then `:androidApp:assembleDebug`), and `build-ios`. No passing build is fabricated.

Static review performed: all referenced APIs verified against source (`StateFlow`/`MutableSharedFlow`/`flow.update` present in `commonMain` coroutines-core; `coroutines-test` present in `commonTest`; `FavoritesRepository`/`InquiryRepository`/`ListingRepository` constructors and `getListingDetail`/`addFavorite`/`removeFavorite`/`createInquiry` signatures match usage). Removed now-unused imports from the composable (`kotlinx.coroutines.launch`, `FavoritesRepository`, `InquiryRepository`, `CreateInquiryRequest`).

## Built (Band B — full build)
Skipped — cannot run (see above). CI is the gate.

## CI parity (Band C — hot-path only)
Skipped — not a hot-path PR (client-side UI state refactor; no auth/billing/data-integrity change).

## Notes for the reviewer
- **Behavioral nuance:** the VM is `remember`-keyed on `sessionToken`, so on login/logout it is re-created and `start()` re-runs — which now re-fetches the **listing** as well (the old code re-fetched only the favorite state on auth change, keeping the listing keyed on `listingId`). The re-fetch is idempotent and low-risk (public listing detail); flagged for awareness. Happy to split auth updates into a VM setter if you prefer exact prior behavior.
- The Android-only phone-dial `Intent` stays inline in the composable (it is a UI intent with no VM state); the VM exposes only `listing.realtor.phone`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012oejVXzjVPDw1B64Pr1Q4U

---
_Generated by [Claude Code](https://claude.ai/code/session_012oejVXzjVPDw1B64Pr1Q4U)_