### PR TITLE
gh-issue-2141: bump crossbeam-epoch to 0.9.20 to clear RUSTSEC-2026-0204

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1894,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Task
The `cargo-deny` advisories check is failing on `dev` with **RUSTSEC-2026-0204** (`crossbeam-epoch 0.9.18` — "Invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared`"). Because `cargo deny check advisories` trips on the dependency graph, this goes red on **every backend PR** regardless of the PR's own diff (confirmed on the test-only PR #2131, whose only failing check is `cargo-deny`).

Closes #2141

## Change (lockfile-only)
`cargo update -p crossbeam-epoch --precise 0.9.20` in `backend/`. Diff is confined to `backend/Cargo.lock` (2 lines): `crossbeam-epoch 0.9.18 → 0.9.20`. The advisory's recommended remediation is exactly ">=0.9.20". No `Cargo.toml`, source, or public API change.

Dependency chain: `crossbeam-epoch → metrics-util 0.15.1 → metrics-exporter-prometheus 0.12.2` (pulled by `api-server`, `reality-server`, `accounting-server`).

## Verification
- `backend/Cargo.lock` now pins `crossbeam-epoch = 0.9.20`; no `0.9.18` remains.
- The full `cargo deny check advisories` re-run + backend build are deferred to CI (`backend.yml`) — the sandbox lacks Postgres and a full api-server build hits a pre-existing `utoipa-swagger-ui` archive-download limitation unrelated to this change.

## Impact
Clears the systemic advisory so `cargo-deny` goes green on `dev` and stops masking the advisory gate on all backend PRs.

---
_Opened by the research dispatcher (2026-07-07)._

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT5X6QR6pF4tEMszhxkrrj)_