### PR TITLE
code-review-mobile-rn-screens-mock-data: wire mobile Meters/Leases/Forms/Threads screens to api-server

### DIFF
--- a/frontend/apps/mobile/src/screens/forms/FormsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/forms/FormsScreen.test.ts
@@ -1,0 +1,58 @@
+import { type ApiFormSummary, parseFormSummaries, toResidentForm } from './FormsScreen';
+
+const validForm: ApiFormSummary = {
+  id: 'f-1',
+  title: 'Fire-safety declaration',
+  description: 'Confirm equipment is functional.',
+  category: 'compliance',
+  status: 'published',
+  require_signatures: true,
+  submission_deadline: '2026-04-30T23:59:00Z',
+};
+
+describe('parseFormSummaries', () => {
+  it('accepts the wrapped `{ forms: [...] }` envelope', () => {
+    expect(parseFormSummaries({ forms: [validForm] })).toEqual([validForm]);
+  });
+
+  it('accepts a bare array (defensive)', () => {
+    expect(parseFormSummaries([validForm])).toEqual([validForm]);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['a string', 'nope'],
+    ['an object without forms', { error: 'boom' }],
+    ['an object whose forms is not an array', { forms: 'nope' }],
+  ])('returns [] for an unexpected top-level shape: %s', (_label, input) => {
+    expect(parseFormSummaries(input)).toEqual([]);
+  });
+
+  it('drops malformed entries instead of throwing', () => {
+    const mixed = [validForm, null, 'garbage', { id: 'no-title' }, { title: 'no-id' }];
+    expect(parseFormSummaries({ forms: mixed })).toEqual([validForm]);
+  });
+});
+
+describe('toResidentForm', () => {
+  it('maps the api summary onto the UI form shape', () => {
+    expect(toResidentForm(validForm)).toEqual({
+      id: 'f-1',
+      title: 'Fire-safety declaration',
+      description: 'Confirm equipment is functional.',
+      dueAt: '2026-04-30T23:59:00Z',
+      status: 'pending',
+      required: true,
+    });
+  });
+
+  it('defaults optional fields', () => {
+    const mapped = toResidentForm({ id: 'f-2', title: 'Survey' });
+    expect(mapped.description).toBe('');
+    expect(mapped.dueAt).toBeUndefined();
+    expect(mapped.required).toBe(false);
+    expect(mapped.status).toBe('pending');
+  });
+});

--- a/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
@@ -2,10 +2,23 @@
  * FormsScreen (UC-09).
  *
  * Lists forms residents need to complete (consent, declarations, surveys).
+ *
+ * Wired to `GET /api/v1/forms/available` on the api-server, which returns an
+ * `AvailableFormsResponse { forms: FormSummary[] }` (see
+ * `db::models::form::FormSummary` and `routes::forms::types` — default
+ * snake_case serde). `list_available_forms` runs under `RlsConnection`, so the
+ * bearer token + `X-Tenant-ID` header that `useApiQuery` sends are sufficient
+ * (unlike `GET /api/v1/forms`, which is manager-only). The response is consumed
+ * without a generated client, so it is validated defensively.
+ *
+ * `FormSummary` carries the form's own lifecycle status, not a per-resident
+ * completion state, so the screen presents available forms as actionable
+ * ("pending") and surfaces the signature requirement + submission deadline.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export type FormStatus = 'pending' | 'in_progress' | 'completed';
@@ -19,38 +32,54 @@ export interface ResidentForm {
   required: boolean;
 }
 
-const MOCK_FORMS: ResidentForm[] = [
-  {
-    id: 'f1',
-    title: 'Annual fire-safety declaration',
-    description: 'Confirm that all fire-safety equipment in your unit is functional.',
-    dueAt: '2026-04-30T23:59:00Z',
+/** Subset of `FormSummary` from `GET /api/v1/forms/available`. */
+export interface ApiFormSummary {
+  id: string;
+  title: string;
+  description?: string | null;
+  category?: string | null;
+  status?: string | null;
+  require_signatures?: boolean;
+  submission_deadline?: string | null;
+}
+
+interface ApiAvailableFormsResponse {
+  forms: ApiFormSummary[];
+}
+
+function isApiFormSummary(value: unknown): value is ApiFormSummary {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string' && typeof v.title === 'string';
+}
+
+/** Normalise the `/api/v1/forms/available` response into a validated list.
+ *  Accepts the `{ forms: [...] }` envelope and a bare array (defensively);
+ *  any other shape yields `[]`. Malformed rows are dropped. */
+export function parseFormSummaries(data: unknown): ApiFormSummary[] {
+  const candidates: unknown[] =
+    typeof data === 'object' &&
+    data !== null &&
+    Array.isArray((data as ApiAvailableFormsResponse).forms)
+      ? (data as ApiAvailableFormsResponse).forms
+      : Array.isArray(data)
+        ? data
+        : [];
+  return candidates.filter(isApiFormSummary);
+}
+
+/** Map an api-server form summary onto the UI shape. Exported for unit
+ *  testing without rendering the screen. */
+export function toResidentForm(f: ApiFormSummary): ResidentForm {
+  return {
+    id: f.id,
+    title: f.title,
+    description: f.description?.trim() || '',
+    dueAt: f.submission_deadline ?? undefined,
     status: 'pending',
-    required: true,
-  },
-  {
-    id: 'f2',
-    title: 'Pet registration',
-    description: 'Optional: register pets living in your unit.',
-    status: 'in_progress',
-    required: false,
-  },
-  {
-    id: 'f3',
-    title: 'Energy-efficiency survey',
-    description: 'Help the building plan upgrades by sharing your usage habits.',
-    dueAt: '2026-05-10T23:59:00Z',
-    status: 'pending',
-    required: false,
-  },
-  {
-    id: 'f4',
-    title: 'GDPR consent — communications',
-    description: 'Choose which channels we may use to contact you.',
-    status: 'completed',
-    required: true,
-  },
-];
+    required: f.require_signatures ?? false,
+  };
+}
 
 function statusBadgeStyle(status: FormStatus) {
   switch (status) {
@@ -68,15 +97,18 @@ interface FormsScreenProps {
 }
 
 export function FormsScreen({ onNavigate }: FormsScreenProps) {
-  const [refreshing, setRefreshing] = useState(false);
+  const { data, isLoading, error, refetch, isFetching } = useApiQuery<unknown>(
+    ['forms', 'available'],
+    '/api/v1/forms/available',
+    { staleTime: 30_000 }
+  );
+
+  const forms: ResidentForm[] = parseFormSummaries(data).map(toResidentForm);
+  const pending = forms.filter((f) => f.status !== 'completed').length;
 
   const onRefresh = useCallback(async () => {
-    setRefreshing(true);
-    await new Promise((r) => setTimeout(r, 500));
-    setRefreshing(false);
-  }, []);
-
-  const pending = MOCK_FORMS.filter((f) => f.status !== 'completed').length;
+    await refetch();
+  }, [refetch]);
 
   return (
     <View style={s.container}>
@@ -91,42 +123,60 @@ export function FormsScreen({ onNavigate }: FormsScreenProps) {
 
       <ScrollView
         style={s.scrollView}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        refreshControl={<RefreshControl refreshing={isFetching} onRefresh={onRefresh} />}
       >
-        {MOCK_FORMS.map((form) => {
-          const style = statusBadgeStyle(form.status);
-          return (
-            <Pressable
-              key={form.id}
-              style={s.card}
-              onPress={() => onNavigate?.('FormFill', { formId: form.id })}
-            >
-              <View style={s.cardHeader}>
-                <Text style={s.cardTitle} numberOfLines={2}>
-                  {form.title}
-                </Text>
-                <View style={[s.badge, { backgroundColor: style.background }]}>
-                  <Text style={[s.badgeText, { color: style.color }]}>
-                    {form.status.replace('_', ' ')}
+        {isLoading ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyTitle}>Loading…</Text>
+          </View>
+        ) : error ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>⚠️</Text>
+            <Text style={s.emptyTitle}>Couldn't load forms</Text>
+            <Text style={s.emptyText}>{error.message}</Text>
+          </View>
+        ) : forms.length === 0 ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>📝</Text>
+            <Text style={s.emptyTitle}>No forms</Text>
+            <Text style={s.emptyText}>You have no forms to complete right now.</Text>
+          </View>
+        ) : (
+          forms.map((form) => {
+            const style = statusBadgeStyle(form.status);
+            return (
+              <Pressable
+                key={form.id}
+                style={s.card}
+                onPress={() => onNavigate?.('FormFill', { formId: form.id })}
+              >
+                <View style={s.cardHeader}>
+                  <Text style={s.cardTitle} numberOfLines={2}>
+                    {form.title}
                   </Text>
-                </View>
-              </View>
-              <Text style={s.cardBody}>{form.description}</Text>
-              <View style={s.cardFooter}>
-                {form.required && (
-                  <View style={[s.badge, { backgroundColor: colors.dangerBg }]}>
-                    <Text style={[s.badgeText, { color: colors.danger }]}>Required</Text>
+                  <View style={[s.badge, { backgroundColor: style.background }]}>
+                    <Text style={[s.badgeText, { color: style.color }]}>
+                      {form.status.replace('_', ' ')}
+                    </Text>
                   </View>
-                )}
-                {form.dueAt && (
-                  <Text style={[s.cardMeta, { marginLeft: 'auto' }]}>
-                    Due {new Date(form.dueAt).toLocaleDateString()}
-                  </Text>
-                )}
-              </View>
-            </Pressable>
-          );
-        })}
+                </View>
+                {form.description ? <Text style={s.cardBody}>{form.description}</Text> : null}
+                <View style={s.cardFooter}>
+                  {form.required && (
+                    <View style={[s.badge, { backgroundColor: colors.dangerBg }]}>
+                      <Text style={[s.badgeText, { color: colors.danger }]}>Required</Text>
+                    </View>
+                  )}
+                  {form.dueAt && (
+                    <Text style={[s.cardMeta, { marginLeft: 'auto' }]}>
+                      Due {new Date(form.dueAt).toLocaleDateString()}
+                    </Text>
+                  )}
+                </View>
+              </Pressable>
+            );
+          })
+        )}
 
         <View style={s.bottomSpacer} />
       </ScrollView>

--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.test.ts
@@ -1,0 +1,72 @@
+import { parseLeaseDetail, toUiLease, toUiPayments } from './LeaseDetailScreen';
+
+const validDetail = {
+  lease: {
+    id: 'l-1',
+    landlord_name: 'Anna Novak',
+    tenant_name: 'John Doe',
+    start_date: '2024-09-01',
+    end_date: '2026-08-31',
+    monthly_rent: '850.00',
+    status: 'active',
+  },
+  unit_name: 'Apt 3B',
+  building_name: 'Lipová Residence',
+  upcoming_payments: [
+    { id: 'p1', due_date: '2026-03-01', amount: '850', paid_at: '2026-03-01T09:00:00Z' },
+    { id: 'p2', due_date: '2026-04-01', amount: '850', paid_at: null },
+  ],
+};
+
+describe('parseLeaseDetail', () => {
+  it('parses a well-formed LeaseWithDetails', () => {
+    const parsed = parseLeaseDetail(validDetail);
+    expect(parsed?.lease.id).toBe('l-1');
+    expect(parsed?.unit_name).toBe('Apt 3B');
+    expect(parsed?.upcoming_payments).toHaveLength(2);
+  });
+
+  it.each([
+    ['null', null],
+    ['a string', 'nope'],
+    ['no lease', { unit_name: 'x' }],
+    ['lease without id', { lease: {} }],
+  ])('returns null for an unexpected shape: %s', (_label, input) => {
+    expect(parseLeaseDetail(input)).toBeNull();
+  });
+});
+
+describe('toUiLease', () => {
+  it('maps the api detail onto the UI lease shape', () => {
+    const lease = toUiLease(parseLeaseDetail(validDetail)!);
+    expect(lease).toEqual({
+      id: 'l-1',
+      unitLabel: 'Apt 3B',
+      buildingName: 'Lipová Residence',
+      role: 'tenant',
+      rentAmount: 850,
+      currency: 'EUR',
+      startsAt: '2024-09-01',
+      endsAt: '2026-08-31',
+      status: 'active',
+      counterpartyName: 'Anna Novak',
+    });
+  });
+
+  it('coerces a non-numeric rent to 0', () => {
+    const parsed = parseLeaseDetail({
+      ...validDetail,
+      lease: { ...validDetail.lease, monthly_rent: 'n/a' },
+    })!;
+    expect(toUiLease(parsed).rentAmount).toBe(0);
+  });
+});
+
+describe('toUiPayments', () => {
+  it('maps payments newest first with period labels and paid state', () => {
+    const rows = toUiPayments(parseLeaseDetail(validDetail)!);
+    expect(rows.map((r) => r.id)).toEqual(['p2', 'p1']);
+    expect(rows[0].paidAt).toBeNull();
+    expect(rows[1].paidAt).toBe('2026-03-01T09:00:00Z');
+  });
+});

--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
@@ -2,44 +2,140 @@
  * LeaseDetailScreen (UC-34.4).
  *
  * Single-lease view with payment summary and document downloads.
+ *
+ * Wired to `GET /api/v1/leases/{id}` on the api-server, which returns a
+ * `LeaseWithDetails { lease, unit_name, building_name, upcoming_payments, … }`
+ * (see `db::models::lease::{Lease, LeasePayment, LeaseWithDetails}` — default
+ * snake_case serde, `Decimal`/`NaiveDate` fields as JSON strings). The lease id
+ * arrives as a navigation param. The response is consumed without a generated
+ * client, so it is validated defensively.
  */
 
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useCallback } from 'react';
+import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
-import type { Lease } from './LeasesScreen';
+import { type Lease, toUiLeaseStatus } from './LeasesScreen';
 
-const MOCK_LEASE: Lease = {
-  id: 'l1',
-  unitLabel: 'Apt 3B',
-  buildingName: 'Lipová Residence',
-  role: 'tenant',
-  rentAmount: 850,
-  currency: 'EUR',
-  startsAt: '2024-09-01T00:00:00Z',
-  endsAt: '2026-08-31T00:00:00Z',
-  status: 'active',
-  counterpartyName: 'Anna Novak',
-};
+export interface LeasePaymentRow {
+  id: string;
+  period: string;
+  amount: number;
+  paidAt: string | null;
+}
 
-const MOCK_PAYMENTS: Array<{ id: string; period: string; amount: number; paidAt: string | null }> =
-  [
-    { id: 'p1', period: 'April 2026', amount: 850, paidAt: '2026-04-01T09:00:00Z' },
-    { id: 'p2', period: 'March 2026', amount: 850, paidAt: '2026-03-01T09:00:00Z' },
-    { id: 'p3', period: 'February 2026', amount: 850, paidAt: '2026-02-02T11:30:00Z' },
-  ];
+/** Subset of `Lease` inside `LeaseWithDetails`. */
+interface ApiLease {
+  id: string;
+  unit_id?: string;
+  landlord_name?: string;
+  tenant_name?: string;
+  start_date: string;
+  end_date: string;
+  monthly_rent: string | number;
+  status: string;
+}
+
+/** Subset of `LeasePayment` from `upcoming_payments`. */
+interface ApiLeasePayment {
+  id: string;
+  due_date: string;
+  amount: string | number;
+  paid_at?: string | null;
+}
+
+export interface ApiLeaseDetail {
+  lease: ApiLease;
+  unit_name: string;
+  building_name: string;
+  upcoming_payments?: ApiLeasePayment[];
+}
+
+function toNumber(value: string | number | null | undefined): number {
+  if (value == null) return 0;
+  const n = typeof value === 'number' ? value : Number.parseFloat(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Validate the raw `GET /api/v1/leases/{id}` body, or null on a bad shape. */
+export function parseLeaseDetail(data: unknown): ApiLeaseDetail | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const v = data as Record<string, unknown>;
+  const lease = v.lease;
+  if (typeof lease !== 'object' || lease === null) return null;
+  const l = lease as Record<string, unknown>;
+  if (typeof l.id !== 'string') return null;
+  return {
+    lease: lease as ApiLease,
+    unit_name: typeof v.unit_name === 'string' ? v.unit_name : '',
+    building_name: typeof v.building_name === 'string' ? v.building_name : '',
+    upcoming_payments: Array.isArray(v.upcoming_payments)
+      ? (v.upcoming_payments as ApiLeasePayment[])
+      : [],
+  };
+}
+
+/** Map the api-server lease detail onto the UI `Lease` shape. Exported for
+ *  unit testing without rendering the screen. */
+export function toUiLease(detail: ApiLeaseDetail): Lease {
+  const { lease } = detail;
+  return {
+    id: lease.id,
+    unitLabel: detail.unit_name || 'Unit',
+    buildingName: detail.building_name || '',
+    role: 'tenant',
+    rentAmount: toNumber(lease.monthly_rent),
+    currency: 'EUR',
+    startsAt: lease.start_date,
+    endsAt: lease.end_date,
+    status: toUiLeaseStatus(lease.status),
+    counterpartyName: lease.landlord_name || lease.tenant_name || '',
+  };
+}
+
+/** Format a payment `due_date` (ISO date) as a "Month Year" period label. */
+function periodLabel(dueDate: string): string {
+  const d = new Date(dueDate);
+  if (Number.isNaN(d.getTime())) return dueDate;
+  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+/** Map api-server payments onto the UI payment rows, newest `due_date` first.
+ *  Sorting is done on the raw ISO `due_date` (not the formatted month label,
+ *  which would sort alphabetically). */
+export function toUiPayments(detail: ApiLeaseDetail): LeasePaymentRow[] {
+  return (detail.upcoming_payments ?? [])
+    .slice()
+    .sort((a, b) => new Date(b.due_date).getTime() - new Date(a.due_date).getTime())
+    .map((p) => ({
+      id: p.id,
+      period: periodLabel(p.due_date),
+      amount: toNumber(p.amount),
+      paidAt: p.paid_at ?? null,
+    }));
+}
 
 interface LeaseDetailScreenProps {
   leaseId?: string;
-  lease?: Lease;
   onBack?: () => void;
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
 
-export function LeaseDetailScreen({
-  lease = MOCK_LEASE,
-  onBack,
-  onNavigate,
-}: LeaseDetailScreenProps) {
+export function LeaseDetailScreen({ leaseId, onBack, onNavigate }: LeaseDetailScreenProps) {
+  const { data, isLoading, error, refetch, isFetching } = useApiQuery<unknown>(
+    ['leases', 'detail', leaseId],
+    `/api/v1/leases/${leaseId ?? ''}`,
+    { staleTime: 30_000, enabled: !!leaseId }
+  );
+
+  const detail = parseLeaseDetail(data);
+  const lease = detail ? toUiLease(detail) : null;
+  const payments = detail ? toUiPayments(detail) : [];
+
+  const onRefresh = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
   return (
     <View style={s.container}>
       <View style={s.header}>
@@ -48,55 +144,86 @@ export function LeaseDetailScreen({
             <Text style={styles.backLinkText}>← Leases</Text>
           </Pressable>
         )}
-        <Text style={s.headerTitle}>
-          {lease.unitLabel} · {lease.buildingName}
-        </Text>
-        <Text style={s.headerSubtitle}>
-          {new Date(lease.startsAt).toLocaleDateString()} –{' '}
-          {new Date(lease.endsAt).toLocaleDateString()}
-        </Text>
+        {lease ? (
+          <>
+            <Text style={s.headerTitle}>
+              {lease.unitLabel}
+              {lease.buildingName ? ` · ${lease.buildingName}` : ''}
+            </Text>
+            <Text style={s.headerSubtitle}>
+              {new Date(lease.startsAt).toLocaleDateString()} –{' '}
+              {new Date(lease.endsAt).toLocaleDateString()}
+            </Text>
+          </>
+        ) : (
+          <Text style={s.headerTitle}>Lease</Text>
+        )}
       </View>
 
-      <ScrollView style={s.scrollView}>
-        <View style={s.card}>
-          <Text style={styles.metricLabel}>Monthly rent</Text>
-          <Text style={styles.metricValue}>
-            {lease.rentAmount} {lease.currency}
-          </Text>
-          <Text style={[s.cardMeta, { marginTop: 8 }]}>
-            As {lease.role}, paid to {lease.counterpartyName}
-          </Text>
-        </View>
-
-        <Text style={styles.sectionTitle}>Payment history</Text>
-        {MOCK_PAYMENTS.map((payment) => (
-          <View key={payment.id} style={s.card}>
-            <View style={s.cardHeader}>
-              <Text style={s.cardTitle}>{payment.period}</Text>
-              <Text style={s.cardMeta}>
-                {payment.amount} {lease.currency}
+      <ScrollView
+        style={s.scrollView}
+        refreshControl={<RefreshControl refreshing={isFetching} onRefresh={onRefresh} />}
+      >
+        {isLoading || !leaseId ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyTitle}>Loading…</Text>
+          </View>
+        ) : error || !lease ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>⚠️</Text>
+            <Text style={s.emptyTitle}>Couldn't load lease</Text>
+            <Text style={s.emptyText}>{error?.message ?? 'Lease not found.'}</Text>
+          </View>
+        ) : (
+          <>
+            <View style={s.card}>
+              <Text style={styles.metricLabel}>Monthly rent</Text>
+              <Text style={styles.metricValue}>
+                {lease.rentAmount} {lease.currency}
+              </Text>
+              <Text style={[s.cardMeta, { marginTop: 8 }]}>
+                As {lease.role}
+                {lease.counterpartyName ? `, paid to ${lease.counterpartyName}` : ''}
               </Text>
             </View>
-            <Text style={s.cardBody}>
-              {payment.paidAt
-                ? `Paid on ${new Date(payment.paidAt).toLocaleDateString()}`
-                : 'Awaiting payment'}
-            </Text>
-          </View>
-        ))}
 
-        <Text style={styles.sectionTitle}>Documents</Text>
-        <Pressable
-          style={s.card}
-          onPress={() =>
-            onNavigate?.('DocumentDetail', {
-              documentId: `lease-${lease.id}-contract`,
-            })
-          }
-        >
-          <Text style={s.cardTitle}>📄 Lease agreement</Text>
-          <Text style={s.cardMeta}>Signed PDF — open to review or share.</Text>
-        </Pressable>
+            <Text style={styles.sectionTitle}>Payment history</Text>
+            {payments.length === 0 ? (
+              <View style={s.card}>
+                <Text style={s.cardBody}>No payments recorded yet.</Text>
+              </View>
+            ) : (
+              payments.map((payment) => (
+                <View key={payment.id} style={s.card}>
+                  <View style={s.cardHeader}>
+                    <Text style={s.cardTitle}>{payment.period}</Text>
+                    <Text style={s.cardMeta}>
+                      {payment.amount} {lease.currency}
+                    </Text>
+                  </View>
+                  <Text style={s.cardBody}>
+                    {payment.paidAt
+                      ? `Paid on ${new Date(payment.paidAt).toLocaleDateString()}`
+                      : 'Awaiting payment'}
+                  </Text>
+                </View>
+              ))
+            )}
+
+            <Text style={styles.sectionTitle}>Documents</Text>
+            <Pressable
+              style={s.card}
+              onPress={() =>
+                onNavigate?.('DocumentDetail', {
+                  documentId: `lease-${lease.id}-contract`,
+                })
+              }
+            >
+              <Text style={s.cardTitle}>📄 Lease agreement</Text>
+              <Text style={s.cardMeta}>Signed PDF — open to review or share.</Text>
+            </Pressable>
+          </>
+        )}
 
         <View style={s.bottomSpacer} />
       </ScrollView>

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.test.ts
@@ -1,0 +1,68 @@
+import { parseThreadDetail, threadTitle, toUiMessages } from './ThreadDetailScreen';
+
+const validDetail = {
+  participants: [{ id: 'u-2', firstName: 'Building', lastName: 'Manager', email: 'm@x.sk' }],
+  messages: [
+    { id: 'm2', content: 'Reply', createdAt: '2026-04-22T09:15:00Z', sender: { id: 'u-2' } },
+    { id: 'm1', content: 'Question', createdAt: '2026-04-22T08:30:00Z', sender: { id: 'u-1' } },
+  ],
+};
+
+describe('parseThreadDetail', () => {
+  it('parses a well-formed ThreadDetailResponse', () => {
+    const parsed = parseThreadDetail(validDetail);
+    expect(parsed?.messages).toHaveLength(2);
+    expect(parsed?.participants).toHaveLength(1);
+  });
+
+  it.each([
+    ['null', null],
+    ['a string', 'nope'],
+    ['a number', 42],
+  ])('returns null for an unexpected shape: %s', (_label, input) => {
+    expect(parseThreadDetail(input)).toBeNull();
+  });
+
+  it('drops malformed messages', () => {
+    const parsed = parseThreadDetail({
+      messages: [{ id: 'm1', content: 'ok', createdAt: 'x' }, null, { id: 'no-content' }],
+    });
+    expect(parsed?.messages).toHaveLength(1);
+  });
+});
+
+describe('threadTitle', () => {
+  it('uses the single participant name', () => {
+    expect(threadTitle(parseThreadDetail(validDetail), 'fallback')).toBe('Building Manager');
+  });
+
+  it('appends +N for group threads', () => {
+    const detail = parseThreadDetail({
+      participants: [
+        { id: 'a', firstName: 'Ann' },
+        { id: 'b', firstName: 'Bob' },
+      ],
+      messages: [],
+    });
+    expect(threadTitle(detail, 'fallback')).toBe('Ann +1');
+  });
+
+  it('falls back when there are no participants', () => {
+    expect(threadTitle(parseThreadDetail({ messages: [] }), 'Conversation')).toBe('Conversation');
+  });
+});
+
+describe('toUiMessages', () => {
+  it('derives fromMe from the current user id and sorts oldest first', () => {
+    const msgs = toUiMessages(parseThreadDetail(validDetail), 'u-1');
+    expect(msgs.map((m) => m.id)).toEqual(['m1', 'm2']);
+    expect(msgs[0].fromMe).toBe(true);
+    expect(msgs[0].authorName).toBe('You');
+    expect(msgs[1].fromMe).toBe(false);
+  });
+
+  it('treats every message as not-from-me when the user id is unknown', () => {
+    const msgs = toUiMessages(parseThreadDetail(validDetail), undefined);
+    expect(msgs.every((m) => !m.fromMe)).toBe(true);
+  });
+});

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -1,11 +1,19 @@
 /**
  * ThreadDetailScreen (UC-05.4 / 05.5).
  *
- * Conversation view with a simple compose input. Mock data backs the
- * message list until the messaging API client is wired in.
+ * Conversation view with a compose input.
+ *
+ * Wired to `GET /api/v1/messages/threads/{id}` (returns a
+ * `ThreadDetailResponse { thread, participants, messages, messageCount }`) and
+ * `POST /api/v1/messages/threads/{id}/messages` for sending. The messaging
+ * response structs use `#[serde(rename_all = "camelCase")]`, so the wire format
+ * is camelCase (see `MessageWithSender`, `ParticipantInfo`). `fromMe` is derived
+ * by comparing each message's `sender.id` to the authenticated user id
+ * (`useAuth().user.id`). The response is consumed without a generated client,
+ * so it is validated defensively.
  */
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -16,9 +24,11 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useAuth } from '../../contexts/AuthContext';
+import { useApiMutation, useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
-interface Message {
+export interface Message {
   id: string;
   body: string;
   sentAt: string;
@@ -26,29 +36,74 @@ interface Message {
   authorName: string;
 }
 
-const MOCK_MESSAGES: Message[] = [
-  {
-    id: 'm1',
-    body: 'Hi! When can we expect the elevator repair to be finished?',
-    sentAt: '2026-04-22T08:30:00Z',
-    fromMe: true,
-    authorName: 'You',
-  },
-  {
-    id: 'm2',
-    body: 'The technicians are scheduled for Wednesday morning. We expect it to be done by lunchtime.',
-    sentAt: '2026-04-22T09:15:00Z',
-    fromMe: false,
-    authorName: 'Building manager',
-  },
-  {
-    id: 'm3',
-    body: 'Great, thank you for the update!',
-    sentAt: '2026-04-22T09:18:00Z',
-    fromMe: true,
-    authorName: 'You',
-  },
-];
+/** Subset of `ParticipantInfo` (camelCase wire format). */
+interface ApiParticipant {
+  id: string;
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+}
+
+/** Subset of `MessageWithSender` (camelCase wire format). */
+interface ApiMessage {
+  id: string;
+  content: string;
+  createdAt: string;
+  sender?: ApiParticipant;
+}
+
+interface ApiThreadDetail {
+  participants?: ApiParticipant[];
+  messages?: ApiMessage[];
+}
+
+function participantName(p: ApiParticipant | undefined): string {
+  if (!p) return '';
+  const full = `${p.firstName ?? ''} ${p.lastName ?? ''}`.trim();
+  return full || p.email || '';
+}
+
+/** Derive the conversation title from the thread's other participants. */
+export function threadTitle(detail: ApiThreadDetail | null, fallback: string): string {
+  const people = detail?.participants ?? [];
+  if (people.length === 0) return fallback;
+  const [first, ...rest] = people;
+  const name = participantName(first) || fallback;
+  return rest.length > 0 ? `${name} +${rest.length}` : name;
+}
+
+function isApiMessage(value: unknown): value is ApiMessage {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string' && typeof v.content === 'string';
+}
+
+/** Validate the raw `GET .../threads/{id}` body, or null on a bad shape. */
+export function parseThreadDetail(data: unknown): ApiThreadDetail | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const v = data as Record<string, unknown>;
+  return {
+    participants: Array.isArray(v.participants) ? (v.participants as ApiParticipant[]) : [],
+    messages: Array.isArray(v.messages) ? (v.messages as unknown[]).filter(isApiMessage) : [],
+  };
+}
+
+/** Map api-server messages onto UI bubbles, oldest first. `currentUserId`
+ *  drives the `fromMe` flag. Exported for unit testing. */
+export function toUiMessages(detail: ApiThreadDetail | null, currentUserId?: string): Message[] {
+  return (detail?.messages ?? [])
+    .map((m) => {
+      const fromMe = !!currentUserId && m.sender?.id === currentUserId;
+      return {
+        id: m.id,
+        body: m.content,
+        sentAt: m.createdAt,
+        fromMe,
+        authorName: fromMe ? 'You' : participantName(m.sender) || 'Participant',
+      };
+    })
+    .sort((a, b) => new Date(a.sentAt).getTime() - new Date(b.sentAt).getTime());
+}
 
 interface ThreadDetailScreenProps {
   threadId?: string;
@@ -57,26 +112,44 @@ interface ThreadDetailScreenProps {
 }
 
 export function ThreadDetailScreen({
-  participantName = 'Building manager',
+  threadId,
+  participantName: participantNameProp = 'Conversation',
   onBack,
 }: ThreadDetailScreenProps) {
-  const [messages, setMessages] = useState<Message[]>(MOCK_MESSAGES);
+  const { user } = useAuth();
   const [draft, setDraft] = useState('');
+
+  const { data, isLoading, error, refetch, isFetching } = useApiQuery<unknown>(
+    ['messages', 'thread', threadId],
+    `/api/v1/messages/threads/${threadId ?? ''}`,
+    { staleTime: 15_000, enabled: !!threadId }
+  );
+
+  const sendMessage = useApiMutation<unknown, { content: string }>(
+    `/api/v1/messages/threads/${threadId ?? ''}/messages`,
+    'POST'
+  );
+
+  const detail = parseThreadDetail(data);
+  const messages = toUiMessages(detail, user?.id);
+  const title = threadTitle(detail, participantNameProp);
+
+  const onRefresh = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   const handleSend = () => {
     const trimmed = draft.trim();
-    if (!trimmed) return;
-    setMessages((prev) => [
-      ...prev,
+    if (!trimmed || !threadId || sendMessage.isPending) return;
+    sendMessage.mutate(
+      { content: trimmed },
       {
-        id: `m${prev.length + 1}`,
-        body: trimmed,
-        sentAt: new Date().toISOString(),
-        fromMe: true,
-        authorName: 'You',
-      },
-    ]);
-    setDraft('');
+        onSuccess: () => {
+          setDraft('');
+          refetch();
+        },
+      }
+    );
   };
 
   return (
@@ -90,25 +163,47 @@ export function ThreadDetailScreen({
             <Text style={styles.backLinkText}>← Messages</Text>
           </Pressable>
         )}
-        <Text style={s.headerTitle}>{participantName}</Text>
+        <Text style={s.headerTitle}>{title}</Text>
       </View>
 
       <ScrollView style={s.scrollView} contentContainerStyle={styles.threadContent}>
-        {messages.map((message) => (
-          <View
-            key={message.id}
-            style={[styles.bubble, message.fromMe ? styles.bubbleMine : styles.bubbleTheirs]}
-          >
-            {!message.fromMe && <Text style={styles.author}>{message.authorName}</Text>}
-            <Text style={[styles.body, message.fromMe && styles.bodyMine]}>{message.body}</Text>
-            <Text style={[styles.time, message.fromMe && styles.timeMine]}>
-              {new Date(message.sentAt).toLocaleTimeString('en-US', {
-                hour: '2-digit',
-                minute: '2-digit',
-              })}
-            </Text>
+        {isLoading || !threadId ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyTitle}>Loading…</Text>
           </View>
-        ))}
+        ) : error ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>⚠️</Text>
+            <Text style={s.emptyTitle}>Couldn't load conversation</Text>
+            <Text style={s.emptyText}>{error.message}</Text>
+            <Pressable style={s.primaryButton} onPress={onRefresh}>
+              <Text style={s.primaryButtonText}>Try again</Text>
+            </Pressable>
+          </View>
+        ) : messages.length === 0 ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>💬</Text>
+            <Text style={s.emptyTitle}>No messages yet</Text>
+            <Text style={s.emptyText}>Say hello to start the conversation.</Text>
+          </View>
+        ) : (
+          messages.map((message) => (
+            <View
+              key={message.id}
+              style={[styles.bubble, message.fromMe ? styles.bubbleMine : styles.bubbleTheirs]}
+            >
+              {!message.fromMe && <Text style={styles.author}>{message.authorName}</Text>}
+              <Text style={[styles.body, message.fromMe && styles.bodyMine]}>{message.body}</Text>
+              <Text style={[styles.time, message.fromMe && styles.timeMine]}>
+                {new Date(message.sentAt).toLocaleTimeString('en-US', {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </Text>
+            </View>
+          ))
+        )}
+        {isFetching && !isLoading ? <Text style={styles.syncing}>Syncing…</Text> : null}
         <View style={s.bottomSpacer} />
       </ScrollView>
 
@@ -122,10 +217,13 @@ export function ThreadDetailScreen({
         />
         <Pressable
           onPress={handleSend}
-          style={[styles.sendButton, !draft.trim() && styles.sendButtonDisabled]}
-          disabled={!draft.trim()}
+          style={[
+            styles.sendButton,
+            (!draft.trim() || sendMessage.isPending) && styles.sendButtonDisabled,
+          ]}
+          disabled={!draft.trim() || sendMessage.isPending}
         >
-          <Text style={styles.sendButtonText}>Send</Text>
+          <Text style={styles.sendButtonText}>{sendMessage.isPending ? '…' : 'Send'}</Text>
         </Pressable>
       </View>
     </KeyboardAvoidingView>
@@ -136,6 +234,7 @@ const styles = StyleSheet.create({
   backLink: { marginBottom: 8 },
   backLinkText: { color: colors.accent, fontSize: 14 },
   threadContent: { paddingBottom: 24 },
+  syncing: { textAlign: 'center', color: colors.textMuted, fontSize: 12, marginTop: 8 },
   bubble: {
     padding: 12,
     borderRadius: 16,

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.test.ts
@@ -1,0 +1,43 @@
+import { parseMeterResponse, toUiReadings } from './MeterDetailScreen';
+
+const validResponse = {
+  meter: { id: 'm-1', meter_number: 'CW-001', unit_of_measure: 'm³' },
+  recent_readings: [
+    { id: 'r1', reading: '141.2', reading_date: '2026-02-28' },
+    { id: 'r2', reading: '142.4', reading_date: '2026-03-31' },
+  ],
+};
+
+describe('parseMeterResponse', () => {
+  it('parses a well-formed MeterResponse', () => {
+    const parsed = parseMeterResponse(validResponse);
+    expect(parsed?.meter.id).toBe('m-1');
+    expect(parsed?.recent_readings).toHaveLength(2);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a string', 'nope'],
+    ['no meter', { recent_readings: [] }],
+    ['meter without id', { meter: {}, recent_readings: [] }],
+  ])('returns null for an unexpected shape: %s', (_label, input) => {
+    expect(parseMeterResponse(input)).toBeNull();
+  });
+
+  it('drops malformed readings but keeps the meter', () => {
+    const parsed = parseMeterResponse({
+      meter: { id: 'm-1' },
+      recent_readings: [{ id: 'r1', reading: '1', reading_date: '2026-01-01' }, null, 'x', {}],
+    });
+    expect(parsed?.recent_readings).toHaveLength(1);
+  });
+});
+
+describe('toUiReadings', () => {
+  it('maps readings and sorts newest first', () => {
+    const rows = toUiReadings(parseMeterResponse(validResponse)!);
+    expect(rows.map((r) => r.id)).toEqual(['r2', 'r1']);
+    expect(rows[0]).toEqual({ id: 'r2', value: 142.4, unit: 'm³', takenAt: '2026-03-31' });
+  });
+});

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
@@ -3,24 +3,99 @@
  *
  * Single meter view: history of readings, consumption summary and a CTA to
  * submit a new reading.
+ *
+ * Wired to `GET /api/v1/meters/{id}` on the api-server, which returns a
+ * `MeterResponse { meter, recent_readings }` (see
+ * `db::models::meter::{Meter, MeterReading, MeterResponse}`). Those structs
+ * serialize with the default (snake_case) serde naming, so the wire format is
+ * snake_case and `Decimal` fields arrive as JSON strings. The response is
+ * consumed without a generated client, so it is validated defensively — a
+ * malformed shape degrades to an empty history rather than crashing.
  */
 
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useCallback } from 'react';
+import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
-interface MeterReadingRecord {
+export interface MeterReadingRecord {
   id: string;
   value: number;
   unit: string;
   takenAt: string;
 }
 
-const MOCK_READINGS: MeterReadingRecord[] = [
-  { id: 'r1', value: 142.4, unit: 'm³', takenAt: '2026-03-31T09:10:00Z' },
-  { id: 'r2', value: 141.2, unit: 'm³', takenAt: '2026-02-28T08:45:00Z' },
-  { id: 'r3', value: 139.7, unit: 'm³', takenAt: '2026-01-31T09:05:00Z' },
-  { id: 'r4', value: 138.0, unit: 'm³', takenAt: '2025-12-31T09:00:00Z' },
-];
+/** Subset of `Meter` from `GET /api/v1/meters/{id}`. */
+export interface ApiMeter {
+  id: string;
+  meter_number?: string | null;
+  meter_type?: string | null;
+  unit_of_measure?: string | null;
+  current_reading?: string | number | null;
+  last_reading_date?: string | null;
+  location?: string | null;
+  description?: string | null;
+}
+
+/** Subset of `MeterReading` from the `recent_readings` list. */
+export interface ApiMeterReading {
+  id: string;
+  reading: string | number;
+  reading_date: string;
+  created_at?: string;
+}
+
+export interface ApiMeterResponse {
+  meter: ApiMeter;
+  recent_readings: ApiMeterReading[];
+}
+
+/** Parse a `Decimal`-as-string (or number) into a finite number, or null. */
+function toNumber(value: string | number | null | undefined): number | null {
+  if (value == null) return null;
+  const n = typeof value === 'number' ? value : Number.parseFloat(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function isApiMeterReading(value: unknown): value is ApiMeterReading {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.id === 'string' &&
+    (typeof v.reading === 'string' || typeof v.reading === 'number') &&
+    typeof v.reading_date === 'string'
+  );
+}
+
+/** Narrow the raw `GET /api/v1/meters/{id}` body into a validated response.
+ *  Tolerates any garbage top-level shape by returning null so the screen can
+ *  fall back to its empty state instead of dereferencing `undefined.meter`. */
+export function parseMeterResponse(data: unknown): ApiMeterResponse | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const v = data as Record<string, unknown>;
+  const meter = v.meter;
+  if (typeof meter !== 'object' || meter === null) return null;
+  const m = meter as Record<string, unknown>;
+  if (typeof m.id !== 'string') return null;
+  const readings = Array.isArray(v.recent_readings)
+    ? (v.recent_readings as unknown[]).filter(isApiMeterReading)
+    : [];
+  return { meter: meter as ApiMeter, recent_readings: readings };
+}
+
+/** Map api-server readings onto the UI record shape, newest first. Exported so
+ *  the mapping can be unit-tested without rendering the screen. */
+export function toUiReadings(response: ApiMeterResponse): MeterReadingRecord[] {
+  const unit = response.meter.unit_of_measure?.trim() || '';
+  return response.recent_readings
+    .map((r) => ({
+      id: r.id,
+      value: toNumber(r.reading) ?? 0,
+      unit,
+      takenAt: r.reading_date,
+    }))
+    .sort((a, b) => new Date(b.takenAt).getTime() - new Date(a.takenAt).getTime());
+}
 
 interface MeterDetailScreenProps {
   meterId?: string;
@@ -31,12 +106,26 @@ interface MeterDetailScreenProps {
 
 export function MeterDetailScreen({
   meterId,
-  meterLabel = 'Cold water',
+  meterLabel = 'Meter',
   onBack,
   onNavigate,
 }: MeterDetailScreenProps) {
-  const lastTwo = MOCK_READINGS.slice(0, 2);
+  const { data, isLoading, error, refetch, isFetching } = useApiQuery<unknown>(
+    ['meters', 'detail', meterId],
+    `/api/v1/meters/${meterId ?? ''}`,
+    { staleTime: 30_000, enabled: !!meterId }
+  );
+
+  const response = parseMeterResponse(data);
+  const readings = response ? toUiReadings(response) : [];
+  const label = response?.meter.meter_number?.trim() || meterLabel;
+
+  const lastTwo = readings.slice(0, 2);
   const monthDelta = lastTwo.length === 2 ? Math.max(0, lastTwo[0].value - lastTwo[1].value) : null;
+
+  const onRefresh = useCallback(async () => {
+    await refetch();
+  }, [refetch]);
 
   return (
     <View style={s.container}>
@@ -46,42 +135,69 @@ export function MeterDetailScreen({
             <Text style={styles.backLinkText}>← Meters</Text>
           </Pressable>
         )}
-        <Text style={s.headerTitle}>{meterLabel}</Text>
+        <Text style={s.headerTitle}>{label}</Text>
         {meterId && <Text style={s.headerSubtitle}>ID: {meterId}</Text>}
       </View>
 
-      <ScrollView style={s.scrollView}>
-        <View style={s.card}>
-          <Text style={styles.metricLabel}>Latest reading</Text>
-          <Text style={styles.metricValue}>
-            {MOCK_READINGS[0].value} {MOCK_READINGS[0].unit}
-          </Text>
-          <Text style={s.cardMeta}>{new Date(MOCK_READINGS[0].takenAt).toLocaleDateString()}</Text>
-          {monthDelta != null && (
-            <Text style={[s.cardBody, { marginTop: 8 }]}>
-              Used in last month: {monthDelta.toFixed(2)} {MOCK_READINGS[0].unit}
-            </Text>
-          )}
-        </View>
-
-        <Text style={styles.sectionTitle}>Reading history</Text>
-        {MOCK_READINGS.map((r) => (
-          <View key={r.id} style={s.card}>
-            <View style={s.cardHeader}>
-              <Text style={s.cardTitle}>
-                {r.value} {r.unit}
-              </Text>
-              <Text style={s.cardMeta}>{new Date(r.takenAt).toLocaleDateString()}</Text>
-            </View>
+      <ScrollView
+        style={s.scrollView}
+        refreshControl={<RefreshControl refreshing={isFetching} onRefresh={onRefresh} />}
+      >
+        {isLoading || !meterId ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyTitle}>Loading…</Text>
           </View>
-        ))}
+        ) : error ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>⚠️</Text>
+            <Text style={s.emptyTitle}>Couldn't load meter</Text>
+            <Text style={s.emptyText}>{error.message}</Text>
+          </View>
+        ) : (
+          <>
+            {readings.length > 0 && (
+              <View style={s.card}>
+                <Text style={styles.metricLabel}>Latest reading</Text>
+                <Text style={styles.metricValue}>
+                  {readings[0].value} {readings[0].unit}
+                </Text>
+                <Text style={s.cardMeta}>{new Date(readings[0].takenAt).toLocaleDateString()}</Text>
+                {monthDelta != null && (
+                  <Text style={[s.cardBody, { marginTop: 8 }]}>
+                    Used since previous reading: {monthDelta.toFixed(2)} {readings[0].unit}
+                  </Text>
+                )}
+              </View>
+            )}
 
-        <Pressable
-          style={s.primaryButton}
-          onPress={() => onNavigate?.('MeterReading', { meterId })}
-        >
-          <Text style={s.primaryButtonText}>Submit new reading</Text>
-        </Pressable>
+            <Text style={styles.sectionTitle}>Reading history</Text>
+            {readings.length === 0 ? (
+              <View style={s.emptyState}>
+                <Text style={s.emptyIcon}>📏</Text>
+                <Text style={s.emptyTitle}>No readings yet</Text>
+                <Text style={s.emptyText}>Submit your first reading for this meter.</Text>
+              </View>
+            ) : (
+              readings.map((r) => (
+                <View key={r.id} style={s.card}>
+                  <View style={s.cardHeader}>
+                    <Text style={s.cardTitle}>
+                      {r.value} {r.unit}
+                    </Text>
+                    <Text style={s.cardMeta}>{new Date(r.takenAt).toLocaleDateString()}</Text>
+                  </View>
+                </View>
+              ))
+            )}
+
+            <Pressable
+              style={s.primaryButton}
+              onPress={() => onNavigate?.('MeterReading', { meterId })}
+            >
+              <Text style={s.primaryButtonText}>Submit new reading</Text>
+            </Pressable>
+          </>
+        )}
 
         <View style={s.bottomSpacer} />
       </ScrollView>

--- a/frontend/apps/mobile/src/screens/meters/MetersScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/meters/MetersScreen.test.ts
@@ -1,0 +1,73 @@
+import { type ApiMeter, parseMeters, toUiCommodity, toUiMeter } from './MetersScreen';
+
+const validMeter: ApiMeter = {
+  id: 'm-1',
+  meter_number: 'CW-001',
+  meter_type: 'cold_water',
+  unit_of_measure: 'm³',
+  current_reading: '142.4',
+  last_reading_date: '2026-03-31',
+};
+
+describe('parseMeters', () => {
+  it('accepts a bare array (the unit route returns Vec<Meter>)', () => {
+    expect(parseMeters([validMeter])).toEqual([validMeter]);
+  });
+
+  it('accepts a `{ meters: [...] }` envelope (defensive)', () => {
+    expect(parseMeters({ meters: [validMeter] })).toEqual([validMeter]);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['a string', 'nope'],
+    ['an object without meters', { error: 'boom' }],
+  ])('returns [] for an unexpected top-level shape: %s', (_label, input) => {
+    expect(parseMeters(input)).toEqual([]);
+  });
+
+  it('drops malformed rows', () => {
+    expect(parseMeters([validMeter, null, 'x', { noId: true }])).toEqual([validMeter]);
+  });
+});
+
+describe('toUiCommodity', () => {
+  it.each([
+    ['cold_water', 'water_cold'],
+    ['hot_water', 'water_hot'],
+    ['water', 'water'],
+    ['gas', 'gas'],
+    ['heat', 'heat'],
+    ['solar', 'heat'],
+    ['electricity', 'electricity'],
+    ['unknown', 'electricity'],
+    [null, 'electricity'],
+  ])('maps meter_type %s → %s', (input, expected) => {
+    expect(toUiCommodity(input as string | null)).toBe(expected);
+  });
+});
+
+describe('toUiMeter', () => {
+  it('maps an api meter onto the UI shape', () => {
+    expect(toUiMeter(validMeter)).toEqual({
+      id: 'm-1',
+      label: 'CW-001',
+      commodity: 'water_cold',
+      unit: 'm³',
+      lastReading: 142.4,
+      lastReadingAt: '2026-03-31',
+    });
+  });
+
+  it('handles a missing current reading', () => {
+    const mapped = toUiMeter({ ...validMeter, current_reading: null });
+    expect(mapped.lastReading).toBeNull();
+  });
+
+  it('falls back to location then a generic label when meter_number is absent', () => {
+    expect(toUiMeter({ id: 'm-2', location: 'Basement' }).label).toBe('Basement');
+    expect(toUiMeter({ id: 'm-3' }).label).toBe('Meter');
+  });
+});

--- a/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
@@ -1,16 +1,26 @@
 /**
  * MetersScreen (UC-11.1).
  *
- * Lists meters assigned to the user's unit with their last reading and the
- * next due date. The existing `MeterReadingScreen` handles the submission
- * flow; this screen wraps that flow with a list view.
+ * Lists meters assigned to the signed-in resident's unit with their last
+ * reading. The existing `MeterReadingScreen` handles the submission flow; this
+ * screen wraps that flow with a list view.
+ *
+ * Wired to `GET /api/v1/meters/units/{unit_id}` on the api-server, which
+ * returns `Vec<Meter>` (see `db::models::meter::Meter` — default snake_case
+ * serde, `Decimal` fields as JSON strings). The unit id comes from the
+ * authenticated user (`useAuth().user.unitId`); the query stays disabled until
+ * it is known. The response is consumed without a generated client, so it is
+ * validated defensively — malformed rows are dropped rather than crashing the
+ * list.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useAuth } from '../../contexts/AuthContext';
+import { useApiQuery } from '../../hooks/useApi';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
-export type MeterCommodity = 'water_cold' | 'water_hot' | 'electricity' | 'gas' | 'heat';
+export type MeterCommodity = 'water_cold' | 'water_hot' | 'water' | 'electricity' | 'gas' | 'heat';
 
 export interface Meter {
   id: string;
@@ -19,51 +29,84 @@ export interface Meter {
   unit: string;
   lastReading: number | null;
   lastReadingAt: string | null;
-  dueAt: string;
 }
 
-const MOCK_METERS: Meter[] = [
-  {
-    id: 'm-w-cold',
-    label: 'Cold water',
-    commodity: 'water_cold',
-    unit: 'm³',
-    lastReading: 142.4,
-    lastReadingAt: '2026-03-31T09:10:00Z',
-    dueAt: '2026-04-30T23:59:00Z',
-  },
-  {
-    id: 'm-w-hot',
-    label: 'Hot water',
-    commodity: 'water_hot',
-    unit: 'm³',
-    lastReading: 88.6,
-    lastReadingAt: '2026-03-31T09:12:00Z',
-    dueAt: '2026-04-30T23:59:00Z',
-  },
-  {
-    id: 'm-elec',
-    label: 'Electricity',
-    commodity: 'electricity',
-    unit: 'kWh',
-    lastReading: 4521,
-    lastReadingAt: '2026-04-01T08:00:00Z',
-    dueAt: '2026-05-01T23:59:00Z',
-  },
-  {
-    id: 'm-heat',
-    label: 'Heating',
-    commodity: 'heat',
-    unit: 'GJ',
-    lastReading: null,
-    lastReadingAt: null,
-    dueAt: '2026-04-30T23:59:00Z',
-  },
-];
+/** Subset of `Meter` from `GET /api/v1/meters/units/{unit_id}`. */
+export interface ApiMeter {
+  id: string;
+  meter_number?: string | null;
+  /** `MeterType` serialized snake_case: electricity|gas|water|heat|cold_water|hot_water|solar|other. */
+  meter_type?: string | null;
+  unit_of_measure?: string | null;
+  current_reading?: string | number | null;
+  last_reading_date?: string | null;
+  location?: string | null;
+}
+
+interface ApiMetersEnvelope {
+  meters: ApiMeter[];
+}
+
+function isApiMeter(value: unknown): value is ApiMeter {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.id === 'string';
+}
+
+/** Normalise the `/api/v1/meters/units/{unit_id}` response into a validated
+ *  list. The unit route returns a bare `Vec<Meter>`; a `{ meters: [...] }`
+ *  envelope is also accepted defensively. Any other shape yields `[]`. */
+export function parseMeters(data: unknown): ApiMeter[] {
+  const candidates: unknown[] = Array.isArray(data)
+    ? data
+    : typeof data === 'object' && data !== null && Array.isArray((data as ApiMetersEnvelope).meters)
+      ? (data as ApiMetersEnvelope).meters
+      : [];
+  return candidates.filter(isApiMeter);
+}
+
+/** Map the api-server `meter_type` string onto the UI commodity enum. */
+export function toUiCommodity(meterType: string | null | undefined): MeterCommodity {
+  switch (meterType) {
+    case 'cold_water':
+      return 'water_cold';
+    case 'hot_water':
+      return 'water_hot';
+    case 'water':
+      return 'water';
+    case 'gas':
+      return 'gas';
+    case 'heat':
+    case 'solar':
+      return 'heat';
+    default:
+      return 'electricity';
+  }
+}
+
+/** Map an api-server meter onto the UI shape. Exported for unit testing. */
+export function toUiMeter(m: ApiMeter): Meter {
+  const rawReading = m.current_reading;
+  const reading =
+    rawReading == null
+      ? null
+      : typeof rawReading === 'number'
+        ? rawReading
+        : Number.parseFloat(rawReading);
+  return {
+    id: m.id,
+    label: m.meter_number?.trim() || m.location?.trim() || 'Meter',
+    commodity: toUiCommodity(m.meter_type),
+    unit: m.unit_of_measure?.trim() || '',
+    lastReading: reading != null && Number.isFinite(reading) ? reading : null,
+    lastReadingAt: m.last_reading_date ?? null,
+  };
+}
 
 function commodityIcon(commodity: MeterCommodity): string {
   switch (commodity) {
     case 'water_cold':
+    case 'water':
       return '💧';
     case 'water_hot':
       return '🔥';
@@ -76,39 +119,61 @@ function commodityIcon(commodity: MeterCommodity): string {
   }
 }
 
-function daysUntil(dueAt: string): number {
-  return Math.ceil((new Date(dueAt).getTime() - Date.now()) / (1000 * 60 * 60 * 24));
-}
-
 interface MetersScreenProps {
   onNavigate?: (screen: string, params?: Record<string, unknown>) => void;
 }
 
 export function MetersScreen({ onNavigate }: MetersScreenProps) {
-  const [refreshing, setRefreshing] = useState(false);
+  const { user } = useAuth();
+  const unitId = user?.unitId;
+
+  const { data, isLoading, error, refetch, isFetching } = useApiQuery<unknown>(
+    ['meters', 'unit', unitId],
+    `/api/v1/meters/units/${unitId ?? ''}`,
+    { staleTime: 30_000, enabled: !!unitId }
+  );
+
+  const meters: Meter[] = parseMeters(data).map(toUiMeter);
 
   const onRefresh = useCallback(async () => {
-    setRefreshing(true);
-    await new Promise((r) => setTimeout(r, 600));
-    setRefreshing(false);
-  }, []);
+    await refetch();
+  }, [refetch]);
 
   return (
     <View style={s.container}>
       <View style={s.header}>
         <Text style={s.headerTitle}>Meters</Text>
-        <Text style={s.headerSubtitle}>Submit your readings before the due date.</Text>
+        <Text style={s.headerSubtitle}>Meters registered to your unit.</Text>
       </View>
 
       <ScrollView
         style={s.scrollView}
-        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        refreshControl={<RefreshControl refreshing={isFetching} onRefresh={onRefresh} />}
       >
-        {MOCK_METERS.map((meter) => {
-          const days = daysUntil(meter.dueAt);
-          const overdue = days < 0;
-          const dueSoon = days >= 0 && days <= 7;
-          return (
+        {!unitId ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>🏠</Text>
+            <Text style={s.emptyTitle}>No unit linked</Text>
+            <Text style={s.emptyText}>Meters appear once your account is linked to a unit.</Text>
+          </View>
+        ) : isLoading ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyTitle}>Loading…</Text>
+          </View>
+        ) : error ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>⚠️</Text>
+            <Text style={s.emptyTitle}>Couldn't load meters</Text>
+            <Text style={s.emptyText}>{error.message}</Text>
+          </View>
+        ) : meters.length === 0 ? (
+          <View style={s.emptyState}>
+            <Text style={s.emptyIcon}>📏</Text>
+            <Text style={s.emptyTitle}>No meters</Text>
+            <Text style={s.emptyText}>No meters are registered for your unit yet.</Text>
+          </View>
+        ) : (
+          meters.map((meter) => (
             <Pressable
               key={meter.id}
               style={s.card}
@@ -117,23 +182,6 @@ export function MetersScreen({ onNavigate }: MetersScreenProps) {
               <View style={s.cardHeader}>
                 <Text style={styles.icon}>{commodityIcon(meter.commodity)}</Text>
                 <Text style={[s.cardTitle, { marginLeft: 8 }]}>{meter.label}</Text>
-                <View
-                  style={[
-                    s.badge,
-                    overdue && styles.badgeOverdue,
-                    dueSoon && !overdue && styles.badgeDueSoon,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      s.badgeText,
-                      overdue && styles.badgeOverdueText,
-                      dueSoon && !overdue && styles.badgeDueSoonText,
-                    ]}
-                  >
-                    {overdue ? `${Math.abs(days)}d overdue` : `${days}d left`}
-                  </Text>
-                </View>
               </View>
 
               <Text style={s.cardBody}>
@@ -155,8 +203,8 @@ export function MetersScreen({ onNavigate }: MetersScreenProps) {
                 </Pressable>
               </View>
             </Pressable>
-          );
-        })}
+          ))
+        )}
 
         <View style={s.bottomSpacer} />
       </ScrollView>
@@ -166,10 +214,6 @@ export function MetersScreen({ onNavigate }: MetersScreenProps) {
 
 const styles = StyleSheet.create({
   icon: { fontSize: 20 },
-  badgeOverdue: { backgroundColor: colors.dangerBg },
-  badgeOverdueText: { color: colors.danger },
-  badgeDueSoon: { backgroundColor: colors.warningBg },
-  badgeDueSoonText: { color: colors.warningDark },
   linkButton: { paddingVertical: 4 },
   linkButtonText: { color: colors.accent, fontSize: 14, fontWeight: '500' },
 });

--- a/frontend/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
@@ -1,8 +1,14 @@
 /**
  * NotificationsScreen (UC-01.4).
  *
- * Inbox-style list of all notifications delivered to the user. Mock data is
- * used until the notification-preferences hooks are wired in.
+ * Inbox-style list of all notifications delivered to the user.
+ *
+ * NOTE: still backed by mock data. The api-server currently exposes only a
+ * WebSocket sync endpoint for the notification inbox (`ws_notifications` at
+ * `GET /api/v1/users/me/notifications/ws`) plus preference/critical-notification
+ * routes — there is no REST list endpoint to page the inbox. Wiring this screen
+ * needs a backend `GET /api/v1/users/me/notifications` (REST list) first, so it
+ * is intentionally left on mock data (tracked as a backend follow-up).
  */
 
 import { useCallback, useMemo, useState } from 'react';

--- a/frontend/apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
@@ -2,8 +2,16 @@
  * PersonMonthsScreen (UC-10).
  *
  * Lets a resident view and edit the number of person-months declared per
- * unit per month, used for cost-allocation. Mock data shows the convention
- * until the API client hooks are wired in.
+ * unit per month, used for cost-allocation.
+ *
+ * NOTE: still backed by mock data. The read endpoint
+ * (`GET /api/v1/buildings/{building_id}/units/{unit_id}/person-months?year=…`)
+ * needs both a building id and a unit id plus a year, and its `PersonMonth`
+ * rows carry no per-entry draft/submitted/confirmed status — the field this
+ * screen's editing flow depends on. Wiring it cleanly needs a resident-scoped
+ * "my person-months" endpoint (or a status column) on the backend, so it is
+ * intentionally left on mock data (tracked as a backend follow-up). Sibling
+ * list/detail screens (Meters, Leases, Forms, Threads) are already wired.
  */
 
 import { useCallback, useState } from 'react';


### PR DESCRIPTION
## Task
Mobile RN production screens (Buildings/Meters/Leases/PersonMonths/Notifications/Threads/Forms) render hardcoded MOCK_* arrays — no API wiring.

## Owner
`pm-backend` (advisory hint only). Actual work is React Native under `frontend/apps/mobile` → specialist: **react-native**.

## What changed
Replaced hardcoded `MOCK_*` arrays with live api-server data in **5** screens, following the established `useApiQuery` + defensive-parse pattern already used by `BuildingsScreen`/`LeasesScreen`/`MessagesScreen` (validate `unknown` → drop malformed rows → loading/error/empty states):

| Screen | Endpoint |
|---|---|
| `MetersScreen` | `GET /api/v1/meters/units/{unitId}` (unit id from `useAuth().user.unitId`) |
| `MeterDetailScreen` | `GET /api/v1/meters/{id}` → `MeterResponse { meter, recent_readings }` |
| `LeaseDetailScreen` | `GET /api/v1/leases/{id}` → `LeaseWithDetails` (+ payment history) |
| `FormsScreen` | `GET /api/v1/forms/available` (resident-scoped; `/forms` is manager-only) |
| `ThreadDetailScreen` | `GET /api/v1/messages/threads/{id}` + `POST .../messages` (send) |

Each screen exports pure `parse*`/`toUi*` helpers with new unit tests (envelope / bare-array / garbage-shape / malformed-row cases). `fromMe` in threads is derived from `sender.id === useAuth().user.id`.

### Intentionally left on mock data (documented inline, backend follow-ups)
- **NotificationsScreen** — the api-server exposes only a **WebSocket** sync endpoint for the inbox (`ws_notifications`) plus preference/critical routes; there is **no REST list endpoint** to page the inbox. Needs `GET /api/v1/users/me/notifications` (REST) first.
- **PersonMonthsScreen** — the read endpoint needs building+unit+year, and `PersonMonth` rows carry **no per-entry draft/submitted/confirmed status** (the field this screen's edit flow depends on). Needs a resident-scoped endpoint or a status column.

`BuildingsScreen` and `LeasesScreen` (list) were already wired — untouched.

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → **exit 0**
- `pnpm -F mobile test -- src/screens/meters src/screens/leases src/screens/forms src/screens/messages` → **82 mapper tests pass**. Two pre-existing `.tsx` render suites (`MessagesScreen.test.tsx`, `LeaseSignatureScreen.test.tsx`) fail to *load* due to an environment peer-dep mismatch (`react-test-renderer` 19.2.6 vs expected 19.2.0) — unrelated to this diff (those files are untouched; my new tests are `.ts`, no renderer).
- `pnpm exec biome check <changed>` → **exit 0**

One real bug was caught by the new tests during development: `toUiPayments` was sorting by the formatted month label (alphabetical) instead of the raw `due_date` — fixed.

## Built (Band B)
Skipped: no Metro/Expo build in this cloud env; change is UI-layer data wiring (no config/build-output change). Static verify (typecheck + biome + jest) is green.

## CI parity (Band C)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Scope drift
`scope-check.sh --owner pm-backend` → exit 2 (drift) **only** because the advisory `owner_role=pm-backend` maps to `backend/`, while the correct work for this task is entirely under `frontend/apps/mobile` (the task brief states owner_role is a routing hint and the real work is React Native). All 12 changed files are within the legitimate mobile scope. No backend files touched.

## Code-reuse review
`reuse-grep.sh --specialist react-native` → clean (no duplicated helpers).

## Notes
- 5 of 7 screens wired; 2 remain blocked on missing backend surface (documented above) — safer than shipping wiring against non-existent/ill-fitting endpoints.
- No new networking abstraction: reuses `useApiQuery`/`useApiMutation` from `src/hooks/useApi.ts` (which already sends bearer + `X-Tenant-ID`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGv3DTbGBzuyusMVWoiz1W

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGv3DTbGBzuyusMVWoiz1W)_