### PR TITLE
gh-issue-2126: fix MCP-push size guard dead no-op (run before commit)

### DIFF
--- a/.github/workflows/dispatcher-self-test.yml
+++ b/.github/workflows/dispatcher-self-test.yml
@@ -7,8 +7,10 @@ on:
       - ".research/dispatcher-self-test.sh"
       - ".research/backlog-refill.sh"
       - ".research/issue-ingest.sh"
+      - ".research/mcp-push-size-guard.sh"
       - ".research/test-backlog-refill.sh"
       - ".research/test-issue-ingest.sh"
+      - ".research/test-mcp-push-size-guard.sh"
       - ".research/management/assignments.json"
       - ".claude/skills/ppt-implement/**"
       - ".claude/skills/ppt-pr-merge/**"
@@ -37,6 +39,8 @@ jobs:
         run: bash .research/test-backlog-refill.sh
       - name: issue-ingest behavioral smoke test
         run: bash .research/test-issue-ingest.sh
+      - name: mcp-push-size-guard behavioral smoke test
+        run: bash .research/test-mcp-push-size-guard.sh
       - name: goal-check (enforcing)
         env:
           GOAL_CHECK_ENFORCE: "1"

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -2037,6 +2037,26 @@ bash .claude/skills/ppt-implement/scripts/commit-scope-guard.sh \
   exit 0
 }
 
+# MCP-push size guard (issue #1014 / #2102 / #2126) — MUST run BEFORE `git commit`,
+# while `git diff --cached` still reflects the staged push payload. FAIL CLOSED:
+# hard-check every STAGED file against the 64 KiB MCP inline-push ceiling. A
+# blocked push is recoverable (the next run retries on a fixed base); a silently-
+# truncated MCP push is not. The structural fix is the action-list reconcile
+# staged above; this guard is the belt-and-suspenders that catches any file still
+# oversize (e.g. the reconcile was skipped or failed).
+#
+# REGRESSION #2126: this guard was previously invoked in the push branch AFTER
+# `git commit`, where the index equals HEAD and `git diff --cached` returns an
+# empty set — so `--staged` inspected nothing, the guard printed "no files to
+# check — OK", exited 0 every run, and never saw the real push payload (dead
+# code). It is now placed here, right after the final `git add`, so the check
+# actually fires. The guard self-skips when PUSH_METHOD != mcp (direct `git push`
+# has no inline-content limit), so it is safe to run unconditionally.
+if ! PUSH_METHOD="${PUSH_METHOD:-mcp}" bash .research/mcp-push-size-guard.sh --staged; then
+  echo "PHASE 6 ABORT: mcp-push-size-guard tripped — a staged file exceeds the MCP inline-push ceiling; refusing to commit/MCP-push (would truncate/corrupt it on dev, #1014). Remediation: re-run the reconcilers to shrink state, or land this run via 'PUSH_METHOD=git' where the proxy allows. Not marking this run successful." >&2
+  exit 0
+fi
+
 # Pre-commit self-test gate. Phase 8 finding `self-test-fail-recurs-each-run`:
 # T11 / T4 / T18 / T19 were enforced only by the post-hoc self-test, so every
 # claim/archive cycle could introduce a fresh invariant violation that was
@@ -2073,16 +2093,13 @@ INTENDED_TREE=$(git rev-parse HEAD^{tree})   # the state tree we MUST land (reba
 # fall back to git push only when the MCP tool is unavailable. `PUSH_METHOD=git`
 # forces the legacy path for environments where direct push works.
 if [ "${PUSH_METHOD:-mcp}" = "mcp" ]; then
-  # Backstop (issue #1014 / #2102): before the inline MCP push, hard-check every
-  # STAGED file against the 64 KiB inline-push ceiling. FAIL CLOSED — a blocked
-  # push is recoverable (the next run retries on a fixed base), a silently-
-  # truncated MCP push is not. The structural fix is the action-list reconcile
-  # staged above; this guard is the belt-and-suspenders that catches any file
-  # still oversize (e.g. the reconcile was skipped or failed).
-  if ! PUSH_METHOD=mcp bash .research/mcp-push-size-guard.sh --staged; then
-    echo "PHASE 6 ABORT: mcp-push-size-guard tripped — a staged file exceeds the MCP inline-push ceiling; refusing to MCP-push (would truncate/corrupt it on dev, #1014). Remediation: re-run the reconcilers to shrink state, or land this run via 'PUSH_METHOD=git' where the proxy allows. Not marking this run successful." >&2
-    exit 0
-  fi
+  # NOTE (issue #2126): the MCP inline-push size guard already ran BEFORE
+  # `git commit` above (right after the final `git add`), where
+  # `git diff --cached` still reflected the staged payload. Do NOT re-run it
+  # here with `--staged` — post-commit the index equals HEAD, so `git diff
+  # --cached` is empty and the guard is a dead no-op (the exact bug #2126
+  # fixed). The staged tree that guard vetted is the same tree this MCP push
+  # emits, so the push payload is already known-safe.
   : # land the Phase 6 file delta via mcp__github__push_files onto dev (one commit).
     # A GITHUB_TOKEN/API push does not re-trigger version-bump on its own, which also
     # caps the rapid-bump churn (finding subagent-race-on-dev-push).

--- a/.research/test-mcp-push-size-guard.sh
+++ b/.research/test-mcp-push-size-guard.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Smoke test for mcp-push-size-guard.sh (issue #2126).
+#
+# The guard is the belt-and-suspenders backstop that keeps dispatcher Phase 6
+# from MCP-pushing a file larger than the 64 KiB inline ceiling (issue #1014:
+# a truncated inline push corrupts state silently on dev). PR #2114 shipped the
+# guard but wired it AFTER `git commit` in Phase 6, where `git diff --cached` is
+# empty — so the `--staged` mode was never actually exercised and the guard was
+# dead code. This harness locks in the behaviours that matter:
+#
+#   (a) an OVERSIZE STAGED file trips exit 3 (the real push-payload check).
+#   (b) PUSH_METHOD=git SKIPS (exit 0) — direct git push has no inline limit.
+#   (c) the EXACT Phase-6 sequence — final `git add` -> guard --staged (BEFORE
+#       any commit) — catches an oversize staged file. This is the regression
+#       the #2126 reorder fixes: run the guard while the index still differs
+#       from HEAD.
+#
+# Plus a few guardrails: a small staged file passes; explicit-file mode still
+# trips on an oversize arg; and (the dead-guard regression itself) running the
+# guard AFTER a commit sees an empty staged set and is a no-op — proving why the
+# post-commit placement was broken.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/mcp-push-size-guard.sh"
+
+CEIL=65536                       # matches the guard's default MCP_INLINE_MAX_BYTES
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+fail_count=0
+ok()   { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1" >&2; fail_count=$((fail_count+1)); }
+
+# Assert a command exits with an expected code without aborting the run.
+expect_rc() {  # $1=expected rc  $2=label ; command follows on stdin via "$@"
+  local want="$1" label="$2"; shift 2
+  local got=0
+  "$@" >/dev/null 2>&1 || got=$?
+  if [ "$got" = "$want" ]; then ok "$label (rc=$got)"; else fail "$label expected rc=$want got rc=$got"; fi
+}
+
+# --- Build an isolated git repo so `git diff --cached` is deterministic -------
+REPO="$TMP/repo"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" config user.email test@example.com
+git -C "$REPO" config user.name test
+# Seed one committed file so HEAD exists.
+echo "seed" > "$REPO/seed.txt"
+git -C "$REPO" add seed.txt
+git -C "$REPO" -c commit.gpgsign=false commit -qm seed
+
+mk_file() {  # $1=path  $2=size-bytes
+  head -c "$2" /dev/zero | tr '\0' 'x' > "$1"
+}
+
+SMALL="$REPO/small.json"       ; mk_file "$SMALL" 1024                 # 1 KiB
+BIG="$REPO/action-list.json"   ; mk_file "$BIG"   $((CEIL + 4096))     # 68 KiB > ceiling
+
+# =============================================================================
+# (a) an OVERSIZE STAGED file trips exit 3
+# =============================================================================
+git -C "$REPO" add small.json action-list.json
+expect_rc 3 "(a) oversize STAGED file trips exit 3" \
+  bash -c "cd '$REPO' && PUSH_METHOD=mcp bash '$GUARD' --staged"
+
+# =============================================================================
+# (b) PUSH_METHOD=git skips (exit 0) regardless of staged size
+# =============================================================================
+expect_rc 0 "(b) PUSH_METHOD=git skips the guard" \
+  bash -c "cd '$REPO' && PUSH_METHOD=git bash '$GUARD' --staged"
+
+# =============================================================================
+# (c) the exact Phase-6 `git add` -> guard --staged (BEFORE commit) sequence
+#     catches an oversize staged file. Runs against a fresh index that is NOT
+#     yet committed — the state the #2126 reorder guarantees.
+# =============================================================================
+git -C "$REPO" reset -q                          # clear the index from (a)
+mk_file "$REPO/assignments.json" $((CEIL + 20000))   # a 2nd oversize state file
+# Phase-6 shape: the final `git add` of the state files, then the guard, all
+# BEFORE `git commit`.
+git -C "$REPO" add assignments.json small.json
+expect_rc 3 "(c) Phase-6 add->guard (pre-commit) catches oversize staged file" \
+  bash -c "cd '$REPO' && PUSH_METHOD=mcp bash '$GUARD' --staged"
+
+# =============================================================================
+# Guardrail: a small-only staged set passes (exit 0).
+# =============================================================================
+git -C "$REPO" reset -q
+git -C "$REPO" add small.json
+expect_rc 0 "small-only staged set passes" \
+  bash -c "cd '$REPO' && PUSH_METHOD=mcp bash '$GUARD' --staged"
+
+# =============================================================================
+# Guardrail: explicit-file mode still trips on an oversize arg (exit 3).
+# =============================================================================
+expect_rc 3 "explicit oversize file arg trips exit 3" \
+  bash -c "PUSH_METHOD=mcp bash '$GUARD' '$BIG'"
+
+# =============================================================================
+# Regression witness (#2126): running the guard AFTER `git commit` sees an
+# empty staged set (index == HEAD) and is a dead no-op (exit 0) even though the
+# committed file is oversize. This is precisely why the post-commit placement
+# was broken; the fix moves the guard BEFORE the commit.
+# =============================================================================
+git -C "$REPO" reset -q
+git -C "$REPO" add action-list.json
+git -C "$REPO" -c commit.gpgsign=false commit -qm "commit oversize file"
+POST_OUT=$(cd "$REPO" && PUSH_METHOD=mcp bash "$GUARD" --staged 2>&1); POST_RC=$?
+if [ "$POST_RC" = "0" ] && grep -q "no files to check" <<<"$POST_OUT"; then
+  ok "(#2126 witness) post-commit --staged is an empty no-op — why the old placement was dead"
+else
+  fail "(#2126 witness) expected empty-staged no-op post-commit (rc=$POST_RC): $POST_OUT"
+fi
+
+echo
+if [ "$fail_count" -eq 0 ]; then
+  echo "==> mcp-push-size-guard smoke test PASSED"
+else
+  echo "==> mcp-push-size-guard smoke test FAILED ($fail_count)" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Task
Fix the MCP-push size guard so it is not a no-op (GitHub issue #2126). In `.research/dispatcher-prompt.md` Phase 6, `mcp-push-size-guard.sh --staged` was invoked AFTER `git commit`, so post-commit `git diff --cached` is empty and the guard always printed "no files to check — OK" and never inspected the real push payload (dead code). FIX: reorder Phase 6 so the size-guard runs BEFORE `git commit` (right after the final `git add`), where `git diff --cached` still reflects the staged payload. Also add `.research/test-mcp-push-size-guard.sh` and wire it into `.github/workflows/dispatcher-self-test.yml`.

Closes #2126

## Owner
pm-tech-lead

## What changed
- **`.research/dispatcher-prompt.md`** — moved the `mcp-push-size-guard.sh --staged` invocation to run BEFORE `git commit`, right after the final `git add` (and after the commit-scope guard), where the staged index still differs from HEAD. The self-skip for `PUSH_METHOD != mcp` means it's safe to run unconditionally. Removed the dead post-commit invocation from the MCP push branch and left a NOTE explaining why it must not be re-run there (index == HEAD → empty `git diff --cached`).
- **`.research/test-mcp-push-size-guard.sh`** (new, +x) — behavioural smoke test covering (a) oversize STAGED file → exit 3, (b) `PUSH_METHOD=git` skips → exit 0, (c) the exact Phase-6 `git add` → `guard --staged` (pre-commit) sequence catches an oversize staged file, plus guardrails (small-only staged set passes, explicit-file oversize arg trips) and a regression witness proving the old post-commit `--staged` was an empty no-op.
- **`.github/workflows/dispatcher-self-test.yml`** — added the new test as a CI step and added `mcp-push-size-guard.sh` + `test-mcp-push-size-guard.sh` to the path filters.

## Tested (Band A — fast check)
```
$ bash .research/test-mcp-push-size-guard.sh
  ok    (a) oversize STAGED file trips exit 3 (rc=3)
  ok    (b) PUSH_METHOD=git skips the guard (rc=0)
  ok    (c) Phase-6 add->guard (pre-commit) catches oversize staged file (rc=3)
  ok    small-only staged set passes (rc=0)
  ok    explicit oversize file arg trips exit 3 (rc=3)
  ok    (#2126 witness) post-commit --staged is an empty no-op — why the old placement was dead
==> mcp-push-size-guard smoke test PASSED   # exit 0

$ bash .research/dispatcher-self-test.sh
==> dispatcher-self-test: PASS              # exit 0

$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dispatcher-self-test.yml'))"
YAML OK
```

## Built (Band B — full build)
skipped: bash/markdown/yaml only — no compiled artifact. No cargo/gradle/pnpm surface. Cloud cron sandbox has no Docker/Postgres.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change). The new test is itself wired into `dispatcher-self-test.yml`, which is the relevant CI gate for these paths and will run on this PR.

## Scope drift
`scope_drift=true` — `scope-check.sh --owner pm-tech-lead` flagged `.github/workflows/dispatcher-self-test.yml` as outside the owner's mapped areas (exit 2). Justified: the issue explicitly requires wiring the new test into that workflow. All other paths (`.research/**`) are in scope.

## Remote-tested
skipped

## Notes
Reorder chosen over the alternative (`git diff --name-only HEAD~1 HEAD`) per the issue's preference: it's minimal and matches how the guard is meant to protect the push (vet the staged payload before it's committed/pushed). The staged tree the guard vets is the same tree the MCP push emits, so the push payload is known-safe. The #2126 regressions/T26-escape-hatch finding (severity low) is out of scope for this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PikUEMibpMy1Vcjcj189dy)_