### PR TITLE
test(api-server): enlarge include_system tie group to 8 rows

### DIFF
--- a/backend/servers/api-server/tests/migration_pagination_tests.rs
+++ b/backend/servers/api-server/tests/migration_pagination_tests.rs
@@ -440,10 +440,12 @@ async fn include_system_default_tie_group_is_deterministic_id_desc(pool: PgPool)
     let app = TestApp::new(pool.clone()).await;
     let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgtiesys").await;
 
-    // Three org rows + one system row, all sharing a far-future updated_at =>
-    // a 4-row tie group guaranteed to sit at the head of the DESC ordering,
-    // ahead of the migration-seeded system templates.
-    let org_count = 3;
+    // Seven org rows + one system row, all sharing a far-future updated_at =>
+    // an 8-row tie group guaranteed to sit at the head of the DESC ordering,
+    // ahead of the migration-seeded system templates. A large tie group drives
+    // the false-pass probability of an insertion-order-equals-id-DESC accident
+    // down to ~1/8! (negligible) if the secondary `id DESC` key ever regressed.
+    let org_count = 7;
     let head_desc = seed_tied_org_and_system_templates(&pool, org_id, org_count).await;
     assert_eq!(
         head_desc.len(),


### PR DESCRIPTION
## What

Follow-up to post-merge review of PR #2116. Raises `org_count` from 3 to 7 in `include_system_default_tie_group_is_deterministic_id_desc` (`backend/servers/api-server/tests/migration_pagination_tests.rs`), so the shared far-future `updated_at` tie group now spans 8 rows (7 org-scoped + 1 system) instead of 4.

## Why

With a 4-row tie group, a regression of the secondary `id DESC` key (BitmapOr -> Bitmap Heap Scan returning physical/insertion order) could still spuriously pass whenever insertion order happened to match id-DESC — a ~1/4! ≈ 4% false-pass rate per run. Widening the tie group to 8 rows drops that to ~1/8! (negligible) at near-zero cost.

## Scope

- One test function; comment updated to reflect the new count and rationale.
- Head-prefix (`.take(head_desc.len())`) and offset-slice (`page=2&per_page=2` -> `head_desc[2..4]`) assertions already index positionally, so they generalize unchanged.

## Verification

- `cargo fmt -p api-server`: clean.
- The test is a `#[sqlx::test]` requiring Postgres, which the cloud sandbox lacks — DB execution and full workspace compile are deferred to CI (`backend.yml`). Change is a literal + comment edit introducing no new symbols.

Closes #2123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R)_