### PR TITLE
gap-realtor-listings-analytics-endpoints: realtor my-listings LIST + per-listing analytics

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal/listings.rs
+++ b/backend/crates/db/src/repositories/reality_portal/listings.rs
@@ -124,6 +124,79 @@ impl RealityPortalRepository {
         .await
     }
 
+    /// List a portal user's own listings (Epic 15 — realtor "my listings").
+    ///
+    /// The `listings` table is `FORCE ROW LEVEL SECURITY` (migration 00110), so
+    /// unlike the sibling CRUD helpers — which use `SECURITY DEFINER` functions
+    /// to bypass RLS — this method establishes the **portal-owner** RLS context
+    /// (context 5 of `listings_five_context`, migration 00186:
+    /// `portal_owner_id = get_current_portal_user_id()`) before selecting.
+    ///
+    /// The context is set with `set_config(..., is_local => true)` so it is
+    /// scoped to the transaction and auto-cleared on commit — no risk of RLS
+    /// context bleeding onto the pooled connection (the leak class the
+    /// `tenant_context` helpers guard against). The explicit
+    /// `portal_owner_id = $1` predicate is defense-in-depth so the query stays
+    /// correct even for a DB role that bypasses RLS.
+    pub async fn list_portal_listings(
+        &self,
+        user_id: Uuid,
+        status: Option<&str>,
+        limit: i32,
+        offset: i32,
+    ) -> Result<Vec<Listing>, SqlxError> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+            .bind(user_id.to_string())
+            .execute(&mut *tx)
+            .await?;
+        let listings = sqlx::query_as::<_, Listing>(
+            r#"
+            SELECT * FROM listings
+            WHERE portal_owner_id = $1
+              AND ($2::text IS NULL OR status = $2)
+            ORDER BY created_at DESC
+            LIMIT $3 OFFSET $4
+            "#,
+        )
+        .bind(user_id)
+        .bind(status)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(listings)
+    }
+
+    /// Count a portal user's own listings, matching the same filter as
+    /// [`list_portal_listings`](Self::list_portal_listings). Lets paginated
+    /// routes surface the true `total` instead of the current page's `len()`.
+    pub async fn count_portal_listings(
+        &self,
+        user_id: Uuid,
+        status: Option<&str>,
+    ) -> Result<i64, SqlxError> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SELECT set_config('app.current_user_id', $1, true)")
+            .bind(user_id.to_string())
+            .execute(&mut *tx)
+            .await?;
+        let total = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM listings
+            WHERE portal_owner_id = $1
+              AND ($2::text IS NULL OR status = $2)
+            "#,
+        )
+        .bind(user_id)
+        .bind(status)
+        .fetch_one(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(total)
+    }
+
     // ========================================================================
     // Listing Analytics (Story 33.4)
     // ========================================================================

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -203,6 +203,8 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         routes::portal_listings::create_listing,
         routes::portal_listings::get_my_listing,
         routes::portal_listings::update_listing,
+        routes::portal_listings::list_my_listings,
+        routes::portal_listings::get_my_listing_analytics,
         // Compare (UC-48)
         routes::compare::get_compare_list,
         routes::compare::add_to_compare,
@@ -301,6 +303,9 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         routes::portal_listings::PortalListingResponse,
         routes::portal_listings::CreatePortalListingRequest,
         routes::portal_listings::UpdatePortalListingRequest,
+        routes::portal_listings::MyListingsResponse,
+        routes::portal_listings::ListingAnalyticsResponse,
+        routes::portal_listings::DailyListingAnalytics,
         // Compare (UC-48)
         routes::compare::CompareEntry,
         routes::compare::CompareListResponse,

--- a/backend/servers/reality-server/src/routes/portal_listings.rs
+++ b/backend/servers/reality-server/src/routes/portal_listings.rs
@@ -8,21 +8,24 @@
 use crate::state::AppState;
 use api_core::extractors::PortalPrincipal;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     routing::{get, patch, post},
     Json, Router,
 };
+use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 /// Create portal listings router.
 pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", post(create_listing))
+        .route("/", get(list_my_listings))
         .route("/{id}", get(get_my_listing))
         .route("/{id}", patch(update_listing))
+        .route("/{id}/analytics", get(get_my_listing_analytics))
 }
 
 // ============================================================================
@@ -372,4 +375,231 @@ pub async fn update_listing(
         })?;
 
     Ok(Json(map_listing(listing)))
+}
+
+// ============================================================================
+// Realtor "my listings" LIST + per-listing analytics (Epic 15 / Story 33.4).
+//
+// These close the backend gap that left the mobile MyListings / ListingAnalytics
+// screens and the web realtor dashboard rendering permanent empty stubs: there
+// was no LIST endpoint over a portal user's own listings and no HTTP surface for
+// the existing per-listing `get_listing_analytics` repo method. Both are gated by
+// `PortalPrincipal` (portal owners have no org membership) and scoped to the
+// caller's own rows via the portal-owner RLS context / SECURITY DEFINER ownership
+// check — never cross-user.
+// ============================================================================
+
+/// Query parameters for listing a portal user's own listings.
+#[derive(Debug, Deserialize, IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct MyListingsQuery {
+    /// Optional status filter (e.g. `draft`, `active`, `paused`, `sold`,
+    /// `rented`, `archived`). Omit to return all of the caller's listings.
+    pub status: Option<String>,
+    /// Page size (default 20, clamped to 1..=100).
+    pub limit: Option<i32>,
+    /// Row offset (default 0).
+    pub offset: Option<i32>,
+}
+
+/// Paginated response for a portal user's own listings.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MyListingsResponse {
+    pub listings: Vec<PortalListingResponse>,
+    pub total: i64,
+}
+
+/// List the authenticated portal user's own listings.
+///
+/// GET /api/v1/my/listings
+#[utoipa::path(
+    get,
+    path = "/api/v1/my/listings",
+    tag = "PortalListings",
+    params(MyListingsQuery),
+    responses(
+        (status = 200, description = "The caller's listings", body = MyListingsResponse),
+        (status = 401, description = "Unauthorized")
+    )
+)]
+pub async fn list_my_listings(
+    State(state): State<AppState>,
+    principal: PortalPrincipal,
+    Query(query): Query<MyListingsQuery>,
+) -> Result<Json<MyListingsResponse>, (axum::http::StatusCode, String)> {
+    let limit = query.limit.unwrap_or(20).clamp(1, 100);
+    let offset = query.offset.unwrap_or(0).max(0);
+    let status = query.status.as_deref();
+
+    let listings = state
+        .reality_portal_repo
+        .list_portal_listings(principal.user_id, status, limit, offset)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, user_id = %principal.user_id, "Failed to list portal listings");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to list listings".to_string(),
+            )
+        })?;
+
+    let total = state
+        .reality_portal_repo
+        .count_portal_listings(principal.user_id, status)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, user_id = %principal.user_id, "Failed to count portal listings");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to count listings".to_string(),
+            )
+        })?;
+
+    Ok(Json(MyListingsResponse {
+        listings: listings.into_iter().map(map_listing).collect(),
+        total,
+    }))
+}
+
+/// Query parameters for per-listing analytics.
+#[derive(Debug, Deserialize, IntoParams)]
+#[serde(rename_all = "camelCase")]
+pub struct ListingAnalyticsQuery {
+    /// Inclusive lower bound on the analytics day (ISO-8601 date). Omit for no
+    /// lower bound.
+    pub from_date: Option<NaiveDate>,
+    /// Inclusive upper bound on the analytics day (ISO-8601 date). Omit for no
+    /// upper bound.
+    pub to_date: Option<NaiveDate>,
+}
+
+/// One day's analytics counters — camelCase wire mirror of
+/// `db::models::ListingAnalytics` (the model is snake_case; the rest of the
+/// portal API is camelCase, so the endpoint serves a camelCase DTO for a
+/// consistent, wireable contract).
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DailyListingAnalytics {
+    pub date: NaiveDate,
+    pub views: i32,
+    pub unique_views: i32,
+    pub favorites_added: i32,
+    pub favorites_removed: i32,
+    pub inquiries: i32,
+    pub phone_clicks: i32,
+    pub share_clicks: i32,
+    pub source_website: i32,
+    pub source_mobile: i32,
+    pub source_search: i32,
+    pub source_direct: i32,
+}
+
+fn map_daily_analytics(a: db::models::ListingAnalytics) -> DailyListingAnalytics {
+    DailyListingAnalytics {
+        date: a.date,
+        views: a.views,
+        unique_views: a.unique_views,
+        favorites_added: a.favorites_added,
+        favorites_removed: a.favorites_removed,
+        inquiries: a.inquiries,
+        phone_clicks: a.phone_clicks,
+        share_clicks: a.share_clicks,
+        source_website: a.source_website,
+        source_mobile: a.source_mobile,
+        source_search: a.source_search,
+        source_direct: a.source_direct,
+    }
+}
+
+/// Analytics summary + daily series for one of the caller's listings.
+#[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ListingAnalyticsResponse {
+    pub listing_id: Uuid,
+    pub total_views: i64,
+    pub total_inquiries: i64,
+    pub total_favorites: i64,
+    pub days_on_market: i32,
+    pub daily_analytics: Vec<DailyListingAnalytics>,
+}
+
+/// Get analytics for one of the authenticated portal user's own listings.
+///
+/// GET /api/v1/my/listings/{id}/analytics
+///
+/// Ownership is enforced up front via `portal_get_listing` (SECURITY DEFINER,
+/// migration 00186): a listing the caller does not own yields 404, so a realtor
+/// can never read another realtor's analytics.
+#[utoipa::path(
+    get,
+    path = "/api/v1/my/listings/{id}/analytics",
+    tag = "PortalListings",
+    params(
+        ("id" = Uuid, Path, description = "Listing ID"),
+        ListingAnalyticsQuery
+    ),
+    responses(
+        (status = 200, description = "Analytics summary + daily series", body = ListingAnalyticsResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Not found or not owned")
+    )
+)]
+pub async fn get_my_listing_analytics(
+    State(state): State<AppState>,
+    principal: PortalPrincipal,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ListingAnalyticsQuery>,
+) -> Result<Json<ListingAnalyticsResponse>, (axum::http::StatusCode, String)> {
+    // Ownership gate: only the portal owner may read analytics for their listing.
+    let listing = state
+        .reality_portal_repo
+        .get_portal_listing(id, principal.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, listing_id = %id, user_id = %principal.user_id, "Failed to load listing for analytics");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to load listing".to_string(),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "Listing not found or not owned".to_string(),
+            )
+        })?;
+
+    let daily = state
+        .reality_portal_repo
+        .get_listing_analytics(id, query.from_date, query.to_date)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, listing_id = %id, "Failed to load listing analytics");
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to load analytics".to_string(),
+            )
+        })?;
+
+    let total_views: i64 = daily.iter().map(|d| i64::from(d.views)).sum();
+    let total_inquiries: i64 = daily.iter().map(|d| i64::from(d.inquiries)).sum();
+    // Net favorites = added − removed, floored at 0 (a listing can't have a
+    // negative favorite count even if a day removed more than it added).
+    let total_favorites: i64 = daily
+        .iter()
+        .map(|d| i64::from(d.favorites_added) - i64::from(d.favorites_removed))
+        .sum::<i64>()
+        .max(0);
+    let days_on_market = i32::try_from((chrono::Utc::now() - listing.created_at).num_days().max(0))
+        .unwrap_or(i32::MAX);
+
+    Ok(Json(ListingAnalyticsResponse {
+        listing_id: id,
+        total_views,
+        total_inquiries,
+        total_favorites,
+        days_on_market,
+        daily_analytics: daily.into_iter().map(map_daily_analytics).collect(),
+    }))
 }

--- a/backend/servers/reality-server/tests/portal_listings_my_list_analytics_tests.rs
+++ b/backend/servers/reality-server/tests/portal_listings_my_list_analytics_tests.rs
@@ -1,0 +1,319 @@
+//! Integration tests for the realtor "my listings" LIST + per-listing analytics
+//! endpoints added to `reality-server/src/routes/portal_listings.rs`.
+//!
+//! # Background
+//!
+//! Before this change the portal-listings router only exposed
+//! `POST /api/v1/my/listings`, `GET|PATCH /api/v1/my/listings/{id}`. There was
+//! no LIST endpoint over a portal user's own listings and no HTTP surface for
+//! the per-listing `get_listing_analytics` repo method — so the mobile
+//! `MyListings` / `ListingAnalytics` screens and the web realtor dashboard
+//! rendered permanent empty stubs (`GET /api/v1/my/listings` and
+//! `GET /api/v1/my/listings/{id}/analytics` 404'd / 405'd on `main`).
+//!
+//! # IG3 (failing-on-main proof)
+//!
+//! `list_returns_only_owner_listings` and `analytics_owner_returns_200` both
+//! drive routes that **did not exist on `main`** — the request would have
+//! matched no route and returned 404. They pass only with the new handlers.
+//! `list_excludes_other_users_listings` additionally locks the tenant/RLS
+//! scoping: the LIST must never surface another portal user's rows.
+//!
+//! The harness mirrors `portal_listings_idor_tests.rs`: the real production
+//! router (no mocking), real HS256 JWTs, and `#[sqlx::test(migrator =
+//! "db::MIGRATOR")]` for an isolated migrated database.
+
+#![allow(dead_code)]
+
+use api_core::PrincipalClaims;
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+    Router,
+};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use reality_server::{routes, state::AppState};
+use sqlx::PgPool;
+use std::sync::{Arc, Once};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const TEST_JWT_SECRET: &str =
+    "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+static TEST_ENV: Once = Once::new();
+
+fn ensure_test_env() {
+    TEST_ENV.call_once(|| {
+        if std::env::var("RUST_ENV").is_err() {
+            std::env::set_var("RUST_ENV", "development");
+        }
+        if std::env::var("JWT_SECRET").is_err() {
+            std::env::set_var("JWT_SECRET", TEST_JWT_SECRET);
+        }
+    });
+}
+
+/// Real production portal-listings sub-router backed by `pool`.
+fn listings_router(pool: PgPool) -> Router {
+    ensure_test_env();
+
+    let tenant_cache = Arc::new(api_core::TenantResolutionCache::new(60, 60, 1000));
+    let rate_limiters = Arc::new(api_core::TenantRateLimiterSet::new());
+    let state = AppState::new(pool, tenant_cache, rate_limiters);
+    Router::new()
+        .nest("/api/v1/my/listings", routes::portal_listings::router())
+        .with_state(state)
+}
+
+/// Mint a real HS256 access token for `user_id` (portal `public` principal).
+fn mint_token(user_id: Uuid) -> String {
+    let claims = PrincipalClaims {
+        sub: user_id,
+        iat: 0,
+        exp: i64::MAX,
+        kind: Some("public".to_string()),
+        token_type: Some("access".to_string()),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_bytes()),
+    )
+    .expect("mint test token")
+}
+
+/// Seed a `public`-kind portal user (the kind `PortalPrincipal` admits).
+async fn seed_portal_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', $2, 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("{tag}@portal-mylistings.test"))
+    .bind(format!("PortalMyListings {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_portal_user({tag}): {e}"))
+}
+
+/// Create a listing owned by `user_id` via the SECURITY DEFINER repo path.
+async fn seed_listing(pool: &PgPool, user_id: Uuid, title: &str) -> Uuid {
+    let repo = db::repositories::RealityPortalRepository::new(pool.clone());
+    repo.create_portal_listing(
+        user_id,
+        title,
+        Some("desc"),
+        "apartment",
+        "sale",
+        rust_decimal::Decimal::new(100_000, 0),
+        "EUR",
+        "Test Street 1",
+        "Bratislava",
+        "81101",
+        "SK",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("seed_listing")
+    .id
+}
+
+async fn body_json(app: &Router, req: Request<Body>) -> (StatusCode, serde_json::Value) {
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+fn list_req(token: &str, query: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/my/listings{query}"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn analytics_req(id: Uuid, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::GET)
+        .uri(format!("/api/v1/my/listings/{id}/analytics"))
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+// ============================================================================
+// LIST — my listings
+// ============================================================================
+
+/// The owner's LIST returns exactly their own listings with a correct `total`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_returns_only_owner_listings(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "list-a").await;
+    seed_listing(&pool, user_a, "A-one").await;
+    seed_listing(&pool, user_a, "A-two").await;
+
+    let app = listings_router(pool);
+    let (status, json) = body_json(&app, list_req(&mint_token(user_a), "")).await;
+
+    assert_eq!(status, StatusCode::OK, "owner LIST must return 200");
+    assert_eq!(
+        json["total"].as_i64(),
+        Some(2),
+        "total must count owned rows"
+    );
+    assert_eq!(
+        json["listings"].as_array().map(|a| a.len()),
+        Some(2),
+        "owner must see both their listings"
+    );
+}
+
+/// The LIST must never surface another portal user's listings (tenant/RLS
+/// scoping): user B's listing must not appear in user A's LIST.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_excludes_other_users_listings(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "excl-a").await;
+    let user_b = seed_portal_user(&pool, "excl-b").await;
+    seed_listing(&pool, user_a, "A-owned").await;
+    seed_listing(&pool, user_b, "B-owned").await;
+    seed_listing(&pool, user_b, "B-owned-2").await;
+
+    let app = listings_router(pool);
+
+    let (status_a, json_a) = body_json(&app, list_req(&mint_token(user_a), "")).await;
+    assert_eq!(status_a, StatusCode::OK);
+    assert_eq!(
+        json_a["total"].as_i64(),
+        Some(1),
+        "A must only see their single listing, not B's"
+    );
+
+    let (status_b, json_b) = body_json(&app, list_req(&mint_token(user_b), "")).await;
+    assert_eq!(status_b, StatusCode::OK);
+    assert_eq!(
+        json_b["total"].as_i64(),
+        Some(2),
+        "B must see exactly their two listings"
+    );
+}
+
+/// The status filter narrows the LIST to matching listings.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_status_filter_applies(pool: PgPool) {
+    let user = seed_portal_user(&pool, "filter-u").await;
+    let draft_id = seed_listing(&pool, user, "draft-one").await;
+    let paused_id = seed_listing(&pool, user, "to-pause").await;
+
+    // Move one listing to `paused` via the SECURITY DEFINER update.
+    let repo = db::repositories::RealityPortalRepository::new(pool.clone());
+    repo.update_portal_listing(
+        paused_id,
+        user,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some("paused"),
+        None,
+    )
+    .await
+    .expect("pause listing");
+
+    let app = listings_router(pool);
+
+    let (status, json) = body_json(&app, list_req(&mint_token(user), "?status=paused")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        json["total"].as_i64(),
+        Some(1),
+        "only the paused listing must match status=paused"
+    );
+    let listings = json["listings"].as_array().unwrap();
+    assert_eq!(listings.len(), 1);
+    assert_eq!(
+        listings[0]["id"].as_str(),
+        Some(paused_id.to_string().as_str())
+    );
+    assert_ne!(
+        listings[0]["id"].as_str(),
+        Some(draft_id.to_string().as_str())
+    );
+}
+
+/// Unauthenticated LIST → 401.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_unauthenticated_returns_401(pool: PgPool) {
+    let app = listings_router(pool);
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/api/v1/my/listings")
+        .body(Body::empty())
+        .unwrap();
+    let (status, _) = body_json(&app, req).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+}
+
+// ============================================================================
+// Per-listing analytics
+// ============================================================================
+
+/// Owner reads analytics for their own listing → 200 with a zeroed summary
+/// (no analytics rows have been recorded yet).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn analytics_owner_returns_200(pool: PgPool) {
+    let user = seed_portal_user(&pool, "an-owner").await;
+    let listing_id = seed_listing(&pool, user, "analytics-me").await;
+
+    let app = listings_router(pool);
+    let (status, json) = body_json(&app, analytics_req(listing_id, &mint_token(user))).await;
+
+    assert_eq!(status, StatusCode::OK, "owner analytics must return 200");
+    assert_eq!(
+        json["listingId"].as_str(),
+        Some(listing_id.to_string().as_str())
+    );
+    assert_eq!(json["totalViews"].as_i64(), Some(0));
+    assert!(json["dailyAnalytics"].is_array());
+}
+
+/// User B requesting analytics for user A's listing → 404 (ownership gate),
+/// never leaking that the listing exists.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn analytics_cross_user_returns_404(pool: PgPool) {
+    let user_a = seed_portal_user(&pool, "an-a").await;
+    let user_b = seed_portal_user(&pool, "an-b").await;
+    let listing_id = seed_listing(&pool, user_a, "analytics-a").await;
+
+    let app = listings_router(pool);
+    let (status, _) = body_json(&app, analytics_req(listing_id, &mint_token(user_b))).await;
+    assert_eq!(
+        status,
+        StatusCode::NOT_FOUND,
+        "cross-user analytics must 404"
+    );
+}


### PR DESCRIPTION
## Task
backend gap (blocks realtor dashboard on mobile + web): the api-server nests only POST /listings, GET /listings/{id}, PATCH /listings/{id} — there is no realtor 'my listings' LIST endpoint (GET /api/v1/my/listings or /api/v1/realtors/me/listings) and no realtor-level analytics HTTP route (only a per-listing DB get_listing_analytics with no list_portal_listings DB method). Mobile MyListings/ListingAnalytics (Navigation.kt:440,:458) and web useMyListings(/api/v1/realtors/me/listings) + useAgencyListings(/api/v1/agencies/{id}/listings) all target these unimplemented endpoints and render permanent empty stubs. Implement the realtor listings-list + analytics endpoints (repo method + route + tenant/RLS scoping) so the clients can be wired. Discovered by the blocked implementer for code-review-mobile-native-kmp-mylistings-analytics-stub.

## Owner
pm-backend (specialist: rust-backend)

## What landed
Portal/realtor listings live in **reality-server** (Reality Portal), nested at `/api/v1/my/listings` with the `PortalPrincipal` extractor (portal owners have no org membership, so `RequestPrincipal` would 403 them). The router previously had only `POST /`, `GET /{id}`, `PATCH /{id}`. Added:

- **`db::RealityPortalRepository::list_portal_listings` + `count_portal_listings`** — the `listings` table is `FORCE ROW LEVEL SECURITY` (migration 00110), so unlike the sibling SECURITY DEFINER CRUD helpers these establish the **portal-owner** RLS context (context-5 of `listings_five_context`, migration 00186: `portal_owner_id = get_current_portal_user_id()`) via a **transaction-local `set_config(..., is_local => true)`** — bleed-proof (auto-cleared on commit, no pooled-connection context leak) — and filter on `portal_owner_id` for defense-in-depth (correct even for a role that bypasses RLS).
- **`GET /api/v1/my/listings`** — paginated (`limit` clamped 1..=100, `offset`), optional `status` filter; returns `{ listings, total }` (camelCase, matching the web `{ listings, total }` contract).
- **`GET /api/v1/my/listings/{id}/analytics`** — exposes the existing per-listing `get_listing_analytics` DB method over HTTP, **ownership-gated** via `portal_get_listing` (cross-user → 404, no existence leak). Returns a camelCase `ListingAnalyticsResponse` (summary + daily series) for a consistent, wireable portal contract.
- Registered both handlers + `MyListingsResponse` / `ListingAnalyticsResponse` / `DailyListingAnalytics` in the reality-server OpenAPI doc.

No migration touched (RLS context is set from Rust); no frontend/mobile touched (backend-only, so the clients can now be wired in a follow-up). Note: web `useMyListings` currently points at `/api/v1/realtors/me/listings`; the task lists `/api/v1/my/listings` as an accepted target and that is the established portal path (`getMyListing` already uses `/api/v1/my/listings/{id}`), so the frontend wiring task should repoint that hook.

## Tested (Band A — fast check)
Against a live Postgres 16 (superuser `postgres`, RLS-bypass — same as CI's `cargo test --workspace`).
- `SQLX_OFFLINE=true cargo check -p db` → exit 0
- `SQLX_OFFLINE=true cargo check -p reality-server` → exit 0 (with `file://` `SWAGGER_UI_DOWNLOAD_URL` workaround — github egress is policy-blocked locally; CI has normal egress)
- `cargo test -p reality-server --test portal_listings_my_list_analytics_tests` → **6 passed; 0 failed**

## Built (Band B — full build)
Change is >50 LOC and adds public API surface, so Band B ran:
- `cargo clippy -p db --all-targets -- -D warnings` → exit 0
- `cargo clippy -p reality-server --all-targets -- -D warnings` → exit 0
- `cargo fmt --all -- --check` → exit 0

## IG3 (failing-on-main regression evidence)
`backend/servers/reality-server/tests/portal_listings_my_list_analytics_tests.rs` drives the real production router (no mocking), real HS256 JWTs, `#[sqlx::test(migrator = "db::MIGRATOR")]`:
- `list_returns_only_owner_listings` and `analytics_owner_returns_200` hit routes that **did not exist on `main`** (would have 404'd) — pass only with the new handlers.
- `list_excludes_other_users_listings` locks tenant/RLS scoping (A never sees B's rows).
- `analytics_cross_user_returns_404` locks the ownership gate.
- Plus `list_status_filter_applies` and `list_unauthenticated_returns_401`.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no billing/auth-token/data-integrity change). The endpoints are read-only and ownership/RLS-scoped; the scoping is covered by the IG3 tests above.

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- Follow-up (out of scope here): a realtor-level aggregate stats endpoint (`/api/v1/realtors/me/stats` → totalListings/activeListings/totalViews/…) that the web analytics page's `getMyRealtorAnalytics` targets, and repointing the web `useMyListings`/`useAgencyListings` hooks + wiring mobile MyListings/ListingAnalytics to the new routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WwnvFen1eZSa1LSJ48Si1

---
_Generated by [Claude Code](https://claude.ai/code/session_018WwnvFen1eZSa1LSJ48Si1)_