### PR TITLE
gap-screens-normalize-epic-frontmatter: normalize screen-map epic frontmatter to canonical Epic-N

### DIFF
--- a/docs/screens/ppt/ai-dashboards.md
+++ b/docs/screens/ppt/ai-dashboards.md
@@ -19,7 +19,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "13"
+  - Epic-13
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/ai-predictive-maintenance.md
+++ b/docs/screens/ppt/ai-predictive-maintenance.md
@@ -21,7 +21,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "13"
+  - Epic-13
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/ai-sentiment.md
+++ b/docs/screens/ppt/ai-sentiment.md
@@ -21,7 +21,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "13"
+  - Epic-13
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/document-templates.md
+++ b/docs/screens/ppt/document-templates.md
@@ -20,7 +20,7 @@ sharedComponents:
 diagrams: []
 useCases: []
 epics:
-  - 7B
+  - Epic-7B
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/financial-reports.md
+++ b/docs/screens/ppt/financial-reports.md
@@ -18,7 +18,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "Epic 11 / Story 11.7 — Financial statement reports"
+  - Epic-11-7
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/iot-dashboard.md
+++ b/docs/screens/ppt/iot-dashboard.md
@@ -15,7 +15,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "14"
+  - Epic-14
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/iot-sensors.md
+++ b/docs/screens/ppt/iot-sensors.md
@@ -18,7 +18,7 @@ sharedComponents:
 diagrams: []
 useCases: []
 epics:
-  - "14"
+  - Epic-14
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/iot-thresholds.md
+++ b/docs/screens/ppt/iot-thresholds.md
@@ -21,7 +21,7 @@ sharedComponents:
 diagrams: []
 useCases: []
 epics:
-  - "14"
+  - Epic-14
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/iot.md
+++ b/docs/screens/ppt/iot.md
@@ -20,7 +20,7 @@ sharedComponents:
 diagrams: []
 useCases: []
 epics:
-  - "14"
+  - Epic-14
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/message-thread.md
+++ b/docs/screens/ppt/message-thread.md
@@ -20,7 +20,7 @@ useCases:
   - UC-07
   - UC-05.9
 epics:
-  - "6-5"
+  - Epic-6-5
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/messages-new.md
+++ b/docs/screens/ppt/messages-new.md
@@ -19,7 +19,7 @@ diagrams: []
 useCases:
   - UC-07
 epics:
-  - "6-5"
+  - Epic-6-5
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/messages.md
+++ b/docs/screens/ppt/messages.md
@@ -17,7 +17,7 @@ diagrams: []
 useCases:
   - UC-07
 epics:
-  - "6-5"
+  - Epic-6-5
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/my-unit.md
+++ b/docs/screens/ppt/my-unit.md
@@ -18,7 +18,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "3"
+  - Epic-3
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/person-months.md
+++ b/docs/screens/ppt/person-months.md
@@ -17,7 +17,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "Epic 3 / Story 3.5"
+  - Epic-3-5
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/reality-mobile/account.md
+++ b/docs/screens/reality-mobile/account.md
@@ -23,7 +23,7 @@ diagrams: []
 useCases:
   - UC-47
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/agencies.md
+++ b/docs/screens/reality-mobile/agencies.md
@@ -26,7 +26,7 @@ diagrams: []
 useCases:
   - UC-51
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/auth-login.md
+++ b/docs/screens/reality-mobile/auth-login.md
@@ -22,7 +22,7 @@ diagrams: []
 useCases:
   - UC-47
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/compare-listings.md
+++ b/docs/screens/reality-mobile/compare-listings.md
@@ -25,7 +25,7 @@ diagrams: []
 useCases:
   - UC-46
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/env-config.md
+++ b/docs/screens/reality-mobile/env-config.md
@@ -26,7 +26,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "85"
+  - Epic-85
 designSources: []
 owner: reality-frontend
 lastReview: 2026-06-28

--- a/docs/screens/reality-mobile/favorites.md
+++ b/docs/screens/reality-mobile/favorites.md
@@ -26,7 +26,7 @@ diagrams: []
 useCases:
   - UC-44
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/home.md
+++ b/docs/screens/reality-mobile/home.md
@@ -36,7 +36,7 @@ useCases:
   - UC-31
   - UC-44
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/inquiries.md
+++ b/docs/screens/reality-mobile/inquiries.md
@@ -26,7 +26,7 @@ diagrams: []
 useCases:
   - UC-46
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/listing-detail.md
+++ b/docs/screens/reality-mobile/listing-detail.md
@@ -34,7 +34,7 @@ useCases:
   - UC-44
   - UC-46
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/navigation.md
+++ b/docs/screens/reality-mobile/navigation.md
@@ -22,7 +22,7 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/project-setup.md
+++ b/docs/screens/reality-mobile/project-setup.md
@@ -22,8 +22,8 @@ sharedComponents: []
 diagrams: []
 useCases: []
 epics:
-  - "82"
-  - "85"
+  - Epic-82
+  - Epic-85
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/realtors.md
+++ b/docs/screens/reality-mobile/realtors.md
@@ -23,7 +23,7 @@ diagrams: []
 useCases:
   - UC-49
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/saved-searches.md
+++ b/docs/screens/reality-mobile/saved-searches.md
@@ -26,7 +26,7 @@ diagrams: []
 useCases:
   - UC-45
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---

--- a/docs/screens/reality-mobile/search.md
+++ b/docs/screens/reality-mobile/search.md
@@ -38,7 +38,7 @@ useCases:
   - UC-31
   - UC-45
 epics:
-  - "82"
+  - Epic-82
 designSources: []
 owner: reality-frontend
 ---


### PR DESCRIPTION
## Task
Normalize screen-map epic frontmatter across docs/screens/** (Epic-N vs epic-N / epic-7a casing/format drift): ~31 stories are unmapped and ~30 screens read as orphans because of inconsistent epic frontmatter keys. Normalize the frontmatter to the canonical form, then run `/screens validate` to confirm clean. This is a docs/screens change (frontend/docs owner).

## Owner
pm-frontend

## What changed
Normalized inconsistent `epics:` frontmatter list values across `docs/screens/**` to the canonical `Epic-{N}` citation form — the form used by `docs/superpowers/plans/epic-82-story-mapping.md` and produced by `extractEpics()` in `frontend/packages/screen-map/src/extract-known.ts`.

28 files, 29 list-item edits. Transformations applied (frontmatter `epics:` items only — screen bodies untouched):

| Was | Now |
|---|---|
| `"82"`, `"85"`, `"14"`, `"13"`, `"3"` (bare numerics) | `Epic-82`, `Epic-85`, `Epic-14`, `Epic-13`, `Epic-3` |
| `"6-5"` (bare story ref) | `Epic-6-5` |
| `7B` (unquoted alnum) | `Epic-7B` |
| `"Epic 11 / Story 11.7 — Financial statement reports"` (prose) | `Epic-11-7` |
| `"Epic 3 / Story 3.5"` (prose) | `Epic-3-5` |

Already-canonical entries (`Epic-8A`, `Epic-10B-6`, `Epic-39`, `Epic-9-1`, …) were left unchanged.

## Tested (Band A — fast check)
`pnpm --filter @ppt/screen-map cli validate --root <repo> --strict`
→ `Validated 162 screen-maps: 0 errors, 0 warnings.` (exit 0)

## Built (Band B — full build)
skipped: docs-only change (no code, no public API/config touch)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs/screens frontmatter only, no security/auth/billing/data-integrity change)

## Scope drift
None. `scope-check.sh --owner pm-frontend` exit 0 — `docs/screens/**` is inside pm-frontend's owner area.

## Code-reuse review
n/a — no new helpers (docs-only).

## Notes
- `/screens validate` checks frontmatter schema / sitemap IDs / endpoints / related-screen IDs — it treats `epics` as free-form `string[]`, so it was already green; the value here is consistency for the `/screens update` drift scanner and human readability, matching the canonical `Epic-{N}` convention.
- `docs/epics/` does not currently exist in the tree, so `extractEpics()` returns an empty known-set today; normalizing to `Epic-{N}` aligns these entries with that extractor's output for when the epic docs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sxZE9fYzGSdKVCBcYHuFc

---
_Generated by [Claude Code](https://claude.ai/code/session_016sxZE9fYzGSdKVCBcYHuFc)_