### PR TITLE
fix(api-server): project LEASE_COLUMNS on all lease reads/writes (Closes #2169)

### DIFF
--- a/backend/crates/db/src/repositories/lease.rs
+++ b/backend/crates/db/src/repositories/lease.rs
@@ -62,6 +62,27 @@ const LEASE_COLUMNS: &str = "id, organization_id, unit_id, application_id, templ
      renewal_offered_at, renewal_offer_expires_at, \
      notes, created_by, created_at, updated_at";
 
+/// Canonical single-lease `SELECT` (`WHERE id = $1`) projecting
+/// [`LEASE_COLUMNS`] so the `status` / `termination_reason` Postgres enums are
+/// cast to `text`. Shared by `find_lease_by_id_rls` and
+/// `get_lease_with_details_rls` so the projection can't drift back to a bare
+/// `SELECT *` (regression #2169, where `get_lease_with_details_rls` still used
+/// `SELECT *` and 500'd on GET /leases/{id}).
+#[inline]
+fn select_lease_by_id_sql() -> String {
+    format!("SELECT {LEASE_COLUMNS} FROM leases WHERE id = $1")
+}
+
+/// Wrap a lease `INSERT`/`UPDATE` body with a `RETURNING` clause that projects
+/// [`LEASE_COLUMNS`] (enum columns cast to `text`), never `RETURNING *`. Every
+/// lease write method routes through this helper so a `RETURNING *` — which
+/// yields native enum types and fails `Lease` decode with `ColumnDecode` — can't
+/// be reintroduced.
+#[inline]
+fn lease_write_sql(body: &str) -> String {
+    format!("{body}\nRETURNING {LEASE_COLUMNS}")
+}
+
 /// Repository for lease operations.
 #[derive(Clone)]
 pub struct LeaseRepository {
@@ -776,7 +797,7 @@ impl LeaseRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let lease = sqlx::query_as::<_, Lease>(
+        let lease = sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(lease_write_sql(
             r#"
             INSERT INTO leases (
                 organization_id, unit_id, application_id, template_id,
@@ -790,9 +811,8 @@ impl LeaseRepository {
                 notes, status, created_by
             )
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, 'draft', $31)
-            RETURNING *
             "#,
-        )
+        )))
         .bind(org_id)
         .bind(data.unit_id)
         .bind(data.application_id)
@@ -839,12 +859,10 @@ impl LeaseRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let lease = sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(format!(
-            "SELECT {LEASE_COLUMNS} FROM leases WHERE id = $1"
-        )))
-        .bind(id)
-        .fetch_optional(executor)
-        .await?;
+        let lease = sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(select_lease_by_id_sql()))
+            .bind(id)
+            .fetch_optional(executor)
+            .await?;
 
         Ok(lease)
     }
@@ -859,7 +877,7 @@ impl LeaseRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let lease = sqlx::query_as::<_, Lease>(
+        let lease = sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(lease_write_sql(
             r#"
             UPDATE leases SET
                 landlord_address = COALESCE($2, landlord_address),
@@ -875,9 +893,8 @@ impl LeaseRepository {
                 notes = COALESCE($12, notes),
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING *
             "#,
-        )
+        )))
         .bind(id)
         .bind(&data.landlord_address)
         .bind(&data.tenant_phone)
@@ -913,16 +930,15 @@ impl LeaseRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let lease = sqlx::query_as::<_, Lease>(
+        let lease = sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(lease_write_sql(
             r#"
             UPDATE leases SET
                 signature_request_id = $2,
                 status = CASE WHEN status = 'draft' THEN 'pending_signature' ELSE status END,
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING *
             "#,
-        )
+        )))
         .bind(id)
         .bind(signature_request_id)
         .fetch_one(executor)
@@ -942,7 +958,7 @@ impl LeaseRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let lease = sqlx::query_as::<_, Lease>(
+        let lease = sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(lease_write_sql(
             r#"
             UPDATE leases SET
                 status = 'terminated',
@@ -952,9 +968,8 @@ impl LeaseRepository {
                 termination_initiated_by = $5,
                 updated_at = NOW()
             WHERE id = $1
-            RETURNING *
             "#,
-        )
+        )))
         .bind(id)
         .bind(&data.termination_reason)
         .bind(&data.termination_notes)
@@ -980,8 +995,10 @@ impl LeaseRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        // Use a CTE to create new lease and update old one in a single query
-        let new_lease = sqlx::query_as::<_, Lease>(
+        // Use a CTE to create new lease and update old one in a single query.
+        // The inner `RETURNING *` only feeds the CTE; the outer `SELECT` casts
+        // the lease enum columns via LEASE_COLUMNS so the row decodes into `Lease`.
+        let new_lease = sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(format!(
             r#"
             WITH new_lease AS (
                 INSERT INTO leases (
@@ -1015,9 +1032,9 @@ impl LeaseRepository {
                     updated_at = NOW()
                 WHERE id = $1
             )
-            SELECT * FROM new_lease
+            SELECT {LEASE_COLUMNS} FROM new_lease
             "#,
-        )
+        )))
         .bind(id)
         .bind(data.new_end_date)
         .bind(data.term_months)
@@ -1175,8 +1192,10 @@ impl LeaseRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
-        // Get lease first
-        let lease = match sqlx::query_as::<_, Lease>(r#"SELECT * FROM leases WHERE id = $1"#)
+        // Get lease first. Uses the shared LEASE_COLUMNS projection (enum columns
+        // cast to text) — a bare `SELECT *` here returned native enum types and
+        // failed `Lease` decode with ColumnDecode, 500'ing GET /leases/{id} (#2169).
+        let lease = match sqlx::query_as::<_, Lease>(sqlx::AssertSqlSafe(select_lease_by_id_sql()))
             .bind(id)
             .fetch_optional(executor)
             .await?

--- a/backend/crates/db/tests/lease_units_join_tests.rs
+++ b/backend/crates/db/tests/lease_units_join_tests.rs
@@ -19,14 +19,21 @@
 //! are Postgres ENUM columns, while the models decode them as `String` — the
 //! read paths must project `status::text` (and `find_lease_by_id_rls` must use
 //! the explicit `LEASE_COLUMNS` list instead of `SELECT *`) or every fetch
-//! fails with `ColumnDecode` ("mismatched types"). Seeding is done via raw SQL
-//! because the create paths (`create_application_rls` / `create_lease_rls`)
-//! still use `RETURNING *` and carry the same decode drift (known residual,
-//! tracked in the PR body).
+//! fails with `ColumnDecode` ("mismatched types").
+//!
+//! #2169 (follow-up to PR #2150): the residual `SELECT *` in
+//! `get_lease_with_details_rls` and the `RETURNING *` in every lease write
+//! method (`create_lease_rls` / `update_lease_rls` / `terminate_lease_rls` /
+//! `renew_lease_rls` / `mark_sent_for_signature_rls`) carried the same drift and
+//! 500'd GET /leases/{id} and all lease mutations. The second test in this file
+//! (`lease_rls_detail_and_write_paths_decode_enum_status`) drives those exact
+//! paths through the repo — no raw-SQL seeding — and asserts the enum-backed
+//! `status` / `termination_reason` decode as text.
 
 use chrono::{Duration, Utc};
-use db::models::lease::{ApplicationListQuery, LeaseListQuery};
+use db::models::lease::{ApplicationListQuery, CreateLease, LeaseListQuery, TerminateLease};
 use db::repositories::LeaseRepository;
+use rust_decimal::Decimal;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -208,5 +215,115 @@ async fn lease_read_paths_project_units_designation_as_unit_label(pool: PgPool) 
     assert_eq!(
         details.lease.status, "active",
         "lease status must decode via LEASE_COLUMNS status::text"
+    );
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (email, password_hash, name) VALUES ($1, 'x', 'Lease User') RETURNING id",
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+/// #2169 regression. Drives the RLS single-lease detail read and the lease
+/// write paths (create + terminate) that previously used `SELECT *` /
+/// `RETURNING *` and 500'd with `ColumnDecode` because `leases.status`
+/// (`lease_status`) and `leases.termination_reason` (`termination_reason`) are
+/// Postgres ENUMs decoded as `String`. Pre-fix, `get_lease_with_details_rls`
+/// and every mutation fail at fetch; post-fix, the enum columns decode as text.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn lease_rls_detail_and_write_paths_decode_enum_status(pool: PgPool) {
+    let org = seed_org(&pool, "rls-detail").await;
+    let building = seed_building(&pool, org).await;
+    let unit = seed_unit(&pool, building, "B-202-RLS").await;
+    let user = seed_user(&pool, "creator@lease.test").await;
+
+    let repo = LeaseRepository::new(pool.clone());
+    let today = Utc::now().date_naive();
+
+    // 1) create_lease_rls — INSERT ... RETURNING LEASE_COLUMNS. Pre-fix this
+    //    used `RETURNING *` and failed to decode the `status` enum.
+    let created = repo
+        .create_lease_rls(
+            &pool,
+            org,
+            user,
+            CreateLease {
+                unit_id: unit,
+                application_id: None,
+                template_id: None,
+                landlord_user_id: None,
+                landlord_name: "Landlord Ltd".to_string(),
+                landlord_address: None,
+                tenant_user_id: None,
+                tenant_name: "Jane Tenant".to_string(),
+                tenant_email: "jane@lease.test".to_string(),
+                tenant_phone: None,
+                occupants: None,
+                start_date: today - Duration::days(10),
+                end_date: today + Duration::days(355),
+                term_months: 12,
+                is_fixed_term: Some(true),
+                monthly_rent: Decimal::new(1000, 0),
+                security_deposit: Decimal::new(1000, 0),
+                deposit_held_by: None,
+                rent_due_day: Some(1),
+                late_fee_amount: None,
+                late_fee_grace_days: None,
+                utilities_included: None,
+                parking_spaces: None,
+                storage_units: None,
+                pets_allowed: None,
+                pet_deposit: None,
+                max_occupants: None,
+                smoking_allowed: None,
+                notes: None,
+            },
+        )
+        .await
+        .expect("create_lease_rls must decode the status enum (RETURNING LEASE_COLUMNS, #2169)");
+    assert_eq!(
+        created.status, "draft",
+        "newly created lease status must decode via status::text"
+    );
+
+    // 2) get_lease_with_details_rls — the exact #2169 500. Pre-fix used
+    //    `SELECT *` and failed at fetch on the `status` enum.
+    let details = repo
+        .get_lease_with_details_rls(&pool, created.id)
+        .await
+        .expect("get_lease_with_details_rls must not ColumnDecode on status (#2169)")
+        .expect("the created lease must be found");
+    assert_eq!(
+        details.lease.status, "draft",
+        "RLS detail lease status must decode via LEASE_COLUMNS status::text"
+    );
+
+    // 3) terminate_lease_rls — UPDATE ... RETURNING LEASE_COLUMNS. Exercises the
+    //    `termination_reason` enum decode as well as `status`.
+    let terminated = repo
+        .terminate_lease_rls(
+            &pool,
+            created.id,
+            user,
+            TerminateLease {
+                termination_reason: "mutual_agreement".to_string(),
+                termination_notes: Some("closed early".to_string()),
+                effective_date: Some(today),
+            },
+        )
+        .await
+        .expect("terminate_lease_rls must decode status + termination_reason enums (#2169)");
+    assert_eq!(
+        terminated.status, "terminated",
+        "terminated lease status must decode via status::text"
+    );
+    assert_eq!(
+        terminated.termination_reason.as_deref(),
+        Some("mutual_agreement"),
+        "termination_reason enum must decode via termination_reason::text"
     );
 }


### PR DESCRIPTION
## Summary

Completes the enum-decode fix that PR #2150 started. #2150 only patched `find_lease_by_id_rls`; the same `ColumnDecode` bug remained in **`get_lease_with_details_rls`** (still `SELECT * FROM leases`) and in **every lease write method** (`RETURNING *`), so `GET /leases/{id}`, `/amendments`, `/payments`, `/reminders` and all lease mutations still returned **HTTP 500**.

### Root cause
`leases.status` (`lease_status`) and `leases.termination_reason` (`termination_reason`) are Postgres ENUM columns, but the `Lease` model decodes them as `String`. sqlx cannot decode a user-defined enum straight into `String`, so any `SELECT *` / `RETURNING *` that hydrates a `Lease` fails at fetch with `ColumnDecode` ("mismatched types").

### Fix (`backend/crates/db/src/repositories/lease.rs`)
- Added two shared helpers built on the existing `LEASE_COLUMNS` projection (which casts `status::text` / `termination_reason::text`):
  - `select_lease_by_id_sql()` — the single canonical `SELECT … FROM leases WHERE id = $1`, now used by both `find_lease_by_id_rls` and `get_lease_with_details_rls`.
  - `lease_write_sql(body)` — appends `RETURNING {LEASE_COLUMNS}` to an INSERT/UPDATE body; used by `create_lease_rls`, `update_lease_rls`, `mark_sent_for_signature_rls`, `terminate_lease_rls`.
- `renew_lease_rls`: the inner CTE keeps `RETURNING *` (it only feeds the CTE); the decoded outer read now projects `SELECT {LEASE_COLUMNS} FROM new_lease`.
- Routing every `Lease`-hydrating read/RETURNING through the shared column list means a bare `*` can't be reintroduced (the drift that caused #2169).

All 7 `query_as::<_, Lease>` sites now use the `LEASE_COLUMNS` projection; no `SELECT * FROM leases` / lease `RETURNING *` remain.

### Test (`backend/crates/db/tests/lease_units_join_tests.rs`)
Added `lease_rls_detail_and_write_paths_decode_enum_status`, which drives the exact broken paths through the repo (no raw-SQL seeding):
- `create_lease_rls` → asserts `status == "draft"` (INSERT … RETURNING decode)
- `get_lease_with_details_rls` → asserts `status` decodes (the exact #2169 500)
- `terminate_lease_rls` → asserts `status == "terminated"` and `termination_reason == "mutual_agreement"` (UPDATE … RETURNING + the second enum column)

Pre-fix these fetches fail with `ColumnDecode`; post-fix they decode as text.

## Verification
Local Postgres/Docker is unavailable in this environment, so DB-backed tests are left to CI (`backend.yml` provisions Postgres). Locally verified the compile gate on the `db` crate:
- `cargo fmt --all --check` — clean
- `cargo check -p db` — clean
- `cargo test -p db --test lease_units_join_tests --no-run` — compiles
- `cargo clippy -p db --tests -- -D warnings` — clean

The seeded, DB-backed assertions run under `backend.yml` on this PR.

Closes #2169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFyUpB8Fs2EksstvYEXcnL)_