### PR TITLE
gh-issue-2086: enforce SlovakAccountingExport honesty invariant by construction

### DIFF
--- a/backend/crates/db/src/models/regional_compliance.rs
+++ b/backend/crates/db/src/models/regional_compliance.rs
@@ -392,38 +392,88 @@ pub struct SlovakAccountingExport {
     /// `true` when one or more monetary fields could not be computed and are
     /// returned as `null`. A partial export is NOT a complete accounting
     /// statement — see `unsupported_fields` for which figures are missing.
-    pub partial: bool,
+    ///
+    /// Intentionally `pub(crate)`: this flag is *derived* from the `Option`
+    /// monetary fields and must never be hand-set. External crates therefore
+    /// cannot build a literal and are forced through [`SlovakAccountingExport::new`],
+    /// which computes it — the honesty invariant (#2030/#2086) is enforced by
+    /// construction, not by remembering to call a mutator.
+    pub(crate) partial: bool,
     /// Names of the fields that are not yet computed and are returned as
     /// `null` (e.g. `["total_expenses", "total_payables"]`). Empty when the
     /// export is complete.
-    pub unsupported_fields: Vec<String>,
+    ///
+    /// `pub(crate)` for the same reason as [`Self::partial`] — derived, never
+    /// hand-set; use [`SlovakAccountingExport::new`].
+    pub(crate) unsupported_fields: Vec<String>,
     pub download_url: Option<String>,
     pub export_data: Option<serde_json::Value>,
     pub generated_at: DateTime<Utc>,
 }
 
 impl SlovakAccountingExport {
-    /// Derive `partial` and `unsupported_fields` from the `Option` monetary
-    /// fields, keeping the honesty invariant (#2030) co-located with the fields
-    /// it depends on instead of being hand-rolled in the route handler.
+    /// Smart constructor: the ONLY way to build a `SlovakAccountingExport`.
+    ///
+    /// Takes every non-derived field and computes `partial` +
+    /// `unsupported_fields` internally from the `Option` monetary fields before
+    /// returning, so no caller can obtain an instance whose honesty flags are
+    /// un-derived or stale (#2086). This replaces the old
+    /// build-literal-then-`compute_partial(&mut self)` dance, where a caller who
+    /// forgot the mutator would silently ship a "looks complete but isn't"
+    /// export — exactly the dishonesty #2030 set out to kill.
     ///
     /// A monetary field that is `None` is **not available** (not a genuine
     /// zero): it serializes as JSON `null` and its name is enumerated in
     /// `unsupported_fields`. `partial` is `true` iff at least one such field is
     /// missing. When a new `Option` monetary field is added to this struct,
     /// extend the checks below so it is covered here in one place rather than
-    /// being silently omitted from the derivation (which would re-introduce the
-    /// "looks complete but isn't" dishonesty #2030 set out to kill).
-    pub fn compute_partial(&mut self) {
+    /// being silently omitted from the derivation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        export_id: Uuid,
+        organization_id: Uuid,
+        from_date: NaiveDate,
+        to_date: NaiveDate,
+        format: SlovakAccountingFormat,
+        invoice_count: i32,
+        payment_count: i32,
+        journal_entry_count: i32,
+        total_revenue: Decimal,
+        total_expenses: Option<Decimal>,
+        total_receivables: Decimal,
+        total_payables: Option<Decimal>,
+        download_url: Option<String>,
+        export_data: Option<serde_json::Value>,
+        generated_at: DateTime<Utc>,
+    ) -> Self {
         let mut unsupported_fields = Vec::new();
-        if self.total_expenses.is_none() {
+        if total_expenses.is_none() {
             unsupported_fields.push("total_expenses".to_string());
         }
-        if self.total_payables.is_none() {
+        if total_payables.is_none() {
             unsupported_fields.push("total_payables".to_string());
         }
-        self.partial = !unsupported_fields.is_empty();
-        self.unsupported_fields = unsupported_fields;
+        let partial = !unsupported_fields.is_empty();
+
+        Self {
+            export_id,
+            organization_id,
+            from_date,
+            to_date,
+            format,
+            invoice_count,
+            payment_count,
+            journal_entry_count,
+            total_revenue,
+            total_expenses,
+            total_receivables,
+            total_payables,
+            partial,
+            unsupported_fields,
+            download_url,
+            export_data,
+            generated_at,
+        }
     }
 }
 
@@ -678,25 +728,23 @@ mod tests {
     /// serialize as a number.
     #[test]
     fn uncomputed_totals_serialize_as_null_not_zero() {
-        let export = SlovakAccountingExport {
-            export_id: Uuid::nil(),
-            organization_id: Uuid::nil(),
-            from_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
-            to_date: NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
-            format: SlovakAccountingFormat::Pohoda,
-            invoice_count: 3,
-            payment_count: 2,
-            journal_entry_count: 5,
-            total_revenue: Decimal::new(12345, 2),
-            total_expenses: None,
-            total_receivables: Decimal::ZERO,
-            total_payables: None,
-            partial: true,
-            unsupported_fields: vec!["total_expenses".into(), "total_payables".into()],
-            download_url: None,
-            export_data: None,
-            generated_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
-        };
+        let export = SlovakAccountingExport::new(
+            Uuid::nil(),
+            Uuid::nil(),
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            SlovakAccountingFormat::Pohoda,
+            3,
+            2,
+            5,
+            Decimal::new(12345, 2),
+            None,
+            Decimal::ZERO,
+            None,
+            None,
+            None,
+            DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        );
 
         let json = serde_json::to_value(&export).expect("serialize export");
 
@@ -714,47 +762,41 @@ mod tests {
         );
     }
 
-    /// Baseline export whose `partial`/`unsupported_fields` are deliberately
-    /// seeded with WRONG values, so a passing assertion proves
-    /// `compute_partial` actually (re)derived them rather than reading stale
-    /// hand-set state.
+    /// Build an export via the smart constructor with only the two monetary
+    /// `Option`s varied — `new` is responsible for deriving `partial` /
+    /// `unsupported_fields`, so there is no hand-set state to go stale.
     fn export_with(
         total_expenses: Option<Decimal>,
         total_payables: Option<Decimal>,
     ) -> SlovakAccountingExport {
-        SlovakAccountingExport {
-            export_id: Uuid::nil(),
-            organization_id: Uuid::nil(),
-            from_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
-            to_date: NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
-            format: SlovakAccountingFormat::Pohoda,
-            invoice_count: 0,
-            payment_count: 0,
-            journal_entry_count: 0,
-            total_revenue: Decimal::ZERO,
+        SlovakAccountingExport::new(
+            Uuid::nil(),
+            Uuid::nil(),
+            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            SlovakAccountingFormat::Pohoda,
+            0,
+            0,
+            0,
+            Decimal::ZERO,
             total_expenses,
-            total_receivables: Decimal::ZERO,
+            Decimal::ZERO,
             total_payables,
-            // Intentionally inconsistent seed values — compute_partial must
-            // overwrite both.
-            partial: false,
-            unsupported_fields: vec!["stale".to_string()],
-            download_url: None,
-            export_data: None,
-            generated_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
-        }
+            None,
+            None,
+            DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        )
     }
 
-    /// #2053: exercise the derivation itself (not just serialization). Feeds
-    /// every combination of present/absent monetary fields through
-    /// `compute_partial` and asserts the exact `partial` + `unsupported_fields`
-    /// outcome, so a handler that forgets to set `partial` or mislabels a field
-    /// is caught.
+    /// #2053/#2086: exercise the derivation performed by the smart constructor.
+    /// Feeds every combination of present/absent monetary fields through
+    /// `SlovakAccountingExport::new` and asserts the exact `partial` +
+    /// `unsupported_fields` outcome, so a construction path that mislabels or
+    /// omits a field is caught.
     #[test]
     fn compute_partial_derives_from_option_fields() {
         // Both monetary fields missing -> partial, both enumerated in order.
-        let mut both_missing = export_with(None, None);
-        both_missing.compute_partial();
+        let both_missing = export_with(None, None);
         assert!(both_missing.partial);
         assert_eq!(
             both_missing.unsupported_fields,
@@ -762,8 +804,7 @@ mod tests {
         );
 
         // Only expenses missing -> partial, only expenses listed.
-        let mut expenses_missing = export_with(None, Some(Decimal::new(500, 2)));
-        expenses_missing.compute_partial();
+        let expenses_missing = export_with(None, Some(Decimal::new(500, 2)));
         assert!(expenses_missing.partial);
         assert_eq!(
             expenses_missing.unsupported_fields,
@@ -771,8 +812,7 @@ mod tests {
         );
 
         // Only payables missing -> partial, only payables listed.
-        let mut payables_missing = export_with(Some(Decimal::new(500, 2)), None);
-        payables_missing.compute_partial();
+        let payables_missing = export_with(Some(Decimal::new(500, 2)), None);
         assert!(payables_missing.partial);
         assert_eq!(
             payables_missing.unsupported_fields,
@@ -780,8 +820,7 @@ mod tests {
         );
 
         // Everything present (incl. genuine zero) -> complete, no unsupported.
-        let mut complete = export_with(Some(Decimal::ZERO), Some(Decimal::ZERO));
-        complete.compute_partial();
+        let complete = export_with(Some(Decimal::ZERO), Some(Decimal::ZERO));
         assert!(!complete.partial);
         assert!(complete.unsupported_fields.is_empty());
     }

--- a/backend/servers/api-server/src/routes/regional_compliance.rs
+++ b/backend/servers/api-server/src/routes/regional_compliance.rs
@@ -448,12 +448,18 @@ async fn export_slovak_accounting(
 
     let journal_entry_count = invoice_count + payment_count;
 
-    let mut export = SlovakAccountingExport {
-        export_id: Uuid::new_v4(),
-        organization_id: org_id,
-        from_date: payload.from_date,
-        to_date: payload.to_date,
-        format: payload.format,
+    // Build via the smart constructor (#2086): `partial` + `unsupported_fields`
+    // are derived inside `new` from the `Option` monetary fields, so this
+    // handler cannot ship a "looks complete but isn't" export by forgetting a
+    // mutator. Un-computed fields serialize as JSON `null` and are enumerated in
+    // `unsupported_fields`, letting consumers distinguish "not available" from a
+    // genuine zero (#2030).
+    let export = SlovakAccountingExport::new(
+        Uuid::new_v4(),
+        org_id,
+        payload.from_date,
+        payload.to_date,
+        payload.format,
         invoice_count,
         payment_count,
         journal_entry_count,
@@ -461,22 +467,13 @@ async fn export_slovak_accounting(
         total_expenses,
         total_receivables,
         total_payables,
-        // Derived below by `compute_partial` from the `Option` monetary fields.
-        partial: false,
-        unsupported_fields: Vec::new(),
-        download_url: Some(format!(
+        Some(format!(
             "/api/v1/regional-compliance/slovak/accounting/download/{}",
             Uuid::new_v4()
         )),
-        export_data: None,
-        generated_at: Utc::now(),
-    };
-    // Surface un-computed monetary fields honestly (#2030): sets `partial` +
-    // `unsupported_fields` so consumers can distinguish "not available" from a
-    // genuine zero, rather than the previous misleading hardcoded 0. The
-    // derivation lives on the model (#2053) so the invariant stays co-located
-    // with the fields it depends on.
-    export.compute_partial();
+        None,
+        Utc::now(),
+    );
 
     let result = Ok(Json(export));
     rls.release().await;


### PR DESCRIPTION
## Task
Make the SlovakAccountingExport honesty invariant enforced-by-construction, not call-me-or-forget. Closes #2086. Replaces `SlovakAccountingExport::compute_partial(&mut self)` — which the caller had to remember to call after building a literal with placeholder `partial:false, unsupported_fields:vec[]` — with a smart constructor `SlovakAccountingExport::new(...)` that takes all non-derived fields and computes `partial` + `unsupported_fields` internally before returning, so no caller can obtain an instance with un-derived flags. Updates the single caller in `backend/servers/api-server/src/routes/regional_compliance.rs` and ports the existing `compute_partial` unit-test cases (all four) onto the constructor.

## Design
- New `SlovakAccountingExport::new(...) -> Self` derives `partial` + `unsupported_fields` from the `Option` monetary fields.
- The two derived fields are now `pub(crate)`, so **external crates cannot literal-construct** the struct — api-server (a separate crate) is forced through `new`. That is what makes the invariant enforced *by construction* rather than by remembering a mutator. Serialization / `ToSchema` / `Deserialize` are unaffected (derives live in the same module and JSON output is unchanged).
- `compute_partial(&mut self)` removed; the derivation logic is unchanged, just relocated into `new`.

## Owner
pm-tech-lead (routed to rust-backend)

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports exit 2 because `pm-tech-lead` maps only to `docs/**` / `.research/**`. Both changed files are backend Rust and are the *exact* files named by the task (routed pm-tech-lead → rust-backend). Drift is expected and justified:
- `backend/crates/db/src/models/regional_compliance.rs`
- `backend/servers/api-server/src/routes/regional_compliance.rs`

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no warnings.

## Tested (Band A — fast check)
- `cargo check -p db` → exit 0
- `cargo test -p db --lib regional_compliance` → exit 0 (2 passed: `compute_partial_derives_from_option_fields` covering all four present/absent combos, `uncomputed_totals_serialize_as_null_not_zero`)
- `cargo fmt -p db --check` → exit 0; `cargo clippy -p db --lib` → exit 0 (no warnings)
- `cargo fmt -p api-server --check` → exit 0

## Built (Band B — full build)
Skipped a full `api-server` build: `utoipa-swagger-ui` downloads swagger-ui at build time, which fails in this sandbox. The caller edit is a mechanical positional call matching `new`'s signature and is fmt-clean; compilation of the api-server crate is deferred to CI (`backend.yml`).

## CI parity (Band C — hot-path only)
Skipped: pure model refactor, no auth/billing/data-integrity behavior change (JSON output identical).

## Remote-tested
skipped

## Notes
- No behavior change on the wire: same fields, same JSON, same `partial`/`unsupported_fields` derivation.
- Deferred to CI: full api-server compile (swagger-ui download blocked locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJSW1kPkZ6yrKGyp2D7kuG

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJSW1kPkZ6yrKGyp2D7kuG)_