### PR TITLE
gh-issue-2129: type mobile RN screen parsers against generated @ppt/api-client payloads

### DIFF
--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
@@ -11,6 +11,11 @@
  * client, so it is validated defensively.
  */
 
+import type {
+  Lease as ApiLease,
+  LeasePayment as ApiLeasePayment,
+  LeaseWithDetails,
+} from '@ppt/api-client';
 import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
@@ -24,32 +29,18 @@ export interface LeasePaymentRow {
   paidAt: string | null;
 }
 
-/** Subset of `Lease` inside `LeaseWithDetails`. */
-interface ApiLease {
-  id: string;
-  unit_id?: string;
-  landlord_name?: string;
-  tenant_name?: string;
-  start_date: string;
-  end_date: string;
-  monthly_rent: string | number;
-  status: string;
-}
-
-/** Subset of `LeasePayment` from `upcoming_payments`. */
-interface ApiLeasePayment {
-  id: string;
-  due_date: string;
-  amount: string | number;
-  paid_at?: string | null;
-}
-
-export interface ApiLeaseDetail {
-  lease: ApiLease;
-  unit_name: string;
-  building_name: string;
-  upcoming_payments?: ApiLeasePayment[];
-}
+/**
+ * The subset of the generated `@ppt/api-client` `LeaseWithDetails` payload
+ * (`GET /api/v1/leases/{id}`) that this screen consumes. Deriving it from the
+ * generated type (rather than a hand-rolled interface) surfaces OpenAPI drift
+ * — a field rename/type-change on `Lease`, `LeasePayment`, or `LeaseWithDetails`
+ * breaks compilation here. `ApiLease` / `ApiLeasePayment` are the generated
+ * entity types, used by the defensive parser casts below.
+ */
+export type ApiLeaseDetail = Pick<
+  LeaseWithDetails,
+  'lease' | 'unit_name' | 'building_name' | 'upcoming_payments'
+>;
 
 function toNumber(value: string | number | null | undefined): number {
   if (value == null) return 0;
@@ -187,7 +178,7 @@ export function LeaseDetailScreen({ leaseId, onBack, onNavigate }: LeaseDetailSc
               </Text>
             </View>
 
-            <Text style={styles.sectionTitle}>Payment history</Text>
+            <Text style={styles.sectionTitle}>Upcoming payments</Text>
             {payments.length === 0 ? (
               <View style={s.card}>
                 <Text style={s.cardBody}>No payments recorded yet.</Text>

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -13,6 +13,11 @@
  * so it is validated defensively.
  */
 
+import type {
+  MessageWithSender as ApiMessage,
+  ParticipantInfo as ApiParticipant,
+  ThreadDetailResponse,
+} from '@ppt/api-client';
 import { useCallback, useState } from 'react';
 import {
   KeyboardAvoidingView,
@@ -36,26 +41,12 @@ export interface Message {
   authorName: string;
 }
 
-/** Subset of `ParticipantInfo` (camelCase wire format). */
-interface ApiParticipant {
-  id: string;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-}
-
-/** Subset of `MessageWithSender` (camelCase wire format). */
-interface ApiMessage {
-  id: string;
-  content: string;
-  createdAt: string;
-  sender?: ApiParticipant;
-}
-
-interface ApiThreadDetail {
-  participants?: ApiParticipant[];
-  messages?: ApiMessage[];
-}
+// `ApiParticipant` / `ApiMessage` are the generated `@ppt/api-client`
+// (camelCase) payload types; `ApiThreadDetail` is the subset of
+// `ThreadDetailResponse` (`GET /api/v1/messages/threads/{id}`) that this screen
+// consumes. Deriving from the generated types surfaces OpenAPI drift (field
+// rename/type-change) at compile time.
+type ApiThreadDetail = Pick<ThreadDetailResponse, 'participants' | 'messages'>;
 
 function participantName(p: ApiParticipant | undefined): string {
   if (!p) return '';

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
@@ -13,6 +13,11 @@
  * malformed shape degrades to an empty history rather than crashing.
  */
 
+import type {
+  Meter as ApiMeter,
+  MeterReading as ApiMeterReading,
+  MeterResponse as ApiMeterResponse,
+} from '@ppt/api-client';
 import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
@@ -25,30 +30,10 @@ export interface MeterReadingRecord {
   takenAt: string;
 }
 
-/** Subset of `Meter` from `GET /api/v1/meters/{id}`. */
-export interface ApiMeter {
-  id: string;
-  meter_number?: string | null;
-  meter_type?: string | null;
-  unit_of_measure?: string | null;
-  current_reading?: string | number | null;
-  last_reading_date?: string | null;
-  location?: string | null;
-  description?: string | null;
-}
-
-/** Subset of `MeterReading` from the `recent_readings` list. */
-export interface ApiMeterReading {
-  id: string;
-  reading: string | number;
-  reading_date: string;
-  created_at?: string;
-}
-
-export interface ApiMeterResponse {
-  meter: ApiMeter;
-  recent_readings: ApiMeterReading[];
-}
+// `ApiMeter` / `ApiMeterReading` / `ApiMeterResponse` are the generated
+// `@ppt/api-client` payload types for `GET /api/v1/meters/{id}`
+// (`MeterResponse { meter, recent_readings }`). Typing the defensive parser
+// against them surfaces OpenAPI drift (field rename/type-change) at compile time.
 
 /** Parse a `Decimal`-as-string (or number) into a finite number, or null. */
 function toNumber(value: string | number | null | undefined): number | null {

--- a/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
@@ -14,6 +14,7 @@
  * list.
  */
 
+import type { Meter as ApiMeterPayload } from '@ppt/api-client';
 import { useCallback } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
@@ -31,17 +32,14 @@ export interface Meter {
   lastReadingAt: string | null;
 }
 
-/** Subset of `Meter` from `GET /api/v1/meters/units/{unit_id}`. */
-export interface ApiMeter {
-  id: string;
-  meter_number?: string | null;
-  /** `MeterType` serialized snake_case: electricity|gas|water|heat|cold_water|hot_water|solar|other. */
-  meter_type?: string | null;
-  unit_of_measure?: string | null;
-  current_reading?: string | number | null;
-  last_reading_date?: string | null;
-  location?: string | null;
-}
+/**
+ * The unit route returns `Vec<Meter>`. The parser guarantees only `id` and
+ * reads a defensive subset, so `ApiMeter` is a partial view of the generated
+ * `@ppt/api-client` `Meter` payload (every field optional but `id`). Deriving
+ * it from the generated type means an OpenAPI field rename/type-change surfaces
+ * here at compile time instead of silently returning `undefined` at runtime.
+ */
+export type ApiMeter = Partial<ApiMeterPayload> & Pick<ApiMeterPayload, 'id'>;
 
 interface ApiMetersEnvelope {
   meters: ApiMeter[];


### PR DESCRIPTION
## Task
Follow-up to PR #2118 (mobile RN screen wiring). Addresses the MEDIUM findings in #2129:

1. **TYPE DRIFT** — replace the hand-rolled `Api*` interfaces in the mobile screens with types derived from the generated `@ppt/api-client` payloads, and type the defensive parsers against them so OpenAPI drift surfaces at compile time. `useApiQuery` is kept for the fetch layer (mobile needs absolute URLs).
2. **CORRECTNESS** — in `LeaseDetailScreen`, the section titled "Payment history" actually renders `upcoming_payments`; relabel it "Upcoming payments".

## Owner
pm-frontend (task hint) — but the touched files live under `frontend/apps/mobile/**`, which `owner-areas.json` maps to **pm-mobile**. Specialist selected: `react-native` (correct per the skill's scoring). See Scope drift below.

## What changed (4 of 5 named type-drift screens + correctness)
- `meters/MetersScreen.tsx` — `ApiMeter` is now `Partial<Meter> & Pick<Meter,'id'>` over the generated `Meter`. The unit route returns `Vec<Meter>` and the parser guarantees only `id`, so the partial view preserves the defensive contract while tying every read to the generated field names/types.
- `meters/MeterDetailScreen.tsx` — `ApiMeter`/`ApiMeterReading`/`ApiMeterResponse` are now aliased imports of the generated `Meter`/`MeterReading`/`MeterResponse` (the parser already returns exactly `{ meter, recent_readings }`).
- `leases/LeaseDetailScreen.tsx` — `ApiLeaseDetail` is now `Pick<LeaseWithDetails, 'lease'|'unit_name'|'building_name'|'upcoming_payments'>`; parser casts use generated `Lease`/`LeasePayment`. **Correctness:** section label "Payment history" → "Upcoming payments" (verified against the generated `LeaseWithDetails` — the field is `upcoming_payments`; there is no payment-history field). No new fetch.
- `messages/ThreadDetailScreen.tsx` — `ApiThreadDetail` is now `Pick<ThreadDetailResponse, 'participants'|'messages'>`; `ApiParticipant`/`ApiMessage` are aliased imports of generated `ParticipantInfo`/`MessageWithSender` (camelCase, matching the messaging wire format).

## Deferred (documented follow-up, NOT in this PR)
- **`forms/FormsScreen.tsx`** — left as-is. The generated `@ppt/api-client` `FormSummary` is the **manager-side camelCase** shape returned by the Epic-54 paginated client (`FormPaginatedResponse<FormSummary>`, fields `requireSignatures`/`submissionDeadline`). The mobile screen consumes the **resident** endpoint `GET /api/v1/forms/available`, whose backend `AvailableFormsResponse { forms: [...] }` (`routes::forms::types`, no `rename_all`) is **snake_case** (`require_signatures`/`submission_deadline`). No generated type matches this payload, so wiring the screen to the camelCase type would invent a wrong mapping (and read `undefined` at runtime). Per the implement-skill guidance, the screen's local type is left untouched and this is surfaced as a follow-up: the available-forms DTO needs a generated snake_case type in `@ppt/api-client`.
- LOW-severity items from #2129 (i18n, `__DEV__` warns, pagination, FormsScreen pending-counter, meter due-date badge) are intentionally out of scope.

## Tested (Band A — fast check)
- `pnpm exec biome check <4 touched files>` → exit 0 ("No fixes applied").
- `pnpm -F mobile typecheck` (`tsc --noEmit`) → exit 0.
- `pnpm -F mobile exec jest src/screens/{meters,leases,messages}` → the touched screens' unit suites pass: `MetersScreen`, `MeterDetailScreen`, `LeaseDetailScreen`, `ThreadDetailScreen`, `LeasesScreen` all PASS (71 tests).
  - Two unrelated `.tsx` render suites (`LeaseSignatureScreen.test.tsx`, `MessagesScreen.test.tsx`) fail on a pre-existing `react-test-renderer` peer-version guard (found 19.2.6, `@testing-library/react-native@13.3.3` expects 19.2.0). **Verified pre-existing**: they fail identically with my changes stashed. Neither file is touched by this PR and the failure is thrown at the `@testing-library` import, before any screen code runs.

## Built (Band B — full build)
skipped: type-only change (~4 files, no public API/config/build-output change; no runtime logic added).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
`scope-check.sh --owner pm-frontend` exits 2 because all four files are under `frontend/apps/mobile/**` → `pm-mobile` in `owner-areas.json`, not `pm-frontend`. This is an owner-label mismatch in the dispatch (the task hint was `pm-frontend`), not an off-task change: every file is exactly one the issue named, and the `react-native` specialist is the correct handler. Reviewer to confirm the label.

## Notes
- Drift-surfacing mechanism: the local `Api*` types are now derived from the generated payloads via `Partial<>`/`Pick<>`/aliases, so a field rename or type change in the OpenAPI-generated model breaks compilation in these parsers/mappers instead of silently degrading at runtime.
- Related to #2129 (medium items). Not marked `Closes` because 1 of the 5 named type-drift screens (FormsScreen) is deferred for the spec-gap reason above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UT5X6QR6pF4tEMszhxkrrj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UT5X6QR6pF4tEMszhxkrrj)_