### PR TITLE
fix(backend): bump crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1894,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary
The `cargo-deny` job is red on every backend PR since 2026-07-07 due to new advisory [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in `fmt::Pointer` impl for `Atomic`/`Shared`) against `crossbeam-epoch 0.9.18`.

Lockfile-only bump to 0.9.20 (patched). No manifest changes.

## Verify
- `cargo deny check advisories` locally: **advisories ok** (was: RUSTSEC-2026-0204 vulnerability error)

🤖 Generated with [Claude Code](https://claude.ai/code)