### PR TITLE
gh-issue-2153: retry-remint dev-truth guards (coverage-done + dev-log subject)

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -962,7 +962,18 @@ export BUFFER_FLOOR BUFFER_TARGET BUFFER_CEIL
   failure in the stem group, `RETRY_MAX_ROUNDS` (default 2) lifetime rounds per
   stem, never for stems with landed work or any active/live sibling (T24 +
   PR 5/5 hold), ≤ `RETRY_REMINT_CAP` (default 6) per run, never past
-  `BUFFER_CEIL` headroom, append-only fail-closed. The `retry_of` field is what
+  `BUFFER_CEIL` headroom, append-only fail-closed. **Dev-truth guards (issue
+  #2153 — ghost retries):** the archive ledger alone is a blind spot — work
+  can land on dev OUT OF BAND under a different task_id/PR (observed: 2
+  reality-web `code-review-*` retries whose fixes had merged via #1676 etc.,
+  plus `10b-2-feature-flag-management-retry1` for a story coverage already
+  marked done). So before minting, the script also excludes (a) stems whose
+  story id is `status="done"` in `coverage.json` (`COVERAGE_FILE` injectable;
+  missing file degrades to no exclusion), and (b) stems matched by an anchored
+  `<id>:` commit-subject prefix on `origin/dev` — the same squash-merge join
+  convention as `dev-reconcile.sh`, never a loose body grep (`DEV_LOG_FILE`
+  injectable for tests; default `git log origin/dev --format=%s -300`;
+  unreachable remote degrades to no exclusion). The `retry_of` field is what
   Phase 3 and backlog-refill.sh honor to exempt the row from the STEM-aware
   archive exclusion (exact-id exclusion still applies — satisfied by the
   `-retry<N>` suffix). Smoke-tested by `.research/test-retry-remint.sh`.

--- a/.research/retry-remint.sh
+++ b/.research/retry-remint.sh
@@ -31,7 +31,13 @@
 #     - nothing in the stem group ever merged/done (work didn't land);
 #     - no NON-TERMINAL action-list row and no active assignment
 #       (in-progress/review/quarantined) shares the stem (T24 + PR 5/5);
-#     - the minted id itself exists nowhere in action-list or assignments.
+#     - the minted id itself exists nowhere in action-list or assignments;
+#     - dev-truth guards (issue #2153 — ghost retries): the stem's story is
+#       NOT status="done" in coverage.json (work landed on dev under a
+#       DIFFERENT task/PR), and no commit subject on origin/dev starts with
+#       an anchored "<id>:" prefix that stems to the candidate stem (same
+#       join convention as dev-reconcile.sh). Both degrade gracefully when
+#       their input is missing (no exclusion).
 #
 #   Minted rows carry `retry_of` (the original failed task_id) and
 #   `retry_round`. `retry_of` is the field Phase 3 and backlog-refill.sh use
@@ -44,7 +50,9 @@
 #   ./.research/retry-remint.sh            # dry-run: print re-mint set
 #   ./.research/retry-remint.sh --apply    # append rows to action-list.json
 #   Injectables (tests): ACTION_LIST, ASSIGN, ASSIGN_ARCHIVE, ACTION_ARCHIVE,
-#     RETRY_NOW, RETRY_COOLDOWN_DAYS, RETRY_MAX_ROUNDS, RETRY_REMINT_CAP, BUFFER_CEIL
+#     COVERAGE_FILE, DEV_LOG_FILE (one commit subject per line; default is
+#     `git log origin/dev --format=%s -300`), RETRY_NOW, RETRY_COOLDOWN_DAYS,
+#     RETRY_MAX_ROUNDS, RETRY_REMINT_CAP, BUFFER_CEIL
 
 set -euo pipefail
 
@@ -53,6 +61,8 @@ ACTION_LIST="${ACTION_LIST:-$REPO_ROOT/.research/management/action-list.json}"
 ACTION_ARCHIVE="${ACTION_ARCHIVE:-$REPO_ROOT/.research/management/action-list-archive.json}"
 ASSIGN="${ASSIGN:-$REPO_ROOT/.research/management/assignments.json}"
 ASSIGN_ARCHIVE="${ASSIGN_ARCHIVE:-$REPO_ROOT/.research/management/assignments-archive.json}"
+COVERAGE_FILE="${COVERAGE_FILE:-$REPO_ROOT/.research/management/coverage.json}"
+DEV_LOG_MAX="${DEV_LOG_MAX:-300}"
 NOW="${RETRY_NOW:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 COOLDOWN_DAYS="${RETRY_COOLDOWN_DAYS:-7}"
 MAX_ROUNDS="${RETRY_MAX_ROUNDS:-2}"
@@ -90,6 +100,31 @@ else
   echo '[]' > "$WORK/arch-items.json"
 fi
 
+# Dev-truth guard (a) — coverage-done (issue #2153): story ids already "done"
+# in coverage.json. The archive ledger misses work that landed on dev under a
+# DIFFERENT task_id/branch; coverage.json tracks dev truth per story. Optional
+# file; missing/unparseable degrades gracefully to "no exclusion".
+if [ -f "$COVERAGE_FILE" ]; then
+  jq '[ .stories[]? | select(.status=="done") | .id ]' "$COVERAGE_FILE" \
+    > "$WORK/cov-done.json" 2>/dev/null || echo '[]' > "$WORK/cov-done.json"
+else
+  echo '[]' > "$WORK/cov-done.json"
+fi
+
+# Dev-truth guard (b) — dev-log subject join (issue #2153): a commit on
+# origin/dev whose SUBJECT begins with an anchored "<id>:" prefix (up to the
+# first colon, no spaces — the same squash-merge join convention as
+# dev-reconcile.sh, never a loose body grep) proves the stem's work landed
+# even when no archive row recorded it. DEV_LOG_FILE (one subject per line)
+# is injectable for offline tests; an unreachable remote degrades to
+# "nothing landed" rather than aborting the dispatcher.
+if [ -n "${DEV_LOG_FILE:-}" ]; then
+  DEV_SUBJECTS=$(cat "$DEV_LOG_FILE" 2>/dev/null || true)
+else
+  DEV_SUBJECTS=$(git -C "$REPO_ROOT" log origin/dev --format=%s -"$DEV_LOG_MAX" 2>/dev/null || true)
+fi
+printf '%s\n' "$DEV_SUBJECTS" | jq -R . | jq -s . > "$WORK/dev-subjects.json"
+
 # Headroom: never lift the open pool past BUFFER_CEIL.
 OPEN_NOW=$(jq '[ .items[] | select(.status=="open") ] | length' "$ACTION_LIST")
 HEADROOM=$(( BUFFER_CEIL - OPEN_NOW ))
@@ -102,6 +137,8 @@ fi
 CANDIDATES=$(jq -n \
   --slurpfile assign_f "$WORK/assign.json" \
   --slurpfile arch_f "$WORK/arch-items.json" \
+  --slurpfile cov_done_f "$WORK/cov-done.json" \
+  --slurpfile devlog_f "$WORK/dev-subjects.json" \
   --slurpfile al "$ACTION_LIST" \
   --arg now "$NOW" \
   --argjson cooldown_days "$COOLDOWN_DAYS" \
@@ -121,6 +158,13 @@ CANDIDATES=$(jq -n \
   | ([ $al[0].items[] | select(.status != "done" and .status != "dropped") | (.id | stem) ] | unique) as $al_live_stems
   # Every id already known anywhere (exact-id idempotency for the minted id).
   | ([ $assign[].task_id ] + [ $al[0].items[].id ] | unique) as $known_ids
+  # Dev-truth (a): coverage.json stories already done — work landed on dev
+  # under a different task/PR (issue #2153 ghost retries).
+  | ($cov_done_f[0] | map(stem) | unique) as $cov_done_stems
+  # Dev-truth (b): anchored "<id>:" subject prefixes on origin/dev, stemmed —
+  # same join convention as dev-reconcile.sh (prefix must contain no spaces,
+  # so a chore commit merely MENTIONING an id never matches).
+  | ([ $devlog_f[0][] | capture("^(?<p>[^:\\s]+):") | .p | stem ] | unique) as $dev_landed_stems
 
   | ([ $assign[] | select(.status=="failed") ]
      | group_by(.task_id | stem)
@@ -141,6 +185,8 @@ CANDIDATES=$(jq -n \
          and ((.stem | IN($landed_stems[])) | not)
          and ((.stem | IN($active_stems[])) | not)
          and ((.stem | IN($al_live_stems[])) | not)
+         and ((.stem | IN($cov_done_stems[])) | not)
+         and ((.stem | IN($dev_landed_stems[])) | not)
          and (($now_e - (.newest_failure | epoch)) >= $cooldown_s)
        ))
      | map(. + { mint_id: (.stem + "-retry" + ((.rounds_used + 1) | tostring)) })

--- a/.research/test-retry-remint.sh
+++ b/.research/test-retry-remint.sh
@@ -3,7 +3,9 @@
 # Exercises: retryable classification (pr_number=null only), cool-down gate,
 # retry-round cap, landed-stem exclusion, active-stem exclusion, live
 # action-list stem exclusion (T24), minted-id idempotency, retry_of/round
-# stamping, per-run cap + ceil headroom, append-only count guard.
+# stamping, per-run cap + ceil headroom, append-only count guard, and the
+# issue #2153 dev-truth guards (coverage-done exclusion + anchored dev-log
+# subject exclusion, both degrading gracefully when their input is missing).
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -19,6 +21,8 @@ AL="$TMP/action-list.json"
 ALA="$TMP/action-list-archive.json"
 ASG="$TMP/assignments.json"
 ASGA="$TMP/assignments-archive.json"
+COV="$TMP/coverage.json"
+DEVLOG="$TMP/dev-log.txt"
 NOW="2026-07-07T12:00:00Z"          # fixtures fail at 2026-06-20 → 17d ago
 
 seed() {
@@ -64,13 +68,31 @@ EOF
   { "task_id": "bug-second-round",        "status": "failed", "pr_number": null,
     "last_updated": "2026-06-10T00:00:00Z" },
   { "task_id": "bug-second-round-retry1", "status": "failed", "pr_number": null,
-    "last_updated": "2026-06-15T00:00:00Z" }
+    "last_updated": "2026-06-15T00:00:00Z" },
+  { "task_id": "bug-cov-done",        "status": "failed", "pr_number": null,
+    "last_updated": "2026-06-20T00:00:00Z" },
+  { "task_id": "bug-on-dev",          "status": "failed", "pr_number": null,
+    "last_updated": "2026-06-20T00:00:00Z" }
 ] }
+EOF
+  # Dev-truth fixtures (issue #2153): a coverage story flipped "done" out of
+  # band, and a dev commit whose SUBJECT starts with an anchored "<id>:".
+  cat > "$COV" <<'EOF'
+{ "stories": [
+  { "id": "bug-cov-done",  "status": "done" },
+  { "id": "bug-retryable", "status": "partial" }
+] }
+EOF
+  cat > "$DEVLOG" <<'EOF'
+bug-on-dev: fix landed out-of-band on dev (#1676)
+fix(reality-web): unrelated conventional-commit subject
+dispatcher notes bug-second-round: loose mention must NOT match (space before colon)
 EOF
 }
 
 run() {
   ACTION_LIST="$AL" ACTION_ARCHIVE="$ALA" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" \
+  COVERAGE_FILE="$COV" DEV_LOG_FILE="$DEVLOG" \
   RETRY_NOW="$NOW" bash "$SCRIPT" "$@"
 }
 
@@ -85,6 +107,10 @@ grep -q "bug-landed"       <<<"$OUT" && bad "landed stem must not re-mint" || ok
 grep -q "bug-exhausted"    <<<"$OUT" && bad "exhausted retry budget must stop" || ok "retry cap (2 rounds) enforced"
 grep -q "active-stem-task" <<<"$OUT" && bad "active assignment stem must block" || ok "active-stem excluded"
 grep -q "live-stem-task"   <<<"$OUT" && bad "live action-list stem must block (T24)" || ok "live action-list stem excluded"
+grep -q "bug-cov-done"     <<<"$OUT" && bad "coverage-done story must not re-mint (#2153)" || ok "coverage-done stem excluded"
+grep -q "bug-on-dev"       <<<"$OUT" && bad "anchored dev-log subject must block (#2153)" || ok "dev-log subject-prefix excluded"
+grep -q "bug-second-round-retry2" <<<"$OUT" && ok "loose (non-anchored) dev-log mention does NOT exclude" || bad "non-anchored mention wrongly excluded bug-second-round"
+grep -q "bug-retryable-retry1"    <<<"$OUT" && ok "coverage status=partial does NOT exclude" || bad "coverage partial wrongly excluded bug-retryable"
 [ "$(jq '.items | length' "$AL")" = "2" ] && ok "dry-run leaves file untouched" || bad "dry-run mutated action-list"
 
 echo "T2 apply: row shape + metadata inheritance + append-only"
@@ -108,13 +134,13 @@ grep -q "nothing to re-mint" <<<"$OUT" && ok "second run no-op (minted ids now l
 
 echo "T4 per-run cap"
 seed
-OUT=$(RETRY_REMINT_CAP=1 ACTION_LIST="$AL" ACTION_ARCHIVE="$ALA" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" RETRY_NOW="$NOW" bash "$SCRIPT" --apply)
+OUT=$(RETRY_REMINT_CAP=1 ACTION_LIST="$AL" ACTION_ARCHIVE="$ALA" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" COVERAGE_FILE="$COV" DEV_LOG_FILE="$DEVLOG" RETRY_NOW="$NOW" bash "$SCRIPT" --apply)
 grep -q "re-minting 1 of 2" <<<"$OUT" && ok "cap=1 mints exactly 1" || bad "cap not enforced: $OUT"
 grep -q "bug-second-round-retry2" <<<"$OUT" && ok "oldest failure wins under cap" || bad "deterministic order broken"
 
 echo "T5 ceil headroom"
 seed
-OUT=$(BUFFER_CEIL=1 ACTION_LIST="$AL" ACTION_ARCHIVE="$ALA" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" RETRY_NOW="$NOW" bash "$SCRIPT" --apply)
+OUT=$(BUFFER_CEIL=1 ACTION_LIST="$AL" ACTION_ARCHIVE="$ALA" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" COVERAGE_FILE="$COV" DEV_LOG_FILE="$DEVLOG" RETRY_NOW="$NOW" bash "$SCRIPT" --apply)
 grep -q "no headroom" <<<"$OUT" && ok "ceil blocks minting" || bad "ceil not enforced: $OUT"
 
 echo "T6 missing files no-op"
@@ -123,6 +149,16 @@ OUT=$(ACTION_LIST="$TMP/nope.json" bash "$SCRIPT" 2>&1); [ $? -eq 0 ] \
 seed
 OUT=$(ACTION_LIST="$AL" ASSIGN="$TMP/no1.json" ASSIGN_ARCHIVE="$TMP/no2.json" bash "$SCRIPT" 2>&1)
 grep -q "no failures to retry" <<<"$OUT" && ok "missing assignments exits clean" || bad "missing assignments: $OUT"
+
+echo "T7 dev-truth guards degrade gracefully when inputs are missing (#2153)"
+seed
+OUT=$(ACTION_LIST="$AL" ACTION_ARCHIVE="$ALA" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" \
+      COVERAGE_FILE="$TMP/no-cov.json" DEV_LOG_FILE="$TMP/no-devlog.txt" \
+      RETRY_NOW="$NOW" bash "$SCRIPT" 2>&1); RC=$?
+[ "$RC" -eq 0 ] && ok "missing coverage + dev-log exits 0" || bad "missing guard inputs errored (rc=$RC): $OUT"
+grep -q "bug-retryable-retry1" <<<"$OUT" && ok "still mints without guard inputs" || bad "no-guard-input run minted nothing: $OUT"
+grep -q "bug-cov-done-retry1"  <<<"$OUT" && ok "coverage guard inert when file missing" || bad "coverage guard fired without file"
+grep -q "bug-on-dev-retry1"    <<<"$OUT" && ok "dev-log guard inert when file missing" || bad "dev-log guard fired without file"
 
 echo
 [ "$FAIL" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
Closes #2153

## Task
Tier-1c `retry-remint.sh` decided "landed work" only from the assignment ledger (merged/done rows), so fixes that landed on dev out-of-band (different PR, coverage flip) were re-minted as ghost `-retryN` rows — each claimed ghost burned a claim slot plus a full synchronous implementer spawn to produce nothing (observed: 2 reality-web `code-review-*` retries whose fixes had merged via #1676 etc., plus `10b-2-feature-flag-management-retry1` for a story coverage already marked done).

## Change
Two cheap dev-truth guards added to the candidate filter in `.research/retry-remint.sh`:

- **(a) coverage-done** — exclude stems whose story id has `status="done"` in `.research/management/coverage.json`. `COVERAGE_FILE` injectable; missing/unparseable file degrades gracefully to no exclusion.
- **(b) dev-log subject join** — exclude stems matched by an **anchored** `<id>:` commit-subject prefix on `origin/dev` (prefix up to the first colon, no spaces), mirroring `dev-reconcile.sh`'s join convention — never a loose body grep, so a `chore(research)` commit merely mentioning an id can't false-positive. `DEV_LOG_FILE` injectable for tests; default `git log origin/dev --format=%s -300`; unreachable remote degrades to no exclusion.

Also:
- `.research/test-retry-remint.sh`: new fixtures for both exclusions, negative cases (non-anchored mention must NOT exclude; coverage `partial` must NOT exclude), and a new **T7** graceful-degradation test (missing coverage + dev-log inputs → guards inert, script still mints). Existing T1–T6 unchanged and passing.
- `.research/dispatcher-prompt.md`: Tier-1c paragraph documents the new guards.
- `dispatcher-self-test.yml` path filter: already covers `retry-remint.sh`, `test-retry-remint.sh`, and `dispatcher-prompt.md` — no change needed.

## Owner
pm-devops

## Tested (Band A — fast check)
- `bash .research/test-retry-remint.sh` → ALL PASS (T1–T7, exit 0)
- `bash .research/dispatcher-self-test.sh` → PASS (exit 0)

## Built (Band B — full build)
- `bash .research/test-backlog-refill.sh` → PASS
- `bash .research/test-backlog-reconcile.sh` → PASS
- `bash .research/test-issue-ingest.sh` → PASS
- `bash .research/test-mcp-push-size-guard.sh` → PASS
- `bash .claude/skills/ppt-implement/scripts/test-scope-check.sh` → PASS
- `GOAL_CHECK_ENFORCE=1 ./.research/goal-check.sh` → exit 0 (GC3 buffer-bounds record-only FAIL pre-exists on dev, unrelated)

## CI parity (Band C — hot-path only)
Ran the full `dispatcher-self-test.yml` job command set locally (all steps above) — the only workflow triggered by these paths. All green.

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-devops` exits 2 for `.research/dispatcher-prompt.md`, `.research/retry-remint.sh`, `.research/test-retry-remint.sh` — owner-areas.json doesn't map `.research/**` to pm-devops. Drift is nominal: these are exactly the dispatcher-mechanism files the task targets.

## Code-reuse review
`reuse-grep.sh` — no warnings.

## Notes
- goal-check.sh IG1/IG2 are N/A for dispatcher-minted gh-issue tasks (no `.research/plans/<slug>.md`; branch name pre-assigned by the dispatcher). IG3 skipped: the regression coverage is the extended smoke test itself (fixtures fail against the pre-guard script).
- Guard (a) matches the coverage story id after applying the same `stem()` normalization used everywhere else in the script; guard (b) stems the extracted subject prefix, so a landing commit titled `<stem>-v2: …` also blocks the stem.