### PR TITLE
code-review-mobile-native-kmp-listing-detail-path-inject: url-encode listingId in ListingRepository.getListingDetail

### DIFF
--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
@@ -21,6 +21,13 @@ class ListingRepository(
         sessionToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
     }
 
+    /**
+     * Percent-encode a value before splicing it into a request path so that ids containing `/`,
+     * `?`, `#`, or `..` cannot smuggle extra path segments or query parameters into the request
+     * (path-injection). Deep-link / nav-sourced ids are untrusted.
+     */
+    private fun pathSegment(value: String): String = value.encodeURLPathPart()
+
     /** Search listings with filters and pagination. */
     suspend fun searchListings(request: ListingSearchRequest): Result<ListingSearchResponse> {
         return try {
@@ -43,7 +50,8 @@ class ListingRepository(
     /** Get listing details by ID. */
     suspend fun getListingDetail(listingId: String): Result<ListingDetail> {
         return try {
-            val response = client.get("$baseUrl/api/v1/listings/$listingId") { configureRequest() }
+            val response =
+                client.get("$baseUrl/api/v1/listings/${pathSegment(listingId)}") { configureRequest() }
 
             if (response.status.isSuccess()) {
                 Result.success(response.body())

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
@@ -51,7 +51,9 @@ class ListingRepository(
     suspend fun getListingDetail(listingId: String): Result<ListingDetail> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/listings/${pathSegment(listingId)}") { configureRequest() }
+                client.get("$baseUrl/api/v1/listings/${pathSegment(listingId)}") {
+                    configureRequest()
+                }
 
             if (response.status.isSuccess()) {
                 Result.success(response.body())

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/listing/ListingDetailRepositoryTest.kt
@@ -166,4 +166,25 @@ class ListingDetailRepositoryTest {
         assertTrue(result.isFailure, "5xx should surface as failure, got $result")
         assertTrue(result.exceptionOrNull() is ListingException)
     }
+
+    /**
+     * Security (#87ed762c): the listingId is deep-link / nav-sourced and is spliced into the
+     * request path, so it must be percent-encoded — mirroring `ApiClient.getListing` /
+     * `pathSegment()` — so a hostile id cannot smuggle extra path segments or query parameters
+     * (path-injection). A `/`, `?`, `#`, or `..`-bearing id must NOT escape its segment.
+     */
+    @Test
+    fun getListingDetail_url_encodes_listing_id_path_segment() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.OK, fullDetailBody)
+
+        repo.getListingDetail("../admin/secret")
+
+        // The `/` characters must be percent-encoded; the path stays anchored under /listings/.
+        assertEquals(
+            "/api/v1/listings/..%2Fadmin%2Fsecret",
+            cap.path,
+            "listingId must be percent-encoded into a single path segment",
+        )
+    }
 }


### PR DESCRIPTION
## Task
security: `ListingRepository.getListingDetail` (mobile-native KMP, `ListingRepository.kt:46`) spliced `listingId` raw into the URL path with no `encodeURLPathPart()`, unlike `ApiClient.getListing` which hardens via `pathSegment()`. `listingId` is deep-link / nav-sourced, so `/`, `?`, `#`, `..` can smuggle extra path segments. Apply the SAME encoding hardening (mirror `ApiClient.getListing` / `pathSegment()`).

## Owner
pm-security

## Change
- `ListingRepository`: add a private `pathSegment(value) = value.encodeURLPathPart()` helper (identical doc + impl to `ApiClient.pathSegment`) and route `getListingDetail`'s path through it: `"$baseUrl/api/v1/listings/${pathSegment(listingId)}"`. `io.ktor.http.*` (source of `encodeURLPathPart`) was already imported — no new import needed.
- Regression test `getListingDetail_url_encodes_listing_id_path_segment` in `ListingDetailRepositoryTest`, mirroring the existing `FavoritesRepositoryTest.isFavorite_url_encodes_listing_id_path_segment` (#788): a `../admin/secret` id must stay anchored under `/api/v1/listings/` as a single percent-encoded segment (`..%2Fadmin%2Fsecret`). This fails on the pre-fix raw-splice code and passes after.

Diff: 2 files, +30/-1 — surgical, no scope drift.

## Tested (Band A — fast check)
`cd mobile-native && ./gradlew :shared:compileKotlinJvm` — **could not run in this environment.** The Gradle wrapper distribution (`gradle-9.6.1-bin.zip`) is blocked by the org egress proxy (HTTP 403 from services.gradle.org), and the system Gradle 8.14.3 offline cannot resolve the AGP 9.2.1 plugin artifacts. No Android SDK / emulator / ADB is available here either. **Deferred to CI (`mobile-native.yml`)**, matching how other env-limited mobile-native PRs in this repo defer the Gradle build.

Static verification performed instead:
- The change mirrors the already-shipped, already-tested `ApiClient.pathSegment()` / `ApiClient.getListing` pattern verbatim; `encodeURLPathPart()` resolves from `io.ktor.http.*`, which `ListingRepository.kt` already wildcard-imports.
- The new test reuses the existing `Captured` / `repoCapturing` MockEngine harness in the same file (only `assertEquals` + `cap.path`, both already in scope) and mirrors the passing `FavoritesRepositoryTest` assertion 1:1.

## Built (Band B — full build)
skipped: env-blocked (see Band A — Gradle wrapper egress-blocked). Deferred to `mobile-native.yml` CI.

## CI parity (Band C — hot-path only)
Security-relevant path-injection fix, but env-blocked from local CI replication (Gradle unavailable). `mobile-native.yml` (Gradle build + unit tests) will exercise `:shared` compile + the new commonTest on CI.

## Remote-tested
skipped (no ppt-bridge MCP; mobile-native build is not covered by the dev-stack bridge).

## Notes
- Path-injection hardening only; no behavior change for well-formed ids. `pathSegment` is a per-class private one-liner matching the codebase convention (`ApiClient` has its own; `FavoritesRepository` mirrors the same). No shared helper was extracted to keep the diff minimal and inside the pm-security / mobile-native owner area.
- Reviewer: please confirm CI green on `mobile-native.yml` before undrafting, since the Gradle build could not run locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JVKu8xHuepitxs4vKVQ37C)_