### PR TITLE
test(reality): pin ListingDetail updateAuth() + guard favorite rollback after logout

### DIFF
--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModel.kt
@@ -166,11 +166,18 @@ class ListingDetailViewModel(
         if (current.isFavoriteLoading) return
         val previous = current.isFavorite
         val next = !previous
+        // Capture the session (and the repo bound to it) this write is launched against. If the
+        // session changes mid-flight (e.g. the user logs out), [updateAuth] has already reset the
+        // heart — the stale confirm/rollback below must not clobber that, or an un-favorited
+        // listing could show as favorited while unauthenticated (issue #2125).
+        val tokenAtLaunch = currentSessionToken
+        val repoAtLaunch = favoritesRepository
         _state.update { it.copy(isFavorite = next, isFavoriteLoading = true) }
         scope.launch {
             val result =
-                if (next) favoritesRepository.addFavorite(listingId)
-                else favoritesRepository.removeFavorite(listingId)
+                if (next) repoAtLaunch.addFavorite(listingId)
+                else repoAtLaunch.removeFavorite(listingId)
+            if (currentSessionToken != tokenAtLaunch) return@launch
             _state.update { s ->
                 if (result.isFailure) s.copy(isFavorite = previous, isFavoriteLoading = false)
                 else s.copy(isFavoriteLoading = false)

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
@@ -328,7 +328,10 @@ class ListingDetailViewModelTest {
 
             vm.start()
             advanceUntilIdle()
-            assertTrue(vm.state.value.isFavorite, "precondition: authenticated probe turns heart on")
+            assertTrue(
+                vm.state.value.isFavorite,
+                "precondition: authenticated probe turns heart on",
+            )
 
             // Logout: favorites require auth, so the heart can no longer reflect a user's state.
             vm.updateAuth(null)

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailViewModelTest.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
@@ -286,6 +287,160 @@ class ListingDetailViewModelTest {
             assertNotNull(vm.state.value.listing, "retry recovers the listing")
             assertNull(vm.state.value.errorMessage, "error cleared on successful retry")
             assertFalse(vm.state.value.isLoading)
+        }
+
+    // ─── updateAuth(): session change without disturbing the listing ──────────
+
+    @Test
+    fun updateAuth_keeps_loaded_listing_and_does_not_reset_to_spinner() =
+        runTest(StandardTestDispatcher()) {
+            val vm =
+                viewModel(
+                    favorites = favoritesRepo(HttpStatusCode.OK, """{"is_favorited": false}"""),
+                    scope = backgroundScope,
+                    isAuthenticated = true,
+                    listing = listingRepo(HttpStatusCode.OK, listingBody),
+                )
+
+            vm.start()
+            advanceUntilIdle()
+            assertNotNull(vm.state.value.listing, "precondition: listing is loaded")
+
+            // The regression under test (#2108/#2125): an auth-token change must NOT flip the
+            // screen back to the full-screen spinner or drop the already-loaded listing.
+            vm.updateAuth("new-token")
+            advanceUntilIdle()
+
+            val listing = assertNotNull(vm.state.value.listing, "listing survives the auth change")
+            assertEquals("lst-1", listing.id)
+            assertFalse(vm.state.value.isLoading, "auth change must not re-trigger the spinner")
+        }
+
+    @Test
+    fun updateAuth_logout_clears_favorite_heart() =
+        runTest(StandardTestDispatcher()) {
+            val vm =
+                viewModel(
+                    favorites = favoritesRepo(HttpStatusCode.OK, """{"is_favorited": true}"""),
+                    scope = backgroundScope,
+                    isAuthenticated = true,
+                )
+
+            vm.start()
+            advanceUntilIdle()
+            assertTrue(vm.state.value.isFavorite, "precondition: authenticated probe turns heart on")
+
+            // Logout: favorites require auth, so the heart can no longer reflect a user's state.
+            vm.updateAuth(null)
+            advanceUntilIdle()
+
+            assertFalse(vm.state.value.isFavorite, "logout resets the heart to off")
+            assertFalse(vm.state.value.isFavoriteLoading)
+        }
+
+    @Test
+    fun updateAuth_login_reprobes_favorite_state() =
+        runTest(StandardTestDispatcher()) {
+            val vm =
+                viewModel(
+                    favorites = favoritesRepo(HttpStatusCode.OK, """{"is_favorited": true}"""),
+                    scope = backgroundScope,
+                    isAuthenticated = false,
+                )
+
+            vm.start()
+            advanceUntilIdle()
+            assertFalse(vm.state.value.isFavorite, "no probe fires while unauthenticated")
+
+            // Login: updateAuth must re-probe loadFavoriteState() with the new token.
+            vm.updateAuth("test-token")
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value.isFavorite, "login re-probes and reflects the server's true")
+        }
+
+    @Test
+    fun updateAuth_sameToken_is_noop_and_does_not_rebuild_repositories() =
+        runTest(StandardTestDispatcher()) {
+            var favoritesFactoryCalls = 0
+            val favorites = favoritesRepo(HttpStatusCode.OK, """{"is_favorited": true}""")
+            val vm =
+                ListingDetailViewModel(
+                    listingId = "lst-1",
+                    listingRepository = unusedListingRepo(),
+                    favoritesRepositoryFactory = {
+                        favoritesFactoryCalls++
+                        favorites
+                    },
+                    inquiryRepositoryFactory = { unusedInquiryRepo() },
+                    scope = backgroundScope,
+                    initialSessionToken = "test-token",
+                    errorMapper = { it.message ?: "error" },
+                )
+
+            // The factory is invoked exactly once, at construction time.
+            assertEquals(1, favoritesFactoryCalls, "precondition: repo built once on construction")
+
+            // An unchanged token must short-circuit: no repo rebuild, no re-probe.
+            vm.updateAuth("test-token")
+            advanceUntilIdle()
+
+            assertEquals(
+                1,
+                favoritesFactoryCalls,
+                "same-token updateAuth must be a no-op and not rebuild the favorites repository",
+            )
+        }
+
+    @Test
+    fun favoriteToggle_rollback_is_suppressed_after_logout() =
+        runTest(StandardTestDispatcher()) {
+            // GET .../check → favorited=true (so start() lights the heart); the DELETE write 500s,
+            // which would normally roll the heart back ON. But the user logs out mid-flight, so
+            // the stale rollback must be dropped and the heart must stay OFF (issue #2125).
+            val engine =
+                MockEngine { request ->
+                    if (request.method == HttpMethod.Get) {
+                        respond(
+                            content = ByteReadChannel("""{"is_favorited": true}"""),
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    } else {
+                        respond(
+                            content = ByteReadChannel("""{"error":"boom"}"""),
+                            status = HttpStatusCode.InternalServerError,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    }
+                }
+            val repo =
+                FavoritesRepository(
+                    baseUrl = "https://example.test",
+                    sessionToken = "test-token",
+                    client = HttpClient(engine) { install(ContentNegotiation) { json(json) } },
+                )
+            val vm = viewModel(repo, scope = backgroundScope)
+
+            vm.start()
+            advanceUntilIdle()
+            assertTrue(vm.state.value.isFavorite, "precondition: heart is on before the toggle")
+
+            // Toggle OFF (optimistic), then log out before the failing write resolves.
+            vm.onFavoriteToggle()
+            assertFalse(vm.state.value.isFavorite, "optimistic toggle turns the heart off")
+            vm.updateAuth(null)
+            assertFalse(vm.state.value.isFavorite, "logout keeps the heart off")
+
+            advanceUntilIdle()
+
+            // Without the guard the 500 would roll back to previous(=true); the session-change
+            // guard drops that stale write so an unauthenticated user never sees a lit heart.
+            assertFalse(
+                vm.state.value.isFavorite,
+                "stale rollback after logout must not re-light the heart",
+            )
+            assertFalse(vm.state.value.isFavoriteLoading)
         }
 
     // ─── onSubmitInquiry() ────────────────────────────────────────────────────


### PR DESCRIPTION
## What & why

Post-merge follow-up to **PR #2115** (issue #2108 — *ListingDetail auth change resets screen to spinner*). That fix stopped the spinner-reset regression but shipped **no test for `updateAuth()` itself**, and left a latent correctness gap where a favorite write launched before logout could roll back and re-light the heart while unauthenticated.

This PR closes both gaps — scoped to the two files named in the issue.

### Tests — `ListingDetailViewModelTest.kt` (the 4 cases from the issue + 1 for the guard)
1. `updateAuth()` after a load keeps `state.listing` set and `isLoading == false` (pins the #2108 regression: no spinner reset).
2. authenticated → `updateAuth(null)` asserts `isFavorite == false && isFavoriteLoading == false`.
3. unauthenticated `start()` → `updateAuth(token)` re-probes `loadFavoriteState()` and asserts `isFavorite == true`.
4. `updateAuth(sameToken)` is a no-op — the favorites factory is not re-invoked (counting factory).
5. **Guard:** a favorite toggle-off whose write fails *after* a mid-flight logout must **not** roll back to a lit heart.

### Correctness guard — `ListingDetailViewModel.onFavoriteToggle()`
Captures the session token (and the repo bound to it) at launch, and skips the confirm/rollback `_state.update` if the session changed while the write was in flight. Prevents an un-favorited listing from rendering as favorited while unauthenticated (issue #2125, low-severity item). Also pins the write to the repo it was launched against rather than the post-logout one.

## Verification
- Static review only — **local Gradle build was not runnable in this environment**: the project pins Gradle `9.6.1` (AGP 9 KMP library plugin), whose distribution is unreachable here (proxy 403) and no plugin/dependency artifacts are cached for offline resolution; the system gradle is `8.14.3` (wrong major). Compilation + `commonTest` execution are therefore **deferred to CI (`mobile-native.yml`)**, which runs the Gradle build + unit tests on this diff.
- New tests reuse the existing `favoritesRepo` / `listingRepo` / `viewModel` harness; cases 4 and 5 construct directly where a counting factory / path-routing MockEngine is required.

Closes #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R)_