### PR TITLE
gh-issue-2159: rate-limit POST /api/v1/auth/mfa/verify (Closes #2159)

### DIFF
--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -19,59 +19,85 @@ use utoipa::ToSchema;
 
 use crate::state::AppState;
 
-// ── Brute-force throttle for recovery-code verification (GH #1523) ──────────
+// ── Generic per-user in-process brute-force throttle ────────────────────────
 //
-// `verify_recovery_code` is a full MFA-bypass surface on success, so repeated
-// guesses must be throttled. This mirrors the per-key in-process sliding-window
-// limiter in `routes/caddy_ask.rs`, keyed on `user_id` (the authenticated
-// subject) so one user's attempts can never lock out another. A successful
-// verification clears the user's window. NOTE: this counter is per-process; a
-// Redis-backed counter (the sessions Redis is already in the stack) would hold
-// the limit across instances — tracked as a follow-up.
-const MFA_RECOVERY_MAX_ATTEMPTS: u32 = 10;
-const MFA_RECOVERY_WINDOW: Duration = Duration::from_secs(900);
-/// Only sweep expired limiter entries once the map exceeds this size, so the
-/// `retain` walk is amortized rather than run on every request (GH #1583).
-const MFA_RECOVERY_SWEEP_THRESHOLD: usize = 1024;
+// Both the recovery-code verify (GH #1523/#1583) and the MFA setup-verify
+// (issue #2159) endpoints are bearer-authenticated brute-force surfaces keyed
+// on the authenticated `user_id`. They share one sliding-window limiter,
+// differing only in their backing map + tuning constants. This mirrors the
+// per-key in-process limiter in `routes/caddy_ask.rs`. NOTE: the counter is
+// per-process; a Redis-backed counter (the sessions Redis is already in the
+// stack) would hold the limit across instances — tracked as a follow-up.
 
-struct RecoveryRateLimitEntry {
+struct RateLimitEntry {
     count: u32,
     window_start: Instant,
 }
 
-static MFA_RECOVERY_RATE_LIMITER: LazyLock<Mutex<HashMap<uuid::Uuid, RecoveryRateLimitEntry>>> =
+type UserRateLimiter = Mutex<HashMap<uuid::Uuid, RateLimitEntry>>;
+
+/// Record an attempt for `user_id` in `limiter` and report whether it is within
+/// the limit. Returns `false` once more than `max_attempts` attempts occur in a
+/// rolling `window`.
+///
+/// Expired entries are evicted (GH #1583), but only once the map exceeds
+/// `sweep_threshold`, so the `retain` walk is amortized rather than run on every
+/// request. This matters because these maps are keyed on the whole user
+/// population on auth paths: without eviction an attacker enumerating user_ids
+/// could grow the map without bound (slow memory-exhaustion DoS).
+fn rate_limit_allowed(
+    limiter: &UserRateLimiter,
+    user_id: uuid::Uuid,
+    max_attempts: u32,
+    window: Duration,
+    sweep_threshold: usize,
+) -> bool {
+    let mut map = match limiter.lock() {
+        Ok(m) => m,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let now = Instant::now();
+
+    if map.len() > sweep_threshold {
+        map.retain(|_, e| now.duration_since(e.window_start) < window);
+    }
+
+    let entry = map.entry(user_id).or_insert(RateLimitEntry {
+        count: 0,
+        window_start: now,
+    });
+    if now.duration_since(entry.window_start) >= window {
+        entry.count = 0;
+        entry.window_start = now;
+    }
+    entry.count += 1;
+    entry.count <= max_attempts
+}
+
+// ── Brute-force throttle for recovery-code verification (GH #1523) ──────────
+//
+// `verify_recovery_code` is a full MFA-bypass surface on success, so repeated
+// guesses must be throttled, keyed on `user_id` so one user's attempts can
+// never lock out another. A successful verification clears the user's window.
+const MFA_RECOVERY_MAX_ATTEMPTS: u32 = 10;
+const MFA_RECOVERY_WINDOW: Duration = Duration::from_secs(900);
+/// Only sweep expired limiter entries once the map exceeds this size (GH #1583).
+const MFA_RECOVERY_SWEEP_THRESHOLD: usize = 1024;
+
+static MFA_RECOVERY_RATE_LIMITER: LazyLock<UserRateLimiter> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Record an attempt for `user_id` and report whether it is within the limit.
 /// Returns `false` once more than `MFA_RECOVERY_MAX_ATTEMPTS` attempts occur in
 /// a rolling `MFA_RECOVERY_WINDOW`.
 fn recovery_attempt_allowed(user_id: uuid::Uuid) -> bool {
-    let mut map = match MFA_RECOVERY_RATE_LIMITER.lock() {
-        Ok(m) => m,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    let now = Instant::now();
-
-    // Evict entries whose window has fully elapsed (GH #1583). Unlike the
-    // loopback-only caddy_ask limiter this mirrors, this map is keyed on the
-    // whole user population on a PUBLIC auth path, so without eviction an
-    // attacker enumerating user_ids could grow it without bound (slow
-    // memory-exhaustion DoS). The sweep only runs once the map crosses a size
-    // threshold so it is not an O(n) walk on every request under normal load.
-    if map.len() > MFA_RECOVERY_SWEEP_THRESHOLD {
-        map.retain(|_, e| now.duration_since(e.window_start) < MFA_RECOVERY_WINDOW);
-    }
-
-    let entry = map.entry(user_id).or_insert(RecoveryRateLimitEntry {
-        count: 0,
-        window_start: now,
-    });
-    if now.duration_since(entry.window_start) >= MFA_RECOVERY_WINDOW {
-        entry.count = 0;
-        entry.window_start = now;
-    }
-    entry.count += 1;
-    entry.count <= MFA_RECOVERY_MAX_ATTEMPTS
+    rate_limit_allowed(
+        &MFA_RECOVERY_RATE_LIMITER,
+        user_id,
+        MFA_RECOVERY_MAX_ATTEMPTS,
+        MFA_RECOVERY_WINDOW,
+        MFA_RECOVERY_SWEEP_THRESHOLD,
+    )
 }
 
 /// Clear a user's attempt counter after a successful verification, so a
@@ -79,6 +105,42 @@ fn recovery_attempt_allowed(user_id: uuid::Uuid) -> bool {
 /// tests to reset the process-global limiter for a given user (GH #1583).
 pub fn recovery_attempts_reset(user_id: uuid::Uuid) {
     if let Ok(mut map) = MFA_RECOVERY_RATE_LIMITER.lock() {
+        map.remove(&user_id);
+    }
+}
+
+// ── Brute-force throttle for MFA setup-verification (issue #2159) ───────────
+//
+// `POST /api/v1/auth/mfa/verify` completes enrolment by checking a 6-digit TOTP
+// against the pending secret. The login-path TOTP check is already throttled
+// (`SessionRepository::check_rate_limit` — 429 after 5 email-keyed failures)
+// and the recovery path above is throttled, but this endpoint had NO limiter,
+// leaving a 10^6 code space brute-forceable by an authenticated caller who
+// replays `/verify` with the pending secret still active. Same in-process
+// sliding-window limiter as recovery, keyed on the authenticated `user_id`.
+const MFA_SETUP_VERIFY_MAX_ATTEMPTS: u32 = 10;
+const MFA_SETUP_VERIFY_WINDOW: Duration = Duration::from_secs(900);
+const MFA_SETUP_VERIFY_SWEEP_THRESHOLD: usize = 1024;
+
+static MFA_SETUP_VERIFY_RATE_LIMITER: LazyLock<UserRateLimiter> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Record a setup-verify attempt for `user_id`; `false` once more than
+/// `MFA_SETUP_VERIFY_MAX_ATTEMPTS` occur in a rolling `MFA_SETUP_VERIFY_WINDOW`.
+fn setup_verify_attempt_allowed(user_id: uuid::Uuid) -> bool {
+    rate_limit_allowed(
+        &MFA_SETUP_VERIFY_RATE_LIMITER,
+        user_id,
+        MFA_SETUP_VERIFY_MAX_ATTEMPTS,
+        MFA_SETUP_VERIFY_WINDOW,
+        MFA_SETUP_VERIFY_SWEEP_THRESHOLD,
+    )
+}
+
+/// Clear a user's setup-verify counter (on successful enable, and for tests to
+/// reset the process-global limiter).
+pub fn setup_verify_attempts_reset(user_id: uuid::Uuid) {
+    if let Ok(mut map) = MFA_SETUP_VERIFY_RATE_LIMITER.lock() {
         map.remove(&user_id);
     }
 }
@@ -302,6 +364,22 @@ pub async fn verify_mfa_setup(
         )
     })?;
 
+    // Brute-force throttle (issue #2159): a 6-digit TOTP has a 10^6 code space,
+    // so cap verification attempts per user within a rolling window before doing
+    // any work. The (N+1)th attempt in the window is rejected with 429; a
+    // successful enable later clears the counter (see below). Runs before any DB
+    // access so a flood cannot amplify into load.
+    if !setup_verify_attempt_allowed(user_id) {
+        tracing::warn!(%user_id, "mfa/verify: setup-verification rate limited");
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(ErrorResponse::new(
+                "RATE_LIMITED",
+                "Too many verification attempts. Please try again later.",
+            )),
+        ));
+    }
+
     // Get pending MFA setup
     let mfa_record = state
         .two_factor_repo
@@ -507,6 +585,10 @@ pub async fn verify_mfa_setup(
     }
 
     tracing::info!(user_id = %user_id, codes = plain_codes.len(), "MFA enabled successfully; recovery codes issued");
+
+    // Clear the brute-force counter now that enrolment succeeded (issue #2159),
+    // so earlier mistyped codes don't leave a lingering window for this user.
+    setup_verify_attempts_reset(user_id);
 
     rls.release().await;
 

--- a/backend/servers/api-server/tests/mfa_brute_force_rate_limit_tests.rs
+++ b/backend/servers/api-server/tests/mfa_brute_force_rate_limit_tests.rs
@@ -25,12 +25,12 @@
 //!    the limiter cannot be raced/bypassed by eventually guessing right.
 //! 2. **Lockout scoping** — the limiter is keyed on the email, so one user's
 //!    brute-force lockout must not lock out anybody else.
-//! 3. **`/api/v1/auth/mfa/verify`** — the setup-completion endpoint has no
-//!    dedicated limiter yet; the `#[ignore]`d stub documents that gap (same
-//!    contract as the dead-subtree stub from PR #548, now in a binary that
-//!    actually compiles). Note the recovery-code path
-//!    (`/api/v1/users/me/mfa/recovery-codes/verify`) *is* limited (GH #1523)
-//!    and is covered by `mfa_recovery_cross_user_idor_tests.rs`.
+//! 3. **`/api/v1/auth/mfa/verify`** — the setup-completion endpoint now has a
+//!    dedicated per-user brute-force limiter (issue #2159): the (N+1)th
+//!    verification within the window is `429 RATE_LIMITED`, closing the
+//!    unthrottled 10^6-code-space brute-force window. Note the recovery-code
+//!    path (`/api/v1/users/me/mfa/recovery-codes/verify`) *is* likewise limited
+//!    (GH #1523) and is covered by `mfa_recovery_cross_user_idor_tests.rs`.
 
 // Each integration-test binary compiles `common` independently and uses only a
 // subset of its helpers; without this the rest trip `-D dead_code` under CI's
@@ -299,17 +299,20 @@ async fn login_with_valid_totp_succeeds_without_prior_failures(pool: PgPool) {
     cleanup_test_user(&pool, &user.email).await;
 }
 
-/// Issue #487 stub (ported from the never-compiled
+/// Issue #2159 (originally the #487 stub, ported from the never-compiled
 /// `tests/integration/mfa_e2e_tests.rs` copy added in PR #548): the
-/// setup-completion endpoint `/api/v1/auth/mfa/verify` has no dedicated
-/// brute-force limiter yet. The exposure is smaller than login (the caller is
-/// already authenticated and *received* the pending secret from `/setup`),
-/// but a throttle is still defense-in-depth — e.g. against a confused-deputy
-/// client replaying codes. Un-`#[ignore]` and keep the 429 assertion once a
-/// limiter (mirroring `MFA_RECOVERY_RATE_LIMITER` in `routes/mfa.rs`, GH
-/// #1523) lands on this route.
+/// setup-completion endpoint `/api/v1/auth/mfa/verify` now has a dedicated
+/// per-user brute-force limiter (`MFA_SETUP_VERIFY_RATE_LIMITER` in
+/// `routes/mfa.rs`, mirroring `MFA_RECOVERY_RATE_LIMITER`, GH #1523). A 6-digit
+/// TOTP has only a 10^6 code space, so an unthrottled `/verify` is
+/// brute-forceable even though the caller is already authenticated and holds
+/// the pending secret from `/setup`.
+///
+/// The limiter trips by *count* within its window
+/// (`MFA_SETUP_VERIFY_MAX_ATTEMPTS = 10`): this test hammers 11 quick requests
+/// and asserts the 11th is 429. It performs NO real-time waits — deliberately,
+/// so it does not reintroduce the CI-duration blow-up flagged in issue #2163.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "Awaiting rate-limit on POST /api/v1/auth/mfa/verify — issue #487"]
 async fn mfa_setup_verify_is_rate_limited(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();

--- a/backend/servers/api-server/tests/mfa_brute_force_rate_limit_tests.rs
+++ b/backend/servers/api-server/tests/mfa_brute_force_rate_limit_tests.rs
@@ -40,7 +40,9 @@
 mod common;
 
 use axum::http::StatusCode;
-use common::{cleanup_test_user, verify_user_email, TestApp, TestUser};
+use common::{
+    cleanup_test_user, create_authenticated_user_with_org, verify_user_email, TestApp, TestUser,
+};
 use serde_json::json;
 use sqlx::PgPool;
 use totp_rs::{Algorithm, Secret, TOTP};
@@ -318,27 +320,15 @@ async fn mfa_setup_verify_is_rate_limited(pool: PgPool) {
     let user = TestUser::new();
     cleanup_test_user(&pool, &user.email).await;
 
-    // Register + verify + login (MFA not yet enabled) to get a bearer token.
-    let reg = app
-        .post("/api/v1/auth/register")
-        .json(user.registration_body())
-        .build();
-    app.execute(reg).await.assert_status(StatusCode::CREATED);
-    verify_user_email(&pool, &user.email).await;
-    let login = app
-        .post("/api/v1/auth/login")
-        .json(user.login_body())
-        .send()
-        .await;
-    login.assert_status(StatusCode::OK);
-    let token = login.json_value()["accessToken"]
-        .as_str()
-        .expect("access token")
-        .to_string();
+    // Register + verify + login (MFA not yet enabled) with an org membership —
+    // the MFA setup/verify routes are tenant-scoped and reject requests
+    // without a valid `X-Tenant-ID` header.
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "mfa-rl-setup").await;
 
     // Start MFA enrolment so there is a pending secret to verify against.
     app.post("/api/v1/auth/mfa/setup")
         .bearer(&token)
+        .tenant(org_id)
         .send()
         .await
         .assert_status(StatusCode::OK);
@@ -349,6 +339,7 @@ async fn mfa_setup_verify_is_rate_limited(pool: PgPool) {
         let resp = app
             .post("/api/v1/auth/mfa/verify")
             .bearer(&token)
+            .tenant(org_id)
             .json(json!({ "code": "000000" }))
             .send()
             .await;


### PR DESCRIPTION
## Task
security: `/auth/mfa/verify` has no rate limiter — brute-force window on TOTP verification (Closes #2159)

The login-path TOTP check is already throttled (`SessionRepository::check_rate_limit` → 429 after 5 email-keyed failures) and the recovery-code verify is throttled (GH #1523), but the standalone setup-completion endpoint `POST /api/v1/auth/mfa/verify` had **no** limiter. A 6-digit TOTP has only a 10^6 code space, so an authenticated caller could brute-force it by replaying `/verify` while the pending secret is active.

## Owner
pm-security

## What changed
- **`backend/servers/api-server/src/routes/mfa.rs`**
  - Extracted the recovery limiter's per-user sliding-window logic into a shared `rate_limit_allowed(limiter, user_id, max, window, sweep_threshold)` helper (in-process, amortized eviction, GH #1583 behavior preserved). `recovery_attempt_allowed()` now delegates to it — recovery behavior is byte-for-byte unchanged (same constants: 10 attempts / 900 s / 1024 sweep threshold).
  - Added `MFA_SETUP_VERIFY_RATE_LIMITER` (10 attempts / 900 s window, keyed on the authenticated `user_id`) and wired it into `verify_mfa_setup`: the (N+1)th attempt in the window returns `429 RATE_LIMITED` **before any DB work**; the counter is cleared on successful enable so a legit user isn't penalized by earlier mistyped codes.
- **`backend/servers/api-server/tests/mfa_brute_force_rate_limit_tests.rs`**
  - De-`#[ignore]`d `mfa_setup_verify_is_rate_limited` and refreshed the stale module/test docs.

## #2163 (CI-duration) note
The de-ignored test trips the limiter **by count** (hammers 11 quick requests, asserts the 11th is 429) with **zero real-time waits** — so it does not reintroduce the >60 min CI blow-up flagged in #2163. The limiter is per-process and each test uses a fresh random `user_id`, so there is no cross-test contamination and no wait needed.

## Tested (Band A — fast check)
- `cargo fmt --all -- --check` → exit 0
- `cargo check -p api-server` → exit 0
- `cargo test -p api-server --test mfa_brute_force_rate_limit_tests --no-run` → exit 0 (test binary links)

## Built / CI parity (Band B/C — hot-path auth change)
- `cargo clippy -p api-server --all-targets -- -D warnings` → exit 0 (compiles the test target too)
- DB-backed test execution (`#[sqlx::test]`) was **not** run locally: no Postgres/Docker in this environment. Deferred to CI (`backend.yml`). The new assertion is straightforward (11th hammered request → 429).
- Build-env note: `utoipa-swagger-ui`'s build script downloads the Swagger UI zip from `github.com`, which this environment's egress policy blocks (403). Compilation was unblocked by pointing `SWAGGER_UI_DOWNLOAD_URL` at a locally-built zip of the same asset (build-time UI asset only — not exercised by the code under test). CI is unaffected.

## Scope drift
`scope-check.sh` flags `routes/mfa.rs` + its test as outside `pm-security`'s globs. This is a **false positive**: `owner-areas.json` lists `backend/servers/api-server/src/handlers/mfa/**`, but this repo keeps MFA route code at `backend/servers/api-server/src/routes/mfa.rs` (routes/, not handlers/). The change is squarely pm-security's domain (MFA auth hot path). Consider updating the glob to `routes/mfa.rs`.

## Code-reuse review
`reuse-grep.sh` → clean. The change *reduces* duplication by extracting the shared `rate_limit_allowed` helper rather than copy-pasting the recovery limiter.

## Notes
- Follow-up (pre-existing, not in scope): the limiter is per-process; a Redis-backed counter would hold the limit across instances — same caveat already documented for the recovery limiter.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AFyUpB8Fs2EksstvYEXcnL)_