### PR TITLE
gh-issue-2128: document required-status-check dependency of exec-bit gate

### DIFF
--- a/.github/workflows/script-exec-bit-gate.yml
+++ b/.github/workflows/script-exec-bit-gate.yml
@@ -16,6 +16,25 @@ name: Script exec-bit gate
 # executable matches convention and prevents a repeat of the silent
 # mode revert. The check reads git's index modes directly (git ls-files
 # -s), so it is filesystem-independent and DB-free.
+#
+# IMPORTANT — this gate only BLOCKS a regression if it is wired as a
+# REQUIRED status check on the `dev` branch-protection rule / ruleset.
+# The pull_request trigger below is path-filtered and the push trigger
+# runs post-merge (advisory only). If the job
+# "Workflow scripts must be executable (100755)" is NOT marked required
+# in branch protection, a future exec-bit revert PR can still merge green
+# and defeat the gate. That required-check wiring is a repo-settings /
+# operator action (out of code scope); see issue #2128. Do not remove
+# this dependency silently on a settings change.
+#
+# SCOPE — this gate is deliberately narrow: it guards only the workflow
+# helper scripts under .github/workflows/scripts/. Other tracked *.sh
+# meant to be run directly (e.g. scripts/*.sh) are NOT covered here.
+# Broadening the gate to an explicit allowlist of runnable repo scripts
+# is tracked separately as a low-priority hygiene item (issue #2128,
+# "better approach"); it is kept out of this file to avoid coupling
+# unrelated mode fixes across docker/, scripts/, and .research/ to this
+# workflow-scripts guard.
 
 on:
   pull_request:


### PR DESCRIPTION
## Task
Follow-up: exec-bit gate only blocks if wired as a required status check on dev (PR #2119). Document, in `.github/workflows/script-exec-bit-gate.yml`, that the gate's blocking guarantee depends on it being marked a REQUIRED status check in `dev` branch protection; and evaluate the low-severity "better approach" of extending the gate to other runnable repo scripts.

## Owner
pm-tech-lead

## What changed
Header-comment-only edit to `.github/workflows/script-exec-bit-gate.yml`:
- **(a) Required-status-check dependency** — documents that the `pull_request` trigger is path-filtered and the `push` trigger runs post-merge (advisory), so the gate only actually BLOCKS a regression when the job is marked required in branch protection. Points at issue #2128 and warns not to drop the dependency silently on a settings change.
- **(b) Scope note** — records that broadening the gate to an allowlist of other runnable repo scripts is deliberately kept out and tracked as a separate low-priority hygiene item.

No workflow logic, triggers, or gate assertion changed — comment-only.

## Out of code scope (operator / repo-settings)
The primary ask — marking **"Workflow scripts must be executable (100755)"** as a REQUIRED status check on the `dev` branch-protection rule / ruleset — is a repo-settings action that cannot be done from code. This PR documents that dependency in-repo; an operator must still wire the required check.

## Evaluation of the "better approach" (part b) — deferred, by design
Evaluated whether other tracked `*.sh` at `100644` should be `100755` and the gate extended to an allowlist. Findings:
- `docker/nginx/render-template.sh` — copied into the image and `chmod +x`'d in the Dockerfile; repo mode is intentionally irrelevant. Not a candidate.
- `.research/dispatcher-self-test.sh` — invoked as `bash .research/dispatcher-self-test.sh` in its workflow; exec bit not required.
- `scripts/generate-rn-app-icons.sh`, `scripts/build-ios.sh` — genuine run-directly candidates, but flipping modes spans `docker/`, `scripts/`, and `.research/` and couples unrelated mode fixes to this workflow-scripts guard.

The issue itself asks to "track as a separate low-priority hygiene issue." Doing the mode flips + allowlist here would be scope drift on a medium-priority follow-up whose (b) is low severity, so it is documented and deferred rather than bundled in. This keeps the change minimal and in-scope.

## Tested (Band A — fast check)
- `python3 -c "yaml.safe_load(...)"` → YAML OK, `jobs=['exec-bit-gate']` (parses after edit)
- gate assertion replayed locally (`git ls-files -s '.github/workflows/scripts/*.sh' | awk '$1!="100755"'`) → no offenders, passes
- `git diff --check` → clean

## Built (Band B — full build)
skipped: comment-only change, no build output affected

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (CI-doc comment only; no security/auth/billing/data-integrity change)

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 because `.github/workflows/**` isn't in pm-tech-lead's mapped owner areas. The drift is justified: the task IS a CI-workflow documentation change. Only one file touched: `.github/workflows/script-exec-bit-gate.yml`.

## Notes
Comment-only; the actionable operator step (wiring the required status check) is intentionally out of code scope and called out above.

Closes #2128

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R)_