### PR TITLE
gap-81-1-create-new-schedule-endpoint-still-stubbed: implement real create-schedule handler

### DIFF
--- a/backend/crates/db/src/models/report_schedule.rs
+++ b/backend/crates/db/src/models/report_schedule.rs
@@ -65,6 +65,27 @@ pub struct ReportSchedule {
     pub cron_expression: Option<String>,
 }
 
+/// Input for creating a new report schedule (gap-81-1).
+///
+/// Carries only the fields a caller supplies; `organization_id` is derived from
+/// the authenticated tenant (never from the request body) and all other columns
+/// (`id`, `status`, `is_active`, timestamps, `cron_expression`) take their DB
+/// defaults. `recipients` is exposed as `Vec<String>` here and serialised to a
+/// JSONB array by the repository.
+#[derive(Debug, Clone)]
+pub struct NewReportSchedule {
+    pub organization_id: Uuid,
+    pub report_id: Uuid,
+    pub name: String,
+    pub frequency: String,
+    pub day_of_week: Option<i32>,
+    pub day_of_month: Option<i32>,
+    pub time: String,
+    pub timezone: String,
+    pub format: String,
+    pub recipients: Vec<String>,
+}
+
 /// Raw DB row for `report_schedules`.
 ///
 /// `recipients` is stored as JSONB so we use `serde_json::Value` for

--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -7,7 +7,8 @@
 
 use crate::models::report_schedule::{
     report_execution_status, report_schedule_status, ExecutionDownloadUrl, ExecutionHistoryQuery,
-    ExecutionHistoryResponse, NewReportSchedule, ReportExecution, ReportSchedule, ReportScheduleRow,
+    ExecutionHistoryResponse, NewReportSchedule, ReportExecution, ReportSchedule,
+    ReportScheduleRow,
 };
 use crate::DbPool;
 use chrono::{Duration, Utc};

--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -7,7 +7,7 @@
 
 use crate::models::report_schedule::{
     report_execution_status, report_schedule_status, ExecutionDownloadUrl, ExecutionHistoryQuery,
-    ExecutionHistoryResponse, ReportExecution, ReportSchedule, ReportScheduleRow,
+    ExecutionHistoryResponse, NewReportSchedule, ReportExecution, ReportSchedule, ReportScheduleRow,
 };
 use crate::DbPool;
 use chrono::{Duration, Utc};
@@ -166,6 +166,64 @@ impl ReportScheduleRepository {
             AppError::Database(e.to_string())
         })?
         .ok_or_else(|| AppError::NotFound(format!("Report schedule {} not found", id)))?;
+
+        Ok(ReportSchedule::from(row))
+    }
+
+    /// Create (persist) a new report schedule (gap-81-1).
+    ///
+    /// Inserts a row into `report_schedules` and returns the persisted record.
+    /// The new schedule starts `is_active = true` / `status = 'active'` and has
+    /// no `cron_expression` (callers use the legacy `time`/`frequency` fields at
+    /// creation time and may later switch to a cron expression via
+    /// `update_schedule`).
+    ///
+    /// # Cross-tenant safety
+    ///
+    /// `organization_id` comes from `input.organization_id`, which the handler
+    /// derives from the authenticated tenant (`RlsConnection::tenant_id()`) —
+    /// never from the request body — so a caller cannot create a schedule inside
+    /// another organisation.
+    pub async fn create(&self, input: NewReportSchedule) -> Result<ReportSchedule, AppError> {
+        // Serialise the recipients Vec<String> into a JSON array for JSONB storage.
+        let recipients_json = serde_json::Value::Array(
+            input
+                .recipients
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        );
+
+        let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "INSERT INTO report_schedules \
+             (report_id, organization_id, name, frequency, day_of_week, day_of_month, \
+              time, timezone, format, recipients, is_active, status) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true, $11) \
+             RETURNING ",
+            report_schedule_columns!()
+        ))
+        .bind(input.report_id)
+        .bind(input.organization_id)
+        .bind(input.name)
+        .bind(input.frequency)
+        .bind(input.day_of_week)
+        .bind(input.day_of_month)
+        .bind(input.time)
+        .bind(input.timezone)
+        .bind(input.format)
+        .bind(recipients_json)
+        .bind(report_schedule_status::ACTIVE)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                org_id = %input.organization_id,
+                report_id = %input.report_id,
+                "Failed to create report schedule"
+            );
+            AppError::Database(e.to_string())
+        })?;
 
         Ok(ReportSchedule::from(row))
     }

--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -210,6 +210,8 @@ pub fn router() -> Router<AppState> {
         // Story 55.5: Export Reports (Story 84.1: Background job implementation)
         .route("/export", axum::routing::post(export_report))
         .route("/export/{job_id}/status", get(get_export_job_status))
+        // gap-81-1: Create a new report schedule
+        .route("/schedules", axum::routing::post(create_schedule))
         // gap-81-1: Update schedule (cron expression, recipients, enabled flag)
         .route("/schedules/{id}", axum::routing::put(update_schedule))
         // Epic 81: Story 81.1 — Schedule pause/resume
@@ -1874,6 +1876,250 @@ pub async fn retry_execution(
 }
 
 // ============================================================================
+// gap-81-1: Create report schedule
+// ============================================================================
+
+/// Allowed schedule frequencies (matches the `report_schedules.frequency`
+/// CHECK constraint in migration 00162).
+const VALID_SCHEDULE_FREQUENCIES: &[&str] = &["daily", "weekly", "monthly"];
+
+/// Allowed export formats for a schedule.
+const VALID_SCHEDULE_FORMATS: &[&str] = &["pdf", "excel", "csv"];
+
+/// Default delivery time (HH:MM) when the caller omits `time`.
+const DEFAULT_SCHEDULE_TIME: &str = "08:00";
+
+/// Validate an `HH:MM` 24-hour time-of-day string.
+fn validate_time_hhmm(s: &str) -> bool {
+    let Some((h, m)) = s.split_once(':') else {
+        return false;
+    };
+    // Reject empty components and non-numeric input; enforce 24h/60m bounds.
+    match (h.parse::<u32>(), m.parse::<u32>()) {
+        (Ok(hour), Ok(minute)) => !h.is_empty() && !m.is_empty() && hour <= 23 && minute <= 59,
+        _ => false,
+    }
+}
+
+/// Request body for `POST /api/v1/reports/schedules`.
+///
+/// `organization_id` is intentionally absent — it is derived from the
+/// authenticated tenant so a caller cannot create a schedule in another org.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateScheduleRequest {
+    /// Report definition this schedule generates.
+    pub report_id: Uuid,
+    /// Human-readable schedule name.
+    pub name: String,
+    /// Delivery cadence: `daily`, `weekly`, or `monthly`.
+    pub frequency: String,
+    /// Day of week (0=Sunday … 6=Saturday). Required when `frequency = weekly`.
+    pub day_of_week: Option<i32>,
+    /// Day of month (1–31). Required when `frequency = monthly`.
+    pub day_of_month: Option<i32>,
+    /// Delivery time of day in `HH:MM` (24h). Defaults to `08:00`.
+    pub time: Option<String>,
+    /// IANA timezone for the delivery time. Defaults to `UTC`.
+    pub timezone: Option<String>,
+    /// Export format: `pdf`, `excel`, or `csv`. Defaults to `pdf`.
+    pub format: Option<String>,
+    /// Recipient email addresses (max 50).
+    #[serde(default)]
+    pub recipients: Vec<String>,
+}
+
+/// Create a new report schedule (gap-81-1).
+///
+/// Persists a new `report_schedules` row for the authenticated tenant and
+/// returns it with `201 Created`. Replaces the previous stub which never
+/// persisted the schedule.
+///
+/// # Security
+///
+/// Uses `RlsConnection` so the caller's role and tenant are re-verified against
+/// the database (not JWT claims). Manager role or above is required, and the
+/// new schedule's `organization_id` is taken from `rls.tenant_id()` — never the
+/// request body — preventing cross-tenant creation.
+#[utoipa::path(
+    post,
+    path = "/api/v1/reports/schedules",
+    tag = "reports",
+    request_body = CreateScheduleRequest,
+    responses(
+        (status = 201, description = "Schedule created", body = ReportSchedule),
+        (status = 400, description = "Validation error", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 403, description = "Forbidden - manager role required", body = ErrorResponse),
+    )
+)]
+pub async fn create_schedule(
+    State(state): State<AppState>,
+    mut rls: RlsConnection,
+    Json(req): Json<CreateScheduleRequest>,
+) -> Result<(StatusCode, Json<ReportSchedule>), (StatusCode, Json<ErrorResponse>)> {
+    // RBAC: only manager-tier roles may create report schedules. Role is derived
+    // from the DB-backed `RlsConnection`, NOT from JWT claims.
+    if !rls.role().is_manager() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role or above required to create report schedules",
+            )),
+        ));
+    }
+    // Tenant for the new schedule comes from the authenticated context.
+    let caller_org_id = rls.tenant_id();
+    rls.release().await;
+
+    // --- Validation --------------------------------------------------------
+    let name = req.name.trim();
+    if name.is_empty() {
+        return Err(bad_request("EMPTY_NAME", "Schedule name must not be empty"));
+    }
+
+    let frequency = req.frequency.to_lowercase();
+    if !VALID_SCHEDULE_FREQUENCIES.contains(&frequency.as_str()) {
+        return Err(bad_request(
+            "INVALID_FREQUENCY",
+            "frequency must be one of: daily, weekly, monthly",
+        ));
+    }
+
+    // Weekly schedules need a day-of-week; monthly schedules need a day-of-month.
+    match frequency.as_str() {
+        "weekly" => match req.day_of_week {
+            Some(d) if (0..=6).contains(&d) => {}
+            _ => {
+                return Err(bad_request(
+                    "INVALID_DAY_OF_WEEK",
+                    "weekly schedules require day_of_week in 0..=6 (0=Sunday)",
+                ))
+            }
+        },
+        "monthly" => match req.day_of_month {
+            Some(d) if (1..=31).contains(&d) => {}
+            _ => {
+                return Err(bad_request(
+                    "INVALID_DAY_OF_MONTH",
+                    "monthly schedules require day_of_month in 1..=31",
+                ))
+            }
+        },
+        _ => {}
+    }
+    // Range-check any provided day fields even when not required by frequency.
+    if let Some(d) = req.day_of_week {
+        if !(0..=6).contains(&d) {
+            return Err(bad_request(
+                "INVALID_DAY_OF_WEEK",
+                "day_of_week must be in 0..=6 (0=Sunday)",
+            ));
+        }
+    }
+    if let Some(d) = req.day_of_month {
+        if !(1..=31).contains(&d) {
+            return Err(bad_request(
+                "INVALID_DAY_OF_MONTH",
+                "day_of_month must be in 1..=31",
+            ));
+        }
+    }
+
+    let time = req
+        .time
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .unwrap_or(DEFAULT_SCHEDULE_TIME)
+        .to_string();
+    if !validate_time_hhmm(&time) {
+        return Err(bad_request(
+            "INVALID_TIME",
+            "time must be a 24-hour HH:MM value (e.g. \"08:30\")",
+        ));
+    }
+
+    let format = req
+        .format
+        .as_deref()
+        .map(str::to_lowercase)
+        .unwrap_or_else(|| "pdf".to_string());
+    if !VALID_SCHEDULE_FORMATS.contains(&format.as_str()) {
+        return Err(bad_request(
+            "INVALID_FORMAT",
+            "format must be one of: pdf, excel, csv",
+        ));
+    }
+
+    if req.recipients.len() > 50 {
+        return Err(bad_request(
+            "TOO_MANY_RECIPIENTS",
+            "A schedule may have at most 50 recipients",
+        ));
+    }
+    for email in &req.recipients {
+        if !crate::services::auth::AuthService::validate_email(email) {
+            return Err(bad_request(
+                "INVALID_RECIPIENT_EMAIL",
+                format!("Invalid recipient email address: {email}"),
+            ));
+        }
+    }
+
+    let timezone = req
+        .timezone
+        .as_deref()
+        .map(str::trim)
+        .filter(|t| !t.is_empty())
+        .unwrap_or("UTC")
+        .to_string();
+
+    // --- Persist -----------------------------------------------------------
+    let schedule = state
+        .report_schedule_repo
+        .create(db::models::report_schedule::NewReportSchedule {
+            organization_id: caller_org_id,
+            report_id: req.report_id,
+            name: name.to_string(),
+            frequency,
+            day_of_week: req.day_of_week,
+            day_of_month: req.day_of_month,
+            time,
+            timezone,
+            format,
+            recipients: req.recipients,
+        })
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                org_id = %caller_org_id,
+                report_id = %req.report_id,
+                "Failed to create report schedule"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Failed to create schedule")),
+            )
+        })?;
+
+    Ok((StatusCode::CREATED, Json(schedule)))
+}
+
+/// Small helper to build a `400 Bad Request` error tuple.
+fn bad_request(
+    code: &'static str,
+    message: impl Into<String>,
+) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::new(code, message.into())),
+    )
+}
+
+// ============================================================================
 // gap-81-1: Update report schedule (cron_expression, recipients, enabled)
 // ============================================================================
 
@@ -2072,7 +2318,25 @@ pub async fn update_schedule(
 
 #[cfg(test)]
 mod tests {
-    use super::validate_cron_expression;
+    use super::{validate_cron_expression, validate_time_hhmm};
+
+    // --- validate_time_hhmm (gap-81-1: create schedule) ---
+
+    #[test]
+    fn time_valid_values() {
+        for t in ["00:00", "08:00", "08:30", "23:59", "9:05", "0:0"] {
+            assert!(validate_time_hhmm(t), "{t:?} should be a valid HH:MM time");
+        }
+    }
+
+    #[test]
+    fn time_invalid_values() {
+        for t in [
+            "", ":", "24:00", "08:60", "08", "08:", ":30", "aa:bb", "-1:00", "12:-5", "8:0:0",
+        ] {
+            assert!(!validate_time_hhmm(t), "{t:?} should be rejected");
+        }
+    }
 
     // --- valid expressions ---
 

--- a/backend/servers/api-server/tests/report_schedule_create_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_create_tests.rs
@@ -1,0 +1,200 @@
+//! End-to-end tests for `POST /api/v1/reports/schedules` (gap-81-1).
+//!
+//! The create-schedule endpoint was previously stubbed and never persisted a
+//! row. These tests pin the real behaviour against a live Postgres:
+//!
+//!   1. a same-org Manager creating a valid schedule gets `201 Created`, a body
+//!      that echoes the submitted fields, and a persisted `report_schedules`
+//!      row scoped to *their* org (never the request body's choosing);
+//!   2. a non-manager (resident) is rejected with `403 Forbidden` and no row is
+//!      written;
+//!   3. an invalid `frequency` is rejected with `400 Bad Request`.
+//!
+//! # TestApp wiring note
+//!
+//! `TestApp` does not layer `host_tenant_middleware`, so the tenant is resolved
+//! purely from the `X-Tenant-ID` header. `ValidatedTenantExtractor` still
+//! validates membership against `organization_members`, which the fixtures seed.
+
+#![allow(dead_code)]
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, seed_membership, seed_org, TestApp, TestUser};
+
+/// Look up the user id created by `create_authenticated_user`.
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("fetch user id")
+}
+
+/// Count schedules owned by an org.
+async fn count_schedules(pool: &PgPool, org_id: Uuid) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM report_schedules WHERE organization_id = $1",
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("count schedules")
+}
+
+/// Build an authenticated `POST /api/v1/reports/schedules` request.
+fn post_schedule_req(access_token: &str, org_id: Uuid, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri("/api/v1/reports/schedules")
+        .header(header::AUTHORIZATION, format!("Bearer {}", access_token))
+        .header("X-Tenant-ID", org_id.to_string())
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body.to_string()))
+        .expect("build request")
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — a same-org Manager creates a schedule that is persisted
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn manager_creates_schedule_persists(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "sched-create").await;
+
+    let manager = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &manager).await;
+    let manager_user_id = user_id_for(&pool, &manager.email).await;
+    seed_membership(&pool, org, manager_user_id, "manager").await;
+
+    assert_eq!(count_schedules(&pool, org).await, 0, "pre: no schedules yet");
+
+    let report_id = Uuid::new_v4();
+    let response = app
+        .execute(post_schedule_req(
+            &access_token,
+            org,
+            serde_json::json!({
+                "report_id": report_id,
+                "name": "Weekly occupancy",
+                "frequency": "weekly",
+                "day_of_week": 1,
+                "time": "08:30",
+                "format": "pdf",
+                "recipients": ["ops@example.test"]
+            }),
+        ))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::CREATED,
+        "manager create must return 201, got {} body={}",
+        response.status,
+        response.text()
+    );
+
+    let body: serde_json::Value = response.json_value();
+    assert_eq!(
+        body.get("organization_id").and_then(|v| v.as_str()),
+        Some(org.to_string().as_str()),
+        "org must be derived from the authenticated tenant, body={body}"
+    );
+    assert_eq!(body.get("name").and_then(|v| v.as_str()), Some("Weekly occupancy"));
+    assert_eq!(body.get("frequency").and_then(|v| v.as_str()), Some("weekly"));
+    assert_eq!(body.get("is_active").and_then(|v| v.as_bool()), Some(true));
+    assert_eq!(body.get("status").and_then(|v| v.as_str()), Some("active"));
+
+    // Persisted exactly once for the caller's org.
+    assert_eq!(
+        count_schedules(&pool, org).await,
+        1,
+        "schedule must be persisted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — a non-manager is forbidden and nothing is written
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn non_manager_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "sched-create-403").await;
+
+    let resident = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &resident).await;
+    let resident_user_id = user_id_for(&pool, &resident.email).await;
+    seed_membership(&pool, org, resident_user_id, "resident").await;
+
+    let response = app
+        .execute(post_schedule_req(
+            &access_token,
+            org,
+            serde_json::json!({
+                "report_id": Uuid::new_v4(),
+                "name": "Should be blocked",
+                "frequency": "daily",
+                "recipients": []
+            }),
+        ))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "resident must be forbidden, got {} body={}",
+        response.status,
+        response.text()
+    );
+    assert_eq!(
+        count_schedules(&pool, org).await,
+        0,
+        "no schedule may be written on a forbidden request"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — an invalid frequency is rejected with 400
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn invalid_frequency_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let org = seed_org(&pool, "sched-create-400").await;
+
+    let manager = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &manager).await;
+    let manager_user_id = user_id_for(&pool, &manager.email).await;
+    seed_membership(&pool, org, manager_user_id, "manager").await;
+
+    let response = app
+        .execute(post_schedule_req(
+            &access_token,
+            org,
+            serde_json::json!({
+                "report_id": Uuid::new_v4(),
+                "name": "Bad frequency",
+                "frequency": "fortnightly",
+                "recipients": []
+            }),
+        ))
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::BAD_REQUEST,
+        "invalid frequency must be 400, got {} body={}",
+        response.status,
+        response.text()
+    );
+    assert_eq!(count_schedules(&pool, org).await, 0, "no row on validation failure");
+}

--- a/backend/servers/api-server/tests/report_schedule_create_tests.rs
+++ b/backend/servers/api-server/tests/report_schedule_create_tests.rs
@@ -40,13 +40,11 @@ async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
 
 /// Count schedules owned by an org.
 async fn count_schedules(pool: &PgPool, org_id: Uuid) -> i64 {
-    sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM report_schedules WHERE organization_id = $1",
-    )
-    .bind(org_id)
-    .fetch_one(pool)
-    .await
-    .expect("count schedules")
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM report_schedules WHERE organization_id = $1")
+        .bind(org_id)
+        .fetch_one(pool)
+        .await
+        .expect("count schedules")
 }
 
 /// Build an authenticated `POST /api/v1/reports/schedules` request.
@@ -75,7 +73,11 @@ async fn manager_creates_schedule_persists(pool: PgPool) {
     let manager_user_id = user_id_for(&pool, &manager.email).await;
     seed_membership(&pool, org, manager_user_id, "manager").await;
 
-    assert_eq!(count_schedules(&pool, org).await, 0, "pre: no schedules yet");
+    assert_eq!(
+        count_schedules(&pool, org).await,
+        0,
+        "pre: no schedules yet"
+    );
 
     let report_id = Uuid::new_v4();
     let response = app
@@ -108,8 +110,14 @@ async fn manager_creates_schedule_persists(pool: PgPool) {
         Some(org.to_string().as_str()),
         "org must be derived from the authenticated tenant, body={body}"
     );
-    assert_eq!(body.get("name").and_then(|v| v.as_str()), Some("Weekly occupancy"));
-    assert_eq!(body.get("frequency").and_then(|v| v.as_str()), Some("weekly"));
+    assert_eq!(
+        body.get("name").and_then(|v| v.as_str()),
+        Some("Weekly occupancy")
+    );
+    assert_eq!(
+        body.get("frequency").and_then(|v| v.as_str()),
+        Some("weekly")
+    );
     assert_eq!(body.get("is_active").and_then(|v| v.as_bool()), Some(true));
     assert_eq!(body.get("status").and_then(|v| v.as_str()), Some("active"));
 
@@ -196,5 +204,9 @@ async fn invalid_frequency_rejected(pool: PgPool) {
         response.status,
         response.text()
     );
-    assert_eq!(count_schedules(&pool, org).await, 0, "no row on validation failure");
+    assert_eq!(
+        count_schedules(&pool, org).await,
+        0,
+        "no row on validation failure"
+    );
 }


### PR DESCRIPTION
## Task
The "create new schedule" endpoint for Report Schedule Editing (epic 81-1) is still stubbed out in the backend api-server. Implement the real handler (persist the schedule) replacing the stub. This is a Rust backend change under backend/servers/api-server.

## Owner
pm-backend

## What changed
The frontend `@ppt/api-client` already calls `POST /api/v1/reports/schedules` with a `CreateReportSchedule` body, but the backend had **no route mounted** for it — creation never persisted. This PR wires the real handler end-to-end:

- **`db` crate** — new `NewReportSchedule` input model + `ReportScheduleRepository::create()` which `INSERT`s into `report_schedules` and returns the row via the shared canonical column projection (`report_schedule_columns!`). New schedules start `is_active = true` / `status = 'active'`, no `cron_expression`.
- **`api-server`** — new `create_schedule` handler mounted at `POST /schedules`:
  - Manager-tier RBAC via `RlsConnection::role()` (DB-derived, not JWT claims).
  - `organization_id` is taken from `rls.tenant_id()` — **never** the request body — preventing cross-tenant creation, matching the existing pause/resume/update handlers.
  - Validation: non-empty name; `frequency ∈ {daily,weekly,monthly}` (matches the migration CHECK); weekly requires `day_of_week ∈ 0..=6`, monthly requires `day_of_month ∈ 1..=31`; `time` HH:MM (default `08:00`); `format ∈ {pdf,excel,csv}` (default `pdf`); `timezone` default `UTC`; ≤50 recipients, each a valid email.
  - Returns `201 Created`.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p db` → exit 0
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib routes::reports` → exit 0 (31 passed, incl. new `validate_time_hhmm` valid/invalid cases)

> Verify env note: the `utoipa-swagger-ui` build script cannot download the Swagger UI archive through the agent proxy, so `SWAGGER_UI_DOWNLOAD_URL` was pointed at a local build-time stub zip (not committed).

## Built (Band B — full build)
- `SQLX_OFFLINE=true cargo clippy -p api-server -- -D warnings` → exit 0
- `cargo test -p api-server --test report_schedule_create_tests --no-run` → exit 0 (compiles)

## CI parity (Band C — hot-path only)
This touches auth/RBAC + tenant-scoping, so the hot-path DB-backed regression tests were authored in `report_schedule_create_tests.rs`:
- `manager_creates_schedule_persists` — 201 + persisted row scoped to caller's org
- `non_manager_forbidden` — resident → 403, no row written
- `invalid_frequency_rejected` — 400, no row written

**These `#[sqlx::test]` tests are deferred to CI** — this environment has no local Postgres/Docker, so they compile here but run green only under the CI Postgres service.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- No migration change — reuses the `report_schedules` schema from `00162` + `00166`.
- The repository `create()` uses the pool directly with the org supplied from the authenticated context, consistent with the established Epic 81 mutation pattern (`pause`/`resume`/`update_schedule`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sxZE9fYzGSdKVCBcYHuFc

---
_Generated by [Claude Code](https://claude.ai/code/session_016sxZE9fYzGSdKVCBcYHuFc)_