### PR TITLE
gh-issue-2106: gate backend/deny.toml with code-owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,8 +22,16 @@
 # in-range Dependabot bump changes ONLY the lockfile. Without an owner on
 # Cargo.lock the resolved quick-xml version could move with no review request.
 #
+# backend/deny.toml is owned for the same reason (see GH #2106 / PR #2096):
+# enforcement of the quick-xml pin moved from the manifest + an advisory
+# workflow to a hard `bans` entry in deny.toml. That ban is now the
+# load-bearing guard — a PR that widens or deletes it would silently re-open
+# the XXE / billion-laughs pin, so every change to deny.toml must get an
+# explicit owner review just like the manifest and lockfile above.
+#
 # NOTE: CODEOWNERS review is only *mandatory* when branch protection on `dev`
 # has "Require review from Code Owners" enabled. That setting is not
 # verifiable in-repo — confirm it is on, otherwise this guard is advisory.
 /backend/Cargo.toml    @martin-janci
 /backend/Cargo.lock    @martin-janci
+/backend/deny.toml     @martin-janci


### PR DESCRIPTION
## Task
Follow-up: `deny.toml` quick-xml ban is now load-bearing but not CODEOWNERS-gated (PR #2096). Enforcement of the quick-xml XXE/billion-laughs pin moved from CODEOWNERS-gated files (`Cargo.toml`/`Cargo.lock`) + an advisory workflow to a hard `bans` entry in `backend/deny.toml` — but `backend/deny.toml` was NOT in `.github/CODEOWNERS`, so a PR could widen or delete the ban with no code-owner review, silently re-opening the pin.

Closes #2106

## Change
- Add `/backend/deny.toml    @martin-janci` to `.github/CODEOWNERS`, mirroring the exact path/owner convention of the existing `/backend/Cargo.toml` and `/backend/Cargo.lock` lines (leading slash, owner column aligned).
- Extend the "Security-pinned dependency manifest" header comment to record that `deny.toml` now carries the load-bearing quick-xml ban (the `bans` entry at `backend/deny.toml:93-94` pinning `quick-xml =0.41.0`).

Config/docs-only change — no compiled code touched.

## Owner
pm-tech-lead (routed to `generic` specialist — config/docs change)

## Tested (Band A — fast check)
- `git diff --check` → exit 0 (no whitespace errors)
- Verified CODEOWNERS well-formedness by hand: `/backend/deny.toml` is a root-anchored path pattern that matches `backend/deny.toml`; owner `@martin-janci` matches the existing lines; `@martin-janci` column (24) aligned across all three owner lines.
- Confirmed the ban it guards exists and is load-bearing: `backend/deny.toml` `[bans]` at lines 93-94 pin `quick-xml` to `=0.41.0` (XXE/billion-laughs).
- No `.pre-commit-config.yaml` in repo → nothing further to run for the `generic` band.

## Built (Band B — full build)
skipped: config/docs-only change (<50 LOC, no compiled code / build output touched). No cargo build needed.

## CI parity (Band C — hot-path only)
skipped: no security/auth/billing/data-integrity *code* changed. This is a governance/config edit; the guarantee it restores (code-owner review of `deny.toml`) is enforced by GitHub branch protection, not by CI.

## Scope drift
None — `scope-check.sh` exit 0. Only `.github/CODEOWNERS` touched.

## Code-reuse review
None — no new helpers/symbols added.

## Notes
- This diff only adds the CODEOWNERS ownership entry. The guard is **only mandatory** when branch protection on `dev` has "Require review from Code Owners" enabled — that is an operator / GitHub-settings concern outside this diff and not verifiable in-repo. The existing header NOTE already flags this; please confirm the setting is on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aca3fAc11N1fEqQoxdLEy2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aca3fAc11N1fEqQoxdLEy2)_