### PR TITLE
code-review-api-handlers-webhook-portal-signature-not-verified: verify HMAC signature on portal webhook receiver

### DIFF
--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -1030,7 +1030,42 @@ pub async fn booking_push_notification(
 
 // ==================== Inbound: Portal Webhook ====================
 
-/// Handle incoming portal webhook (public endpoint, no auth required).
+/// Verify the `X-Webhook-Signature` HMAC-SHA256 over a portal webhook's raw
+/// body.
+///
+/// The header value is the hex-encoded HMAC of the raw body under the shared
+/// `PORTAL_WEBHOOK_SECRET`, optionally `sha256=`-prefixed (matching the format
+/// this service emits for its own outbound webhook test deliveries — see
+/// [`test_webhook`]). A missing header, an empty secret, or a mismatching
+/// digest all yield `false`. The comparison is constant-time (delegated to
+/// [`integrations::verify_webhook_signature`]) so it cannot leak the expected
+/// signature through timing.
+fn verify_portal_webhook_signature(
+    secret: &str,
+    body: &str,
+    signature_header: Option<&str>,
+) -> bool {
+    if secret.is_empty() {
+        return false;
+    }
+    let Some(signature) = signature_header else {
+        return false;
+    };
+    let signature = signature.trim_start_matches("sha256=");
+    integrations::verify_webhook_signature(secret, body, signature)
+}
+
+/// Handle incoming portal webhook (public endpoint, no session auth).
+///
+/// The endpoint has no request principal — external portals POST here using the
+/// URL handed to them at connection time. Authenticity is instead established by
+/// verifying the `X-Webhook-Signature` HMAC-SHA256 over the raw body against the
+/// shared `PORTAL_WEBHOOK_SECRET` **before** the payload is parsed or acted on,
+/// exactly like the sibling Airbnb ([`handle_airbnb_webhook`]) and Stripe
+/// ([`handle_payment_webhook`]) receivers. The receiver fails closed: an unset
+/// secret is a `500 CONFIG_ERROR` and an invalid/absent signature is a
+/// `401 INVALID_SIGNATURE` — an unverified, attacker-forged payload is never
+/// processed.
 #[utoipa::path(
     post,
     path = "/api/v1/integrations/webhooks/portal/{connection_id}",
@@ -1045,7 +1080,7 @@ pub async fn booking_push_notification(
     tag = "Integrations - Portals"
 )]
 pub async fn handle_portal_webhook(
-    State(_state): State<AppState>,
+    State(state): State<AppState>,
     Path(path): Path<ConnectionIdPath>,
     headers: HeaderMap,
     body: String,
@@ -1055,6 +1090,39 @@ pub async fn handle_portal_webhook(
         "Received portal webhook"
     );
 
+    // Fail closed when the signing secret is not configured — never accept an
+    // unverified webhook.
+    let secret = state.portal_config.webhook_secret.as_str();
+    if secret.is_empty() {
+        tracing::error!("PORTAL_WEBHOOK_SECRET is not configured — refusing portal webhook");
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "CONFIG_ERROR",
+                "Portal webhook signature verification is not configured",
+            )),
+        ));
+    }
+
+    // Verify the HMAC signature over the raw body BEFORE parsing or acting.
+    let signature = headers
+        .get("X-Webhook-Signature")
+        .and_then(|v| v.to_str().ok());
+
+    if !verify_portal_webhook_signature(secret, &body, signature) {
+        tracing::warn!(
+            connection_id = %path.connection_id,
+            "Portal webhook signature verification failed"
+        );
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new(
+                "INVALID_SIGNATURE",
+                "Webhook signature verification failed",
+            )),
+        ));
+    }
+
     let _: serde_json::Value = serde_json::from_str(&body).map_err(|e| {
         tracing::warn!(error = %e, "Failed to parse webhook body");
         (
@@ -1062,11 +1130,6 @@ pub async fn handle_portal_webhook(
             Json(ErrorResponse::new("PARSE_ERROR", "Invalid JSON body")),
         )
     })?;
-
-    if let Some(signature) = headers.get("X-Webhook-Signature") {
-        let _sig = signature.to_str().unwrap_or_default();
-        tracing::debug!("Webhook signature present");
-    }
 
     Ok(StatusCode::OK)
 }
@@ -1758,5 +1821,83 @@ mod airbnb_webhook_tests {
         let later = RESERVATION_NO_ID.replace("00:00:00Z", "00:05:00Z");
         let c = super::airbnb_dedup_key(&parse(&later));
         assert_ne!(a, c);
+    }
+}
+
+// ==================== Portal webhook signature verification tests ====================
+//
+// Regression cover for the latent auth bypass: the connection-scoped portal
+// webhook receiver read `X-Webhook-Signature` but never verified it, so any
+// unauthenticated caller was accepted (200). These tests pin the fixed
+// contract of `verify_portal_webhook_signature` — the guard the handler now
+// runs before parsing/acting on the payload.
+#[cfg(test)]
+mod portal_webhook_signature_tests {
+    use super::verify_portal_webhook_signature;
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    const SECRET: &str = "portal_webhook_secret";
+    const BODY: &str = r#"{"event":"listing.viewed","external_id":"abc123"}"#;
+
+    fn sign(secret: &str, body: &str) -> String {
+        let mut mac =
+            HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+        mac.update(body.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    #[test]
+    fn accepts_valid_hex_signature() {
+        let sig = sign(SECRET, BODY);
+        assert!(verify_portal_webhook_signature(SECRET, BODY, Some(&sig)));
+    }
+
+    #[test]
+    fn accepts_valid_signature_with_sha256_prefix() {
+        let sig = format!("sha256={}", sign(SECRET, BODY));
+        assert!(verify_portal_webhook_signature(SECRET, BODY, Some(&sig)));
+    }
+
+    #[test]
+    fn rejects_missing_signature_header() {
+        // The pre-fix bug: no signature header was still accepted. Now rejected.
+        assert!(!verify_portal_webhook_signature(SECRET, BODY, None));
+    }
+
+    #[test]
+    fn rejects_wrong_signature() {
+        assert!(!verify_portal_webhook_signature(
+            SECRET,
+            BODY,
+            Some("deadbeef")
+        ));
+    }
+
+    #[test]
+    fn rejects_signature_for_tampered_body() {
+        let sig = sign(SECRET, BODY);
+        let tampered = r#"{"event":"listing.viewed","external_id":"evil999"}"#;
+        assert!(!verify_portal_webhook_signature(
+            SECRET,
+            tampered,
+            Some(&sig)
+        ));
+    }
+
+    #[test]
+    fn rejects_signature_under_wrong_secret() {
+        let sig = sign("attacker_secret", BODY);
+        assert!(!verify_portal_webhook_signature(SECRET, BODY, Some(&sig)));
+    }
+
+    #[test]
+    fn rejects_when_secret_empty() {
+        // Defense-in-depth: even a syntactically valid signature cannot pass
+        // when the server secret is unset (the handler also fails closed).
+        let sig = sign("", BODY);
+        assert!(!verify_portal_webhook_signature("", BODY, Some(&sig)));
     }
 }

--- a/backend/servers/api-server/src/state.rs
+++ b/backend/servers/api-server/src/state.rs
@@ -150,6 +150,35 @@ impl StripeAppConfig {
     }
 }
 
+/// Portal (real-estate listing-site) inbound-webhook configuration loaded once
+/// at startup. Mirrors [`AirbnbAppConfig`]/[`StripeAppConfig`]: the signing
+/// secret is read from the environment at boot, never accepted from a request
+/// body, and an empty `webhook_secret` fails closed at the handler so an
+/// unverified, attacker-forged payload is never processed.
+///
+/// Backs the connection-scoped receiver
+/// `POST /api/v1/integrations/webhooks/portal/{connection_id}` in
+/// `routes/integrations/webhook.rs`. (The per-portal
+/// `<PORTAL>_WEBHOOK_SECRET` receivers in `routes/portal_webhooks.rs` are a
+/// separate surface keyed by portal name.)
+#[derive(Debug, Clone, Default)]
+pub struct PortalAppConfig {
+    /// `PORTAL_WEBHOOK_SECRET` — HMAC-SHA256 signing secret for inbound portal
+    /// webhook signature verification (`X-Webhook-Signature` header). Required
+    /// to accept a portal webhook; empty ⇒ the receiver fails closed.
+    pub webhook_secret: String,
+}
+
+impl PortalAppConfig {
+    /// Load from the standard env var. An empty string is preserved so the
+    /// handler can fail closed on a missing secret.
+    pub fn from_env() -> Self {
+        Self {
+            webhook_secret: std::env::var("PORTAL_WEBHOOK_SECRET").unwrap_or_default(),
+        }
+    }
+}
+
 /// A single realtime preference-sync event captured by a
 /// [`PreferenceEventRecorder`] (issue #1376).
 ///
@@ -413,6 +442,11 @@ pub struct AppState {
     /// [BIT-181]). Handlers fail closed when `secret_key`/`webhook_secret`
     /// are empty.
     pub stripe_config: StripeAppConfig,
+    /// Portal inbound-webhook configuration loaded once at startup. The
+    /// connection-scoped portal webhook receiver fails closed when
+    /// `webhook_secret` is empty and verifies the `X-Webhook-Signature` HMAC
+    /// over the raw body before acting.
+    pub portal_config: PortalAppConfig,
 }
 
 impl AppState {
@@ -713,6 +747,10 @@ impl AppState {
             booking_config: BookingOAuthAppConfig::from_env(),
             // Story 11.5 (BIT-181): Stripe Checkout env vars cached at startup.
             stripe_config: StripeAppConfig::from_env(),
+            // Portal inbound-webhook signing secret cached at startup so the
+            // connection-scoped receiver can fail closed and verify signatures
+            // without a per-request env read.
+            portal_config: PortalAppConfig::from_env(),
         }
     }
 


### PR DESCRIPTION
## Task
security (latent auth bypass): `backend/servers/api-server/src/routes/integrations/webhook.rs` `handle_portal_webhook` (public no-auth endpoint `/api/v1/integrations/webhooks/portal/{connection_id}`, handed to external portals as callback at `install.rs:1673`) read `X-Webhook-Signature` but never verified it (`let _sig = signature.to_str()...; debug!("present")`) and returned 200. OpenAPI advertised a 401 invalid-signature response the code could never emit. Currently low-impact (handler only parses JSON, no state mutation) but a latent bypass the moment it acts on the payload. Verify HMAC over the raw body like the sibling Airbnb (`:1157`) / Stripe (`:1452`) handlers before acting.

## Fix
Mirrors the sibling Airbnb / Stripe inbound receivers exactly:
- New `PortalAppConfig` on `AppState`, loading `PORTAL_WEBHOOK_SECRET` once at startup (never read from the request), alongside `airbnb_config` / `stripe_config`.
- `handle_portal_webhook` now **fails closed**: unset secret ⇒ `500 CONFIG_ERROR` (matches the e-signature/Airbnb not-configured convention and the pre-existing OpenAPI `500`), and it verifies the `X-Webhook-Signature` HMAC-SHA256 over the raw body **before** parsing/acting — returning the now-reachable `401 INVALID_SIGNATURE` on an absent/invalid signature.
- Signature check is constant-time and **reuses the existing exported helper** `integrations::verify_webhook_signature` (the portal-domain HMAC verifier), via a small `verify_portal_webhook_signature` wrapper that also strips an optional `sha256=` prefix (matching this service's own outbound test-delivery format). No new crypto helper introduced.
- Consistent with the fail-closed contract established for the sibling per-portal receivers in `routes/portal_webhooks.rs` (#833).

## Owner
pm-security

## Scope drift
`scope-check.sh --owner pm-security` reported drift (exit 2) on:
- `backend/servers/api-server/src/routes/integrations/webhook.rs`
- `backend/servers/api-server/src/state.rs`

Expected and justified: `pm-security`'s mapped globs are auth/mfa/extractors/migrations, but this specific security finding lives in the integrations webhook route + `AppState`. The change is a pure security fix (signature verification); no auth/mfa/migration code was touched. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. The fix deliberately reuses `integrations::verify_webhook_signature` rather than adding a new HMAC helper.

## Tested (Band A — fast check)
```
SQLX_OFFLINE=true cargo check -p api-server        # exit 0
SQLX_OFFLINE=true cargo test  -p api-server --lib portal_webhook_signature   # exit 0 — 7 passed; 0 failed
```
New regression tests (`portal_webhook_signature_tests`) pin the fixed contract — the pre-fix bug was that a **missing** signature header was still accepted:
- `accepts_valid_hex_signature`, `accepts_valid_signature_with_sha256_prefix`
- `rejects_missing_signature_header`, `rejects_wrong_signature`, `rejects_signature_for_tampered_body`, `rejects_signature_under_wrong_secret`, `rejects_when_secret_empty`

## Built (Band B — full build)
```
cargo fmt -p api-server -- --check                 # exit 0
SQLX_OFFLINE=true cargo clippy -p api-server --all-targets -- -D warnings   # exit 0
```

## CI parity (Band C — hot-path only)
Hot-path (public webhook auth). Replicated the backend CI trio locally: `cargo fmt --check` (0), `clippy -D warnings` (0), `cargo check` (0), targeted `cargo test` (7 passed). No SQL changed, so `.sqlx` offline data is untouched. DB-backed `#[sqlx::test]` execution defers to CI.

Note: local `cargo` builds required a `file://` `SWAGGER_UI_DOWNLOAD_URL` workaround because `github.com` is egress-blocked in this environment (the `utoipa-swagger-ui` build script's release-zip download); this affects only the swagger static assets, never this change. CI has normal egress.

## Remote-tested
skipped

## Notes
- New env var `PORTAL_WEBHOOK_SECRET` must be provisioned in each environment for portal webhooks to be accepted (fail-closed until set). Consider adding it to `.env.example` / deployment secrets in a follow-up.
- Signature convention chosen: hex-encoded HMAC-SHA256 with optional `sha256=` prefix, matching the same file's outbound `test_webhook` format. (The `routes/portal_webhooks.rs` per-portal surface uses base64 — a separate, portal-name-keyed receiver.)
- `create_portal_connection` currently returns a non-persisted connection stub, so there is no per-connection secret to key on; a single shared secret mirrors the Airbnb/Stripe model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCWp7SpQoz6oU6DrR7t9AZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCWp7SpQoz6oU6DrR7t9AZ)_