### PR TITLE
gap-84-5-rag-retrieval-query-service-embedding-generation: embedding-provider trait + org-scoped upsert_document_embedding wrapper

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -1117,6 +1117,125 @@ impl LlmDocumentRepository {
         })
     }
 
+    /// Upsert a document-embedding chunk, org-scoped (Story 84.5).
+    ///
+    /// Fast path: calls the `upsert_document_embedding` SQL function shipped by
+    /// migration 00081 (present only when the pgvector extension is installed),
+    /// which stores the vector in the native `embedding_vector` column.
+    ///
+    /// Fallback (stock PostgreSQL, e.g. CI): mirrors the SQL function's
+    /// select-then-update/insert semantics against the JSONB `embedding`
+    /// column, additionally scoped to `organization_id` so a chunk can never
+    /// be rewritten across org boundaries even on a privileged connection.
+    ///
+    /// `document_embeddings` is FORCE-RLS: the connection must carry the org
+    /// GUC (or global-read context) or both paths return zero rows / fail the
+    /// policy `WITH CHECK`.
+    ///
+    /// Returns the id of the inserted or updated row.
+    ///
+    /// Multi-statement: takes `&mut PgConnection` so every query runs on the
+    /// same RLS-context connection.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upsert_embedding(
+        &self,
+        conn: &mut PgConnection,
+        organization_id: Uuid,
+        document_id: Uuid,
+        chunk_index: i32,
+        chunk_text: &str,
+        embedding: &[f32],
+        metadata: serde_json::Value,
+    ) -> Result<Uuid, SqlxError> {
+        // Check whether migration 00081's pgvector upsert function exists.
+        let function_exists: Option<bool> = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'upsert_document_embedding')",
+        )
+        .fetch_optional(&mut *conn)
+        .await?;
+
+        if function_exists == Some(true) {
+            let embedding_str = format!(
+                "[{}]",
+                embedding
+                    .iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+
+            let id: Uuid = sqlx::query_scalar(
+                "SELECT upsert_document_embedding($1, $2, $3, $4, $5::vector, $6)",
+            )
+            .bind(organization_id)
+            .bind(document_id)
+            .bind(chunk_index)
+            .bind(chunk_text)
+            .bind(&embedding_str)
+            .bind(&metadata)
+            .fetch_one(&mut *conn)
+            .await?;
+
+            return Ok(id);
+        }
+
+        // Fallback: JSONB upsert with the same (document_id, chunk_index)
+        // identity, org-scoped.
+        let embedding_json = serde_json::to_value(embedding).unwrap_or_default();
+
+        let existing: Option<Uuid> = sqlx::query_scalar(
+            r#"
+            SELECT id FROM document_embeddings
+            WHERE organization_id = $1 AND document_id = $2 AND chunk_index = $3
+            "#,
+        )
+        .bind(organization_id)
+        .bind(document_id)
+        .bind(chunk_index)
+        .fetch_optional(&mut *conn)
+        .await?;
+
+        if let Some(id) = existing {
+            sqlx::query(
+                r#"
+                UPDATE document_embeddings SET
+                    chunk_text = $2,
+                    embedding = $3,
+                    metadata = $4,
+                    updated_at = NOW()
+                WHERE id = $1
+                "#,
+            )
+            .bind(id)
+            .bind(chunk_text)
+            .bind(&embedding_json)
+            .bind(&metadata)
+            .execute(&mut *conn)
+            .await?;
+            return Ok(id);
+        }
+
+        let id: Uuid = sqlx::query_scalar(
+            r#"
+            INSERT INTO document_embeddings (
+                organization_id, document_id, chunk_index, chunk_text, embedding, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id
+            "#,
+        )
+        .bind(organization_id)
+        .bind(document_id)
+        .bind(chunk_index)
+        .bind(chunk_text)
+        .bind(&embedding_json)
+        .bind(&metadata)
+        .fetch_one(&mut *conn)
+        .await?;
+
+        Ok(id)
+    }
+
     /// Migrate pending JSONB embeddings to pgvector format (Story 103.5).
     ///
     /// Returns the number of embeddings migrated.

--- a/backend/crates/db/tests/rag_similarity_search_tests.rs
+++ b/backend/crates/db/tests/rag_similarity_search_tests.rs
@@ -326,4 +326,72 @@ async fn rag_retrieval_correctness(pool: PgPool) {
         stats.last_updated.is_some(),
         "last_updated should be populated"
     );
+
+    // -------------------------------------------------------------------------
+    // D. Upsert wrapper (Story 84.5): insert-then-update identity on
+    //    (org, document, chunk_index) via the JSONB fallback path (CI has no
+    //    pgvector, so the SQL function from 00081 is absent).
+    // -------------------------------------------------------------------------
+
+    let org_up = seed_org(&pool, "rag-upsert-a").await;
+    let user_up = seed_user(&pool, "upsert-a@rag.test").await;
+    let doc_up = seed_document(&pool, org_up, user_up, "rag-upsert-doc").await;
+
+    let first_id = repo
+        .upsert_embedding(
+            &mut conn,
+            org_up,
+            doc_up,
+            0,
+            "original chunk text",
+            &[1.0, 0.0, 0.0],
+            serde_json::json!({"rev": 1}),
+        )
+        .await
+        .expect("upsert (insert path)");
+
+    let second_id = repo
+        .upsert_embedding(
+            &mut conn,
+            org_up,
+            doc_up,
+            0,
+            "revised chunk text",
+            &[0.0, 1.0, 0.0],
+            serde_json::json!({"rev": 2}),
+        )
+        .await
+        .expect("upsert (update path)");
+
+    assert_eq!(
+        first_id, second_id,
+        "same (org, document, chunk_index) must update in place, not insert"
+    );
+
+    let chunks = repo
+        .find_document_embeddings(&mut *conn, doc_up)
+        .await
+        .expect("find upserted chunks");
+    assert_eq!(chunks.len(), 1, "upsert must not duplicate the chunk");
+    assert_eq!(chunks[0].chunk_text, "revised chunk text");
+    assert_eq!(
+        chunks[0].embedding.as_deref(),
+        Some(&[0.0_f32, 1.0, 0.0][..])
+    );
+    assert_eq!(chunks[0].metadata["rev"], 2);
+
+    // A different chunk_index for the same document inserts a new row.
+    let third_id = repo
+        .upsert_embedding(
+            &mut conn,
+            org_up,
+            doc_up,
+            1,
+            "second chunk",
+            &[0.0, 0.0, 1.0],
+            serde_json::json!({}),
+        )
+        .await
+        .expect("upsert (new chunk_index)");
+    assert_ne!(third_id, first_id, "new chunk_index must create a new row");
 }

--- a/backend/crates/integrations/src/embedding.rs
+++ b/backend/crates/integrations/src/embedding.rs
@@ -1,0 +1,201 @@
+//! Embedding provider abstraction for the RAG pipeline (Story 84.5).
+//!
+//! The RAG retrieval path (`routes/ai/sessions.rs` +
+//! `LlmDocumentRepository::search_documents_*`) previously depended directly
+//! on `LlmClient::generate_embedding`, which requires a live OpenAI API key.
+//! This module introduces a provider trait so callers (indexing pipelines,
+//! tests, air-gapped deployments) can swap the embedding backend:
+//!
+//! * [`EmbeddingProvider`] — the trait (single + batch embedding),
+//! * [`LlmClient`] — implements it by delegating to the OpenAI embedding API,
+//! * [`StubEmbeddingProvider`] — deterministic, offline, no-network provider
+//!   for tests and local development. It is NOT semantically meaningful; it
+//!   only guarantees determinism, unit norm, and dimension stability.
+
+use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+
+use crate::llm::{EmbeddingResult, LlmClient, LlmError};
+
+/// Default embedding dimension (OpenAI `text-embedding-3-small`, matches the
+/// `vector(1536)` column added by migration 00081).
+pub const DEFAULT_EMBEDDING_DIM: usize = 1536;
+
+/// Backend-agnostic embedding generation for RAG indexing and retrieval.
+#[async_trait]
+pub trait EmbeddingProvider: Send + Sync {
+    /// Generate an embedding for a single text.
+    async fn embed(&self, text: &str) -> Result<EmbeddingResult, LlmError>;
+
+    /// Generate embeddings for multiple texts. Default: sequential `embed`.
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<EmbeddingResult>, LlmError> {
+        let mut results = Vec::with_capacity(texts.len());
+        for text in texts {
+            results.push(self.embed(text).await?);
+        }
+        Ok(results)
+    }
+
+    /// Dimension of the vectors this provider produces.
+    fn dimension(&self) -> usize {
+        DEFAULT_EMBEDDING_DIM
+    }
+}
+
+/// The production provider: OpenAI embeddings via [`LlmClient`].
+#[async_trait]
+impl EmbeddingProvider for LlmClient {
+    async fn embed(&self, text: &str) -> Result<EmbeddingResult, LlmError> {
+        self.generate_embedding(text, None).await
+    }
+
+    async fn embed_batch(&self, texts: &[String]) -> Result<Vec<EmbeddingResult>, LlmError> {
+        self.generate_embeddings_batch(texts, None).await
+    }
+}
+
+/// Deterministic offline embedding provider.
+///
+/// Produces a unit-norm vector derived from a SHA-256 hash chain over the
+/// input text. The same text always yields the same vector; different texts
+/// yield (with overwhelming probability) different vectors. Cosine similarity
+/// between stub vectors carries no semantic meaning — use it only where
+/// determinism matters more than relevance (tests, CI, local dev without an
+/// OpenAI key).
+#[derive(Debug, Clone)]
+pub struct StubEmbeddingProvider {
+    dim: usize,
+}
+
+impl StubEmbeddingProvider {
+    /// Provider with the default (1536) dimension.
+    pub fn new() -> Self {
+        Self::with_dimension(DEFAULT_EMBEDDING_DIM)
+    }
+
+    /// Provider with a custom dimension (e.g. 3 for cheap tests).
+    pub fn with_dimension(dim: usize) -> Self {
+        assert!(dim > 0, "embedding dimension must be > 0");
+        Self { dim }
+    }
+
+    /// Deterministically expand `text` into a unit-norm vector of `self.dim`.
+    fn embed_sync(&self, text: &str) -> Vec<f32> {
+        let mut values = Vec::with_capacity(self.dim);
+        let mut counter: u64 = 0;
+        let mut block = [0u8; 32];
+
+        while values.len() < self.dim {
+            let mut hasher = Sha256::new();
+            hasher.update(text.as_bytes());
+            hasher.update(counter.to_le_bytes());
+            block.copy_from_slice(&hasher.finalize());
+            counter += 1;
+
+            for chunk in block.chunks_exact(4) {
+                if values.len() == self.dim {
+                    break;
+                }
+                let raw = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                // Map to [-1.0, 1.0)
+                let v = (raw as f64 / u32::MAX as f64) * 2.0 - 1.0;
+                values.push(v as f32);
+            }
+        }
+
+        // L2-normalize so cosine similarity behaves like a dot product.
+        let norm = values
+            .iter()
+            .map(|v| (*v as f64).powi(2))
+            .sum::<f64>()
+            .sqrt();
+        if norm > 0.0 {
+            for v in &mut values {
+                *v = (*v as f64 / norm) as f32;
+            }
+        }
+        values
+    }
+}
+
+impl Default for StubEmbeddingProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for StubEmbeddingProvider {
+    async fn embed(&self, text: &str) -> Result<EmbeddingResult, LlmError> {
+        Ok(EmbeddingResult {
+            embedding: self.embed_sync(text),
+            model: format!("stub-deterministic-{}", self.dim),
+            tokens_used: 0,
+        })
+    }
+
+    fn dimension(&self) -> usize {
+        self.dim
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("build runtime")
+            .block_on(fut)
+    }
+
+    #[test]
+    fn stub_is_deterministic() {
+        let provider = StubEmbeddingProvider::with_dimension(64);
+        let a = block_on(provider.embed("lease agreement clause")).unwrap();
+        let b = block_on(provider.embed("lease agreement clause")).unwrap();
+        assert_eq!(a.embedding, b.embedding, "same text must embed identically");
+    }
+
+    #[test]
+    fn stub_differs_for_different_texts() {
+        let provider = StubEmbeddingProvider::with_dimension(64);
+        let a = block_on(provider.embed("water damage in unit 4")).unwrap();
+        let b = block_on(provider.embed("annual assembly minutes")).unwrap();
+        assert_ne!(
+            a.embedding, b.embedding,
+            "different texts must produce different vectors"
+        );
+    }
+
+    #[test]
+    fn stub_produces_unit_norm_at_requested_dimension() {
+        for dim in [3usize, 64, DEFAULT_EMBEDDING_DIM] {
+            let provider = StubEmbeddingProvider::with_dimension(dim);
+            assert_eq!(provider.dimension(), dim);
+            let result = block_on(provider.embed("dimension check")).unwrap();
+            assert_eq!(result.embedding.len(), dim);
+            let norm: f64 = result
+                .embedding
+                .iter()
+                .map(|v| (*v as f64).powi(2))
+                .sum::<f64>()
+                .sqrt();
+            assert!(
+                (norm - 1.0).abs() < 1e-3,
+                "vector must be unit-norm, got {norm} at dim {dim}"
+            );
+        }
+    }
+
+    #[test]
+    fn stub_batch_matches_single() {
+        let provider = StubEmbeddingProvider::with_dimension(16);
+        let texts = vec!["one".to_string(), "two".to_string()];
+        let batch = block_on(provider.embed_batch(&texts)).unwrap();
+        let single = block_on(provider.embed("one")).unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].embedding, single.embedding);
+    }
+}

--- a/backend/crates/integrations/src/lib.rs
+++ b/backend/crates/integrations/src/lib.rs
@@ -33,6 +33,9 @@ pub mod redis;
 // Epic 64: Advanced AI & LLM Capabilities
 pub mod llm;
 
+// Story 84.5: Embedding provider abstraction for RAG (OpenAI + deterministic stub)
+pub mod embedding;
+
 // Story 3.1 AC3 (BIT-200): Building geocoding
 pub mod geocoding;
 
@@ -120,6 +123,9 @@ pub use llm::{
     ListingDescriptionInput, ListingDescriptionResult, LlmClient, LlmConfig, LlmError,
     SentimentResult, TenantAiConfig, TokenUsage,
 };
+
+// Story 84.5: Embedding provider abstraction for RAG
+pub use embedding::{EmbeddingProvider, StubEmbeddingProvider, DEFAULT_EMBEDDING_DIM};
 
 // Story 84.2: E-Signature Email Integration
 pub use esignature::{


### PR DESCRIPTION
## Task
RAG retrieval/query service (embedding generation + similarity search) not implemented in routes/repositories (84-5-pgvector-rag pgvector RAG Migration)

## Owner
pm-backend

## Scope note (verify-before-fixing)
The gap statement is partially stale — most of the RAG application layer already exists on `dev`:
- `LlmDocumentRepository` already has `create_embedding`, `create_embeddings_batch`, `search_documents_by_embedding` (JSONB fallback + pgvector path), `search_documents_pgvector` (wraps migration 00081's `search_similar_documents` SQL fn), `get_rag_statistics`, `migrate_embeddings_to_pgvector`.
- `routes/ai/sessions.rs` already runs the RAG query flow (embedding generation → similarity search → context injection) behind `RAG_SEMANTIC_SEARCH_ENABLED`, with an RLS guard (PAP-150).
- `integrations::LlmClient::generate_embedding` (OpenAI) exists (Story 97.2).

What was genuinely missing, and what this PR adds (minimal honest slice):
1. **`EmbeddingProvider` trait** (`backend/crates/integrations/src/embedding.rs`) — backend-agnostic `embed` / `embed_batch` / `dimension`; implemented by `LlmClient` (OpenAI) and by a new **deterministic offline `StubEmbeddingProvider`** (SHA-256 hash-chain → unit-norm vector) for tests/dev without an API key. **No paid API wired.**
2. **`LlmDocumentRepository::upsert_embedding`** — the `upsert_document_embedding` SQL helper from migration 00081 had zero callers. New RLS-aware wrapper (`&mut PgConnection`): pgvector fast path via the SQL function (native `embedding_vector`), org-scoped JSONB select-then-update/insert fallback for stock PostgreSQL (CI).
3. **Tests** — 4 unit tests for the stub provider (run everywhere, no DB); upsert insert-then-update/no-duplicate coverage added as section D of `rag_retrieval_correctness` in `rag_similarity_search_tests.rs` (following the single-migration-run pattern; that suite is BIT-351-quarantined with `#[ignore]`, repair tracked in BIT-352).

No new route added: the story's RAG query endpoint already exists in `routes/ai/sessions.rs`; adding another would duplicate it.

## Tested (Band A — fast check)
- `cargo check -p integrations -p db` → exit 0
- `cargo test -p integrations embedding::` → 4 passed, 0 failed (exit 0)
- `cargo test -p db --test rag_similarity_search_tests --no-run` → exit 0 (compile gate)
- Bounded live run on local PG :5433 (`timeout 480 cargo test -p db --test rag_similarity_search_tests -- --ignored`) → **timed out at 480 s** while applying the ~194-migration set (known-slow local PG). The suite is `#[ignore]`d (BIT-351) so this does not affect the CI gate; the fallback-path SQL in `upsert_embedding` mirrors the already-tested `create_embedding`/`find_document_embeddings` statements. Being explicit: the new sqlx section D compiled but was not executed against a live DB here.

## Built (Band B — full build)
- `cargo clippy -p integrations -p db --all-targets -- -D warnings` → no issues, exit 0
- `cargo fmt --all -- --check` → clean, exit 0

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no auth/billing change; RLS behavior unchanged — wrapper runs on the caller's RLS-context connection like existing methods)

## Remote-tested
skipped

## Notes
- DB-free-compile convention respected: runtime `sqlx::query*` only, no macros needing `.sqlx` data.
- The fallback upsert additionally filters by `organization_id` (defense-in-depth beyond FORCE RLS); the SQL function relies on RLS + its own lookup by `(document_id, chunk_index)`.
- Follow-up candidates (out of scope): switch `routes/ai/sessions.rs` to take `dyn EmbeddingProvider` for testability; wire the indexing path (`create_embeddings_batch`) to `upsert_embedding` for re-index idempotency.