### PR TITLE
gh-issue-2107: authorize outage mutations on DB role, not JWT claim

### DIFF
--- a/backend/servers/api-server/src/routes/outages.rs
+++ b/backend/servers/api-server/src/routes/outages.rs
@@ -199,13 +199,18 @@ pub fn router() -> Router<AppState> {
 async fn create_outage(
     State(state): State<AppState>,
     auth: AuthUser,
-    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Json(req): Json<CreateOutageRequest>,
 ) -> Result<(StatusCode, Json<CreateOutageResponse>), (StatusCode, Json<ErrorResponse>)> {
-    // Authorization: require manager-level role
-    let role = tenant.role;
-    if !role.is_manager() {
+    // Authorization: require manager-level role.
+    //
+    // Derive the role from validated DB membership — `RlsConnection` is built on
+    // `ValidatedTenantExtractor`, which reads the caller's `organization_members`
+    // role_type — rather than from the JWT `role` claim. The production login flow
+    // (`JwtService::generate_access_token`) emits `org_id`/`roles`, which the
+    // `AuthUser`/`TenantExtractor` path never reads, so trusting the JWT role
+    // resolves a real manager to `Guest` and 403s every mutation (issue #2107).
+    if !rls.role().is_manager() {
         rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
@@ -217,7 +222,7 @@ async fn create_outage(
     }
 
     let created_by = auth.user_id;
-    let org_id = tenant.tenant_id;
+    let org_id = rls.tenant_id();
 
     // Validate content length
     if req.title.len() > MAX_TITLE_LENGTH {
@@ -497,13 +502,12 @@ async fn get_outage(
 async fn update_outage(
     State(state): State<AppState>,
     _auth: AuthUser,
-    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateOutageRequest>,
 ) -> Result<Json<OutageActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Authorization: require manager-level role
-    if !tenant.role.is_manager() {
+    // Authorization: require manager-level role (DB-validated via RlsConnection).
+    if !rls.role().is_manager() {
         rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
@@ -597,12 +601,11 @@ async fn update_outage(
 async fn delete_outage(
     State(state): State<AppState>,
     _auth: AuthUser,
-    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    // Authorization: require manager-level role
-    if !tenant.role.is_manager() {
+    // Authorization: require manager-level role (DB-validated via RlsConnection).
+    if !rls.role().is_manager() {
         rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
@@ -649,13 +652,12 @@ async fn delete_outage(
 async fn start_outage(
     State(state): State<AppState>,
     _auth: AuthUser,
-    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<StartOutageRequest>,
 ) -> Result<Json<OutageActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Authorization: require manager-level role
-    if !tenant.role.is_manager() {
+    // Authorization: require manager-level role (DB-validated via RlsConnection).
+    if !rls.role().is_manager() {
         rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
@@ -705,13 +707,12 @@ async fn start_outage(
 async fn resolve_outage(
     State(state): State<AppState>,
     _auth: AuthUser,
-    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<ResolveOutageRequest>,
 ) -> Result<Json<OutageActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Authorization: require manager-level role
-    if !tenant.role.is_manager() {
+    // Authorization: require manager-level role (DB-validated via RlsConnection).
+    if !rls.role().is_manager() {
         rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,
@@ -761,13 +762,12 @@ async fn resolve_outage(
 async fn cancel_outage(
     State(state): State<AppState>,
     _auth: AuthUser,
-    tenant: TenantExtractor,
     mut rls: RlsConnection,
     Path(id): Path<Uuid>,
     Json(req): Json<CancelOutageRequest>,
 ) -> Result<Json<OutageActionResponse>, (StatusCode, Json<ErrorResponse>)> {
-    // Authorization: require manager-level role
-    if !tenant.role.is_manager() {
+    // Authorization: require manager-level role (DB-validated via RlsConnection).
+    if !rls.role().is_manager() {
         rls.release().await;
         return Err((
             StatusCode::FORBIDDEN,

--- a/backend/servers/api-server/tests/outages_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/outages_happy_path_tests.rs
@@ -23,17 +23,29 @@
 //! all admit a freshly-created `planned` outage, so each lifecycle test creates
 //! its own outage to stay independent of transition ordering.
 //!
-//! # Authorization wiring
+//! # Authorization wiring (fixed — issue #2107)
 //!
-//! The mutating handlers gate on `TenantExtractor::role.is_manager()`, and that
-//! role is read from the **JWT `role` claim** — not the seeded DB membership
-//! (`TenantExtractor` does no DB lookup). `JwtService::generate_access_token`
-//! (used by the login flow) emits `org_id`/`roles` claims, which the `AuthUser`
-//! extractor does *not* read, so a login token resolves to `Guest` and every
-//! mutating route 403s. We therefore mint a raw HS256 token carrying
-//! `tenant_id = org_id` and `role = "org_admin"`. The seeded `organization_members`
-//! row is still required: `RlsConnection` validates DB membership via
-//! `ValidatedTenantExtractor` and scopes RLS to `org_id`.
+//! The mutating handlers now gate on `RlsConnection::role().is_manager()`, and
+//! that role is the **DB-validated** `organization_members.role_type` resolved by
+//! `ValidatedTenantExtractor` (which `RlsConnection` is built on) — not the JWT
+//! `role` claim. Previously they gated on `TenantExtractor::role.is_manager()`,
+//! read from the JWT `role` claim; but `JwtService::generate_access_token` (the
+//! production login flow) emits `org_id`/`roles`, which the `AuthUser` extractor
+//! never surfaces as `role`, so a real manager's login token resolved to `Guest`
+//! and every mutating route 403'd in production while the raw-token tests below
+//! stayed green (JWT-role vs DB-role mismatch).
+//!
+//! Two harnesses exercise the routes here:
+//!
+//! * The bulk of the tests mint a raw HS256 token (`mint_token`) carrying
+//!   `tenant_id = org_id` and a `role` claim, alongside a seeded `org_admin`
+//!   membership. This still authenticates and still passes after the fix
+//!   (authorization now reads the DB `org_admin` membership, not the claim).
+//! * `full_lifecycle_via_real_login_*` drives the **production** login flow via
+//!   `create_authenticated_user_with_org` (register → verify → login →
+//!   `org_admin` membership). It is the regression guard for #2107: before the
+//!   fix these mutations 403'd on the login token; after it they succeed, and we
+//!   assert the response-body `outage.status` transitions, not just HTTP 200.
 
 #![allow(dead_code)]
 
@@ -46,7 +58,9 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{seed_membership, seed_org, TestApp, TestConfig};
+use common::{
+    create_authenticated_user_with_org, seed_membership, seed_org, TestApp, TestConfig, TestUser,
+};
 
 const BASE: &str = "/api/v1/outages";
 
@@ -336,4 +350,93 @@ async fn get_unread_count_succeeds(pool: PgPool) {
         .build();
     let resp = app.execute(r).await;
     assert_eq!(resp.status, StatusCode::OK, "unread-count: {}", resp.text());
+}
+
+// ---------------------------------------------------------------------------
+// Regression: real login → X-Tenant-ID → mutate (issue #2107)
+//
+// The raw-token fixtures above passed even while production 403'd, because they
+// hand-crafted a JWT carrying the `role` claim the handlers used to trust. These
+// tests instead drive the *real* login flow (`create_authenticated_user_with_org`
+// → register/verify/login + `org_admin` membership); the resulting access token
+// has no `role` claim (`generate_access_token` emits `org_id`/`roles`), so it
+// only authorizes the mutating routes once they derive the manager role from DB
+// membership. They also assert the lifecycle response-body `status` transitions,
+// not merely HTTP 200.
+// ---------------------------------------------------------------------------
+
+/// Read `outage.status` out of an `OutageActionResponse` body.
+fn action_status(resp: &common::TestResponse) -> String {
+    resp.json_value()["outage"]["status"]
+        .as_str()
+        .unwrap_or_else(|| panic!("missing outage.status in body: {}", resp.text()))
+        .to_string()
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_outage_via_real_login_succeeds(pool: PgPool) {
+    // The narrowest regression: before #2107, the production login token
+    // resolved to `Guest` and this create 403'd.
+    let app = TestApp::new(pool).await;
+    let user = TestUser::new();
+    let (token, org_id) =
+        create_authenticated_user_with_org(&app, &user, "outage-login-create").await;
+
+    let id = create_outage(&app, &token, org_id).await;
+    assert!(!id.is_nil());
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn full_lifecycle_via_real_login_transitions_status(pool: PgPool) {
+    let app = TestApp::new(pool).await;
+    let user = TestUser::new();
+    let (token, org_id) =
+        create_authenticated_user_with_org(&app, &user, "outage-login-lifecycle").await;
+
+    // planned → ongoing → resolved on one outage.
+    let id = create_outage(&app, &token, org_id).await;
+
+    let r = app
+        .post(&format!("{BASE}/{id}/start"))
+        .bearer(&token)
+        .tenant(org_id)
+        .json(json!({}))
+        .build();
+    let resp = app.execute(r).await;
+    assert_eq!(resp.status, StatusCode::OK, "start: {}", resp.text());
+    assert_eq!(
+        action_status(&resp),
+        "ongoing",
+        "start should set status=ongoing"
+    );
+
+    let r = app
+        .post(&format!("{BASE}/{id}/resolve"))
+        .bearer(&token)
+        .tenant(org_id)
+        .json(json!({ "resolution_notes": "Service restored" }))
+        .build();
+    let resp = app.execute(r).await;
+    assert_eq!(resp.status, StatusCode::OK, "resolve: {}", resp.text());
+    assert_eq!(
+        action_status(&resp),
+        "resolved",
+        "resolve should set status=resolved"
+    );
+
+    // planned → cancelled on a second outage.
+    let id2 = create_outage(&app, &token, org_id).await;
+    let r = app
+        .post(&format!("{BASE}/{id2}/cancel"))
+        .bearer(&token)
+        .tenant(org_id)
+        .json(json!({ "reason": "Supplier rescheduled" }))
+        .build();
+    let resp = app.execute(r).await;
+    assert_eq!(resp.status, StatusCode::OK, "cancel: {}", resp.text());
+    assert_eq!(
+        action_status(&resp),
+        "cancelled",
+        "cancel should set status=cancelled"
+    );
 }


### PR DESCRIPTION
## Task

Follow-up (Closes #2107): outages happy-path tests bypassed real login/authz via a fabricated JWT (JWT-role vs DB-role mismatch, PR #1979). The outage routes in `backend/servers/api-server/src/routes/outages.rs` authorized on the JWT `role` claim (plain `TenantExtractor` + `is_manager`), but the production login flow emits `org_id`+`roles` which the `AuthUser` path never surfaces as `role` → a real manager resolved to `Guest` → all six mutating outage endpoints 403'd in production. Fix: derive the manager role from validated DB membership instead of trusting the JWT role claim, and add a regression test that drives the real login → X-Tenant-ID → mutate path and asserts lifecycle status transitions.

## Owner

pm-tech-lead

## Change

- `src/routes/outages.rs`: the six mutating handlers (`create`/`update`/`delete`/`start`/`resolve`/`cancel`) now gate on `rls.role().is_manager()` instead of `tenant.role.is_manager()`. Each handler already holds an `RlsConnection`, which is built on `ValidatedTenantExtractor` and therefore carries the DB-validated `organization_members.role_type` — no extra DB round-trip, no new helper. The now-unused `TenantExtractor` param was dropped from those handlers; `create_outage` reads `org_id` from `rls.tenant_id()`. Read-only handlers are unchanged.
- `tests/outages_happy_path_tests.rs`: added `create_outage_via_real_login_succeeds` and `full_lifecycle_via_real_login_transitions_status`, which use `create_authenticated_user_with_org` (register → verify → login → `org_admin` membership) so the token is a **real login token with no `role` claim**. The lifecycle test asserts the response-body `outage.status` transitions to `ongoing` (start), `resolved` (resolve), and `cancelled` (cancel) — not just HTTP 200. Before the fix these 403'd; the pre-existing raw-token tests still pass because authorization now reads the seeded DB membership. Module doc updated to describe the fix and the two harnesses.

## Tested (Band A — fast check)

- `cargo fmt -p api-server` → exit 0.
- `cargo check -p api-server --tests` → **blocked by environment**, not by this change: the `utoipa-swagger-ui v9.0.2` build script downloads `swagger-ui` from `github.com`, which this sandbox's egress policy returns `403` for (`InvalidArchive("Could not find EOCD")`). This is a documented sandbox limitation for the api-server crate. Compile + the DB-backed `#[sqlx::test]` cases therefore defer to CI (`backend.yml`), which is the verifying gate for this PR — hence draft.
- Scope-check (`--owner pm-tech-lead`) → exit 0 (`scope_drift=false`). Reuse-grep → exit 0 (`code_reuse_warn=none`).

## Built (Band B — full build)

skipped: blocked by the same utoipa-swagger-ui env limitation above; deferred to CI.

## CI parity (Band C — hot-path only)

This is an auth/authorization change, so it is hot-path. Local CI parity could not be replicated because of the swagger-ui build-script egress block; `backend.yml` (`fmt`, `clippy`, `test`) is relied on as the verifying gate — kept as draft until it is green.

## Remote-tested

skipped

## Notes

- Manual correctness review done: all six mutating gates confirmed switched to `rls.role()`; `TenantExtractor`/`AuthUser` imports remain in use by read-only handlers; extractor ordering intact (body-consuming `Json` remains last).
- No production behavioral change for admins/managers who *do* carry a legacy `role` claim — the DB role is authoritative and, for a seeded `org_admin`, `is_manager()` is true either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015By7YAzYSvvCZQqrXZN2xn

---
_Generated by [Claude Code](https://claude.ai/code/session_015By7YAzYSvvCZQqrXZN2xn)_