### PR TITLE
gh-issue-2108: ListingDetail auth change resets screen to spinner; test hoisted paths

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
@@ -66,7 +66,8 @@ fun ListingDetailScreen(
     val sessionToken = (authState as? AuthState.Authenticated)?.sessionToken
     // State + side-effects are hoisted into ListingDetailViewModel (commonMain). This composable
     // is now a `collectAsState()` render + intent wiring — see issue #2079. The VM is keyed only on
-    // `listingId`: an auth change no longer re-creates it (which would flip the whole screen back to
+    // `listingId`: an auth change no longer re-creates it (which would flip the whole screen back
+    // to
     // the full-screen spinner and reload the listing — issue #2108). Instead `updateAuth` below
     // rebuilds the auth-scoped repositories and re-syncs just the favorite heart.
     val viewModel =

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
@@ -65,10 +65,12 @@ fun ListingDetailScreen(
 
     val sessionToken = (authState as? AuthState.Authenticated)?.sessionToken
     // State + side-effects are hoisted into ListingDetailViewModel (commonMain). This composable
-    // is now a `collectAsState()` render + intent wiring — see issue #2079. The VM is re-created on
-    // session-token change so its repositories carry the current auth header.
+    // is now a `collectAsState()` render + intent wiring — see issue #2079. The VM is keyed only on
+    // `listingId`: an auth change no longer re-creates it (which would flip the whole screen back to
+    // the full-screen spinner and reload the listing — issue #2108). Instead `updateAuth` below
+    // rebuilds the auth-scoped repositories and re-syncs just the favorite heart.
     val viewModel =
-        remember(sessionToken, listingId) {
+        remember(listingId) {
             ListingDetailViewModel.create(
                 listingId = listingId,
                 listingRepository = repository,
@@ -81,6 +83,9 @@ fun ListingDetailScreen(
     val state by viewModel.state.collectAsState()
 
     LaunchedEffect(viewModel) { viewModel.start() }
+    // Re-key the auth-scoped repos + re-probe the favorite heart on login/logout, without
+    // disturbing the loaded listing. No-op on first composition (token unchanged).
+    LaunchedEffect(sessionToken) { viewModel.updateAuth(sessionToken) }
     LaunchedEffect(viewModel) {
         viewModel.events.collect { event ->
             when (event) {

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
@@ -56,9 +56,10 @@ sealed interface ListingDetailEvent {
  * @param scope the coroutine scope the loads/writes launch into. On Android this is a
  *   `rememberCoroutineScope()`, so in-flight work is cancelled when the screen leaves composition;
  *   in tests it is the `TestScope` from `runTest`.
- * @param favoritesRepositoryFactory builds a [FavoritesRepository] carrying the given session token.
- *   Held as a factory (rather than a ready-made repo) so [updateAuth] can rebuild the auth-scoped
- *   repositories on a login/logout without re-creating the whole view-model — see issue #2108.
+ * @param favoritesRepositoryFactory builds a [FavoritesRepository] carrying the given session
+ *   token. Held as a factory (rather than a ready-made repo) so [updateAuth] can rebuild the
+ *   auth-scoped repositories on a login/logout without re-creating the whole view-model — see
+ *   issue #2108.
  * @param inquiryRepositoryFactory builds an [InquiryRepository] carrying the given session token.
  * @param initialSessionToken the session token at construction time (`null` == unauthenticated).
  * @param errorMapper maps a caught [Throwable] to a user-facing message — injected because the
@@ -85,8 +86,7 @@ class ListingDetailViewModel(
     private var isAuthenticated: Boolean = initialSessionToken != null
     private var favoritesRepository: FavoritesRepository =
         favoritesRepositoryFactory(initialSessionToken)
-    private var inquiryRepository: InquiryRepository =
-        inquiryRepositoryFactory(initialSessionToken)
+    private var inquiryRepository: InquiryRepository = inquiryRepositoryFactory(initialSessionToken)
 
     private var started = false
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
@@ -56,16 +56,21 @@ sealed interface ListingDetailEvent {
  * @param scope the coroutine scope the loads/writes launch into. On Android this is a
  *   `rememberCoroutineScope()`, so in-flight work is cancelled when the screen leaves composition;
  *   in tests it is the `TestScope` from `runTest`.
+ * @param favoritesRepositoryFactory builds a [FavoritesRepository] carrying the given session token.
+ *   Held as a factory (rather than a ready-made repo) so [updateAuth] can rebuild the auth-scoped
+ *   repositories on a login/logout without re-creating the whole view-model — see issue #2108.
+ * @param inquiryRepositoryFactory builds an [InquiryRepository] carrying the given session token.
+ * @param initialSessionToken the session token at construction time (`null` == unauthenticated).
  * @param errorMapper maps a caught [Throwable] to a user-facing message — injected because the
  *   Android strings come from `stringResource(...)`, which is not reachable from `commonMain`.
  */
 class ListingDetailViewModel(
     private val listingId: String,
     private val listingRepository: ListingRepository,
-    private val favoritesRepository: FavoritesRepository,
-    private val inquiryRepository: InquiryRepository,
+    private val favoritesRepositoryFactory: (sessionToken: String?) -> FavoritesRepository,
+    private val inquiryRepositoryFactory: (sessionToken: String?) -> InquiryRepository,
     private val scope: CoroutineScope,
-    private val isAuthenticated: Boolean,
+    initialSessionToken: String?,
     private val errorMapper: (Throwable) -> String,
 ) {
     private val _state = MutableStateFlow(ListingDetailUiState())
@@ -73,6 +78,15 @@ class ListingDetailViewModel(
 
     private val _events = MutableSharedFlow<ListingDetailEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<ListingDetailEvent> = _events.asSharedFlow()
+
+    // Auth-scoped state. The favorites/inquiry repositories carry the bearer token, so they are
+    // rebuilt (not the whole view-model) whenever the session changes — see [updateAuth].
+    private var currentSessionToken: String? = initialSessionToken
+    private var isAuthenticated: Boolean = initialSessionToken != null
+    private var favoritesRepository: FavoritesRepository =
+        favoritesRepositoryFactory(initialSessionToken)
+    private var inquiryRepository: InquiryRepository =
+        inquiryRepositoryFactory(initialSessionToken)
 
     private var started = false
 
@@ -116,6 +130,30 @@ class ListingDetailViewModel(
 
     /** Retry the failed listing load. */
     fun retry() = loadListing()
+
+    /**
+     * React to a session change (login / logout) without disturbing the loaded listing.
+     *
+     * The view-model is keyed only on `listingId` at the composition layer (issue #2108), so an
+     * auth transition no longer re-creates it and no longer flips the whole screen back to the
+     * full-screen spinner. Instead this rebuilds the auth-scoped repositories with the new token
+     * and re-syncs only the favorite heart — leaving `listing` / `isLoading` untouched. A no-op
+     * when the token is unchanged, so it is safe to drive from `LaunchedEffect(sessionToken)`
+     * (which also fires on first composition).
+     */
+    fun updateAuth(sessionToken: String?) {
+        if (sessionToken == currentSessionToken) return
+        currentSessionToken = sessionToken
+        isAuthenticated = sessionToken != null
+        favoritesRepository = favoritesRepositoryFactory(sessionToken)
+        inquiryRepository = inquiryRepositoryFactory(sessionToken)
+        if (isAuthenticated) {
+            loadFavoriteState()
+        } else {
+            // Favorites require auth; on logout the heart can no longer reflect a user's state.
+            _state.update { it.copy(isFavorite = false, isFavoriteLoading = false) }
+        }
+    }
 
     /**
      * Optimistic favorite toggle: flip the heart immediately, then reconcile with the server. On
@@ -199,12 +237,14 @@ class ListingDetailViewModel(
             ListingDetailViewModel(
                 listingId = listingId,
                 listingRepository = listingRepository,
-                favoritesRepository =
-                    FavoritesRepository(baseUrl = baseUrl, sessionToken = sessionToken),
-                inquiryRepository =
-                    InquiryRepository(baseUrl = baseUrl, sessionToken = sessionToken),
+                favoritesRepositoryFactory = { token ->
+                    FavoritesRepository(baseUrl = baseUrl, sessionToken = token)
+                },
+                inquiryRepositoryFactory = { token ->
+                    InquiryRepository(baseUrl = baseUrl, sessionToken = token)
+                },
                 scope = scope,
-                isAuthenticated = sessionToken != null,
+                initialSessionToken = sessionToken,
                 errorMapper = errorMapper,
             )
     }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
@@ -10,8 +10,12 @@ import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -57,10 +61,14 @@ class ListingDetailViewModelTest {
         )
     }
 
-    /** Repositories that are constructed but never exercised in these toggle tests. */
-    private fun unusedListingRepo(): ListingRepository {
+    /** A ListingRepository whose every request returns [status] with [body]. */
+    private fun listingRepo(status: HttpStatusCode, body: String): ListingRepository {
         val engine = MockEngine {
-            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
         }
         return ListingRepository(
             baseUrl = "https://example.test",
@@ -68,28 +76,66 @@ class ListingDetailViewModelTest {
         )
     }
 
-    private fun unusedInquiryRepo(): InquiryRepository {
+    /** An InquiryRepository whose every request returns [status] with [body]. */
+    private fun inquiryRepo(status: HttpStatusCode, body: String): InquiryRepository {
         val engine = MockEngine {
-            respond(content = ByteReadChannel(""), status = HttpStatusCode.OK)
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
         }
         return InquiryRepository(
             baseUrl = "https://example.test",
+            sessionToken = "test-token",
             client = HttpClient(engine) { install(ContentNegotiation) { json(json) } },
         )
     }
+
+    /** Repositories that are constructed but never exercised in a given test. */
+    private fun unusedListingRepo(): ListingRepository =
+        listingRepo(HttpStatusCode.OK, "")
+
+    private fun unusedInquiryRepo(): InquiryRepository =
+        inquiryRepo(HttpStatusCode.OK, "")
+
+    /**
+     * A minimal-but-valid `ListingDetail` JSON body the repository can decode — only the fields
+     * required by the `ListingDetail` data class plus a couple the render binds.
+     */
+    private val listingBody =
+        """
+        {
+          "id": "lst-1",
+          "title": "Bright 3br with terrace",
+          "description": "A lovely flat in Old Town.",
+          "type": "sale",
+          "category": "apartment",
+          "status": "active",
+          "price": 285000,
+          "area_sqm": 75.0,
+          "address": { "street": "Hlavna 1", "city": "Bratislava",
+            "postal_code": "81101", "country": "SK" },
+          "created_at": "2026-04-26T10:00:00Z",
+          "updated_at": "2026-04-27T09:00:00Z"
+        }
+        """
+            .trimIndent()
 
     private fun viewModel(
         favorites: FavoritesRepository,
         scope: kotlinx.coroutines.CoroutineScope,
         isAuthenticated: Boolean = true,
+        listing: ListingRepository = unusedListingRepo(),
+        inquiry: InquiryRepository = unusedInquiryRepo(),
     ) =
         ListingDetailViewModel(
             listingId = "lst-1",
-            listingRepository = unusedListingRepo(),
-            favoritesRepository = favorites,
-            inquiryRepository = unusedInquiryRepo(),
+            listingRepository = listing,
+            favoritesRepositoryFactory = { favorites },
+            inquiryRepositoryFactory = { inquiry },
             scope = scope,
-            isAuthenticated = isAuthenticated,
+            initialSessionToken = if (isAuthenticated) "test-token" else null,
             errorMapper = { it.message ?: "error" },
         )
 
@@ -172,5 +218,135 @@ class ListingDetailViewModelTest {
             // Only the first toggle took effect; state settled on favorited.
             assertTrue(vm.state.value.isFavorite)
             assertFalse(vm.state.value.isFavoriteLoading)
+        }
+
+    // ─── start(): initial listing load ────────────────────────────────────────
+
+    @Test
+    fun start_loads_listing_and_clears_spinner() =
+        runTest(StandardTestDispatcher()) {
+            val vm =
+                viewModel(
+                    favorites = favoritesRepo(HttpStatusCode.OK, "{}"),
+                    scope = backgroundScope,
+                    isAuthenticated = false,
+                    listing = listingRepo(HttpStatusCode.OK, listingBody),
+                )
+
+            // Default state is the full-screen spinner until start() resolves.
+            assertTrue(vm.state.value.isLoading)
+            assertNull(vm.state.value.listing)
+
+            vm.start()
+            advanceUntilIdle()
+
+            val listing = assertNotNull(vm.state.value.listing, "listing should be loaded")
+            assertEquals("lst-1", listing.id)
+            assertFalse(vm.state.value.isLoading, "spinner clears once the listing arrives")
+            assertNull(vm.state.value.errorMessage)
+        }
+
+    @Test
+    fun start_maps_error_then_retry_recovers() =
+        runTest(StandardTestDispatcher()) {
+            // A mock backend that 500s first, then is flipped to 200 before retry().
+            var status = HttpStatusCode.InternalServerError
+            var body = """{"error":"boom"}"""
+            val engine = MockEngine {
+                respond(
+                    content = ByteReadChannel(body),
+                    status = status,
+                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                )
+            }
+            val repo =
+                ListingRepository(
+                    baseUrl = "https://example.test",
+                    client = HttpClient(engine) { install(ContentNegotiation) { json(json) } },
+                )
+            val vm =
+                viewModel(
+                    favorites = favoritesRepo(HttpStatusCode.OK, "{}"),
+                    scope = backgroundScope,
+                    isAuthenticated = false,
+                    listing = repo,
+                )
+
+            vm.start()
+            advanceUntilIdle()
+
+            assertNull(vm.state.value.listing, "a failed load leaves no listing")
+            assertNotNull(vm.state.value.errorMessage, "5xx surfaces an error message")
+            assertFalse(vm.state.value.isLoading)
+
+            // Backend recovers → retry() reloads the listing and clears the error.
+            status = HttpStatusCode.OK
+            body = listingBody
+            vm.retry()
+            advanceUntilIdle()
+
+            assertNotNull(vm.state.value.listing, "retry recovers the listing")
+            assertNull(vm.state.value.errorMessage, "error cleared on successful retry")
+            assertFalse(vm.state.value.isLoading)
+        }
+
+    // ─── onSubmitInquiry() ────────────────────────────────────────────────────
+
+    @Test
+    fun submitInquiry_success_emits_event_and_closes_dialog() =
+        runTest(StandardTestDispatcher()) {
+            val vm =
+                viewModel(
+                    favorites = favoritesRepo(HttpStatusCode.OK, "{}"),
+                    scope = backgroundScope,
+                    inquiry =
+                        inquiryRepo(
+                            HttpStatusCode.Created,
+                            """{"id":"inq-1","listing_id":"lst-1","status":"pending",""" +
+                                """"created_at":"2026-04-26T10:00:00Z"}""",
+                        ),
+                )
+            val events = mutableListOf<ListingDetailEvent>()
+            backgroundScope.launch { vm.events.collect { events += it } }
+
+            vm.onShowInquiryDialog()
+            vm.onSubmitInquiry("Hello", "Jana", "jana@example.test", "+421900000000")
+
+            // Optimistic: the submit spinner is on before the server answers.
+            assertTrue(vm.state.value.isInquirySubmitting)
+
+            advanceUntilIdle()
+
+            assertFalse(vm.state.value.isInquirySubmitting, "spinner clears on success")
+            assertFalse(vm.state.value.showInquiryDialog, "dialog closes on success")
+            assertNull(vm.state.value.inquiryError)
+            assertEquals(
+                listOf<ListingDetailEvent>(ListingDetailEvent.InquirySubmitted),
+                events,
+                "a 201 must emit InquirySubmitted so the UI can navigate",
+            )
+        }
+
+    @Test
+    fun submitInquiry_failure_sets_error_and_keeps_dialog() =
+        runTest(StandardTestDispatcher()) {
+            val vm =
+                viewModel(
+                    favorites = favoritesRepo(HttpStatusCode.OK, "{}"),
+                    scope = backgroundScope,
+                    inquiry =
+                        inquiryRepo(HttpStatusCode.InternalServerError, """{"error":"boom"}"""),
+                )
+            val events = mutableListOf<ListingDetailEvent>()
+            backgroundScope.launch { vm.events.collect { events += it } }
+
+            vm.onShowInquiryDialog()
+            vm.onSubmitInquiry("Hello", null, null, null)
+            advanceUntilIdle()
+
+            assertNotNull(vm.state.value.inquiryError, "5xx surfaces an inquiry error")
+            assertFalse(vm.state.value.isInquirySubmitting, "spinner clears on failure")
+            assertTrue(vm.state.value.showInquiryDialog, "dialog stays open so the user can retry")
+            assertTrue(events.isEmpty(), "no success event on a failed submit")
         }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
@@ -93,11 +93,9 @@ class ListingDetailViewModelTest {
     }
 
     /** Repositories that are constructed but never exercised in a given test. */
-    private fun unusedListingRepo(): ListingRepository =
-        listingRepo(HttpStatusCode.OK, "")
+    private fun unusedListingRepo(): ListingRepository = listingRepo(HttpStatusCode.OK, "")
 
-    private fun unusedInquiryRepo(): InquiryRepository =
-        inquiryRepo(HttpStatusCode.OK, "")
+    private fun unusedInquiryRepo(): InquiryRepository = inquiryRepo(HttpStatusCode.OK, "")
 
     /**
      * A minimal-but-valid `ListingDetail` JSON body the repository can decode — only the fields


### PR DESCRIPTION
## Task
Follow-up: ListingDetail auth change resets screen to spinner; hoisted paths untested (PR #2093). Key the VM only on listingId; add an updateAuth(sessionToken) intent driven by LaunchedEffect; add ListingDetailViewModelTest cases exercising start()/onSubmitInquiry. Closes #2108.

## Owner
pm-tech-lead (specialist: kotlin-mp)

## Changes
- **`ListingDetailScreen.kt`** — VM `remember(listingId)` (was `remember(sessionToken, listingId)`); added `LaunchedEffect(sessionToken) { viewModel.updateAuth(sessionToken) }`. An auth transition no longer re-creates the VM, so the loaded listing stays on screen instead of flashing back to the full-screen `CircularProgressIndicator`.
- **`ListingDetailViewModel.kt`** — auth-scoped `FavoritesRepository`/`InquiryRepository` now built via `(sessionToken) -> Repo` factories held on the VM; new `updateAuth(sessionToken)` rebuilds them and re-probes `loadFavoriteState()` (or clears the heart on logout) **without touching `listing`/`isLoading`**. No-op when the token is unchanged, so it is safe to fire on first composition. `create(...)` signature is unchanged (only its internals). Finding #3 (superseded-instance in-flight writes) largely resolves itself since the VM is no longer re-created on auth change.
- **`ListingDetailViewModelTest.kt`** — added executable coverage for the freshly-hoisted paths: `start()` success (listing set, `isLoading=false`), `start()` 500 → `errorMessage` then `retry()` recovery, and `onSubmitInquiry()` 201 (emits `InquirySubmitted`, `showInquiryDialog=false`) / 500 (`inquiryError` set, `isInquirySubmitting=false`, dialog stays open). The 4 existing favorite-toggle tests were reworked onto the new factory-based constructor.

## Tested (Band A — fast check)
`cd mobile-native && ./gradlew :shared:compileKotlinJvm :androidApp:assembleDebug` — **could NOT run in this cloud env**: the Gradle wrapper requires 9.6.1 whose distribution download is 403-blocked by the agent proxy, the only system Gradle is 8.14.3, and `com.android.application:9.2.1` is not resolvable offline. Per the cloud-ok fallback, verification is static (manual compile-review) and deferred to CI.

Static verification performed: confirmed the only caller of `ListingDetailViewModel.create` is `ListingDetailScreen.kt` (signature preserved); the direct constructor is used only in the VM and its test (both updated); factory-lambda types, property-init ordering, test lambda typing, mock JSON bodies, and event-collection ordering all check out.

## Built (Band B — full build)
Skipped — Gradle toolchain unavailable in this env (see above). CI (`mobile-native.yml`) is the gate.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change — this is a Compose state-holder refactor + unit tests).

## Remote-tested
Skipped.

## Notes
- **Verification deferred to CI**: `mobile-native.yml` runs the Gradle build + `:shared` unit tests and must go green before this leaves draft. Please confirm CI passes before review/merge.
- Behavior restored: listing stays rendered across login/logout; only the favorite heart re-syncs.
- `scope_drift=false`, `code_reuse_warn=none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dv1Apw9CZ2o2341KxCK52e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv1Apw9CZ2o2341KxCK52e)_