### PR TITLE
ci: require quick-xml ban presence in deny.toml via gate check

### DIFF
--- a/.github/workflows/branch-protection-setup.yml
+++ b/.github/workflows/branch-protection-setup.yml
@@ -1,7 +1,10 @@
 name: Branch-protection setup
 
-# One-time (and idempotent) workflow that registers "security-gate-conclusion"
-# as a required status check on the `dev` branch protection rule.
+# One-time (and idempotent) workflow that registers the repo's gate check
+# contexts (see NEW_CHECKS below, e.g. "security-gate-conclusion",
+# "deny-toml-ban-gate") as required status checks on the `dev` branch
+# protection rule, and ensures "Require review from Code Owners" is
+# enabled so CODEOWNERS entries actually block (#2127).
 #
 # WHY THIS EXISTS
 # ---------------
@@ -147,34 +150,68 @@ jobs:
         run: |
           set -euo pipefail
 
-          NEW_CHECK="security-gate-conclusion"
+          # Gate check contexts that must be REQUIRED on the dev protection
+          # rule. A gate workflow that is not listed here is advisory-only —
+          # its failure does not block a merge. The context of a GitHub
+          # Actions check is the job's `name`, so keep this list in sync
+          # with the gate job names.
+          NEW_CHECKS=$(printf '%s\n' \
+            "security-gate-conclusion" \
+            "deny-toml-ban-gate")
 
-          # Build the merged list of required status checks.
+          # Build the merged list of required status checks (existing ∪ new).
           MERGED=$(python3 -c "
-          import sys, json
-
           existing_raw = '''$EXISTING_CHECKS'''
-          new_check = '$NEW_CHECK'
+          new_raw = '''$NEW_CHECKS'''
 
           existing = [c.strip() for c in existing_raw.strip().splitlines() if c.strip()]
+          new = [c.strip() for c in new_raw.strip().splitlines() if c.strip()]
 
-          if new_check in existing:
-              print('\n'.join(existing))
-          else:
-              print('\n'.join(existing + [new_check]))
+          print('\n'.join(existing + [c for c in new if c not in existing]))
           ")
 
           echo "Required status checks after merge:"
           echo "$MERGED"
 
-          # Determine if the new check is already registered.
-          if echo "$EXISTING_CHECKS" | grep -qxF "$NEW_CHECK"; then
-            echo "INFO: '$NEW_CHECK' is already in required status checks — nothing to do."
+          # Determine which of the gate checks are not yet registered.
+          MISSING=$(python3 -c "
+          existing_raw = '''$EXISTING_CHECKS'''
+          new_raw = '''$NEW_CHECKS'''
+
+          existing = [c.strip() for c in existing_raw.strip().splitlines() if c.strip()]
+          new = [c.strip() for c in new_raw.strip().splitlines() if c.strip()]
+
+          print('\n'.join(c for c in new if c not in existing))
+          ")
+
+          # Is "Require review from Code Owners" already enabled? Without it
+          # every CODEOWNERS entry (backend/deny.toml, Cargo.toml/Cargo.lock
+          # guards) is advisory-only — see #2127. The payload builder
+          # strengthens it to true, so a run is needed while it is off.
+          CODEOWNER_CURRENT=$(python3 -c "
+          import json
+          raw = '''$PROTECTION_JSON'''
+          try:
+              d = json.loads(raw) if raw.strip() else {}
+          except Exception:
+              d = {}
+          prr = d.get('required_pull_request_reviews') or {}
+          print('true' if prr.get('require_code_owner_reviews') else 'false')
+          ")
+
+          if [ -z "$MISSING" ] && [ "$CODEOWNER_CURRENT" = "true" ]; then
+            echo "INFO: all gate checks are already required and code-owner reviews are enabled — nothing to do."
             exit 0
           fi
 
           if [ "$DRY_RUN" = "true" ]; then
-            echo "DRY-RUN: would add '$NEW_CHECK' to dev branch required status checks."
+            if [ -n "$MISSING" ]; then
+              echo "DRY-RUN: would add these to dev branch required status checks:"
+              echo "$MISSING" | sed 's/^/  - /'
+            fi
+            if [ "$CODEOWNER_CURRENT" != "true" ]; then
+              echo "DRY-RUN: would enable require_code_owner_reviews on dev."
+            fi
             echo "DRY-RUN: no changes applied."
             exit 0
           fi
@@ -185,8 +222,9 @@ jobs:
           # we omit (or send weaker) is overwritten. So we must NOT ship a fixed
           # payload. Instead we round-trip: start from the CURRENT protection that
           # the previous step fetched, then *only add/strengthen*:
-          #   - add the new required status check to the existing contexts,
+          #   - add the new required status checks to the existing contexts,
           #   - force strict=true (never downgrade an existing strict=true),
+          #   - force require_code_owner_reviews=true (#2127, strengthen-only),
           #   - PRESERVE existing restrictions, PR-review rules, enforce_admins,
           #     linear-history, conversation-resolution, etc. exactly as-is.
           # If no protection existed yet, fall back to a safe baseline (strict=true,
@@ -211,19 +249,26 @@ jobs:
             --input - <<< "$PAYLOAD"
 
           echo ""
-          echo "SUCCESS: '$NEW_CHECK' is now a required status check on dev."
+          echo "SUCCESS: these are now required status checks on dev:"
+          echo "$NEW_CHECKS" | sed 's/^/  - /'
+          echo "and require_code_owner_reviews is enforced (strengthen-only)."
           echo ""
           echo "Effect:"
           echo "  - Any PR labelled 'security' that ships without a test file will have"
           echo "    'security-gate-conclusion' fail, which blocks merge."
           echo "  - PRs without the 'security' label: 'security-test-gate' is skipped →"
           echo "    'security-gate-conclusion' succeeds → merge is not blocked."
+          echo "  - Any PR that removes a quick-xml half-range ban line from"
+          echo "    backend/deny.toml fails 'deny-toml-ban-gate', which blocks merge."
+          echo "  - CODEOWNERS-guarded paths (backend/deny.toml, Cargo.toml/lock)"
+          echo "    now require a code-owner review before merge."
 
-      - name: Self-check — verify security-gate-conclusion is required
-        # Idempotent audit step. Reads back required_status_checks from the
-        # API after the apply step ran and fails the run if
-        # 'security-gate-conclusion' is not present. This makes the workflow
-        # self-auditing: a green run guarantees the gate is registered.
+      - name: Self-check — verify gate checks + code-owner reviews are required
+        # Idempotent audit step. Reads back required_status_checks and
+        # required_pull_request_reviews from the API after the apply step ran
+        # and fails the run if any gate check is missing or code-owner
+        # reviews are not enforced. This makes the workflow self-auditing:
+        # a green run guarantees the gates are registered (#2127).
         #
         # In dry-run mode this only warns (the apply step did not patch).
         env:
@@ -232,7 +277,10 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          REQUIRED_CHECK="security-gate-conclusion"
+          # Keep in sync with NEW_CHECKS in the apply step above.
+          REQUIRED_CHECKS=$(printf '%s\n' \
+            "security-gate-conclusion" \
+            "deny-toml-ban-gate")
 
           echo "Reading back required status checks for dev..."
           RESPONSE=$(gh api "repos/$REPO/branches/dev/protection/required_status_checks" 2>&1) || {
@@ -265,12 +313,38 @@ jobs:
             echo "$NAMES" | sed 's/^/  - /'
           fi
 
-          if echo "$NAMES" | grep -qxF "$REQUIRED_CHECK"; then
+          MISSING=""
+          while IFS= read -r required; do
+            [ -n "$required" ] || continue
+            if ! echo "$NAMES" | grep -qxF "$required"; then
+              MISSING="$MISSING $required"
+            fi
+          done <<< "$REQUIRED_CHECKS"
+
+          if [ -z "$MISSING" ]; then
             echo ""
-            echo "OK: '$REQUIRED_CHECK' is registered as a required status check on dev."
+            echo "OK: all gate checks are registered as required status checks on dev."
           else
             echo ""
-            echo "ERROR: '$REQUIRED_CHECK' is NOT in the required status checks for dev."
+            echo "ERROR: NOT in the required status checks for dev:$MISSING"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "DRY-RUN: not failing the run (apply step did not patch)."
+              exit 0
+            fi
+            exit 1
+          fi
+
+          # #2127 finding 2: CODEOWNERS entries only block if branch
+          # protection enforces "Require review from Code Owners". Assert it.
+          echo ""
+          echo "Reading back required_pull_request_reviews for dev..."
+          CODEOWNER=$(gh api "repos/$REPO/branches/dev/protection/required_pull_request_reviews" \
+            --jq '.require_code_owner_reviews' 2>/dev/null || echo "unavailable")
+          if [ "$CODEOWNER" = "true" ]; then
+            echo "OK: require_code_owner_reviews is enabled on dev — CODEOWNERS entries are blocking."
+          else
+            echo "ERROR: require_code_owner_reviews is '$CODEOWNER' on dev — CODEOWNERS"
+            echo "entries (backend/deny.toml, Cargo.toml/Cargo.lock guards) are advisory-only (#2127)."
             if [ "$DRY_RUN" = "true" ]; then
               echo "DRY-RUN: not failing the run (apply step did not patch)."
               exit 0
@@ -288,7 +362,8 @@ jobs:
           echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
           echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
           echo "| Branch | \`dev\` |" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Required check added | \`security-gate-conclusion\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Required checks | \`security-gate-conclusion\`, \`deny-toml-ban-gate\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Code-owner reviews | enforced (strengthen-only) |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Dry-run | $DRY_RUN |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Status | ${{ job.status }} |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deny-toml-ban-gate.yml
+++ b/.github/workflows/deny-toml-ban-gate.yml
@@ -1,0 +1,66 @@
+name: deny.toml ban gate
+
+# Why this exists
+# ---------------
+# Issue #2127 (follow-up to #2106 / PR #2111): the quick-xml XXE /
+# billion-laughs safety pin in backend/deny.toml is enforced as a PAIR of
+# half-range ban lines:
+#
+#   { name = "quick-xml", version = "<0.41.0", ... }
+#   { name = "quick-xml", version = ">0.41.0", ... }
+#
+# Deleting those lines does NOT make `cargo deny check bans` fail — with
+# the bans gone there is simply nothing left to trip, so the check stays
+# green. The CODEOWNERS entry on backend/deny.toml is advisory-only
+# (review-from-code-owners is a branch-protection setting, and cargo-deny
+# itself is not a required check), which leaves the exact silent-reopen
+# threat #2106 describes: a PR can drop the pin and merge green.
+#
+# This gate closes that gap with a review-independent CI assertion: it
+# fails whenever either half-range quick-xml ban line is absent from
+# backend/deny.toml. The check is a pure fixed-string grep — DB-free,
+# compile-free, and fast.
+#
+# NOTE: like security-gate-conclusion and the other gates, this only
+# BLOCKS a merge if "deny-toml-ban-gate" is registered as a required
+# status check on the `dev` branch-protection rule. Registration is
+# handled by .github/workflows/branch-protection-setup.yml — keep the
+# NEW_CHECKS list there in sync with this job's name.
+#
+# The pull_request trigger is intentionally NOT path-filtered: a required
+# status check that is skipped by a path filter never reports a status,
+# which would wedge every PR that does not touch the filtered paths. The
+# job costs a checkout plus two greps, so running it on every PR is cheap.
+
+on:
+  pull_request:
+  push:
+    branches: [dev]
+    paths:
+      - 'backend/deny.toml'
+      - '.github/workflows/deny-toml-ban-gate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  deny-toml-ban-gate:
+    name: deny-toml-ban-gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Assert quick-xml half-range ban lines are present in backend/deny.toml
+        run: |
+          set -euo pipefail
+          fail=0
+          for ver in '<0.41.0' '>0.41.0'; do
+            needle="{ name = \"quick-xml\", version = \"${ver}\""
+            if ! grep -qF "$needle" backend/deny.toml; then
+              echo "::error file=backend/deny.toml::Missing quick-xml ban line: ${needle}, ... } — the XXE/billion-laughs safety pin (GH #2084/#2106/#2127) must not be removed. Changing the pinned version requires a focused ota_xml::tests entity-guard review AND updating this gate."
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "Both quick-xml half-range ban lines are present in backend/deny.toml."

--- a/.github/workflows/scripts/branch-protection-payload.py
+++ b/.github/workflows/scripts/branch-protection-payload.py
@@ -30,8 +30,10 @@ required status-check contexts, produce the body for
   * required_status_checks.strict is ALWAYS true (never weaken; strengthen
     false -> true), and .checks is exactly the merged context list.
   * required_pull_request_reviews is PRESERVED when present (approval
-    count, dismiss-stale, code-owner, require_last_push_approval), else a
-    safe baseline (1 approval).
+    count, dismiss-stale, require_last_push_approval), else a safe
+    baseline (1 approval) — EXCEPT require_code_owner_reviews, which is
+    ALWAYS true (strengthen false -> true, never weaken; #2127: without
+    it every CODEOWNERS entry is advisory-only).
   * enforce_admins is preserved (dict {enabled} or bool), default true.
   * restrictions (push restrictions) are PRESERVED, never nulled, when
     present; null only when the current rule had none.
@@ -79,13 +81,14 @@ def build_payload(current: dict | None, checks: list[str]) -> dict:
     }
 
     # --- required_pull_request_reviews: preserve existing, else safe baseline ---
+    # require_code_owner_reviews is a strengthen-only toggle like strict:
+    # without it every CODEOWNERS entry (backend/deny.toml, Cargo.toml/lock
+    # guards) is advisory-only (#2127). Always true; never set false.
     cur_prr = cur.get("required_pull_request_reviews")
     if cur_prr:
         prr = {
             "dismiss_stale_reviews": bool(cur_prr.get("dismiss_stale_reviews", False)),
-            "require_code_owner_reviews": bool(
-                cur_prr.get("require_code_owner_reviews", False)
-            ),
+            "require_code_owner_reviews": True,
             "required_approving_review_count": int(
                 cur_prr.get("required_approving_review_count", 1)
             ),
@@ -98,7 +101,7 @@ def build_payload(current: dict | None, checks: list[str]) -> dict:
     else:
         prr = {
             "dismiss_stale_reviews": False,
-            "require_code_owner_reviews": False,
+            "require_code_owner_reviews": True,
             "required_approving_review_count": 1,
         }
 
@@ -253,12 +256,22 @@ def _self_test() -> int:
     # currently has strict=false comes back strict=true.
     weak_strict = {
         "required_status_checks": {"strict": False, "checks": []},
+        "required_pull_request_reviews": {
+            "dismiss_stale_reviews": False,
+            "require_code_owner_reviews": False,
+            "required_approving_review_count": 1,
+        },
     }
     p2 = build_payload(weak_strict, [NEW_CHECK])
     _check(
         "strict/strengthened",
         p2["required_status_checks"]["strict"] is True,
         "strict=false strengthened to strict=true (never weakened)",
+    )
+    _check(
+        "code-owner/strengthened",
+        p2["required_pull_request_reviews"]["require_code_owner_reviews"] is True,
+        "require_code_owner_reviews=false strengthened to true (#2127)",
     )
 
     # --- Fixture 3: no existing protection -> safe baseline. ---
@@ -272,6 +285,11 @@ def _self_test() -> int:
         "baseline/one-approval",
         p3["required_pull_request_reviews"]["required_approving_review_count"] == 1,
         "baseline requires 1 approval",
+    )
+    _check(
+        "baseline/code-owner-required",
+        p3["required_pull_request_reviews"]["require_code_owner_reviews"] is True,
+        "baseline enforces code-owner reviews (#2127)",
     )
     _check(
         "baseline/enforce-admins",


### PR DESCRIPTION
Closes #2127

## What

The CODEOWNERS entry on `backend/deny.toml` is advisory-only: deleting the two `quick-xml` half-range ban lines leaves `cargo deny check bans` green (nothing left to trip), so nothing CI-side defends against silently reopening the #2084/#2106 XXE pin. This PR adds a review-independent required-CI-style assertion.

### Finding 1 — deny.toml ban gate
- New workflow `.github/workflows/deny-toml-ban-gate.yml` (pattern follows `ignore-reason-gate.yml` / `script-exec-bit-gate.yml`): fails whenever either `{ name = "quick-xml", version = "<0.41.0" ... }` or `{ name = "quick-xml", version = ">0.41.0" ... }` is absent from `backend/deny.toml` (fixed-string grep, DB-free).
- The `pull_request` trigger is intentionally unfiltered: a path-filtered required check never reports on PRs that miss the paths and would wedge them at "Expected". The job is a checkout + two greps.
- Registered in `branch-protection-setup.yml`: the single `NEW_CHECK="security-gate-conclusion"` was generalized to a `NEW_CHECKS` list now containing `security-gate-conclusion` + `deny-toml-ban-gate`; the self-check audit step verifies all listed checks after apply.

### Finding 2 — require_code_owner_reviews
`branch-protection-setup.yml` never verified "Require review from Code Owners", so the CODEOWNERS mechanism was advisory-in-practice. Extended following the file's existing "never weaken, only strengthen" contract:
- `branch-protection-payload.py`: `require_code_owner_reviews` is now strengthen-only `true` (mirrors the `strict` handling), documented in the CONTRACT docstring.
- Self-test fixtures: new `code-owner/strengthened` (false -> true) and `baseline/code-owner-required` assertions; existing `strong/code-owner-preserved` still passes.
- The workflow's Self-check step now also reads back `required_pull_request_reviews.require_code_owner_reviews` and fails if not `true`.

Note: registration itself still requires the documented `workflow_dispatch` run with `GH_ADMIN_TOKEN` (current live required checks on dev are only `check` + `test`).

## Verification
- Ban lines verified present at `backend/deny.toml:93-94`.
- `python3 -c "import yaml,...safe_load..."` OK for both touched workflows.
- `python3 .github/workflows/scripts/branch-protection-payload.py --self-test` -> ALL FIXTURES PASSED (19 checks incl. the 2 new ones).
- Gate grep simulated locally: passes on real `deny.toml`; fails (both lines reported) on a copy with the bans stripped.
- Apply-step merge/missing/code-owner shell+python logic simulated locally with workflow-identical quoting (existing `check,test` -> MERGED appends both gates; MISSING detected; CODEOWNER_CURRENT=false -> proceeds).

Heads-up: conflicts trivially (union of the `NEW_CHECKS` list) with the sibling PR for #2128.
