### PR TITLE
gap-84-5-no-application-handler-calling-search-similar: wire pgvector RAG search + add embedding-write handler

### DIFF
--- a/backend/crates/integrations/src/llm.rs
+++ b/backend/crates/integrations/src/llm.rs
@@ -124,6 +124,17 @@ impl LlmClient {
         }
     }
 
+    /// Whether an OpenAI API key is configured.
+    ///
+    /// Callers use this to decide between the live OpenAI embedding provider
+    /// and the deterministic offline [`crate::embedding::StubEmbeddingProvider`]
+    /// (Story 84.5) — e.g. the RAG embedding-write flow degrades to the stub
+    /// when no key is present so indexing still works in CI / air-gapped
+    /// deployments instead of hard-failing with `MissingApiKey`.
+    pub fn has_openai_key(&self) -> bool {
+        self.config.openai_api_key.is_some()
+    }
+
     /// Complete a chat using OpenAI API.
     pub async fn openai_chat(
         &self,

--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -23,6 +23,7 @@ use db::models::{
     GenerateListingDescriptionRequest, UpdateEscalationConfig,
 };
 use db::RlsPool;
+use integrations::{EmbeddingProvider, StubEmbeddingProvider};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use uuid::Uuid;
@@ -57,10 +58,201 @@ pub fn llm_router() -> Router<AppState> {
         .route("/voice/devices", post(link_voice_device))
         .route("/voice/devices/{id}", delete(unlink_voice_device))
         .route("/voice/commands/{device_id}", get(list_voice_commands))
+        // RAG indexing / embedding-write flow (Story 84.5 / 103.5)
+        .route("/rag/index", post(index_document))
         // Statistics
         .route("/statistics", get(get_ai_statistics))
         .route("/requests", get(list_generation_requests))
         .route("/requests/{id}", get(get_generation_request))
+}
+
+// ============================================================================
+// Story 84.5 / 103.5: pgvector RAG embedding-write flow
+// ============================================================================
+
+/// Request to index a document's text chunks into the RAG store.
+#[derive(Debug, Deserialize)]
+struct IndexDocumentRequest {
+    /// Logical document identifier the chunks belong to. Embeddings are stored
+    /// org-scoped (RLS) and keyed by `(document_id, chunk_index)`.
+    document_id: Uuid,
+    /// Pre-split text chunks to embed and store. Empty / whitespace-only
+    /// entries are dropped.
+    chunks: Vec<String>,
+    /// Optional human-readable title, folded into each chunk's metadata as
+    /// `title` (used by the retrieval path for `source_title`).
+    #[serde(default)]
+    title: Option<String>,
+    /// Optional extra metadata merged into every chunk's metadata object.
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
+}
+
+/// Result of an indexing run.
+#[derive(Debug, Serialize)]
+struct IndexDocumentResponse {
+    document_id: Uuid,
+    /// Number of chunks embedded and upserted.
+    chunks_indexed: usize,
+    /// IDs of the upserted `document_embeddings` rows, in chunk order.
+    embedding_ids: Vec<Uuid>,
+    /// Embedding provider used: `"openai"` when a key is configured, otherwise
+    /// the deterministic offline stub.
+    provider: String,
+}
+
+/// Upper bound on chunks per request — guards against unbounded embedding cost
+/// and connection hold time.
+const MAX_INDEX_CHUNKS: usize = 512;
+
+/// Index a document into the pgvector RAG store (Story 84.5 / 103.5).
+///
+/// This is the missing application-side embedding-write flow: it generates an
+/// embedding per chunk via the [`EmbeddingProvider`] abstraction and upserts it
+/// through `LlmDocumentRepository::upsert_embedding` (pgvector
+/// `upsert_document_embedding` when the extension is present, JSONB fallback
+/// otherwise). Retrieval (`/chat/enhanced`, `ai_chat_router`) then reads these
+/// rows via the pgvector `search_similar_documents` path.
+///
+/// Provider selection: the live OpenAI embedding backend when an API key is
+/// configured; otherwise a deterministic [`StubEmbeddingProvider`] so indexing
+/// still succeeds in CI / air-gapped deployments instead of hard-failing.
+#[utoipa::path(
+    post,
+    path = "/api/v1/ai/llm/rag/index",
+    request_body = serde_json::Value,
+    responses(
+        (status = 201, description = "Document chunks embedded and stored"),
+        (status = 400, description = "No usable chunks / too many chunks", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 502, description = "Embedding provider failed", body = ErrorResponse),
+    ),
+    tag = "AI LLM"
+)]
+async fn index_document(
+    State(state): State<AppState>,
+    mut rls: RlsConnection,
+    Json(req): Json<IndexDocumentRequest>,
+) -> Result<(StatusCode, Json<IndexDocumentResponse>), (StatusCode, Json<ErrorResponse>)> {
+    // RLS context (org GUC) is set on rls.conn(); tenant_id is the authoritative org.
+    let tenant_id = rls.tenant_id();
+
+    // Normalise chunks: trim + drop empties.
+    let chunks: Vec<String> = req
+        .chunks
+        .iter()
+        .map(|c| c.trim().to_string())
+        .filter(|c| !c.is_empty())
+        .collect();
+
+    if chunks.is_empty() {
+        rls.release().await;
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "INVALID_INPUT",
+                "chunks must contain at least one non-empty entry",
+            )),
+        ));
+    }
+    if chunks.len() > MAX_INDEX_CHUNKS {
+        rls.release().await;
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "INVALID_INPUT",
+                "too many chunks in a single request",
+            )),
+        ));
+    }
+
+    // Provider selection (Story 84.5): live OpenAI when configured, else the
+    // deterministic offline stub so indexing works without a key.
+    let (provider, provider_name): (Box<dyn EmbeddingProvider>, &str) =
+        if state.llm_client.has_openai_key() {
+            (Box::new(state.llm_client.clone()), "openai")
+        } else {
+            (Box::new(StubEmbeddingProvider::new()), "stub-deterministic")
+        };
+
+    // Generate embeddings first. `embed_batch` may make (slow) network calls;
+    // we intentionally do this BEFORE the write loop but the RLS connection is
+    // still held — acceptable for an admin/indexing endpoint and mirrors the
+    // module's other write handlers.
+    let embeddings = match provider.embed_batch(&chunks).await {
+        Ok(e) => e,
+        Err(e) => {
+            rls.release().await;
+            tracing::warn!("RAG embedding generation failed: {}", e);
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse::new(
+                    "EMBEDDING_FAILED",
+                    "Failed to generate embeddings",
+                )),
+            ));
+        }
+    };
+
+    // Base metadata: caller-provided object (if any) plus an optional title.
+    let mut base_meta = req
+        .metadata
+        .filter(|v| v.is_object())
+        .unwrap_or_else(|| serde_json::json!({}));
+    if let (Some(title), Some(obj)) = (req.title.as_ref(), base_meta.as_object_mut()) {
+        obj.entry("title")
+            .or_insert_with(|| serde_json::Value::String(title.clone()));
+    }
+
+    // Upsert each chunk (pgvector-aware, JSONB fallback) on the RLS connection.
+    let mut embedding_ids = Vec::with_capacity(chunks.len());
+    for (idx, (chunk, emb)) in chunks.iter().zip(embeddings.iter()).enumerate() {
+        match state
+            .llm_document_repo
+            .upsert_embedding(
+                rls.conn(),
+                tenant_id,
+                req.document_id,
+                idx as i32,
+                chunk,
+                &emb.embedding,
+                base_meta.clone(),
+            )
+            .await
+        {
+            Ok(id) => embedding_ids.push(id),
+            Err(e) => {
+                rls.release().await;
+                tracing::error!("RAG embedding upsert failed: {}", e);
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "INTERNAL_ERROR",
+                        "Failed to store embeddings",
+                    )),
+                ));
+            }
+        }
+    }
+    rls.release().await;
+
+    tracing::info!(
+        "RAG indexed {} chunk(s) for document {} (org {}) via {}",
+        embedding_ids.len(),
+        req.document_id,
+        tenant_id,
+        provider_name
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(IndexDocumentResponse {
+            document_id: req.document_id,
+            chunks_indexed: embedding_ids.len(),
+            embedding_ids,
+            provider: provider_name.to_string(),
+        }),
+    ))
 }
 
 // ============================================================================

--- a/backend/servers/api-server/src/routes/ai/sessions.rs
+++ b/backend/servers/api-server/src/routes/ai/sessions.rs
@@ -520,10 +520,18 @@ async fn send_message(
                     .await
                 {
                     Ok(embedding_result) => {
-                        // Search documents by embedding similarity
+                        // Search documents by embedding similarity.
+                        //
+                        // Story 84.5 / 103.5: prefer the pgvector-native path
+                        // (`search_similar_documents` SQL function, IVFFlat cosine
+                        // index) which pushes the top-k similarity search into
+                        // Postgres instead of streaming every org row into Rust.
+                        // `search_documents_pgvector` transparently falls back to
+                        // the application-level cosine scan when the pgvector
+                        // extension / function is absent, so this is a safe swap.
                         match state
                             .llm_document_repo
-                            .search_documents_by_embedding(
+                            .search_documents_pgvector(
                                 &mut *guard.conn(),
                                 tenant_id,
                                 &embedding_result.embedding,

--- a/backend/servers/api-server/tests/rag_index_embedding_write_tests.rs
+++ b/backend/servers/api-server/tests/rag_index_embedding_write_tests.rs
@@ -32,6 +32,36 @@ fn live_openai_key_present() -> bool {
     std::env::var("OPENAI_API_KEY").is_ok()
 }
 
+/// Resolve the id of a previously registered test user by email.
+async fn resolve_user_id(app: &TestApp, user: &TestUser) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&app.pool)
+        .await
+        .expect("resolve user id")
+}
+
+/// Seed a `documents` row with an explicit id so the embedding-write FK
+/// (`document_embeddings.document_id → documents(id)`, migration 00081) is
+/// satisfied. The index handler stores embeddings keyed by the caller-supplied
+/// `document_id`, so the referenced document must already exist — otherwise both
+/// the pgvector and JSONB-fallback INSERT paths fail the foreign key with a 500.
+async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, id: Uuid) {
+    sqlx::query(
+        r#"INSERT INTO documents
+               (id, organization_id, title, category, file_key, file_name,
+                mime_type, size_bytes, created_by)
+           VALUES ($1, $2, 'RAG Source', 'other', $3, 'rag.txt', 'text/plain', 1024, $4)"#,
+    )
+    .bind(id)
+    .bind(org_id)
+    .bind(format!("{org_id}/{id}.txt"))
+    .bind(created_by)
+    .execute(pool)
+    .await
+    .expect("seed document");
+}
+
 // POST /api/v1/ai/llm/rag/index → 201, persists one embedding row per chunk.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn rag_index_persists_chunks(pool: PgPool) {
@@ -43,7 +73,11 @@ async fn rag_index_persists_chunks(pool: PgPool) {
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "rag-index-1").await;
     let session = app.session(token, org_id);
 
+    // The RAG store is FK-bound to `documents`; seed the referenced row first.
+    let user_id = resolve_user_id(&app, &user).await;
     let document_id = Uuid::new_v4();
+    seed_document(&app.pool, org_id, user_id, document_id).await;
+
     let resp = app
         .execute(
             session
@@ -95,7 +129,10 @@ async fn rag_index_is_idempotent(pool: PgPool) {
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "rag-index-2").await;
     let session = app.session(token, org_id);
 
+    // The RAG store is FK-bound to `documents`; seed the referenced row first.
+    let user_id = resolve_user_id(&app, &user).await;
     let document_id = Uuid::new_v4();
+    seed_document(&app.pool, org_id, user_id, document_id).await;
     let payload = json!({
         "document_id": document_id,
         "chunks": ["The reserve fund covers roof repairs."],

--- a/backend/servers/api-server/tests/rag_index_embedding_write_tests.rs
+++ b/backend/servers/api-server/tests/rag_index_embedding_write_tests.rs
@@ -1,0 +1,169 @@
+//! Integration tests for the RAG embedding-write flow (Story 84.5 / 103.5).
+//!
+//! Gap closed: "No application handler calling search_similar_documents or
+//! embedding-write flow (84-5-pgvector-rag)". Before this, the pgvector RAG
+//! store could only be populated from tests — there was no application-side
+//! endpoint that generated embeddings and wrote them. `POST
+//! /api/v1/ai/llm/rag/index` is that endpoint.
+//!
+//! ## Provider selection & CI
+//! The handler embeds via the Story 84.5 `EmbeddingProvider` abstraction: the
+//! live OpenAI backend when `OPENAI_API_KEY` is set, otherwise the
+//! deterministic offline `StubEmbeddingProvider`. CI runs without a key, so the
+//! stub path is what these tests exercise. Tests that would trigger a live
+//! embedding call skip themselves when a key is present (same convention as the
+//! other `ai/llm.rs` batches, which skip live-provider endpoints).
+//!
+//! DB-backed via `#[sqlx::test]` (migrator = db::MIGRATOR) — bodies run in CI
+//! where Postgres is available; the local dispatcher runner only compile-gates.
+
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user_with_org, TestApp, TestUser};
+
+/// True when a live OpenAI key is configured — in that case the handler makes a
+/// real network embedding call, so tests that hit the embed path skip.
+fn live_openai_key_present() -> bool {
+    std::env::var("OPENAI_API_KEY").is_ok()
+}
+
+// POST /api/v1/ai/llm/rag/index → 201, persists one embedding row per chunk.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn rag_index_persists_chunks(pool: PgPool) {
+    if live_openai_key_present() {
+        return; // avoid a live embedding network call
+    }
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "rag-index-1").await;
+    let session = app.session(token, org_id);
+
+    let document_id = Uuid::new_v4();
+    let resp = app
+        .execute(
+            session
+                .post("/api/v1/ai/llm/rag/index")
+                .json(json!({
+                    "document_id": document_id,
+                    "title": "House Rules",
+                    "chunks": [
+                        "Quiet hours are between 22:00 and 06:00.",
+                        "Pets are allowed with prior written approval.",
+                    ],
+                }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::CREATED,
+        "index must return 201; body={}",
+        resp.text()
+    );
+    let body = resp.json_value();
+    assert_eq!(body["chunks_indexed"], json!(2));
+    assert_eq!(
+        body["provider"], "stub-deterministic",
+        "no key configured → deterministic stub provider; body={body}"
+    );
+    let ids = body["embedding_ids"]
+        .as_array()
+        .expect("embedding_ids array");
+    assert_eq!(ids.len(), 2, "one embedding id per chunk");
+    assert!(
+        ids.iter().all(|v| v.as_str().is_some_and(|s| !s.is_empty())),
+        "embedding ids must be non-empty UUIDs"
+    );
+}
+
+// Re-indexing the same (document_id, chunk_index) upserts rather than
+// duplicating — the second call returns the same row ids.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn rag_index_is_idempotent(pool: PgPool) {
+    if live_openai_key_present() {
+        return;
+    }
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "rag-index-2").await;
+    let session = app.session(token, org_id);
+
+    let document_id = Uuid::new_v4();
+    let payload = json!({
+        "document_id": document_id,
+        "chunks": ["The reserve fund covers roof repairs."],
+    });
+
+    let first = app
+        .execute(session.post("/api/v1/ai/llm/rag/index").json(&payload).build())
+        .await;
+    assert_eq!(first.status, StatusCode::CREATED, "body={}", first.text());
+    let second = app
+        .execute(session.post("/api/v1/ai/llm/rag/index").json(&payload).build())
+        .await;
+    assert_eq!(second.status, StatusCode::CREATED, "body={}", second.text());
+
+    assert_eq!(
+        first.json_value()["embedding_ids"],
+        second.json_value()["embedding_ids"],
+        "upsert on (document_id, chunk_index) must reuse the same row id"
+    );
+}
+
+// Empty / whitespace-only chunk list → 400 before any embedding work.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn rag_index_rejects_empty_chunks(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "rag-index-3").await;
+    let session = app.session(token, org_id);
+
+    let resp = app
+        .execute(
+            session
+                .post("/api/v1/ai/llm/rag/index")
+                .json(json!({
+                    "document_id": Uuid::new_v4(),
+                    "chunks": ["", "   "],
+                }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::BAD_REQUEST,
+        "empty chunks must be rejected; body={}",
+        resp.text()
+    );
+}
+
+// Unauthenticated request → 401 (RlsConnection extractor guards the route).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn rag_index_requires_auth(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let resp = app
+        .execute(
+            app.post("/api/v1/ai/llm/rag/index")
+                .json(json!({
+                    "document_id": Uuid::new_v4(),
+                    "chunks": ["anything"],
+                }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated index must be 401; body={}",
+        resp.text()
+    );
+}

--- a/backend/servers/api-server/tests/rag_index_embedding_write_tests.rs
+++ b/backend/servers/api-server/tests/rag_index_embedding_write_tests.rs
@@ -77,7 +77,8 @@ async fn rag_index_persists_chunks(pool: PgPool) {
         .expect("embedding_ids array");
     assert_eq!(ids.len(), 2, "one embedding id per chunk");
     assert!(
-        ids.iter().all(|v| v.as_str().is_some_and(|s| !s.is_empty())),
+        ids.iter()
+            .all(|v| v.as_str().is_some_and(|s| !s.is_empty())),
         "embedding ids must be non-empty UUIDs"
     );
 }
@@ -101,11 +102,21 @@ async fn rag_index_is_idempotent(pool: PgPool) {
     });
 
     let first = app
-        .execute(session.post("/api/v1/ai/llm/rag/index").json(&payload).build())
+        .execute(
+            session
+                .post("/api/v1/ai/llm/rag/index")
+                .json(&payload)
+                .build(),
+        )
         .await;
     assert_eq!(first.status, StatusCode::CREATED, "body={}", first.text());
     let second = app
-        .execute(session.post("/api/v1/ai/llm/rag/index").json(&payload).build())
+        .execute(
+            session
+                .post("/api/v1/ai/llm/rag/index")
+                .json(&payload)
+                .build(),
+        )
         .await;
     assert_eq!(second.status, StatusCode::CREATED, "body={}", second.text());
 


### PR DESCRIPTION
## Task
No application handler calling search_similar_documents or embedding-write flow (84-5-pgvector-rag pgvector RAG Migration)

## Owner
pm-backend (specialist: rust-backend)

## What changed
The pgvector RAG migration (00081) shipped SQL helpers (`search_similar_documents`, `upsert_document_embedding`) and repo wrappers (`search_documents_pgvector`, `upsert_embedding`) plus the Story 84.5 `EmbeddingProvider` abstraction — but **no application handler called any of them**. This closes both halves of the gap:

1. **Retrieval (`search_similar_documents`)** — `routes/ai/sessions.rs` RAG retrieval (`/chat/enhanced`) now calls `search_documents_pgvector` instead of the app-level `search_documents_by_embedding`. This pushes top-k similarity into Postgres (IVFFlat cosine index) and transparently falls back to the application-level cosine scan when the pgvector extension/function is absent — a safe drop-in (identical signature + internal fallback).

2. **Embedding-write flow** — new `POST /api/v1/ai/llm/rag/index` (`index_document`): generates an embedding per chunk via the Story 84.5 `EmbeddingProvider` (live OpenAI when a key is configured, else the deterministic offline `StubEmbeddingProvider`) and upserts through `LlmDocumentRepository::upsert_embedding` (pgvector `upsert_document_embedding`, JSONB fallback). RLS-scoped via the `RlsConnection` extractor, consistent with the rest of `ai/llm.rs`. Validates non-empty chunks and caps at 512 chunks/request.

3. Added `LlmClient::has_openai_key()` so the write flow degrades to the offline stub instead of hard-failing with `MissingApiKey` in CI / air-gapped deployments.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p integrations` → exit 0
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0 (Finished in 4m08s)

## Built (Band B — clippy + test-binary compile)
- `cargo clippy -p integrations --lib -- -D warnings` → exit 0
- `cargo clippy -p api-server --tests -- -D warnings` → exit 0 (compiles lib + all test binaries incl. the new integration test)

> Note: `utoipa-swagger-ui`'s build script downloads Swagger UI from `github.com/swagger-api/swagger-ui`, which this sandbox's egress policy blocks. Verified locally by pointing `SWAGGER_UI_DOWNLOAD_URL` at a minimal file:// stub zip (build-script input only — nothing committed, no source/CI change). CI builds the real asset normally.

## CI parity (Band C)
Skipped: not a hot-path change (no auth/billing/data-integrity). Standard `backend.yml` (fmt/clippy/test) covers it.

## DB tests
`backend/servers/api-server/tests/rag_index_embedding_write_tests.rs` — 4 `#[sqlx::test]` cases (persist / idempotent-upsert / empty-chunk 400 / unauth 401). Bodies **deferred to CI** (no local Postgres in this environment), the same pattern other backend PRs on this repo use; they compile-gate clean locally via `clippy --tests`.

## Notes
- The offline-stub tests self-skip when `OPENAI_API_KEY` is set (would trigger a live embedding network call), matching the existing `ai/llm.rs` live-provider skip convention.
- Scope drift: false (diff is entirely under `backend/**` = pm-backend). Code-reuse pre-flight: no warnings.
- The RAG statistics endpoint (`get_rag_statistics`) is also currently uncalled but is out of scope for this gap (search + embedding-write only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PR89K2UYZXJ1GeMZbQYCYx

---
_Generated by [Claude Code](https://claude.ai/code/session_01PR89K2UYZXJ1GeMZbQYCYx)_