### PR TITLE
gh-issue-2127: CI assertion that quick-xml half-range bans stay in deny.toml

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -722,3 +722,41 @@ jobs:
           manifest-path: backend/Cargo.toml
           arguments: --workspace
           rust-version: stable
+
+  # deny-ban-presence (GH #2127, follow-up to #2106/#2111)
+  # ------------------------------------------------------
+  # `cargo deny check bans` only trips when a BANNED version is present in the
+  # graph — DELETING the two quick-xml half-range bans at backend/deny.toml:93-94
+  # leaves `cargo deny` green (nothing to trip). The CODEOWNERS gate on deny.toml
+  # is advisory (branch protection may not enforce "Require review from Code
+  # Owners"), so ban REMOVAL had no independent defence. This job asserts, on the
+  # committed file text, that both half-range bans are still present. It is
+  # deliberately independent of review and of the cargo-deny action.
+  #
+  # Runs on EVERY PR (no `changes` gate): the grep targets a file that always
+  # exists in the tree, so the context is always producible — a prerequisite for
+  # registering it as a required status check on `dev` (see Notes / #2127; the
+  # branch-protection registration in branch-protection-setup.yml needs repo
+  # settings and is intentionally OUT OF SCOPE here).
+  deny-ban-presence:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert quick-xml half-range bans are present in backend/deny.toml
+        run: |
+          set -euo pipefail
+          f=backend/deny.toml
+          fail=0
+          if ! grep -Eq 'name[[:space:]]*=[[:space:]]*"quick-xml".*version[[:space:]]*=[[:space:]]*"<0\.41\.0"' "$f"; then
+            echo "::error file=$f::missing lower-bound ban: name = \"quick-xml\", version = \"<0.41.0\""
+            fail=1
+          fi
+          if ! grep -Eq 'name[[:space:]]*=[[:space:]]*"quick-xml".*version[[:space:]]*=[[:space:]]*">0\.41\.0"' "$f"; then
+            echo "::error file=$f::missing upper-bound ban: name = \"quick-xml\", version = \">0.41.0\""
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "The quick-xml =0.41.0 safety pin (XXE/billion-laughs, GH #1519/#1591/#2033/#2056/#2084) must keep BOTH half-range bans. Do not remove them without a focused ota_xml::tests entity-guard review." >&2
+            exit 1
+          fi
+          echo "OK: both quick-xml half-range bans present in $f"


### PR DESCRIPTION
## Task
Follow-up: deny.toml CODEOWNERS gate is advisory-only; add CI ban-presence check (PR #2111). Add a small required CI assertion (independent of review) that the two `quick-xml` half-range ban lines are present in `backend/deny.toml` — a grep step that fails if `name = "quick-xml"` with `version = "<0.41.0"` and `>0.41.0` are absent.

Closes #2127

## Owner
pm-tech-lead

## What changed
New `deny-ban-presence` job in `.github/workflows/backend.yml`. It greps `backend/deny.toml` and fails if either half-range ban (`<0.41.0` / `>0.41.0` for `quick-xml`) is missing.

Rationale: `cargo deny check bans` only trips when a *banned* version is present in the graph — **deleting** the bans at `backend/deny.toml:93-94` leaves `cargo deny` green. The CODEOWNERS gate is advisory, so ban removal previously had no independent defence. This job closes that half-open silent-reopen threat, independent of review and of the cargo-deny action.

The job runs on every PR (no `changes` gate) because it targets a file that always exists — a prerequisite for later registering it as a required status check on `dev`.

## Tested (Band A — fast check)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/backend.yml'))"` → exit 0 (parses; jobs include new `deny-ban-presence`).
- Ran the exact CI script body:
  - against current `backend/deny.toml` → `OK both present`, exit 0.
  - against a mutated copy with both `quick-xml` ban lines removed → prints missing lower/upper errors, exit 1.
  - against a copy with only the `>0.41.0` line removed → correctly detects the removal.
- `git diff --check` → clean.

## Built (Band B — full build)
skipped: change is a single CI-workflow job (no Rust/TS build output affected).

## CI parity (Band C — hot-path only)
skipped: not a code hot-path (CI-config-only change). The new job itself is the CI surface and was exercised locally as above.

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2: the only changed file is `.github/workflows/backend.yml`, which is outside the pm-tech-lead owner-area map. Justified — this is a CI-gate change for the assigned follow-up; no product code touched.

## Code-reuse review
`reuse-grep.sh --specialist generic` → no warnings.

## Notes
- **Out of scope (as instructed):** the low-severity `branch-protection-setup.yml` part. Making this check actually *block* merges requires registering `deny-ban-presence` as a required status check on `dev` (the way `security-gate-conclusion` is registered) and asserting `require_code_owner_reviews == true` — both need repo-settings/branch-protection access the implementer cannot change. The job is deliberately written to always produce its context so it is registerable as required without further code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R)_