### PR TITLE
gh-issue-2102: wire MCP-push size guard + action-list reconcile into dispatcher Phase 6

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -1994,6 +1994,26 @@ if [ "$NEW_COMBINED" -lt "$((OLD_COMBINED - 2))" ]; then
   exit 0
 fi
 
+# Action-list archive-move reconcile (issue #1014 / #2102 ROOT-CAUSE fix).
+# Mirror of the assignments split (archive-reconcile.sh keeps assignments.json
+# small): sweep terminal action-list rows (done/dropped) into
+# action-list-archive.json so action-list.json stays well under the 64 KiB MCP
+# inline-push ceiling. An un-swept, bloated action-list.json is exactly what a
+# Phase-6 MCP-push fallback truncates and silently corrupts on dev (#1014). The
+# script is idempotent and combined-count-guarded (see its header) — a no-op on
+# already-clean state, so it is safe to run unconditionally every Phase 6.
+AL_ITEMS_BEFORE=$(jq '.items | length' .research/management/action-list.json 2>/dev/null || echo 0)
+if ! bash .research/action-list-reconcile.sh --apply; then
+  echo "PHASE 6: action-list-reconcile --apply failed (combined-count guard or jq error) — leaving action-list.json untouched and continuing; T26 self-test below will catch any residual terminal bloat." >&2
+fi
+AL_ITEMS_AFTER=$(jq '.items | length' .research/management/action-list.json 2>/dev/null || echo 0)
+# Stage the reconciled pair only when rows actually moved (keeps the commit
+# tight — no churn on a clean no-op run).
+if [ "$AL_ITEMS_AFTER" != "$AL_ITEMS_BEFORE" ]; then
+  git add .research/management/action-list.json \
+          .research/management/action-list-archive.json
+fi
+
 git add .research/management/assignments.json \
         .research/management/assignments-archive.json \
         [.research/management/action-list.json if refilled or GC1 cascade closed rows] \
@@ -2053,6 +2073,16 @@ INTENDED_TREE=$(git rev-parse HEAD^{tree})   # the state tree we MUST land (reba
 # fall back to git push only when the MCP tool is unavailable. `PUSH_METHOD=git`
 # forces the legacy path for environments where direct push works.
 if [ "${PUSH_METHOD:-mcp}" = "mcp" ]; then
+  # Backstop (issue #1014 / #2102): before the inline MCP push, hard-check every
+  # STAGED file against the 64 KiB inline-push ceiling. FAIL CLOSED — a blocked
+  # push is recoverable (the next run retries on a fixed base), a silently-
+  # truncated MCP push is not. The structural fix is the action-list reconcile
+  # staged above; this guard is the belt-and-suspenders that catches any file
+  # still oversize (e.g. the reconcile was skipped or failed).
+  if ! PUSH_METHOD=mcp bash .research/mcp-push-size-guard.sh --staged; then
+    echo "PHASE 6 ABORT: mcp-push-size-guard tripped — a staged file exceeds the MCP inline-push ceiling; refusing to MCP-push (would truncate/corrupt it on dev, #1014). Remediation: re-run the reconcilers to shrink state, or land this run via 'PUSH_METHOD=git' where the proxy allows. Not marking this run successful." >&2
+    exit 0
+  fi
   : # land the Phase 6 file delta via mcp__github__push_files onto dev (one commit).
     # A GITHUB_TOKEN/API push does not re-trigger version-bump on its own, which also
     # caps the rapid-bump churn (finding subagent-race-on-dev-push).

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -42,9 +42,11 @@ FAIL=0
 note() { printf '  ok    %s\n' "$1"; }
 fail() { printf '  FAIL  %s\n' "$1" >&2; FAIL=1; }
 # warn() — advisory only: prints but does NOT set FAIL. Used for invariants
-# that are self-healing on the next run (e.g. action-list archive bloat, which
-# action-list-reconcile.sh sweeps) so introducing the check doesn't retroactively
-# hard-fail an already-bloated dev snapshot.
+# that are self-healing on the next run (e.g. T28 gc1 archive-terminal drift,
+# which gc1-reconcile.sh sweeps) so introducing the check doesn't retroactively
+# hard-fail an already-drifted dev snapshot. (T26 was formerly a warn of this
+# kind but was promoted to fail in #2102 once Phase 6 began running the
+# action-list reconcile before the pre-commit self-test gate.)
 warn() { printf '  WARN  %s\n' "$1" >&2; }
 
 echo "==> dispatcher-self-test"
@@ -618,14 +620,19 @@ fi
 # Spec (dispatcher-prompt.md Phase 1 step 4): action-list.json carries only
 # open/in-progress items; done/dropped live in action-list-archive.json. Bloat
 # from un-archived terminal rows is what pushed the file past the MCP inline
-# push limit and corrupted it on dev. Advisory (warn, not fail) because
-# action-list-reconcile.sh --apply is self-healing on the next Phase 6.
-echo "T26 action-list.json holds non-terminal items only (issue #1014; advisory)"
+# push limit and corrupted it on dev. ENFORCED (fail) as of #2102: Phase 6 now
+# runs `bash .research/action-list-reconcile.sh --apply` BEFORE the pre-commit
+# self-test gate, so a clean action-list is guaranteed on the commit path. A
+# terminal row surviving to this check therefore means the reconcile was
+# skipped or failed — a real invariant breach that must block the MCP push
+# (a bloated action-list.json is the #1014 truncation vector), not transient
+# self-healing bloat. Promoting warn→fail is only safe BECAUSE of that wiring.
+echo "T26 action-list.json holds non-terminal items only (issue #1014; enforced)"
 if [ -f "$ACTION_LIST" ]; then
   TERM=$(jq -r '[.items[] | select(.status=="done" or .status=="dropped" or .status=="merged" or .status=="failed")] | length' "$ACTION_LIST")
   if [ "$TERM" = "0" ]; then note "no terminal items in action-list.json (archive split clean)"
   else
-    warn "$TERM terminal item(s) in action-list.json — run: bash .research/action-list-reconcile.sh --apply"
+    fail "$TERM terminal item(s) in action-list.json — run: bash .research/action-list-reconcile.sh --apply"
   fi
 else
   printf '  skip  %s not found\n' "$ACTION_LIST"


### PR DESCRIPTION
## Task
Follow-up: wire MCP-push size guard + action-list reconcile into dispatcher Phase 6 (PR #2101) (Closes #2102)

Root-cause fix for the #1014 MCP-push corruption class. PR #2101 added a triage doc + exec-bit restore but deliberately left the root cause. This PR wires the two existing scripts into the dispatcher so a bloated `action-list.json` can no longer be truncated/corrupted by a Phase-6 MCP-push fallback.

## Owner
pm-tech-lead (→ `generic` specialist; `.research/**` shell/docs change)

## Changes
**Fix #1 (primary) — `.research/dispatcher-prompt.md` (Phase 6, before the self-commit `git add`):**
- Runs `bash .research/action-list-reconcile.sh --apply` to sweep terminal action-list rows (done/dropped) into `action-list-archive.json`, mirroring how `archive-reconcile.sh` keeps `assignments.json` small.
- Stages `action-list.json` + `action-list-archive.json` only when rows actually moved (keeps the commit tight; no churn on a clean no-op run).
- Keeps `action-list.json` under the 64 KiB MCP inline-push ceiling so a Phase-6 MCP-push fallback can't truncate it.

**Fix #2 (backstop):**
- `.research/dispatcher-prompt.md` (MCP push branch): added a fail-closed `PUSH_METHOD=mcp bash .research/mcp-push-size-guard.sh --staged` guard. A blocked push is recoverable (next run retries on a fixed base); a truncated one is not — so it aborts (`exit 0`) rather than MCP-pushing an oversize staged file.
- `.research/dispatcher-self-test.sh`: promoted **T26 from `warn` → `fail`**. Safe *only* in tandem with Fix #1: Phase 6 now runs the reconcile before the pre-commit self-test gate, so a clean action-list is guaranteed on the commit path and a terminal row surviving to T26 now signals the reconcile was skipped/failed (a real breach), not transient self-healing bloat. Also refreshed the stale `warn()` doc example (T26 was cited there) to point at the still-advisory T28.

Both referenced scripts (`action-list-reconcile.sh`, `mcp-push-size-guard.sh`) already existed and are unmodified — this PR only wires them in.

## Tested (Band A — fast check)
- `bash -n .research/dispatcher-self-test.sh` → exit 0 (syntax OK)
- `bash -n .research/action-list-reconcile.sh` / `.research/mcp-push-size-guard.sh` → exit 0
- `bash .research/dispatcher-self-test.sh` → **PASS** (exit 0); T26 now prints `enforced` and `ok no terminal items in action-list.json` on the current clean state (0 terminal items).
- size-guard fail-closed smoke: `--staged`-equivalent explicit-file run → small file exit 0, 70 KB file exit 3 (ABORT), `PUSH_METHOD=git` → exit 0 (skipped).
- shellcheck not installed in env — `bash -n` used instead.

## Built (Band B — full build)
skipped: docs/scripts change under `.research/**`, no compiled surface.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity code; `.research/**` tooling only).

## Remote-tested
skipped (no ppt-bridge MCP needed for a `.research/**` change).

## Scope drift
None — diff touches exactly `.research/dispatcher-prompt.md` + `.research/dispatcher-self-test.sh`. No `.research/management/**` state files modified.

## Code-reuse review
none — no new helpers; wires two pre-existing scripts.

## Notes
- Current `action-list.json` is clean (0 terminal items, 13 KB), so the T26 warn→fail promotion does not block any run today; the reconcile keeps it that way going forward.
- Verify ran inside an isolated worktree; the dispatcher working tree was untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QRY8GiFiiN4ER6n3WcUqY

---
_Generated by [Claude Code](https://claude.ai/code/session_011QRY8GiFiiN4ER6n3WcUqY)_