### PR TITLE
gh-issue-2122: return named AccountingMetrics struct from get_accounting_metrics

### DIFF
--- a/backend/crates/db/src/models/regional_compliance.rs
+++ b/backend/crates/db/src/models/regional_compliance.rs
@@ -447,6 +447,36 @@ pub struct SlovakAccountingExportInput {
     pub generated_at: DateTime<Utc>,
 }
 
+/// Named-field result of
+/// [`RegionalComplianceRepository::get_accounting_metrics`](crate::repositories::regional_compliance::RegionalComplianceRepository::get_accounting_metrics).
+///
+/// Replaces the positional 6-tuple
+/// `(i32, i32, Decimal, Option<Decimal>, Decimal, Option<Decimal>)` (#2122).
+/// Four of those slots were type-identical and interleaved — two bare
+/// `Decimal` (`total_revenue` / `total_receivables`) and two `Option<Decimal>`
+/// (`total_expenses` / `total_payables`) — so transposing revenue↔receivables
+/// (or the two options) at the return site or the destructuring call site
+/// compiled cleanly and silently shipped wrong accounting figures. That is the
+/// exact #2103 honesty class, one layer upstream of the
+/// [`SlovakAccountingExportInput`] ctor that #2103 fixed. Naming each field
+/// here makes the compiler enforce the
+/// revenue/receivables/expenses/payables identity end-to-end, from the
+/// repository query assembly through to the handler that feeds
+/// [`SlovakAccountingExport::new`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountingMetrics {
+    pub invoice_count: i32,
+    pub payment_count: i32,
+    pub total_revenue: Decimal,
+    /// `None` = **not available**, not zero — see
+    /// [`SlovakAccountingExport::total_expenses`].
+    pub total_expenses: Option<Decimal>,
+    pub total_receivables: Decimal,
+    /// `None` = **not available**, not zero — see
+    /// [`SlovakAccountingExport::total_payables`].
+    pub total_payables: Option<Decimal>,
+}
+
 impl SlovakAccountingExport {
     /// Smart constructor: the ONLY way to build a `SlovakAccountingExport`.
     ///

--- a/backend/crates/db/src/repositories/regional_compliance.rs
+++ b/backend/crates/db/src/repositories/regional_compliance.rs
@@ -1,9 +1,9 @@
 //! Regional Compliance Repository (Epic 72).
 
 use crate::models::regional_compliance::{
-    ConfigureCzechSvj, ConfigureSlovakAccounting, ConfigureSlovakGdpr, ConfigureSlovakVoting,
-    CzechSvjConfig, Jurisdiction, RecordGdprConsent, SlovakAccountingConfig, SlovakDecisionType,
-    SlovakGdprConfig, SlovakGdprConsent, SlovakVotingConfig,
+    AccountingMetrics, ConfigureCzechSvj, ConfigureSlovakAccounting, ConfigureSlovakGdpr,
+    ConfigureSlovakVoting, CzechSvjConfig, Jurisdiction, RecordGdprConsent, SlovakAccountingConfig,
+    SlovakDecisionType, SlovakGdprConfig, SlovakGdprConsent, SlovakVotingConfig,
 };
 use crate::DbPool;
 use chrono::NaiveDate;
@@ -477,8 +477,14 @@ impl RegionalComplianceRepository {
         Ok(row)
     }
 
-    /// Returns `(invoice_count, payment_count, total_revenue, total_expenses,
-    /// total_receivables, total_payables)` for the accounting export.
+    /// Returns the accounting-export metrics for the period as a named
+    /// [`AccountingMetrics`] struct.
+    ///
+    /// The result was formerly a positional 6-tuple; it is now a named struct
+    /// (#2122) so the revenue/receivables/expenses/payables identity is
+    /// compiler-enforced from this assembly through to the handler, rather than
+    /// relying on tuple position where two same-typed pairs could be silently
+    /// transposed.
     ///
     /// **Not yet computed (#1906 finding-3, tracked by #2030):**
     /// `total_expenses` and `total_payables` (the 4th and 6th tuple fields) are
@@ -496,7 +502,7 @@ impl RegionalComplianceRepository {
         organization_id: Uuid,
         from_date: NaiveDate,
         to_date: NaiveDate,
-    ) -> Result<(i32, i32, Decimal, Option<Decimal>, Decimal, Option<Decimal>), SqlxError> {
+    ) -> Result<AccountingMetrics, SqlxError> {
         let (invoice_count, total_revenue): (i64, Option<Decimal>) = sqlx::query_as(
             r#"
             SELECT COUNT(*), SUM(total)
@@ -539,16 +545,16 @@ impl RegionalComplianceRepository {
         let total_revenue = total_revenue.unwrap_or(Decimal::ZERO);
         let total_receivables = total_receivables.unwrap_or(Decimal::ZERO);
 
-        Ok((
-            invoice_count as i32,
-            payment_count as i32,
+        Ok(AccountingMetrics {
+            invoice_count: invoice_count as i32,
+            payment_count: payment_count as i32,
             total_revenue,
             // Not computed — no expense source wired. `None` means "not
             // available", surfaced to clients as a null field, never 0.
-            None,
+            total_expenses: None,
             total_receivables,
             // Not computed — no accounts-payable source wired.
-            None,
-        ))
+            total_payables: None,
+        })
     }
 }

--- a/backend/servers/api-server/src/routes/regional_compliance.rs
+++ b/backend/servers/api-server/src/routes/regional_compliance.rs
@@ -428,14 +428,10 @@ async fn export_slovak_accounting(
     // metrics by putting B's id in the body. The body field is now ignored for
     // scoping.
     let org_id = rls.tenant_id();
-    let (
-        invoice_count,
-        payment_count,
-        total_revenue,
-        total_expenses,
-        total_receivables,
-        total_payables,
-    ) = state
+    // Named-struct result (#2122): field access below is compiler-checked, so a
+    // revenue↔receivables (or expenses↔payables) transposition can no longer be
+    // introduced silently the way a positional tuple destructure allowed.
+    let metrics = state
         .regional_compliance_repo
         .get_accounting_metrics(rls.conn(), org_id, payload.from_date, payload.to_date)
         .await
@@ -446,7 +442,7 @@ async fn export_slovak_accounting(
             )
         })?;
 
-    let journal_entry_count = invoice_count + payment_count;
+    let journal_entry_count = metrics.invoice_count + metrics.payment_count;
 
     // Build via the smart constructor (#2086): `partial` + `unsupported_fields`
     // are derived inside `new` from the `Option` monetary fields, so this
@@ -460,13 +456,13 @@ async fn export_slovak_accounting(
         from_date: payload.from_date,
         to_date: payload.to_date,
         format: payload.format,
-        invoice_count,
-        payment_count,
+        invoice_count: metrics.invoice_count,
+        payment_count: metrics.payment_count,
         journal_entry_count,
-        total_revenue,
-        total_expenses,
-        total_receivables,
-        total_payables,
+        total_revenue: metrics.total_revenue,
+        total_expenses: metrics.total_expenses,
+        total_receivables: metrics.total_receivables,
+        total_payables: metrics.total_payables,
         download_url: Some(format!(
             "/api/v1/regional-compliance/slovak/accounting/download/{}",
             Uuid::new_v4()


### PR DESCRIPTION
## Task
Follow-up: get_accounting_metrics positional tuple still allows same-type transposition (PR #2117). Make get_accounting_metrics return a named struct instead of the positional 6-tuple so revenue/receivables/expenses/payables identity is compiler-enforced end-to-end.

Closes #2122

## Owner
pm-tech-lead (implemented by rust-backend specialist)

## Change
- New `AccountingMetrics` named struct in `backend/crates/db/src/models/regional_compliance.rs` (fields: `invoice_count`, `payment_count`, `total_revenue`, `total_expenses: Option`, `total_receivables`, `total_payables: Option`).
- `RegionalComplianceRepository::get_accounting_metrics` now returns `AccountingMetrics` instead of `(i32, i32, Decimal, Option<Decimal>, Decimal, Option<Decimal>)`; the `Ok(...)` assembly uses named fields.
- The export handler (`backend/servers/api-server/src/routes/regional_compliance.rs`) consumes the struct by field access instead of positional tuple destructuring, then feeds `SlovakAccountingExportInput` by field shorthand.

The two same-typed pairs (`total_revenue`/`total_receivables` as `Decimal`; `total_expenses`/`total_payables` as `Option<Decimal>`) can no longer be transposed silently at the return site or the call site — the compiler enforces field identity from the repository query assembly through to the handler, closing the #2103 honesty class one layer upstream of the ctor that #2103 fixed.

## Tested (Band A — fast check)
- `cd backend && cargo fmt --all` -> exit 0 (no changes)
- `cd backend && cargo check -p db` -> exit 0 (the crate carrying the new struct + repository return type compiles clean)

## Built (Band B — full build)
- `cd backend && cargo clippy -p db -- -D warnings` -> exit 0
- `cargo check -p api-server` (call site) -> FAILS in this cloud sandbox at the `utoipa-swagger-ui v9.0.2` build script only: it tries to download `swagger-ui v5.17.14.zip` and the proxy returns a non-zip body (`InvalidArchive("Could not find EOCD")`). Pre-existing environment/proxy limitation, unrelated to this change. The call-site edit is plain field access on a struct whose definition already compiles in the `db` crate. Full api-server compile + CI (`backend.yml`: fmt/clippy/test with Postgres) is deferred to CI.

## CI parity (Band C — hot-path only)
Deferred to CI. No Postgres in this sandbox, and the full workspace compile is blocked by the swagger-ui build-script download above. `backend.yml` will run fmt/clippy/test on the PR.

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` exited 2 (paths outside the pm-tech-lead owner map): `backend/crates/db/src/models/regional_compliance.rs`, `backend/crates/db/src/repositories/regional_compliance.rs`, `backend/servers/api-server/src/routes/regional_compliance.rs`. This reflects the architectural `owner_role` hint not mapping to concrete backend code paths; all three files are the minimal coherent set for this backend refactor (struct def + return type + sole call site). No unrelated code touched.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` -> no warnings. `AccountingMetrics` is a new domain result type; no existing helper duplicates it.

## Notes
- Pure refactor: no runtime behavior change (field ordering/semantics identical; `total_expenses`/`total_payables` still returned as `None` per #2030/#1906). IG3 failing-on-main regression test is therefore N/A (the safety property is compile-time, enforced by the type system rather than a runtime assertion).
- No new DB unit test added: `get_accounting_metrics` requires a live Postgres connection and had no pre-existing unit coverage; the change is verified by compilation of the named-field assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvPs4eptNMrzabE7uDX92R)_