### PR TITLE
gh-issue-2103: named-field input for SlovakAccountingExport::new (Closes #2103)

### DIFF
--- a/backend/crates/db/src/models/regional_compliance.rs
+++ b/backend/crates/db/src/models/regional_compliance.rs
@@ -918,7 +918,10 @@ mod tests {
         // The two distinct `Option<Decimal>` figures must not be swapped.
         assert_eq!(export.total_expenses, Some(Decimal::new(300, 0)));
         assert_eq!(export.total_payables, Some(Decimal::new(400, 0)));
-        assert_eq!(export.download_url.as_deref(), Some("https://example.test/dl"));
+        assert_eq!(
+            export.download_url.as_deref(),
+            Some("https://example.test/dl")
+        );
         assert_eq!(export.export_data, Some(serde_json::json!({"k": "v"})));
         assert_eq!(export.generated_at, generated_at);
         // All monetary fields present -> honest complete export.

--- a/backend/crates/db/src/models/regional_compliance.rs
+++ b/backend/crates/db/src/models/regional_compliance.rs
@@ -411,16 +411,54 @@ pub struct SlovakAccountingExport {
     pub generated_at: DateTime<Utc>,
 }
 
+/// Named-field input for [`SlovakAccountingExport::new`].
+///
+/// Exists to kill a whole class of quiet dishonesty (#2103): the previous
+/// `new` took 15 positional args, four of which were type-identical and
+/// interleaved — two bare `Decimal` (`total_revenue` / `total_receivables`)
+/// and two `Option<Decimal>` (`total_expenses` / `total_payables`).
+/// Transposing revenue↔receivables (or the two options) at any call site
+/// compiled cleanly and silently shipped wrong accounting figures — the same
+/// "looks right but isn't" failure #2030/#2086 set out to kill, just relocated
+/// from "forgot the mutator" to "swapped two same-typed args". Forcing
+/// callers to name each field makes the compiler catch the transposition.
+///
+/// This carries only the **non-derived** fields. The honesty flags
+/// (`partial` / `unsupported_fields`) are intentionally absent — they are
+/// derived inside `new` and must never be supplied by a caller.
+#[derive(Debug, Clone)]
+pub struct SlovakAccountingExportInput {
+    pub export_id: Uuid,
+    pub organization_id: Uuid,
+    pub from_date: NaiveDate,
+    pub to_date: NaiveDate,
+    pub format: SlovakAccountingFormat,
+    pub invoice_count: i32,
+    pub payment_count: i32,
+    pub journal_entry_count: i32,
+    pub total_revenue: Decimal,
+    /// `None` = not available (see [`SlovakAccountingExport::total_expenses`]).
+    pub total_expenses: Option<Decimal>,
+    pub total_receivables: Decimal,
+    /// `None` = not available (see [`SlovakAccountingExport::total_payables`]).
+    pub total_payables: Option<Decimal>,
+    pub download_url: Option<String>,
+    pub export_data: Option<serde_json::Value>,
+    pub generated_at: DateTime<Utc>,
+}
+
 impl SlovakAccountingExport {
     /// Smart constructor: the ONLY way to build a `SlovakAccountingExport`.
     ///
-    /// Takes every non-derived field and computes `partial` +
+    /// Takes every non-derived field via the named-field
+    /// [`SlovakAccountingExportInput`] and computes `partial` +
     /// `unsupported_fields` internally from the `Option` monetary fields before
     /// returning, so no caller can obtain an instance whose honesty flags are
-    /// un-derived or stale (#2086). This replaces the old
-    /// build-literal-then-`compute_partial(&mut self)` dance, where a caller who
-    /// forgot the mutator would silently ship a "looks complete but isn't"
-    /// export — exactly the dishonesty #2030 set out to kill.
+    /// un-derived or stale (#2086). The named-field input also makes revenue↔
+    /// receivables (and the two option fields) impossible to transpose at a
+    /// call site — the compiler enforces field identity (#2103) — replacing the
+    /// old 15-arg positional signature where four type-identical, interleaved
+    /// args could be silently swapped.
     ///
     /// A monetary field that is `None` is **not available** (not a genuine
     /// zero): it serializes as JSON `null` and its name is enumerated in
@@ -428,24 +466,25 @@ impl SlovakAccountingExport {
     /// missing. When a new `Option` monetary field is added to this struct,
     /// extend the checks below so it is covered here in one place rather than
     /// being silently omitted from the derivation.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        export_id: Uuid,
-        organization_id: Uuid,
-        from_date: NaiveDate,
-        to_date: NaiveDate,
-        format: SlovakAccountingFormat,
-        invoice_count: i32,
-        payment_count: i32,
-        journal_entry_count: i32,
-        total_revenue: Decimal,
-        total_expenses: Option<Decimal>,
-        total_receivables: Decimal,
-        total_payables: Option<Decimal>,
-        download_url: Option<String>,
-        export_data: Option<serde_json::Value>,
-        generated_at: DateTime<Utc>,
-    ) -> Self {
+    pub fn new(input: SlovakAccountingExportInput) -> Self {
+        let SlovakAccountingExportInput {
+            export_id,
+            organization_id,
+            from_date,
+            to_date,
+            format,
+            invoice_count,
+            payment_count,
+            journal_entry_count,
+            total_revenue,
+            total_expenses,
+            total_receivables,
+            total_payables,
+            download_url,
+            export_data,
+            generated_at,
+        } = input;
+
         let mut unsupported_fields = Vec::new();
         if total_expenses.is_none() {
             unsupported_fields.push("total_expenses".to_string());
@@ -728,23 +767,23 @@ mod tests {
     /// serialize as a number.
     #[test]
     fn uncomputed_totals_serialize_as_null_not_zero() {
-        let export = SlovakAccountingExport::new(
-            Uuid::nil(),
-            Uuid::nil(),
-            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
-            NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
-            SlovakAccountingFormat::Pohoda,
-            3,
-            2,
-            5,
-            Decimal::new(12345, 2),
-            None,
-            Decimal::ZERO,
-            None,
-            None,
-            None,
-            DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
-        );
+        let export = SlovakAccountingExport::new(SlovakAccountingExportInput {
+            export_id: Uuid::nil(),
+            organization_id: Uuid::nil(),
+            from_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            to_date: NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            format: SlovakAccountingFormat::Pohoda,
+            invoice_count: 3,
+            payment_count: 2,
+            journal_entry_count: 5,
+            total_revenue: Decimal::new(12345, 2),
+            total_expenses: None,
+            total_receivables: Decimal::ZERO,
+            total_payables: None,
+            download_url: None,
+            export_data: None,
+            generated_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        });
 
         let json = serde_json::to_value(&export).expect("serialize export");
 
@@ -769,23 +808,23 @@ mod tests {
         total_expenses: Option<Decimal>,
         total_payables: Option<Decimal>,
     ) -> SlovakAccountingExport {
-        SlovakAccountingExport::new(
-            Uuid::nil(),
-            Uuid::nil(),
-            NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
-            NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
-            SlovakAccountingFormat::Pohoda,
-            0,
-            0,
-            0,
-            Decimal::ZERO,
+        SlovakAccountingExport::new(SlovakAccountingExportInput {
+            export_id: Uuid::nil(),
+            organization_id: Uuid::nil(),
+            from_date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            to_date: NaiveDate::from_ymd_opt(2026, 3, 31).unwrap(),
+            format: SlovakAccountingFormat::Pohoda,
+            invoice_count: 0,
+            payment_count: 0,
+            journal_entry_count: 0,
+            total_revenue: Decimal::ZERO,
             total_expenses,
-            Decimal::ZERO,
+            total_receivables: Decimal::ZERO,
             total_payables,
-            None,
-            None,
-            DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
-        )
+            download_url: None,
+            export_data: None,
+            generated_at: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        })
     }
 
     /// #2053/#2086: exercise the derivation performed by the smart constructor.
@@ -823,5 +862,67 @@ mod tests {
         let complete = export_with(Some(Decimal::ZERO), Some(Decimal::ZERO));
         assert!(!complete.partial);
         assert!(complete.unsupported_fields.is_empty());
+    }
+
+    /// #2103: pin the positional/field wiring of the smart constructor. Every
+    /// non-derived field gets a *distinct* value so that any transposition of
+    /// two same-typed fields (notably `total_revenue` ↔ `total_receivables`,
+    /// or `total_expenses` ↔ `total_payables`) inside `new` would land a value
+    /// in the wrong slot and fail an assertion here. The named-field input
+    /// makes such a swap uncompilable at call sites; this test guards the
+    /// internal `new` wiring itself.
+    #[test]
+    fn new_wires_each_input_field_to_its_own_slot() {
+        let export_id = Uuid::from_u128(1);
+        let organization_id = Uuid::from_u128(2);
+        let from_date = NaiveDate::from_ymd_opt(2026, 1, 1).unwrap();
+        let to_date = NaiveDate::from_ymd_opt(2026, 3, 31).unwrap();
+        let generated_at = DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+
+        // Distinct monetary values so revenue↔receivables / expenses↔payables
+        // transposition is detectable.
+        let total_revenue = Decimal::new(100, 0);
+        let total_expenses = Some(Decimal::new(300, 0));
+        let total_receivables = Decimal::new(200, 0);
+        let total_payables = Some(Decimal::new(400, 0));
+
+        let export = SlovakAccountingExport::new(SlovakAccountingExportInput {
+            export_id,
+            organization_id,
+            from_date,
+            to_date,
+            format: SlovakAccountingFormat::MoneyS3,
+            invoice_count: 7,
+            payment_count: 11,
+            journal_entry_count: 18,
+            total_revenue,
+            total_expenses,
+            total_receivables,
+            total_payables,
+            download_url: Some("https://example.test/dl".to_string()),
+            export_data: Some(serde_json::json!({"k": "v"})),
+            generated_at,
+        });
+
+        assert_eq!(export.export_id, export_id);
+        assert_eq!(export.organization_id, organization_id);
+        assert_eq!(export.from_date, from_date);
+        assert_eq!(export.to_date, to_date);
+        assert_eq!(export.format, SlovakAccountingFormat::MoneyS3);
+        assert_eq!(export.invoice_count, 7);
+        assert_eq!(export.payment_count, 11);
+        assert_eq!(export.journal_entry_count, 18);
+        // The two distinct bare `Decimal` figures must not be swapped.
+        assert_eq!(export.total_revenue, Decimal::new(100, 0));
+        assert_eq!(export.total_receivables, Decimal::new(200, 0));
+        // The two distinct `Option<Decimal>` figures must not be swapped.
+        assert_eq!(export.total_expenses, Some(Decimal::new(300, 0)));
+        assert_eq!(export.total_payables, Some(Decimal::new(400, 0)));
+        assert_eq!(export.download_url.as_deref(), Some("https://example.test/dl"));
+        assert_eq!(export.export_data, Some(serde_json::json!({"k": "v"})));
+        assert_eq!(export.generated_at, generated_at);
+        // All monetary fields present -> honest complete export.
+        assert!(!export.partial);
+        assert!(export.unsupported_fields.is_empty());
     }
 }

--- a/backend/servers/api-server/src/routes/regional_compliance.rs
+++ b/backend/servers/api-server/src/routes/regional_compliance.rs
@@ -454,12 +454,12 @@ async fn export_slovak_accounting(
     // mutator. Un-computed fields serialize as JSON `null` and are enumerated in
     // `unsupported_fields`, letting consumers distinguish "not available" from a
     // genuine zero (#2030).
-    let export = SlovakAccountingExport::new(
-        Uuid::new_v4(),
-        org_id,
-        payload.from_date,
-        payload.to_date,
-        payload.format,
+    let export = SlovakAccountingExport::new(SlovakAccountingExportInput {
+        export_id: Uuid::new_v4(),
+        organization_id: org_id,
+        from_date: payload.from_date,
+        to_date: payload.to_date,
+        format: payload.format,
         invoice_count,
         payment_count,
         journal_entry_count,
@@ -467,13 +467,13 @@ async fn export_slovak_accounting(
         total_expenses,
         total_receivables,
         total_payables,
-        Some(format!(
+        download_url: Some(format!(
             "/api/v1/regional-compliance/slovak/accounting/download/{}",
             Uuid::new_v4()
         )),
-        None,
-        Utc::now(),
-    );
+        export_data: None,
+        generated_at: Utc::now(),
+    });
 
     let result = Ok(Json(export));
     rls.release().await;


### PR DESCRIPTION
## Task
Follow-up: `SlovakAccountingExport::new` positional 15-arg constructor allows silent same-type transposition (PR #2099) (Closes #2103).

Replace the 15-arg positional `SlovakAccountingExport::new` — four of whose args were type-identical and interleaved (`total_revenue`/`total_receivables` as bare `Decimal`, `total_expenses`/`total_payables` as `Option<Decimal>`) — with a named-field `SlovakAccountingExportInput`. Transposing revenue↔receivables (or the two options) at a call site now fails to compile instead of silently shipping wrong accounting figures — the same honesty class as #2030/#2086, relocated from "forgot the mutator" to "swapped two same-typed args".

The `partial`/`unsupported_fields` honesty derivation stays internal to `new`; the input struct carries only the non-derived fields. The `#[allow(clippy::too_many_arguments)]` is no longer needed and was removed.

## Owner
pm-tech-lead

## Changes
- `backend/crates/db/src/models/regional_compliance.rs` — add `pub struct SlovakAccountingExportInput` (named fields, non-derived only); `new` now takes it and destructures internally, deriving `partial`/`unsupported_fields` as before.
- `backend/servers/api-server/src/routes/regional_compliance.rs` — sole call site converted to named-struct construction.
- New test `new_wires_each_input_field_to_its_own_slot` — feeds distinct values (revenue=100 vs receivables=200, expenses=300 vs payables=400, all counts distinct) and asserts each field reads back from its own slot, pinning the internal `new` wiring (test-coverage finding).

## Tested (Band A — fast check)
- `cargo check -p db` → exit 0
- `cargo test -p db --lib models::regional_compliance` → `test result: ok. 3 passed; 0 failed` (incl. new `new_wires_each_input_field_to_its_own_slot`)

## Built (Band B — full build)
- `cargo clippy -p db --all-targets -- -D warnings` → exit 0 (clean; confirms the removed `too_many_arguments` allow is no longer triggered)
- `cargo check -p api-server` → could not complete in this cloud sandbox: the `utoipa-swagger-ui` build script fails trying to download the Swagger UI archive (`InvalidArchive("Could not find EOCD")` — proxy-blocked network fetch), a pre-existing environment limitation unrelated to this change. The single call-site edit is a mechanical named-struct conversion within an existing `use db::models::regional_compliance::*;` glob import; full api-server compile deferred to CI.

## CI parity (Band C — hot-path only)
Deferred to CI (`backend.yml`) — no local Postgres/Docker in this cloud context.

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 for both changed files. `pm-tech-lead` is an architecture-review role not mapped to code areas in `owner-areas.json`, so any backend file trips it. Both files are exactly the ones named in issue #2103. Not real drift.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings.

## Notes
Chose the named-field input struct over newtypes: it makes *all* same-typed fields (not only the two monetary `Decimal`s) impossible to transpose at call sites, keeps the `Serialize`/`ToSchema` API of `SlovakAccountingExport` unchanged, and keeps the honesty derivation in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dv1Apw9CZ2o2341KxCK52e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dv1Apw9CZ2o2341KxCK52e)_