### PR TITLE
gh-issue-2121: add non-manager RBAC deny test for outage mutations

### DIFF
--- a/backend/servers/api-server/tests/outages_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/outages_happy_path_tests.rs
@@ -59,7 +59,8 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use common::{
-    create_authenticated_user_with_org, seed_membership, seed_org, TestApp, TestConfig, TestUser,
+    create_authenticated_user, create_authenticated_user_with_org, seed_membership, seed_org,
+    TestApp, TestConfig, TestUser,
 };
 
 const BASE: &str = "/api/v1/outages";
@@ -438,5 +439,82 @@ async fn full_lifecycle_via_real_login_transitions_status(pool: PgPool) {
         action_status(&resp),
         "cancelled",
         "cancel should set status=cancelled"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RBAC deny: real login, NON-manager membership → mutating route 403s (#2121)
+//
+// Follow-up to #2107 / PR #2120. The `*_via_real_login_*` tests above prove a
+// real production-login token whose DB membership is `org_admin` is *allowed*
+// through the `rls.role().is_manager()` gate. This is the negative complement:
+// a real-login token whose DB-validated membership is a non-manager role
+// (`resident`) must be *denied* on a mutating outage route.
+//
+// Unlike `create_authenticated_user_with_org` (which seeds an `org_admin`
+// membership), we register/verify/login the user and then attach a `resident`
+// membership by hand, so the caller passes `AuthUser` and
+// `ValidatedTenantExtractor` (they ARE a member) but is rejected by the
+// DB-role manager gate — asserting the exact `403 FORBIDDEN` real behavior so
+// the test fails closed if a future change ever flips `is_manager()` open.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_outage_via_real_login_non_manager_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool).await;
+
+    // Real login flow (register → verify → login), then attach the user to the
+    // org as a NON-manager `resident` instead of the `org_admin` that
+    // `create_authenticated_user_with_org` would seed.
+    let user = TestUser::new();
+    let (token, _refresh) = create_authenticated_user(&app, &user).await;
+
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&app.pool)
+        .await
+        .expect("resolve user id");
+
+    let org_id = seed_org(&app.pool, "outage-login-deny").await;
+    seed_membership(&app.pool, org_id, user_id, "resident").await;
+
+    // POST /api/v1/outages is manager-gated on the DB-validated role. A
+    // resident is a valid tenant member (passes the extractors) but must be
+    // rejected by `rls.role().is_manager()` with `403 FORBIDDEN`.
+    let r = app
+        .post(BASE)
+        .bearer(&token)
+        .tenant(org_id)
+        .json(json!({
+            "title": "Unauthorized outage",
+            "description": "Resident should not be able to create this",
+            "commodity": "water",
+            "severity": "medium",
+            "scheduled_start": "2026-06-01T08:00:00Z",
+            "scheduled_end": "2026-06-01T12:00:00Z",
+            "supplier_name": "City Water Co.",
+        }))
+        .build();
+    let resp = app.execute(r).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "#2121: a real-login resident must be denied the manager-gated create \
+         outage route with 403, got {} body={}",
+        resp.status,
+        resp.text(),
+    );
+
+    // The handler tags this branch with the `FORBIDDEN` error code.
+    let body = resp.json_value();
+    let code = body
+        .get("code")
+        .and_then(|c| c.as_str())
+        .unwrap_or_default();
+    assert_eq!(
+        code, "FORBIDDEN",
+        "#2121: 403 response must carry the FORBIDDEN code, body={}",
+        body
     );
 }


### PR DESCRIPTION
## Task
Follow-up: add non-manager deny test for outage mutations (PR #2120). Closes #2121. The core fix (authz moved to DB-validated role via `RlsConnection::role()`) is solid, but only the positive (manager-allowed) path is tested. Add a negative RBAC-deny test in `backend/servers/api-server/tests/outages_happy_path_tests.rs` that uses a REAL-login token for a NON-manager membership (Resident) and asserts a mutating outage route (`POST /api/v1/outages`) returns 403 — mirroring the pattern in `backend/servers/api-server/tests/report_schedule_rbac_tests.rs`. Assert on the 403 status (real behavior), so it fails on any future change that flips `rls.role().is_manager()` open.

Closes #2121

## Owner
pm-tech-lead (routed to `rust-backend` specialist)

## What changed
One new test in `outages_happy_path_tests.rs`:

- `create_outage_via_real_login_non_manager_is_forbidden` — drives the **production login flow** (`create_authenticated_user` → register/verify/login), then seeds a **non-manager `resident`** membership by hand (rather than the `org_admin` that `create_authenticated_user_with_org` seeds). The resident is a valid tenant member (passes `AuthUser` + `ValidatedTenantExtractor`) but is rejected by the DB-validated `rls.role().is_manager()` gate on `POST /api/v1/outages`.
- Asserts the **exact** `403 FORBIDDEN` status **and** the `FORBIDDEN` error code (real behavior), so the test fails closed if a future change ever flips `is_manager()` open. This is the negative complement of the existing `*_via_real_login_*` positive-path guards.

Plus one minimal test-helper import (`create_authenticated_user`). No product source touched.

## Tested (Band A — fast check)
No local Postgres/Docker in this cloud environment; the new test is a `#[sqlx::test(migrator = "db::MIGRATOR")]` that runs against Postgres only in CI (`backend.yml`) — same deferral pattern as sibling PRs #2089 / #2007.

- `cargo fmt -p api-server` then `cargo fmt --check -p api-server` → **exit 0** (clean).
- `cargo test -p api-server --no-run --test outages_happy_path_tests` → **blocked by a pre-existing env limitation, NOT this change**: the `utoipa-swagger-ui v9.0.2` build script panics because it cannot download `swagger-ui v5.17.14.zip` through the sandbox proxy (`InvalidArchive("Could not find EOCD")`). This is a build-dependency download failure that occurs before the test target itself is compiled; it is documented in prior PRs (#2089) and affects any api-server build in this environment. Compilation of the test crate itself is deferred to CI.

The change is test-only, mirrors existing helpers/patterns already compiled in this same file (`create_authenticated_user`, `seed_org`, `seed_membership`, `sqlx::query_scalar`, `TestApp`), and provably cannot regress product behavior.

## Built (Band B — full build)
Skipped: test-only change (<50 LOC substantive), no public API / migration / config touch. Full DB-backed execution deferred to CI (`backend.yml`).

## CI parity (Band C — hot-path only)
Skipped: no product source changed (test-only). The DB-backed run happens in `backend.yml` on this PR.

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 (advisory): the changed file `backend/servers/api-server/tests/outages_happy_path_tests.rs` is outside the `pm-tech-lead` owner-area mapping. This is a mapping artifact — the task explicitly targets this backend test file (routed to the `rust-backend` specialist), the change is test-only, and it touches no product source. Justified.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. The test reuses the existing shared helpers (`create_authenticated_user`, `seed_org`, `seed_membership`) rather than re-declaring seeding boilerplate.

## Remote-tested
Skipped.

## Notes
Non-manager role chosen: `resident`, which the `ValidatedTenantExtractor` role parser (`backend/crates/api-core/src/extractors/tenant.rs`, case-insensitive) resolves to `TenantRole::Resident` — confirmed non-manager by `TenantRole::is_manager` in `backend/crates/common/src/tenant.rs`. Any unknown role_type would also fall back to `Guest` (also non-manager), so the assertion is robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt9DRqwZMyEXdkJodkKKix

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nt9DRqwZMyEXdkJodkKKix)_