### PR TITLE
gh-issue-2170: OrganizationsPage — reuse DestructiveConfirmDialog with audit reason

### DIFF
--- a/frontend/apps/admin-web/src/components/AuditReasonPrompt.tsx
+++ b/frontend/apps/admin-web/src/components/AuditReasonPrompt.tsx
@@ -28,7 +28,9 @@ export type AuditReasonAction =
   | 'force_update_floor_bump'
   | 'maintenance_mode_on'
   | 'feature_flag_toggle'
-  | 'oauth_scope_grant';
+  | 'oauth_scope_grant'
+  | 'agency_suspend'
+  | 'agency_reactivate';
 
 export interface AuditReasonPromptProps {
   action: AuditReasonAction;
@@ -100,6 +102,18 @@ const ACTION_META: Record<AuditReasonAction, ActionMeta> = {
     defaultMinLength: 20,
     helper:
       'Explain why the OAuth scope list for this client is being changed. Include the business justification and which scopes are being added or removed.',
+    risk: 'amber',
+  },
+  agency_suspend: {
+    defaultMinLength: 20,
+    helper:
+      'Explain why this organization is being suspended. All member sessions are revoked immediately; this reason is stored in the audit log and shown on the organization record.',
+    risk: 'red',
+  },
+  agency_reactivate: {
+    defaultMinLength: 20,
+    helper:
+      'Optionally note why this organization is being reactivated (e.g. invoices settled, dispute resolved). Stored in the audit log.',
     risk: 'amber',
   },
 };

--- a/frontend/apps/admin-web/src/components/DestructiveConfirmDialog.tsx
+++ b/frontend/apps/admin-web/src/components/DestructiveConfirmDialog.tsx
@@ -25,6 +25,7 @@ import { createPortal } from 'react-dom';
 import {
   type AuditReasonAction,
   AuditReasonPrompt,
+  auditReasonMinLength,
   useAuditReasonValid,
 } from './AuditReasonPrompt';
 
@@ -40,7 +41,17 @@ export interface DestructiveConfirmDialogProps {
   confirmLabel?: string;
   delayMs?: number;
   reasonAction?: AuditReasonAction;
-  onConfirm: () => Promise<void>;
+  /**
+   * When false (and `reasonAction` is set), an empty reason is accepted —
+   * but a non-empty reason must still pass audit-reason validation.
+   * Defaults to true (reason required).
+   */
+  reasonRequired?: boolean;
+  /**
+   * Called with the audit reason (trimmed; empty string when no
+   * `reasonAction` is configured or an optional reason was left blank).
+   */
+  onConfirm: (reason: string) => Promise<void>;
   onCancel: () => void;
 }
 
@@ -221,6 +232,7 @@ export function DestructiveConfirmDialog({
   confirmLabel = 'Type the name to confirm',
   delayMs,
   reasonAction,
+  reasonRequired = true,
   onConfirm,
   onCancel,
 }: DestructiveConfirmDialogProps) {
@@ -235,9 +247,12 @@ export function DestructiveConfirmDialog({
   const titleId = useId();
   const delayTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const reasonIsValid = useAuditReasonValid(reason, 20); // min 20 for any action
+  const reasonMinLength = reasonAction ? auditReasonMinLength(reasonAction) : 20;
+  const reasonIsValid = useAuditReasonValid(reason, reasonMinLength);
   const typedMatches = typed === confirmText;
-  const reasonSatisfied = reasonAction ? reasonIsValid : true;
+  const reasonSatisfied = reasonAction
+    ? reasonIsValid || (!reasonRequired && reason.trim() === '')
+    : true;
 
   // Start delay countdown when typed matches (and delay configured)
   useEffect(() => {
@@ -312,11 +327,11 @@ export function DestructiveConfirmDialog({
     if (isPending) return;
     setIsPending(true);
     try {
-      await onConfirm();
+      await onConfirm(reason.trim());
     } finally {
       setIsPending(false);
     }
-  }, [isPending, onConfirm]);
+  }, [isPending, onConfirm, reason]);
 
   const delayInProgress = delayMs !== undefined && delayMs > 0 && delayRemainingMs > 0;
   const confirmDisabled = !typedMatches || !reasonSatisfied || delayInProgress || isPending;
@@ -349,7 +364,12 @@ export function DestructiveConfirmDialog({
         <div className="ppt-dcd-body">{body}</div>
 
         {reasonAction && (
-          <AuditReasonPrompt action={reasonAction} value={reason} onChange={setReason} required />
+          <AuditReasonPrompt
+            action={reasonAction}
+            value={reason}
+            onChange={setReason}
+            required={reasonRequired}
+          />
         )}
 
         <div className="ppt-dcd-input-group">

--- a/frontend/apps/admin-web/src/pages/OrganizationsPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/OrganizationsPage.test.tsx
@@ -7,9 +7,11 @@
  *  3. Organization rows + platform stats cards render from responses.
  *  4. Empty state renders when the platform has no organizations.
  *  5. Suspend/Reactivate buttons hidden without `agencies_suspend`.
- *  6. Suspend flow: confirmation dialog requires a reason, POSTs it.
- *  7. Reactivate flow: confirmation dialog POSTs to /reactivate.
+ *  6. Suspend flow (shared DestructiveConfirmDialog): requires typing the org
+ *     name + a valid audit reason (min 20 chars), POSTs the reason.
+ *  7. Reactivate flow: name confirmation, note optional, POSTs to /reactivate.
  *  8. Details dialog fetches and renders the org detail (incl. suspension).
+ *  9. Stats endpoint is not called without `audit_read` (capability gate).
  */
 
 import { CapabilityProvider } from '@ppt/admin-ui';
@@ -212,7 +214,7 @@ describe('OrganizationsPage', () => {
     expect(screen.getAllByText('Details').length).toBe(2);
   });
 
-  it('suspend flow requires a reason and POSTs it to /suspend', async () => {
+  it('suspend flow requires name confirmation + a valid audit reason and POSTs it to /suspend', async () => {
     const postSpy = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -239,18 +241,26 @@ describe('OrganizationsPage', () => {
     const user = userEvent.setup();
     await user.click(screen.getByText('Suspend'));
 
-    // Confirmation dialog opens
-    const dialog = await screen.findByRole('dialog', { name: /suspend organization/i });
+    // Shared DestructiveConfirmDialog opens, labelled by its title
+    // (i18n isn't initialized in tests, so {{name}} stays uninterpolated)
+    const dialog = await screen.findByRole('dialog', { name: /suspend/i });
     expect(dialog).toBeDefined();
 
-    // Confirm button disabled until a reason is typed
-    const confirmBtn = screen.getByRole('button', { name: 'Suspend organization' });
+    // Confirm disabled until org name typed AND audit reason is valid
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
     expect((confirmBtn as HTMLButtonElement).disabled).toBe(true);
 
-    await user.type(
-      screen.getByPlaceholderText('e.g. Unpaid invoices'),
-      'Terms of service violation'
-    );
+    // Type the org name — still disabled: audit reason missing
+    await user.type(screen.getByLabelText('Type "Acme Property" to confirm'), 'Acme Property');
+    expect((confirmBtn as HTMLButtonElement).disabled).toBe(true);
+
+    // A too-short reason (< 20 chars) is rejected
+    const reasonBox = screen.getByLabelText('Audit reason');
+    await user.type(reasonBox, 'x');
+    expect((confirmBtn as HTMLButtonElement).disabled).toBe(true);
+
+    await user.clear(reasonBox);
+    await user.type(reasonBox, 'Terms of service violation');
     expect((confirmBtn as HTMLButtonElement).disabled).toBe(false);
     await user.click(confirmBtn);
 
@@ -260,9 +270,12 @@ describe('OrganizationsPage', () => {
     expect(JSON.parse(calledOpts.body as string)).toEqual({
       reason: 'Terms of service violation',
     });
+
+    // Dialog closes on success
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /suspend/i })).toBeNull());
   });
 
-  it('reactivate flow POSTs to /reactivate for a suspended org', async () => {
+  it('reactivate flow confirms by name (note optional) and POSTs to /reactivate', async () => {
     const postSpy = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -289,12 +302,19 @@ describe('OrganizationsPage', () => {
     const user = userEvent.setup();
     await user.click(screen.getByText('Reactivate'));
 
-    await screen.findByRole('dialog', { name: /reactivate organization/i });
-    await user.click(screen.getByRole('button', { name: 'Reactivate organization' }));
+    await screen.findByRole('dialog', { name: /reactivate/i });
+
+    // Note is optional — confirm enables as soon as the org name is typed
+    const confirmBtn = screen.getByRole('button', { name: 'Confirm' });
+    expect((confirmBtn as HTMLButtonElement).disabled).toBe(true);
+    await user.type(screen.getByLabelText('Type "Shady Homes" to confirm'), 'Shady Homes');
+    expect((confirmBtn as HTMLButtonElement).disabled).toBe(false);
+    await user.click(confirmBtn);
 
     await waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
-    const calledUrl: string = postSpy.mock.calls[0][0] as string;
+    const [calledUrl, calledOpts] = postSpy.mock.calls[0] as [string, RequestInit];
     expect(calledUrl).toContain(`/platform-admin/organizations/${ORG_SUSPENDED.id}/reactivate`);
+    expect(JSON.parse(calledOpts.body as string)).toEqual({ note: null });
   });
 
   it('details dialog fetches and renders the org detail with suspension info', async () => {
@@ -324,5 +344,19 @@ describe('OrganizationsPage', () => {
     expect(screen.getByText(/Unpaid invoices/)).toBeDefined();
     // metrics: members "5 (4 active)"
     expect(screen.getByText('5 (4 active)')).toBeDefined();
+  });
+
+  it('does not call /stats without audit_read capability', async () => {
+    mockListAndStats();
+    renderPage({ capabilities: ['agencies_read'] });
+    await waitFor(() => expect(screen.getByText('Acme Property')).toBeDefined());
+
+    // No stats cards…
+    expect(screen.queryByText('Active orgs')).toBeNull();
+    // …and, more importantly, no request was ever fired at /stats
+    const statsCalls = vi
+      .mocked(fetch)
+      .mock.calls.filter(([input]) => input.toString().includes('/platform-admin/stats'));
+    expect(statsCalls.length).toBe(0);
   });
 });

--- a/frontend/apps/admin-web/src/pages/OrganizationsPage.tsx
+++ b/frontend/apps/admin-web/src/pages/OrganizationsPage.tsx
@@ -24,6 +24,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { DestructiveConfirmDialog } from '../components/DestructiveConfirmDialog';
 import { useToast } from '../components/Toast';
 
 const PAGE_SIZE = 20;
@@ -158,208 +159,6 @@ const buttonSecondary: React.CSSProperties = {
   fontWeight: 500,
 };
 
-function buttonPrimary(disabled: boolean, danger = false): React.CSSProperties {
-  return {
-    padding: '7px 14px',
-    borderRadius: 8,
-    border: 'none',
-    background: danger ? 'var(--ppt-danger-600, #dc2626)' : 'var(--ppt-brand-600, #2563eb)',
-    color: '#fff',
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    fontSize: 13,
-    fontWeight: 500,
-    opacity: disabled ? 0.5 : 1,
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Suspend confirmation dialog
-// ---------------------------------------------------------------------------
-
-interface SuspendDialogProps {
-  org: AdminOrganizationSummary;
-  onClose: () => void;
-}
-
-function SuspendDialog({ org, onClose }: SuspendDialogProps) {
-  const { t } = useTranslation();
-  const { showToast } = useToast();
-  const [reason, setReason] = useState('');
-  const suspend = useSuspendOrganization();
-
-  const handleConfirm = () => {
-    const trimmed = reason.trim();
-    if (!trimmed) return;
-    suspend.mutate(
-      { id: org.id, data: { reason: trimmed } },
-      {
-        onSuccess: (result) => {
-          showToast({
-            type: 'success',
-            title: t('admin.organizations.suspend.successTitle', 'Organization suspended'),
-            message: result.message,
-          });
-          onClose();
-        },
-        onError: () => {
-          showToast({
-            type: 'error',
-            title: t('admin.organizations.suspend.failedTitle', 'Suspend failed'),
-            message: t(
-              'admin.organizations.suspend.failedMessage',
-              'Could not suspend the organization.'
-            ),
-          });
-        },
-      }
-    );
-  };
-
-  return (
-    <ModalShell label={t('admin.organizations.suspend.dialogLabel', 'Suspend organization')}>
-      <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>
-        {t('admin.organizations.suspend.title', 'Suspend {{name}}?', { name: org.name })}
-      </h2>
-      <p style={{ margin: 0, fontSize: 13, color: 'var(--ppt-fg-secondary, #374151)' }}>
-        {t(
-          'admin.organizations.suspend.warning',
-          'All members of this organization will be logged out immediately and will not be able to sign in until the organization is reactivated.'
-        )}
-      </p>
-      <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
-        {t('admin.organizations.suspend.reasonLabel', 'Reason (required, kept for audit)')}
-        <textarea
-          value={reason}
-          onChange={(e) => setReason(e.target.value)}
-          rows={3}
-          placeholder={t('admin.organizations.suspend.reasonPlaceholder', 'e.g. Unpaid invoices')}
-          style={{
-            padding: '6px 10px',
-            borderRadius: 6,
-            border: '1px solid var(--ppt-border-default, #e5e7eb)',
-            fontSize: 13,
-            fontFamily: 'inherit',
-            resize: 'vertical',
-          }}
-        />
-      </label>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={suspend.isPending}
-          style={buttonSecondary}
-        >
-          {t('admin.common.cancel', 'Cancel')}
-        </button>
-        <button
-          type="button"
-          onClick={handleConfirm}
-          disabled={suspend.isPending || !reason.trim()}
-          style={buttonPrimary(suspend.isPending || !reason.trim(), true)}
-        >
-          {suspend.isPending
-            ? t('admin.organizations.suspend.pending', 'Suspending…')
-            : t('admin.organizations.suspend.confirm', 'Suspend organization')}
-        </button>
-      </div>
-    </ModalShell>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Reactivate confirmation dialog
-// ---------------------------------------------------------------------------
-
-interface ReactivateDialogProps {
-  org: AdminOrganizationSummary;
-  onClose: () => void;
-}
-
-function ReactivateDialog({ org, onClose }: ReactivateDialogProps) {
-  const { t } = useTranslation();
-  const { showToast } = useToast();
-  const [note, setNote] = useState('');
-  const reactivate = useReactivateOrganization();
-
-  const handleConfirm = () => {
-    const trimmed = note.trim();
-    reactivate.mutate(
-      { id: org.id, data: { note: trimmed ? trimmed : null } },
-      {
-        onSuccess: (result) => {
-          showToast({
-            type: 'success',
-            title: t('admin.organizations.reactivate.successTitle', 'Organization reactivated'),
-            message: result.message,
-          });
-          onClose();
-        },
-        onError: () => {
-          showToast({
-            type: 'error',
-            title: t('admin.organizations.reactivate.failedTitle', 'Reactivate failed'),
-            message: t(
-              'admin.organizations.reactivate.failedMessage',
-              'Could not reactivate the organization.'
-            ),
-          });
-        },
-      }
-    );
-  };
-
-  return (
-    <ModalShell label={t('admin.organizations.reactivate.dialogLabel', 'Reactivate organization')}>
-      <h2 style={{ margin: 0, fontSize: 16, fontWeight: 600 }}>
-        {t('admin.organizations.reactivate.title', 'Reactivate {{name}}?', { name: org.name })}
-      </h2>
-      <p style={{ margin: 0, fontSize: 13, color: 'var(--ppt-fg-secondary, #374151)' }}>
-        {t(
-          'admin.organizations.reactivate.info',
-          'Members of this organization will be able to sign in again.'
-        )}
-      </p>
-      <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 13 }}>
-        {t('admin.organizations.reactivate.noteLabel', 'Note (optional)')}
-        <textarea
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-          rows={2}
-          style={{
-            padding: '6px 10px',
-            borderRadius: 6,
-            border: '1px solid var(--ppt-border-default, #e5e7eb)',
-            fontSize: 13,
-            fontFamily: 'inherit',
-            resize: 'vertical',
-          }}
-        />
-      </label>
-      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10 }}>
-        <button
-          type="button"
-          onClick={onClose}
-          disabled={reactivate.isPending}
-          style={buttonSecondary}
-        >
-          {t('admin.common.cancel', 'Cancel')}
-        </button>
-        <button
-          type="button"
-          onClick={handleConfirm}
-          disabled={reactivate.isPending}
-          style={buttonPrimary(reactivate.isPending)}
-        >
-          {reactivate.isPending
-            ? t('admin.organizations.reactivate.pending', 'Reactivating…')
-            : t('admin.organizations.reactivate.confirm', 'Reactivate organization')}
-        </button>
-      </div>
-    </ModalShell>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Detail drill-in dialog
 // ---------------------------------------------------------------------------
@@ -483,6 +282,7 @@ function DetailDialog({ orgId, onClose }: DetailDialogProps) {
 
 const OrganizationsPage: React.FC = () => {
   const { t } = useTranslation();
+  const { showToast } = useToast();
   const canSuspend = useCapability('agencies_suspend');
   const canReadStats = useCapability('audit_read');
 
@@ -501,7 +301,58 @@ const OrganizationsPage: React.FC = () => {
     status: statusFilter || undefined,
     search: search || undefined,
   });
-  const statsQuery = usePlatformStats();
+  // /stats requires audit_read server-side — skip the guaranteed-403 otherwise.
+  const statsQuery = usePlatformStats({ enabled: canReadStats });
+
+  const suspend = useSuspendOrganization();
+  const reactivate = useReactivateOrganization();
+
+  const handleSuspendConfirm = async (reason: string) => {
+    if (!suspendTarget) return;
+    try {
+      const result = await suspend.mutateAsync({ id: suspendTarget.id, data: { reason } });
+      showToast({
+        type: 'success',
+        title: t('admin.organizations.suspend.successTitle', 'Organization suspended'),
+        message: result.message,
+      });
+      setSuspendTarget(null);
+    } catch {
+      showToast({
+        type: 'error',
+        title: t('admin.organizations.suspend.failedTitle', 'Suspend failed'),
+        message: t(
+          'admin.organizations.suspend.failedMessage',
+          'Could not suspend the organization.'
+        ),
+      });
+    }
+  };
+
+  const handleReactivateConfirm = async (note: string) => {
+    if (!reactivateTarget) return;
+    try {
+      const result = await reactivate.mutateAsync({
+        id: reactivateTarget.id,
+        data: { note: note ? note : null },
+      });
+      showToast({
+        type: 'success',
+        title: t('admin.organizations.reactivate.successTitle', 'Organization reactivated'),
+        message: result.message,
+      });
+      setReactivateTarget(null);
+    } catch {
+      showToast({
+        type: 'error',
+        title: t('admin.organizations.reactivate.failedTitle', 'Reactivate failed'),
+        message: t(
+          'admin.organizations.reactivate.failedMessage',
+          'Could not reactivate the organization.'
+        ),
+      });
+    }
+  };
 
   const orgs = listQuery.data?.organizations ?? [];
   const total = listQuery.data?.total ?? 0;
@@ -795,12 +646,37 @@ const OrganizationsPage: React.FC = () => {
       )}
 
       {/* Dialogs */}
-      {suspendTarget && (
-        <SuspendDialog org={suspendTarget} onClose={() => setSuspendTarget(null)} />
-      )}
-      {reactivateTarget && (
-        <ReactivateDialog org={reactivateTarget} onClose={() => setReactivateTarget(null)} />
-      )}
+      <DestructiveConfirmDialog
+        open={suspendTarget !== null}
+        title={t('admin.organizations.suspend.title', 'Suspend {{name}}?', {
+          name: suspendTarget?.name ?? '',
+        })}
+        body={t(
+          'admin.organizations.suspend.warning',
+          'All members of this organization will be logged out immediately and will not be able to sign in until the organization is reactivated.'
+        )}
+        confirmText={suspendTarget?.name ?? ''}
+        confirmLabel={t('admin.organizations.suspend.confirmLabel', 'Type the name to confirm')}
+        reasonAction="agency_suspend"
+        onConfirm={handleSuspendConfirm}
+        onCancel={() => setSuspendTarget(null)}
+      />
+      <DestructiveConfirmDialog
+        open={reactivateTarget !== null}
+        title={t('admin.organizations.reactivate.title', 'Reactivate {{name}}?', {
+          name: reactivateTarget?.name ?? '',
+        })}
+        body={t(
+          'admin.organizations.reactivate.info',
+          'Members of this organization will be able to sign in again.'
+        )}
+        confirmText={reactivateTarget?.name ?? ''}
+        confirmLabel={t('admin.organizations.reactivate.confirmLabel', 'Type the name to confirm')}
+        reasonAction="agency_reactivate"
+        reasonRequired={false}
+        onConfirm={handleReactivateConfirm}
+        onCancel={() => setReactivateTarget(null)}
+      />
       {detailId && <DetailDialog orgId={detailId} onClose={() => setDetailId(null)} />}
     </section>
   );

--- a/frontend/packages/api-client/src/admin/hooks.ts
+++ b/frontend/packages/api-client/src/admin/hooks.ts
@@ -331,12 +331,17 @@ export function useReactivateOrganization() {
 
 /**
  * Platform-wide statistics from `GET /api/v1/platform-admin/stats`.
+ *
+ * The endpoint requires the `audit_read` capability server-side — pass
+ * `{ enabled: canReadStats }` to avoid a guaranteed-403 round-trip when the
+ * operator lacks it (mirrors the `enabled: !!id` pattern in `useOrganization`).
  */
-export function usePlatformStats() {
+export function usePlatformStats(options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: adminKeys.platformStats(),
     queryFn: ({ signal }) => fetchPlatformStats(signal),
     staleTime: 30_000,
+    enabled: options?.enabled ?? true,
   });
 }
 


### PR DESCRIPTION
Closes #2170

## Task
admin-web OrganizationsPage (PR #2164): reuse DestructiveConfirmDialog (audit-reason input) instead of the bespoke confirm dialogs.

## Owner
pm-frontend

## Changes
- **Finding 1:** replaced the hand-rolled `ModalShell` + `SuspendDialog`/`ReactivateDialog` with the shared `DestructiveConfirmDialog` (portal, focus trap, ESC-to-close, backdrop dismiss, type-the-name confirmation, embedded `AuditReasonPrompt`).
  - Added `agency_suspend` (red, min 20 chars) and `agency_reactivate` (amber, optional note) to `AuditReasonAction`/`ACTION_META`.
  - `DestructiveConfirmDialog` now passes the trimmed audit reason to `onConfirm(reason)` (backward compatible — existing callers ignore the arg), gains a `reasonRequired={false}` mode for optional-note flows, and uses `auditReasonMinLength(action)` instead of a hardcoded 20.
  - Permission gating (`agencies_suspend`) and existing i18n keys kept; the suspend `reason` / reactivate `note` are wired through to the existing API calls (`SuspendOrganizationRequest.reason`, `ReactivateOrganizationRequest.note`).
- **Finding 2:** `usePlatformStats` (`packages/api-client/src/admin/hooks.ts`) accepts `{ enabled }`; page calls `usePlatformStats({ enabled: canReadStats })` — no more guaranteed-403 `/stats` round-trip without `audit_read`.

## Tested (Band A — fast check)
- `pnpm check` (Biome, workspace) — exit 0 (one pre-existing schema-version info)
- `pnpm typecheck` (workspace incl. admin-web + api-client) — exit 0
- `vitest run src/pages/OrganizationsPage.test.tsx src/components/DestructiveConfirmDialog.test.tsx src/components/AuditReasonPrompt.test.tsx` — 59/59 passed
- `pnpm -F @ppt/api-client test` — 105/105 passed

## Built (Band B — full build)
skipped: net −51 LOC refactor reusing an existing component; no build-config/public-surface change beyond an optional hook param.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (admin UI dialog refactor).

## Remote-tested
skipped

## Notes
- The reactivate dialog now also requires typing the org name (per the issue's proposal `confirmText={org.name}`); its note stays optional (`reasonRequired={false}`) but a non-empty note must pass audit-reason validation.
- Pre-existing unrelated admin-web test failures are documented in PR #2164; the three affected test files above are fully green.