### PR TITLE
code-review-api-handlers-shares-revoke-doc-mismatch: guard share.document_id == path id in revoke_share

### DIFF
--- a/backend/servers/api-server/src/routes/documents/shares.rs
+++ b/backend/servers/api-server/src/routes/documents/shares.rs
@@ -344,12 +344,12 @@ async fn revoke_share(
     }
 
     // Check share exists
-    match state
+    let share = match state
         .document_repo
         .find_share_by_id_rls(&mut **rls.conn(), share_id)
         .await
     {
-        Ok(Some(_)) => {}
+        Ok(Some(s)) => s,
         Ok(None) => {
             return Err((
                 StatusCode::NOT_FOUND,
@@ -363,6 +363,20 @@ async fn revoke_share(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to find share")),
             ));
         }
+    };
+
+    // The share must belong to the document named in the path. Authorization
+    // above was checked against the path document `id`, but the share is looked
+    // up purely by `share_id`; RLS only scopes to the tenant. Without this
+    // guard a creator of document A could revoke a share of document B in the
+    // same tenant by passing A's id (to pass the creator check) plus B's
+    // share_id (IDOR). Return 404 to avoid leaking the existence of the
+    // cross-document share, mirroring the "Share not found" shape above.
+    if share.document_id != id {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Share not found")),
+        ));
     }
 
     match state

--- a/backend/servers/api-server/tests/documents_core_crud_tests.rs
+++ b/backend/servers/api-server/tests/documents_core_crud_tests.rs
@@ -23,7 +23,10 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{create_authenticated_user_with_org, TestApp, TestUser};
+use common::{
+    create_authenticated_user, create_authenticated_user_with_org, seed_membership, seed_org,
+    TestApp, TestUser,
+};
 
 // ---------------------------------------------------------------------------
 // Seed helpers
@@ -436,4 +439,62 @@ async fn revoke_share_succeeds(pool: PgPool) {
     .await
     .expect("check revoked_at");
     assert!(revoked, "share must have revoked_at set after revocation");
+}
+
+/// Regression (code-review-api-handlers-shares-revoke-doc-mismatch): a share
+/// may only be revoked through the document it actually belongs to.
+///
+/// `revoke_share` authorizes the caller against the *path* document `id`
+/// (creator-or-manager), but previously looked up and revoked the share purely
+/// by `share_id` with no check that the share belonged to that document. RLS on
+/// `document_shares` only scopes to the tenant, so a non-manager who created
+/// document A could revoke a share of a *different* creator's document B in the
+/// same org by passing A's id (to satisfy the creator check) plus B's share_id
+/// — a cross-document IDOR. The handler now guards `share.document_id == id`
+/// and returns 404 otherwise.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn revoke_share_rejects_cross_document_share(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Attacker: a NON-manager (resident) member of the org who owns document A.
+    // A resident is not a manager, so it must rely on the created_by branch of
+    // the authorization check — exactly the branch the IDOR abused.
+    let attacker = TestUser::new();
+    let (token, _refresh) = create_authenticated_user(&app, &attacker).await;
+    let attacker_id = user_id_for(&pool, &attacker.email).await;
+    let org_id = seed_org(&pool, "doc-share-revoke-idor").await;
+    seed_membership(&pool, org_id, attacker_id, "resident").await;
+    let doc_a = seed_document(&pool, org_id, attacker_id).await;
+
+    // Victim: a different creator's document B in the SAME org, carrying a share.
+    let victim = TestUser::new();
+    let (_vtoken, _vrefresh) = create_authenticated_user(&app, &victim).await;
+    let victim_id = user_id_for(&pool, &victim.email).await;
+    let doc_b = seed_document(&pool, org_id, victim_id).await;
+    let share_b = seed_document_share(&pool, doc_b, victim_id).await;
+
+    // Attacker passes document A's id (passes the creator check) but document
+    // B's share_id — the cross-document revoke must be rejected with 404.
+    let resp = app
+        .execute(
+            app.session(token, org_id)
+                .delete(&format!("/api/v1/documents/{doc_a}/shares/{share_b}"))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(resp.status, StatusCode::NOT_FOUND, "body: {}", resp.text());
+
+    // Document B's share must remain active (revoked_at still NULL).
+    let revoked: bool = sqlx::query_scalar::<_, bool>(
+        "SELECT revoked_at IS NOT NULL FROM document_shares WHERE id = $1",
+    )
+    .bind(share_b)
+    .fetch_one(&pool)
+    .await
+    .expect("check revoked_at");
+    assert!(
+        !revoked,
+        "cross-document revoke must NOT have revoked document B's share"
+    );
 }


### PR DESCRIPTION
## Task

`backend/servers/api-server/src/routes/documents/shares.rs` `revoke_share` checks authorization (created_by / is_manager) against the document from the path `id`, but then looks up + revokes the share purely by `share_id` (the `find_share_by_id_rls` result was discarded; `revoke_share_rls` is called on `share_id`) with NO check that `share.document_id == id`. RLS only scopes to tenant, so a non-manager who created any document A can pass A's id (passing the creator check) plus a `share_id` belonging to another creator's document B in the same tenant and revoke B's share (broken access control / IDOR).

**Fix:** add a `share.document_id == id` guard before revoking — return 404 (the handler's existing not-found shape) when the looked-up share's `document_id` does not equal the path `id`. Add a regression test proving the cross-document revoke is now rejected and that the legitimate same-document revoke still succeeds.

## Owner
pm-backend

## Change

- `routes/documents/shares.rs` — `revoke_share` now binds the share returned by `find_share_by_id_rls` (previously discarded as `Ok(Some(_)) => {}`) and returns `404 NOT_FOUND` ("Share not found") when `share.document_id != id`, before calling `revoke_share_rls`. 404 (not 403) mirrors the existing not-found shape and avoids leaking the existence of the cross-document share.
- `tests/documents_core_crud_tests.rs` — added `revoke_share_rejects_cross_document_share`: a non-manager (`resident`) creator of document A tries to revoke a share belonging to a *different* creator's document B in the same org, via A's path id + B's `share_id`. Asserts `404` and that B's share `revoked_at` stays NULL. The pre-existing `revoke_share_succeeds` continues to cover the legitimate same-document revoke.

## Tested (Band A — fast check)

```
cd backend && SQLX_OFFLINE=true cargo check -p api-server
# Finished dev profile ... exit 0

SQLX_OFFLINE=true cargo clippy -p api-server -- -D warnings
# Finished dev profile ... exit 0   (Band B — hot-path/security change)
```

`SWAGGER_UI_DOWNLOAD_URL` was pointed at a local stub zip because the `utoipa-swagger-ui` build script's download is blocked by the sandbox proxy; the stub is not committed.

## DB-backed tests
The new regression test and `revoke_share_succeeds` are `#[sqlx::test]` tests requiring a live Postgres. They compile in this environment but their DB-backed execution runs in CI (`backend.yml`). Not run locally here.

## CI parity (Band C)
Relevant CI job is `backend.yml` (`cargo fmt`, `clippy`, `cargo test`) — clippy replicated locally (exit 0); test execution deferred to CI (needs Postgres).

## Notes
Scope: only `routes/documents/shares.rs` + its test file (pm-backend). No public API / schema / migration change. Scope-drift check clean against origin/dev; code-reuse pre-flight clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kx3VfFczgetRLhj3ZJsy6

---
_Generated by [Claude Code](https://claude.ai/code/session_019kx3VfFczgetRLhj3ZJsy6)_