### PR TITLE
fix(mobile): type RN screen parsers against @ppt/api-client + fix misleading Leases/Forms status (#2129)

### DIFF
--- a/frontend/apps/mobile/src/screens/forms/FormsScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/forms/FormsScreen.test.ts
@@ -1,5 +1,13 @@
 import { type ApiFormSummary, parseFormSummaries, toResidentForm } from './FormsScreen';
 
+let warnSpy: jest.SpyInstance;
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
 const validForm: ApiFormSummary = {
   id: 'f-1',
   title: 'Fire-safety declaration',
@@ -34,16 +42,31 @@ describe('parseFormSummaries', () => {
     const mixed = [validForm, null, 'garbage', { id: 'no-title' }, { title: 'no-id' }];
     expect(parseFormSummaries({ forms: mixed })).toEqual([validForm]);
   });
+
+  it('emits a dev-only warning for an unrecognized non-null payload', () => {
+    parseFormSummaries({ error: 'boom' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('parseFormSummaries'));
+  });
+
+  it('emits a dev-only warning when every candidate row is dropped', () => {
+    parseFormSummaries({ forms: [{ noId: true }] });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dropped all 1'));
+  });
+
+  it('stays silent for a legitimately empty response', () => {
+    parseFormSummaries({ forms: [] });
+    parseFormSummaries(null);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('toResidentForm', () => {
-  it('maps the api summary onto the UI form shape', () => {
+  it('maps the api summary onto the UI form shape (no per-resident status — see #2129)', () => {
     expect(toResidentForm(validForm)).toEqual({
       id: 'f-1',
       title: 'Fire-safety declaration',
       description: 'Confirm equipment is functional.',
       dueAt: '2026-04-30T23:59:00Z',
-      status: 'pending',
       required: true,
     });
   });
@@ -53,6 +76,5 @@ describe('toResidentForm', () => {
     expect(mapped.description).toBe('');
     expect(mapped.dueAt).toBeUndefined();
     expect(mapped.required).toBe(false);
-    expect(mapped.status).toBe('pending');
   });
 });

--- a/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
@@ -12,27 +12,36 @@
  * without a generated client, so it is validated defensively.
  *
  * `FormSummary` carries the form's own lifecycle status, not a per-resident
- * completion state, so the screen presents available forms as actionable
- * ("pending") and surfaces the signature requirement + submission deadline.
+ * completion state, so the screen renders available forms without a completion
+ * badge/counter and surfaces the signature requirement + submission deadline.
+ * A resident-scoped completion-status field is tracked as a backend follow-up
+ * (issue #2129).
  */
 
 import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { warnIfListDegraded } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
-
-export type FormStatus = 'pending' | 'in_progress' | 'completed';
 
 export interface ResidentForm {
   id: string;
   title: string;
   description: string;
   dueAt?: string;
-  status: FormStatus;
   required: boolean;
 }
 
-/** Subset of `FormSummary` from `GET /api/v1/forms/available`. */
+/**
+ * Subset of `FormSummary` from `GET /api/v1/forms/available`.
+ *
+ * Kept hand-rolled deliberately: the backend `db::models::form::FormSummary`
+ * serializes with default snake_case serde, while the `FormSummary` type in
+ * `@ppt/api-client` (`forms/types.ts`) declares camelCase keys — the generated
+ * client type has itself drifted from the wire format, so importing it here
+ * would type the parser against field names the server never sends (tracked in
+ * issue #2129).
+ */
 export interface ApiFormSummary {
   id: string;
   title: string;
@@ -57,39 +66,30 @@ function isApiFormSummary(value: unknown): value is ApiFormSummary {
  *  Accepts the `{ forms: [...] }` envelope and a bare array (defensively);
  *  any other shape yields `[]`. Malformed rows are dropped. */
 export function parseFormSummaries(data: unknown): ApiFormSummary[] {
-  const candidates: unknown[] =
+  const candidates: unknown[] | null =
     typeof data === 'object' &&
     data !== null &&
     Array.isArray((data as ApiAvailableFormsResponse).forms)
       ? (data as ApiAvailableFormsResponse).forms
       : Array.isArray(data)
         ? data
-        : [];
-  return candidates.filter(isApiFormSummary);
+        : null;
+  const forms = (candidates ?? []).filter(isApiFormSummary);
+  warnIfListDegraded('parseFormSummaries', data, candidates, forms.length);
+  return forms;
 }
 
 /** Map an api-server form summary onto the UI shape. Exported for unit
- *  testing without rendering the screen. */
+ *  testing without rendering the screen. No per-resident completion status is
+ *  derived — the endpoint does not expose one (see module docs). */
 export function toResidentForm(f: ApiFormSummary): ResidentForm {
   return {
     id: f.id,
     title: f.title,
     description: f.description?.trim() || '',
     dueAt: f.submission_deadline ?? undefined,
-    status: 'pending',
     required: f.require_signatures ?? false,
   };
-}
-
-function statusBadgeStyle(status: FormStatus) {
-  switch (status) {
-    case 'pending':
-      return { background: colors.dangerBg, color: colors.danger };
-    case 'in_progress':
-      return { background: colors.warningBg, color: colors.warningDark };
-    case 'completed':
-      return { background: colors.successBg, color: colors.successDark };
-  }
 }
 
 interface FormsScreenProps {
@@ -104,7 +104,6 @@ export function FormsScreen({ onNavigate }: FormsScreenProps) {
   );
 
   const forms: ResidentForm[] = parseFormSummaries(data).map(toResidentForm);
-  const pending = forms.filter((f) => f.status !== 'completed').length;
 
   const onRefresh = useCallback(async () => {
     await refetch();
@@ -114,9 +113,9 @@ export function FormsScreen({ onNavigate }: FormsScreenProps) {
     <View style={s.container}>
       <View style={s.header}>
         <Text style={s.headerTitle}>Forms</Text>
-        {pending > 0 && (
+        {forms.length > 0 && (
           <Text style={s.headerSubtitle}>
-            {pending} form{pending === 1 ? '' : 's'} need{pending === 1 ? 's' : ''} attention
+            {forms.length} form{forms.length === 1 ? '' : 's'} available
           </Text>
         )}
       </View>
@@ -142,40 +141,32 @@ export function FormsScreen({ onNavigate }: FormsScreenProps) {
             <Text style={s.emptyText}>You have no forms to complete right now.</Text>
           </View>
         ) : (
-          forms.map((form) => {
-            const style = statusBadgeStyle(form.status);
-            return (
-              <Pressable
-                key={form.id}
-                style={s.card}
-                onPress={() => onNavigate?.('FormFill', { formId: form.id })}
-              >
-                <View style={s.cardHeader}>
-                  <Text style={s.cardTitle} numberOfLines={2}>
-                    {form.title}
-                  </Text>
-                  <View style={[s.badge, { backgroundColor: style.background }]}>
-                    <Text style={[s.badgeText, { color: style.color }]}>
-                      {form.status.replace('_', ' ')}
-                    </Text>
+          forms.map((form) => (
+            <Pressable
+              key={form.id}
+              style={s.card}
+              onPress={() => onNavigate?.('FormFill', { formId: form.id })}
+            >
+              <View style={s.cardHeader}>
+                <Text style={s.cardTitle} numberOfLines={2}>
+                  {form.title}
+                </Text>
+              </View>
+              {form.description ? <Text style={s.cardBody}>{form.description}</Text> : null}
+              <View style={s.cardFooter}>
+                {form.required && (
+                  <View style={[s.badge, { backgroundColor: colors.dangerBg }]}>
+                    <Text style={[s.badgeText, { color: colors.danger }]}>Required</Text>
                   </View>
-                </View>
-                {form.description ? <Text style={s.cardBody}>{form.description}</Text> : null}
-                <View style={s.cardFooter}>
-                  {form.required && (
-                    <View style={[s.badge, { backgroundColor: colors.dangerBg }]}>
-                      <Text style={[s.badgeText, { color: colors.danger }]}>Required</Text>
-                    </View>
-                  )}
-                  {form.dueAt && (
-                    <Text style={[s.cardMeta, { marginLeft: 'auto' }]}>
-                      Due {new Date(form.dueAt).toLocaleDateString()}
-                    </Text>
-                  )}
-                </View>
-              </Pressable>
-            );
-          })
+                )}
+                {form.dueAt && (
+                  <Text style={[s.cardMeta, { marginLeft: 'auto' }]}>
+                    Due {new Date(form.dueAt).toLocaleDateString()}
+                  </Text>
+                )}
+              </View>
+            </Pressable>
+          ))
         )}
 
         <View style={s.bottomSpacer} />

--- a/frontend/apps/mobile/src/screens/forms/index.ts
+++ b/frontend/apps/mobile/src/screens/forms/index.ts
@@ -1,2 +1,2 @@
-export type { FormStatus, ResidentForm } from './FormsScreen';
+export type { ResidentForm } from './FormsScreen';
 export { FormsScreen } from './FormsScreen';

--- a/frontend/apps/mobile/src/screens/index.ts
+++ b/frontend/apps/mobile/src/screens/index.ts
@@ -24,7 +24,7 @@ export {
 // Types
 export type { Fault, FaultCategory, FaultPriority, FaultStatus } from './faults';
 export { FaultsListScreen, ReportFaultScreen } from './faults';
-export type { FormStatus, ResidentForm } from './forms';
+export type { ResidentForm } from './forms';
 export { FormsScreen } from './forms';
 export type { ESignatureRequest, ESignatureStatus, Lease, LeaseRole, LeaseStatus } from './leases';
 export { LeaseDetailScreen, LeaseSignatureScreen, LeasesScreen } from './leases';

--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.test.ts
@@ -1,5 +1,13 @@
 import { parseLeaseDetail, toUiLease, toUiPayments } from './LeaseDetailScreen';
 
+let warnSpy: jest.SpyInstance;
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
 const validDetail = {
   lease: {
     id: 'l-1',
@@ -34,6 +42,16 @@ describe('parseLeaseDetail', () => {
   ])('returns null for an unexpected shape: %s', (_label, input) => {
     expect(parseLeaseDetail(input)).toBeNull();
   });
+
+  it('emits a dev-only warning when a non-null payload fails to parse', () => {
+    parseLeaseDetail({ unit_name: 'x' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('parseLeaseDetail'));
+  });
+
+  it('stays silent for a null payload (query not resolved yet)', () => {
+    parseLeaseDetail(null);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('toUiLease', () => {
@@ -63,10 +81,14 @@ describe('toUiLease', () => {
 });
 
 describe('toUiPayments', () => {
-  it('maps payments newest first with period labels and paid state', () => {
+  it('maps payments soonest first with period labels and due dates', () => {
     const rows = toUiPayments(parseLeaseDetail(validDetail)!);
-    expect(rows.map((r) => r.id)).toEqual(['p2', 'p1']);
-    expect(rows[0].paidAt).toBeNull();
-    expect(rows[1].paidAt).toBe('2026-03-01T09:00:00Z');
+    expect(rows.map((r) => r.id)).toEqual(['p1', 'p2']);
+    expect(rows[0]).toEqual({
+      id: 'p1',
+      period: 'March 2026',
+      amount: 850,
+      dueDate: '2026-03-01',
+    });
   });
 });

--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
@@ -11,9 +11,11 @@
  * client, so it is validated defensively.
  */
 
+import type { Lease as ApiLeasePayload, LeasePayment, LeaseWithDetails } from '@ppt/api-client';
 import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 import { type Lease, toUiLeaseStatus } from './LeasesScreen';
 
@@ -21,29 +23,23 @@ export interface LeasePaymentRow {
   id: string;
   period: string;
   amount: number;
-  paidAt: string | null;
+  dueDate: string;
 }
 
-/** Subset of `Lease` inside `LeaseWithDetails`. */
-interface ApiLease {
-  id: string;
-  unit_id?: string;
-  landlord_name?: string;
-  tenant_name?: string;
-  start_date: string;
-  end_date: string;
-  monthly_rent: string | number;
-  status: string;
-}
+/**
+ * `Lease` inside `LeaseWithDetails`, typed against the generated
+ * `@ppt/api-client` payload so backend field renames surface at compile time.
+ * Relaxed to `Partial` beyond the fields this screen requires, because the
+ * shape is validated defensively at runtime.
+ */
+type ApiLease = Partial<ApiLeasePayload> &
+  Pick<ApiLeasePayload, 'id' | 'start_date' | 'end_date' | 'monthly_rent' | 'status'>;
 
-/** Subset of `LeasePayment` from `upcoming_payments`. */
-interface ApiLeasePayment {
-  id: string;
-  due_date: string;
-  amount: string | number;
-  paid_at?: string | null;
-}
+/** `LeasePayment` fields consumed from `upcoming_payments`. */
+type ApiLeasePayment = Pick<LeasePayment, 'id' | 'due_date' | 'amount'> &
+  Partial<Pick<LeasePayment, 'paid_at'>>;
 
+/** Validated subset of the generated `LeaseWithDetails` envelope. */
 export interface ApiLeaseDetail {
   lease: ApiLease;
   unit_name: string;
@@ -59,19 +55,24 @@ function toNumber(value: string | number | null | undefined): number {
 
 /** Validate the raw `GET /api/v1/leases/{id}` body, or null on a bad shape. */
 export function parseLeaseDetail(data: unknown): ApiLeaseDetail | null {
+  const parsed = parseLeaseDetailInner(data);
+  warnIfParseFailed('parseLeaseDetail', data, parsed);
+  return parsed;
+}
+
+function parseLeaseDetailInner(data: unknown): ApiLeaseDetail | null {
   if (typeof data !== 'object' || data === null) return null;
   const v = data as Record<string, unknown>;
-  const lease = v.lease;
+  const lease = v['lease' satisfies keyof LeaseWithDetails];
   if (typeof lease !== 'object' || lease === null) return null;
   const l = lease as Record<string, unknown>;
   if (typeof l.id !== 'string') return null;
+  const payments = v['upcoming_payments' satisfies keyof LeaseWithDetails];
   return {
     lease: lease as ApiLease,
     unit_name: typeof v.unit_name === 'string' ? v.unit_name : '',
     building_name: typeof v.building_name === 'string' ? v.building_name : '',
-    upcoming_payments: Array.isArray(v.upcoming_payments)
-      ? (v.upcoming_payments as ApiLeasePayment[])
-      : [],
+    upcoming_payments: Array.isArray(payments) ? (payments as ApiLeasePayment[]) : [],
   };
 }
 
@@ -100,18 +101,20 @@ function periodLabel(dueDate: string): string {
   return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
 }
 
-/** Map api-server payments onto the UI payment rows, newest `due_date` first.
- *  Sorting is done on the raw ISO `due_date` (not the formatted month label,
- *  which would sort alphabetically). */
+/** Map api-server payments onto the UI payment rows, soonest `due_date` first.
+ *  `upcoming_payments` only carries scheduled payments (`due_date >= today`,
+ *  see `LeaseRepository`), so no paid/history state is derived here. Sorting is
+ *  done on the raw ISO `due_date` (not the formatted month label, which would
+ *  sort alphabetically). */
 export function toUiPayments(detail: ApiLeaseDetail): LeasePaymentRow[] {
   return (detail.upcoming_payments ?? [])
     .slice()
-    .sort((a, b) => new Date(b.due_date).getTime() - new Date(a.due_date).getTime())
+    .sort((a, b) => new Date(a.due_date).getTime() - new Date(b.due_date).getTime())
     .map((p) => ({
       id: p.id,
       period: periodLabel(p.due_date),
       amount: toNumber(p.amount),
-      paidAt: p.paid_at ?? null,
+      dueDate: p.due_date,
     }));
 }
 
@@ -187,10 +190,10 @@ export function LeaseDetailScreen({ leaseId, onBack, onNavigate }: LeaseDetailSc
               </Text>
             </View>
 
-            <Text style={styles.sectionTitle}>Payment history</Text>
+            <Text style={styles.sectionTitle}>Upcoming payments</Text>
             {payments.length === 0 ? (
               <View style={s.card}>
-                <Text style={s.cardBody}>No payments recorded yet.</Text>
+                <Text style={s.cardBody}>No upcoming payments scheduled.</Text>
               </View>
             ) : (
               payments.map((payment) => (
@@ -202,9 +205,7 @@ export function LeaseDetailScreen({ leaseId, onBack, onNavigate }: LeaseDetailSc
                     </Text>
                   </View>
                   <Text style={s.cardBody}>
-                    {payment.paidAt
-                      ? `Paid on ${new Date(payment.paidAt).toLocaleDateString()}`
-                      : 'Awaiting payment'}
+                    Due {new Date(payment.dueDate).toLocaleDateString()}
                   </Text>
                 </View>
               ))

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.test.ts
@@ -1,5 +1,13 @@
 import { parseThreadDetail, threadTitle, toUiMessages } from './ThreadDetailScreen';
 
+let warnSpy: jest.SpyInstance;
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
 const validDetail = {
   participants: [{ id: 'u-2', firstName: 'Building', lastName: 'Manager', email: 'm@x.sk' }],
   messages: [
@@ -28,6 +36,22 @@ describe('parseThreadDetail', () => {
       messages: [{ id: 'm1', content: 'ok', createdAt: 'x' }, null, { id: 'no-content' }],
     });
     expect(parsed?.messages).toHaveLength(1);
+  });
+
+  it('emits a dev-only warning for an unrecognized non-null payload', () => {
+    parseThreadDetail('nope');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('parseThreadDetail'));
+  });
+
+  it('emits a dev-only warning when every message row is dropped', () => {
+    parseThreadDetail({ messages: [{ id: 'no-content' }] });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dropped all 1'));
+  });
+
+  it('stays silent for a null payload and an empty thread', () => {
+    parseThreadDetail(null);
+    parseThreadDetail({ participants: [], messages: [] });
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -13,6 +13,7 @@
  * so it is validated defensively.
  */
 
+import type { MessageWithSender, ParticipantInfo, ThreadDetailResponse } from '@ppt/api-client';
 import { useCallback, useState } from 'react';
 import {
   KeyboardAvoidingView,
@@ -26,6 +27,7 @@ import {
 } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
 import { useApiMutation, useApiQuery } from '../../hooks/useApi';
+import { warnIfListDegraded, warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export interface Message {
@@ -36,22 +38,20 @@ export interface Message {
   authorName: string;
 }
 
-/** Subset of `ParticipantInfo` (camelCase wire format). */
-interface ApiParticipant {
-  id: string;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-}
+/**
+ * `ParticipantInfo` (camelCase wire format), typed against the generated
+ * `@ppt/api-client` payload so backend field renames surface at compile time.
+ * Relaxed to `Partial` (only `id` required) because the shape is validated
+ * defensively at runtime.
+ */
+type ApiParticipant = Partial<ParticipantInfo> & Pick<ParticipantInfo, 'id'>;
 
-/** Subset of `MessageWithSender` (camelCase wire format). */
-interface ApiMessage {
-  id: string;
-  content: string;
-  createdAt: string;
+/** `MessageWithSender` fields consumed by this screen (camelCase wire format). */
+type ApiMessage = Pick<MessageWithSender, 'id' | 'content' | 'createdAt'> & {
   sender?: ApiParticipant;
-}
+};
 
+/** Validated subset of the generated `ThreadDetailResponse` envelope. */
 interface ApiThreadDetail {
   participants?: ApiParticipant[];
   messages?: ApiMessage[];
@@ -80,11 +80,22 @@ function isApiMessage(value: unknown): value is ApiMessage {
 
 /** Validate the raw `GET .../threads/{id}` body, or null on a bad shape. */
 export function parseThreadDetail(data: unknown): ApiThreadDetail | null {
+  const parsed = parseThreadDetailInner(data);
+  warnIfParseFailed('parseThreadDetail', data, parsed);
+  return parsed;
+}
+
+function parseThreadDetailInner(data: unknown): ApiThreadDetail | null {
   if (typeof data !== 'object' || data === null) return null;
   const v = data as Record<string, unknown>;
+  const rawMessages = v['messages' satisfies keyof ThreadDetailResponse];
+  const candidates: unknown[] | null = Array.isArray(rawMessages) ? rawMessages : null;
+  const messages = (candidates ?? []).filter(isApiMessage);
+  warnIfListDegraded('parseThreadDetail.messages', rawMessages, candidates, messages.length);
+  const rawParticipants = v['participants' satisfies keyof ThreadDetailResponse];
   return {
-    participants: Array.isArray(v.participants) ? (v.participants as ApiParticipant[]) : [],
-    messages: Array.isArray(v.messages) ? (v.messages as unknown[]).filter(isApiMessage) : [],
+    participants: Array.isArray(rawParticipants) ? (rawParticipants as ApiParticipant[]) : [],
+    messages,
   };
 }
 

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.test.ts
@@ -1,5 +1,13 @@
 import { parseMeterResponse, toUiReadings } from './MeterDetailScreen';
 
+let warnSpy: jest.SpyInstance;
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
 const validResponse = {
   meter: { id: 'm-1', meter_number: 'CW-001', unit_of_measure: 'm³' },
   recent_readings: [
@@ -31,6 +39,17 @@ describe('parseMeterResponse', () => {
       recent_readings: [{ id: 'r1', reading: '1', reading_date: '2026-01-01' }, null, 'x', {}],
     });
     expect(parsed?.recent_readings).toHaveLength(1);
+  });
+
+  it('emits a dev-only warning for an unrecognized non-null payload', () => {
+    parseMeterResponse('nope');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('parseMeterResponse'));
+  });
+
+  it('stays silent for a null payload and a valid response', () => {
+    parseMeterResponse(null);
+    parseMeterResponse(validResponse);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
@@ -13,9 +13,11 @@
  * malformed shape degrades to an empty history rather than crashing.
  */
 
+import type { Meter, MeterReading, MeterResponse } from '@ppt/api-client';
 import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { warnIfListDegraded, warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export interface MeterReadingRecord {
@@ -25,26 +27,19 @@ export interface MeterReadingRecord {
   takenAt: string;
 }
 
-/** Subset of `Meter` from `GET /api/v1/meters/{id}`. */
-export interface ApiMeter {
-  id: string;
-  meter_number?: string | null;
-  meter_type?: string | null;
-  unit_of_measure?: string | null;
-  current_reading?: string | number | null;
-  last_reading_date?: string | null;
-  location?: string | null;
-  description?: string | null;
-}
+/**
+ * `Meter` from `GET /api/v1/meters/{id}`, typed against the generated
+ * `@ppt/api-client` payload so backend field renames surface at compile time.
+ * Relaxed to `Partial` (only `id` required) because the shape is validated
+ * defensively at runtime.
+ */
+export type ApiMeter = Partial<Meter> & Pick<Meter, 'id'>;
 
-/** Subset of `MeterReading` from the `recent_readings` list. */
-export interface ApiMeterReading {
-  id: string;
-  reading: string | number;
-  reading_date: string;
-  created_at?: string;
-}
+/** `MeterReading` fields consumed from the `recent_readings` list. */
+export type ApiMeterReading = Pick<MeterReading, 'id' | 'reading' | 'reading_date'> &
+  Partial<Pick<MeterReading, 'created_at'>>;
 
+/** Validated subset of the generated `MeterResponse` envelope. */
 export interface ApiMeterResponse {
   meter: ApiMeter;
   recent_readings: ApiMeterReading[];
@@ -71,15 +66,27 @@ function isApiMeterReading(value: unknown): value is ApiMeterReading {
  *  Tolerates any garbage top-level shape by returning null so the screen can
  *  fall back to its empty state instead of dereferencing `undefined.meter`. */
 export function parseMeterResponse(data: unknown): ApiMeterResponse | null {
+  const parsed = parseMeterResponseInner(data);
+  warnIfParseFailed('parseMeterResponse', data, parsed);
+  return parsed;
+}
+
+function parseMeterResponseInner(data: unknown): ApiMeterResponse | null {
   if (typeof data !== 'object' || data === null) return null;
   const v = data as Record<string, unknown>;
-  const meter = v.meter;
+  const meter = v['meter' satisfies keyof MeterResponse];
   if (typeof meter !== 'object' || meter === null) return null;
   const m = meter as Record<string, unknown>;
   if (typeof m.id !== 'string') return null;
-  const readings = Array.isArray(v.recent_readings)
-    ? (v.recent_readings as unknown[]).filter(isApiMeterReading)
-    : [];
+  const rawReadings = v['recent_readings' satisfies keyof MeterResponse];
+  const candidates: unknown[] | null = Array.isArray(rawReadings) ? rawReadings : null;
+  const readings = (candidates ?? []).filter(isApiMeterReading);
+  warnIfListDegraded(
+    'parseMeterResponse.recent_readings',
+    rawReadings,
+    candidates,
+    readings.length
+  );
   return { meter: meter as ApiMeter, recent_readings: readings };
 }
 

--- a/frontend/apps/mobile/src/screens/meters/MetersScreen.test.ts
+++ b/frontend/apps/mobile/src/screens/meters/MetersScreen.test.ts
@@ -1,5 +1,13 @@
 import { type ApiMeter, parseMeters, toUiCommodity, toUiMeter } from './MetersScreen';
 
+let warnSpy: jest.SpyInstance;
+beforeEach(() => {
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
 const validMeter: ApiMeter = {
   id: 'm-1',
   meter_number: 'CW-001',
@@ -30,6 +38,23 @@ describe('parseMeters', () => {
 
   it('drops malformed rows', () => {
     expect(parseMeters([validMeter, null, 'x', { noId: true }])).toEqual([validMeter]);
+  });
+
+  it('emits a dev-only warning for an unrecognized non-null payload', () => {
+    parseMeters({ error: 'boom' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('parseMeters'));
+  });
+
+  it('emits a dev-only warning when every candidate row is dropped', () => {
+    parseMeters([{ noId: true }]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dropped all 1'));
+  });
+
+  it('stays silent for a legitimately empty response', () => {
+    parseMeters([]);
+    parseMeters({ meters: [] });
+    parseMeters(null);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
@@ -14,10 +14,12 @@
  * list.
  */
 
+import type { Meter as ApiMeterPayload } from '@ppt/api-client';
 import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
 import { useApiQuery } from '../../hooks/useApi';
+import { warnIfListDegraded } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export type MeterCommodity = 'water_cold' | 'water_hot' | 'water' | 'electricity' | 'gas' | 'heat';
@@ -31,17 +33,13 @@ export interface Meter {
   lastReadingAt: string | null;
 }
 
-/** Subset of `Meter` from `GET /api/v1/meters/units/{unit_id}`. */
-export interface ApiMeter {
-  id: string;
-  meter_number?: string | null;
-  /** `MeterType` serialized snake_case: electricity|gas|water|heat|cold_water|hot_water|solar|other. */
-  meter_type?: string | null;
-  unit_of_measure?: string | null;
-  current_reading?: string | number | null;
-  last_reading_date?: string | null;
-  location?: string | null;
-}
+/**
+ * `Meter` row from `GET /api/v1/meters/units/{unit_id}`, typed against the
+ * generated `@ppt/api-client` payload so a regenerated client surfaces backend
+ * field renames at compile time. Relaxed to `Partial` (only `id` is required)
+ * because rows are validated defensively at runtime.
+ */
+export type ApiMeter = Partial<ApiMeterPayload> & Pick<ApiMeterPayload, 'id'>;
 
 interface ApiMetersEnvelope {
   meters: ApiMeter[];
@@ -57,12 +55,14 @@ function isApiMeter(value: unknown): value is ApiMeter {
  *  list. The unit route returns a bare `Vec<Meter>`; a `{ meters: [...] }`
  *  envelope is also accepted defensively. Any other shape yields `[]`. */
 export function parseMeters(data: unknown): ApiMeter[] {
-  const candidates: unknown[] = Array.isArray(data)
+  const candidates: unknown[] | null = Array.isArray(data)
     ? data
     : typeof data === 'object' && data !== null && Array.isArray((data as ApiMetersEnvelope).meters)
       ? (data as ApiMetersEnvelope).meters
-      : [];
-  return candidates.filter(isApiMeter);
+      : null;
+  const meters = (candidates ?? []).filter(isApiMeter);
+  warnIfListDegraded('parseMeters', data, candidates, meters.length);
+  return meters;
 }
 
 /** Map the api-server `meter_type` string onto the UI commodity enum. */

--- a/frontend/apps/mobile/src/screens/shared/parserWarnings.ts
+++ b/frontend/apps/mobile/src/screens/shared/parserWarnings.ts
@@ -1,0 +1,43 @@
+/**
+ * Dev-only guards for the defensive API-response parsers (issue #2129).
+ *
+ * The mobile screens consume api-server responses without a generated fetch
+ * client and validate them defensively: malformed rows are dropped and bad
+ * top-level shapes degrade to an empty state instead of crashing. That
+ * resilience has a downside — a backend serde-naming or shape drift would
+ * silently render as "no data" in the field. These helpers make such a
+ * contract regression loud in development builds (`__DEV__`) while staying
+ * silent in production.
+ */
+
+function warn(parser: string, detail: string): void {
+  console.warn(
+    `[api-parser] ${parser}: ${detail} — possible backend contract drift (serde naming or shape change).`
+  );
+}
+
+/**
+ * Warn when a list parser degraded a non-empty payload to an empty list —
+ * either the top-level shape was unrecognized (`candidates === null`) or
+ * every candidate row was dropped by row validation.
+ */
+export function warnIfListDegraded(
+  parser: string,
+  input: unknown,
+  candidates: readonly unknown[] | null,
+  keptCount: number
+): void {
+  if (!__DEV__ || input == null) return;
+  if (candidates === null) {
+    warn(parser, 'unrecognized top-level response shape');
+  } else if (candidates.length > 0 && keptCount === 0) {
+    warn(parser, `dropped all ${candidates.length} candidate rows`);
+  }
+}
+
+/** Warn when a detail parser returned `null` for a non-null payload. */
+export function warnIfParseFailed(parser: string, input: unknown, result: unknown): void {
+  if (__DEV__ && input != null && result === null) {
+    warn(parser, 'unrecognized response shape');
+  }
+}


### PR DESCRIPTION
Closes #2129

Follow-up to PR #2118 (mobile RN screen wiring). All findings were re-verified against current `dev` before fixing — none were stale.

## Findings addressed (client-side)

### Type drift (medium)
- **Meters / MeterDetail / LeaseDetail / ThreadDetail**: hand-rolled `Api*` interfaces replaced with projections of the generated `@ppt/api-client` payload types (`Meter`, `MeterReading`, `MeterResponse`, `Lease`, `LeasePayment`, `LeaseWithDetails`, `ParticipantInfo`, `MessageWithSender`, `ThreadDetailResponse`), using `Partial<T> & Pick<T, ...>` so runtime validation stays defensive while a regenerated client surfaces backend field renames at compile time. Envelope key access in the parsers is bound via `'key' satisfies keyof <ResponseType>` so envelope renames also break the build. `useApiQuery` fetch layer kept as-is (mobile needs absolute URLs).
- **FormsScreen — deliberately NOT switched**: the generated `FormSummary` in `@ppt/api-client` (`forms/types.ts`) declares **camelCase** keys (`requireSignatures`, `submissionDeadline`), but the backend `db::models::form::FormSummary` has default snake_case serde — the generated client type has itself drifted from the wire format. Importing it would type the parser against field names the server never sends. Kept the hand-rolled snake_case `ApiFormSummary` with an explanatory comment; the client-type/spec fix is a follow-up (see Deferred).

### LeaseDetail heading (medium)
`GET /api/v1/leases/{id}` fills `upcoming_payments` with `due_date >= today ... LIMIT 5` (`LeaseRepository`), i.e. scheduled payments only — no history. Section retitled **"Payment history" → "Upcoming payments"**, rows now sorted soonest-first and render `Due <date>`; the misleading `Paid on …` / `Awaiting payment` states are removed (`LeasePaymentRow.paidAt` → `dueDate`).

### FormsScreen misleading status (medium)
`toResidentForm` no longer hardcodes `status: 'pending'`; the pending-forms counter and the dead `in_progress`/`completed` badge branches (`statusBadgeStyle`, `FormStatus`) are removed. Header now shows an honest "N forms available". **Backend gap**: `GET /api/v1/forms/available` exposes no resident-scoped completion status, so already-submitted forms still render as actionable — needs a backend field (deferred).

### Dev-only parser warnings (low)
New `src/screens/shared/parserWarnings.ts` with `warnIfListDegraded` / `warnIfParseFailed`, wired into all five defensive parsers. In `__DEV__` builds a non-empty payload that parses to empty/null (serde-naming or shape drift) now logs a `console.warn` instead of silently rendering an empty state. Silent for legitimately empty responses and in production.

## Deferred (backend-dependent / larger, per issue scope)
- Payment-history fetch for LeaseDetail (needs a paid-payments endpoint/param).
- Resident-scoped form completion-status field on `GET /api/v1/forms/available` (+ restoring per-form status badges).
- `@ppt/api-client` `forms/types.ts` camelCase vs backend snake_case drift — regenerate/fix the client (and/or backend serde) so `FormSummary` matches the wire.
- ThreadDetail pagination + optimistic append (currently full refetch after send).
- Meter reading due-date badge (endpoint has no due-date field).
- i18n sweep of hardcoded strings across the five screens.
- `react-test-renderer` 19.2.6 vs 19.2.0 peer pin + RN component render tests (blocks 7 pre-existing `.tsx` suites, see below).

## Verify
- `pnpm install` (fresh worktree) — ok
- `pnpm --filter mobile test` — **410/410 tests pass**; 7 test *suites* fail to load with `Incorrect version of "react-test-renderer" detected. Expected "19.2.0", but found "19.2.6"` — pre-existing peer mismatch explicitly listed in #2129 as a deferred item (none of the failing suites are touched by this PR). The 5 changed suites: `jest src/screens/{meters,leases/LeaseDetailScreen.test.ts,forms/FormsScreen.test.ts,messages/ThreadDetailScreen.test.ts}` → 70/70 pass.
- `pnpm --filter mobile typecheck` (`tsc --noEmit`) — clean
- `pnpm check` (Biome) — clean after `check:fix` formatting