### PR TITLE
gh-issue-2087: reuse shared seed_org fixture in favorite_alert_read idempotency test

### DIFF
--- a/backend/crates/db/tests/favorite_alert_read_idempotent_tests.rs
+++ b/backend/crates/db/tests/favorite_alert_read_idempotent_tests.rs
@@ -32,21 +32,8 @@ use db::repositories::{FavoriteAlertReadOutcome, RealityPortalRepository};
 use sqlx::PgPool;
 use uuid::Uuid;
 
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Org {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@fav-idem.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
+mod common;
+use common::seed_org;
 
 async fn seed_portal_user(pool: &PgPool, email: &str) -> Uuid {
     // portal_users was merged into `users` (migration 00132); portal users are


### PR DESCRIPTION
## Task
Reuse the shared tests/common fixture in the favorite_alert_read idempotency test. Closes #2087. In `backend/crates/db/tests/favorite_alert_read_idempotent_tests.rs`, the file declared its own private `seed_org` helper byte-identical (modulo the contact-email suffix) to the canonical `seed_org` in `backend/crates/db/tests/common/mod.rs` (whose doc-comment explicitly says to reuse it, not re-copy). Added `mod common;` and `use common::seed_org;` and DELETED the local `seed_org`. Left the other local helpers (`seed_portal_user`, `seed_listing`, `seed_pending_alert`) as-is. Behavior kept identical.

## Owner
pm-tech-lead (routed to rust-backend)

## Notes
The only difference between the two `seed_org` bodies was the contact-email suffix (`@fav-idem.test` local vs `@orgs.test` canonical). The test never reads or asserts on the org contact email — it uses only the returned `org_id` — so switching to the canonical suffix is behavior-preserving. No email-suffix expectations needed adjustment.

## Tested (Band A — fast check)
- `cargo fmt -p db -- --check` → exit 0
- `SQLX_OFFLINE=true cargo check -p db --test favorite_alert_read_idempotent_tests` → exit 0 (Finished dev profile)

DB execution of the `#[sqlx::test]` body is deferred to CI (backend.yml provisions Postgres).

## Built (Band B — full build)
skipped: change <50 LOC test-only refactor, no public API/config touch

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only, no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
scope-check.sh (owner=pm-tech-lead) flagged `backend/crates/db/tests/favorite_alert_read_idempotent_tests.rs` as outside the owner's mapped areas (exit 2, advisory). The change is a backend db-crate test cleanup that matches the routed `rust-backend` specialist; reviewer to adjudicate.

## Code-reuse review
none — no new auth/crypto/http helpers added; this PR removes a duplicate helper in favor of the canonical one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJSW1kPkZ6yrKGyp2D7kuG)_