### PR TITLE
test(api-server): enlarge tie group in include_system pagination test

### DIFF
--- a/backend/servers/api-server/tests/migration_pagination_tests.rs
+++ b/backend/servers/api-server/tests/migration_pagination_tests.rs
@@ -440,10 +440,14 @@ async fn include_system_default_tie_group_is_deterministic_id_desc(pool: PgPool)
     let app = TestApp::new(pool.clone()).await;
     let (token, org_id) = create_platform_admin(&app, &TestUser::new(), "pgtiesys").await;
 
-    // Three org rows + one system row, all sharing a far-future updated_at =>
-    // a 4-row tie group guaranteed to sit at the head of the DESC ordering,
-    // ahead of the migration-seeded system templates.
-    let org_count = 3;
+    // Seven org rows + one system row, all sharing a far-future updated_at =>
+    // an 8-row tie group guaranteed to sit at the head of the DESC ordering,
+    // ahead of the migration-seeded system templates. The group is kept large
+    // on purpose (#2123): with only 4 rows a regressed `id DESC` secondary key
+    // could spuriously pass whenever the BitmapOr heap-scan order happened to
+    // match id DESC (~1/4! per run); at 8 rows that false-pass chance is
+    // ~1/8! — negligible.
+    let org_count = 7;
     let head_desc = seed_tied_org_and_system_templates(&pool, org_id, org_count).await;
     assert_eq!(
         head_desc.len(),


### PR DESCRIPTION
Closes #2123

## What
Raises `org_count` from 3 to 7 in `include_system_default_tie_group_is_deterministic_id_desc` (`backend/servers/api-server/tests/migration_pagination_tests.rs`), growing the cross-leg tie group from 4 rows to 8 (7 org + 1 system template sharing one far-future `updated_at`).

## Why
With only 4 tied rows, a regressed `id DESC` secondary sort key could spuriously pass whenever the BitmapOr → Bitmap Heap Scan physical order happened to coincide with id-DESC (~1/4! ≈ 4% false-pass per run). At 8 rows the false-pass chance is ~1/8! — negligible — at near-zero cost.

Verified the surrounding assertions generalize: `seed_tied_org_and_system_templates` takes `org_count` as a parameter, the head-prefix assertion takes `head_desc.len()` positionally, and the page-2/per_page-2 offset slice (`head_desc[2..4]`) remains strictly inside the enlarged tie group. No hardcoded constants needed adjusting.

## Verification
- `cargo fmt --all --check` — clean
- `cargo test -p api-server --test migration_pagination_tests --no-run` — compiles clean

This is a `#[sqlx::test]` DB test; runtime execution defers to CI per repo convention (no sqlx offline / DB-free compile).