### PR TITLE
gap-83-1-frontend-integrations-ui-not-wired-settings: wire integrations settings UI route (Airbnb OAuth & Sync)

### DIFF
--- a/docs/screens/ppt/settings-integrations.md
+++ b/docs/screens/ppt/settings-integrations.md
@@ -1,0 +1,53 @@
+---
+id: ppt/settings-integrations
+name: Integrations
+product: ppt
+sitemapRefs:
+  ppt-web: ppt-settings-integrations
+implementations:
+  ppt-web:
+    route: "/settings/integrations"
+    component: IntegrationsPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: complete
+endpoints: []
+relatedScreens:
+  - id: ppt/settings-notifications
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-29
+epics:
+  - Epic-83
+designSources: []
+owner: pm-frontend
+---
+
+# Integrations
+
+Manager-facing surface for external channel integrations. Gap 83-1 wired the
+previously route-less integrations UI: the `@ppt/api-client` `integrations`
+module (Epic 61 + Gap 83) already carried live Airbnb hooks, but no ppt-web
+route rendered them. `IntegrationsPage` now renders the Airbnb card with the
+OAuth connect flow, sync, disconnect, live status, and listing mappings.
+
+Airbnb calls (via `@ppt/api-client` `integrations` hooks):
+- `useAirbnbStatus` — GET `/api/v1/integrations/organizations/{org}/airbnb/status`
+- `useConnectAirbnb` — POST `.../airbnb/connect` (returns OAuth `auth_url`)
+- `useSyncAirbnb` — POST `.../airbnb/sync`
+- `useDisconnectAirbnb` — DELETE `.../airbnb`
+- `useAirbnbListingMappings` — GET `/api/v1/rentals/connections` (platform=airbnb)
+
+## Notes
+
+### Specific (recent)
+- 2026-07-08 — created `IntegrationsPage`, wired route `/settings/integrations`
+  in `routes/groups/core.tsx` (settingsRoutes), and added the
+  `ppt-settings-integrations` sitemap entry. `endpoints` left empty because the
+  Airbnb integration endpoints are not (yet) in the `@ppt/sitemap` endpoint
+  catalogue.
+
+## Agent Log
+- 2026-07-08 — agent: gap-83-1-frontend-integrations-ui-not-wired-settings — created the Integrations settings page (Airbnb OAuth connect/sync/disconnect + status + listing mappings) and wired `/settings/integrations` so the built-but-route-less integrations api-client is reachable.

--- a/frontend/apps/ppt-web/src/features/settings/index.ts
+++ b/frontend/apps/ppt-web/src/features/settings/index.ts
@@ -2,4 +2,5 @@
  * Settings feature exports.
  */
 
+export { IntegrationsPage } from './integrations/IntegrationsPage';
 export { AccessibilitySettingsPage } from './pages/AccessibilitySettingsPage';

--- a/frontend/apps/ppt-web/src/features/settings/integrations/IntegrationsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/settings/integrations/IntegrationsPage.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Regression test for the Integrations settings surface (Gap 83-1).
+ *
+ * Pins the wiring that `IntegrationsPage` adds: the Airbnb card renders its
+ * live status and the connect/sync controls are wired to the corresponding
+ * `@ppt/api-client` integrations hooks. This layer did not exist on `dev`
+ * (the api-client hooks were built but no ppt-web route rendered them), so
+ * this test fails without the page + route wiring.
+ */
+
+/// <reference types="vitest/globals" />
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntegrationsPage } from './IntegrationsPage';
+
+// ── api-client: Airbnb integration hooks ──
+const connectMutateAsync = vi
+  .fn()
+  .mockResolvedValue({ auth_url: 'https://airbnb.test/oauth', state: 's' });
+const syncMutateAsync = vi
+  .fn()
+  .mockResolvedValue({ success: true, items_synced: 3, synced_at: '' });
+const disconnectMutateAsync = vi.fn().mockResolvedValue(undefined);
+
+let airbnbStatus: {
+  data?: { connected: boolean; listings_count: number; reservations_count: number } | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = {
+  data: { connected: false, listings_count: 0, reservations_count: 0 },
+  isLoading: false,
+  isError: false,
+};
+
+vi.mock('@ppt/api-client', () => ({
+  useAirbnbStatus: () => airbnbStatus,
+  useAirbnbListingMappings: () => ({ data: [], isLoading: false }),
+  useConnectAirbnb: () => ({ mutateAsync: connectMutateAsync, isPending: false }),
+  useSyncAirbnb: () => ({ mutateAsync: syncMutateAsync, isPending: false }),
+  useDisconnectAirbnb: () => ({ mutateAsync: disconnectMutateAsync, isPending: false }),
+}));
+
+vi.mock('../../../contexts', () => ({
+  useAuth: () => ({ user: { organizationId: 'org-1' } }),
+}));
+
+const mockShowToast = vi.fn();
+vi.mock('../../../components', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+describe('IntegrationsPage (Gap 83-1)', () => {
+  beforeEach(() => {
+    connectMutateAsync.mockClear();
+    syncMutateAsync.mockClear();
+    disconnectMutateAsync.mockClear();
+    mockShowToast.mockClear();
+    airbnbStatus = {
+      data: { connected: false, listings_count: 0, reservations_count: 0 },
+      isLoading: false,
+      isError: false,
+    };
+  });
+
+  it('renders the integrations surface with the Airbnb card', () => {
+    render(<IntegrationsPage />);
+    expect(screen.getByRole('heading', { level: 1, name: /integrations/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 2, name: /airbnb/i })).toBeInTheDocument();
+  });
+
+  it('fires the Airbnb OAuth connect flow when not connected', async () => {
+    render(<IntegrationsPage />);
+    await userEvent.click(screen.getByRole('button', { name: /connect airbnb/i }));
+    expect(connectMutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes sync + disconnect controls once connected', async () => {
+    airbnbStatus = {
+      data: { connected: true, listings_count: 2, reservations_count: 5 },
+      isLoading: false,
+      isError: false,
+    };
+    render(<IntegrationsPage />);
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }));
+    expect(syncMutateAsync).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/settings/integrations/IntegrationsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/settings/integrations/IntegrationsPage.tsx
@@ -1,0 +1,239 @@
+/**
+ * Integrations settings page (Gap 83-1 / Story 83.1 — Airbnb OAuth & Sync).
+ *
+ * The manager-facing surface that manages external channel integrations. The
+ * api-client `integrations` module (Epic 61 + Gap 83) was already built with
+ * live Airbnb hooks, but no ppt-web route rendered it. This page wires those
+ * hooks into a reachable `/settings/integrations` surface.
+ *
+ * Airbnb calls (via @ppt/api-client):
+ *   GET    /api/v1/integrations/organizations/{org}/airbnb/status   — useAirbnbStatus
+ *   POST   /api/v1/integrations/organizations/{org}/airbnb/connect  — useConnectAirbnb (OAuth)
+ *   POST   /api/v1/integrations/organizations/{org}/airbnb/sync     — useSyncAirbnb
+ *   DELETE /api/v1/integrations/organizations/{org}/airbnb          — useDisconnectAirbnb
+ *   GET    /api/v1/rentals/connections?platform=airbnb             — useAirbnbListingMappings
+ */
+
+import {
+  useAirbnbListingMappings,
+  useAirbnbStatus,
+  useConnectAirbnb,
+  useDisconnectAirbnb,
+  useSyncAirbnb,
+} from '@ppt/api-client';
+import type React from 'react';
+import { useToast } from '../../../components';
+import { useAuth } from '../../../contexts';
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString();
+}
+
+export const IntegrationsPage: React.FC = () => {
+  const { showToast } = useToast();
+  const { user } = useAuth();
+  const organizationId = user?.organizationId ?? '';
+
+  const status = useAirbnbStatus(organizationId);
+  const listings = useAirbnbListingMappings(organizationId);
+  const connectAirbnb = useConnectAirbnb(organizationId);
+  const syncAirbnb = useSyncAirbnb(organizationId);
+  const disconnectAirbnb = useDisconnectAirbnb(organizationId);
+
+  const connected = status.data?.connected ?? false;
+
+  const handleConnect = async () => {
+    try {
+      const res = await connectAirbnb.mutateAsync({
+        redirect_uri: `${window.location.origin}/settings/integrations`,
+      });
+      // Backend returns the OAuth authorize URL; hand off to Airbnb.
+      window.location.href = res.auth_url;
+    } catch (err) {
+      showToast({
+        type: 'error',
+        title: 'Could not start Airbnb connection',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  const handleSync = async () => {
+    try {
+      const res = await syncAirbnb.mutateAsync();
+      showToast({
+        type: res.success ? 'success' : 'error',
+        title: res.success ? 'Airbnb synced' : 'Airbnb sync failed',
+        message: res.success
+          ? `${res.items_synced} item(s) synced.`
+          : (res.error ?? 'The sync did not complete.'),
+      });
+    } catch (err) {
+      showToast({
+        type: 'error',
+        title: 'Airbnb sync failed',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await disconnectAirbnb.mutateAsync();
+      showToast({
+        type: 'success',
+        title: 'Airbnb disconnected',
+        message: 'The Airbnb integration has been removed.',
+      });
+    } catch (err) {
+      showToast({
+        type: 'error',
+        title: 'Could not disconnect Airbnb',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred.',
+      });
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold">Integrations</h1>
+        <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          Connect external booking channels to sync listings and reservations.
+        </p>
+      </header>
+
+      {!organizationId && (
+        <div
+          className="rounded-lg border border-yellow-300 bg-yellow-50 p-4 text-sm text-yellow-800"
+          role="alert"
+        >
+          No organization is selected for your account, so integrations cannot be managed.
+        </div>
+      )}
+
+      {/* Airbnb integration card (Gap 83-1) */}
+      <section className="rounded-lg border border-gray-200 bg-white p-6 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-rose-500 text-white text-sm font-bold"
+              >
+                A
+              </span>
+              Airbnb
+            </h2>
+            <p className="text-sm text-gray-500">
+              OAuth-connected channel for short-term rental listings and reservations.
+            </p>
+          </div>
+          <span
+            className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium ${
+              connected ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'
+            }`}
+          >
+            {status.isLoading ? 'Checking…' : connected ? 'Connected' : 'Not connected'}
+          </span>
+        </div>
+
+        {status.isError && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
+            Could not load Airbnb status.
+          </div>
+        )}
+
+        {connected && status.data && (
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm sm:grid-cols-4">
+            <div>
+              <dt className="text-gray-500">Account</dt>
+              <dd className="font-medium text-gray-900">
+                {status.data.external_account_id ?? '—'}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Last sync</dt>
+              <dd className="font-medium text-gray-900">{formatDate(status.data.last_sync_at)}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Listings</dt>
+              <dd className="font-medium text-gray-900">{status.data.listings_count}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Reservations</dt>
+              <dd className="font-medium text-gray-900">{status.data.reservations_count}</dd>
+            </div>
+          </dl>
+        )}
+
+        {connected && status.data?.sync_error && (
+          <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
+            Last sync error: {status.data.sync_error}
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-3 pt-2">
+          {!connected ? (
+            <button
+              type="button"
+              onClick={handleConnect}
+              disabled={!organizationId || connectAirbnb.isPending}
+              className="rounded-md bg-rose-500 px-4 py-2 text-sm font-medium text-white hover:bg-rose-600 disabled:opacity-50"
+            >
+              {connectAirbnb.isPending ? 'Redirecting…' : 'Connect Airbnb'}
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                onClick={handleSync}
+                disabled={syncAirbnb.isPending}
+                className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {syncAirbnb.isPending ? 'Syncing…' : 'Sync now'}
+              </button>
+              <button
+                type="button"
+                onClick={handleDisconnect}
+                disabled={disconnectAirbnb.isPending}
+                className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                {disconnectAirbnb.isPending ? 'Disconnecting…' : 'Disconnect'}
+              </button>
+            </>
+          )}
+        </div>
+
+        {connected && (
+          <div className="pt-2">
+            <h3 className="text-sm font-semibold text-gray-700">Listing mappings</h3>
+            {listings.isLoading ? (
+              <p className="text-sm text-gray-500">Loading listings…</p>
+            ) : (listings.data?.length ?? 0) === 0 ? (
+              <p className="text-sm text-gray-500">No Airbnb listings mapped yet.</p>
+            ) : (
+              <ul className="mt-2 divide-y divide-gray-100 rounded-md border border-gray-100">
+                {listings.data?.map((mapping) => (
+                  <li
+                    key={mapping.id}
+                    className="flex items-center justify-between px-3 py-2 text-sm"
+                  >
+                    <span className="font-medium text-gray-900">{mapping.unit_name}</span>
+                    <span className={mapping.is_active ? 'text-green-600' : 'text-gray-400'}>
+                      {mapping.is_active ? 'Active' : 'Inactive'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default IntegrationsPage;

--- a/frontend/apps/ppt-web/src/routes/groups/core.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/core.tsx
@@ -44,6 +44,11 @@ const SessionsPage = lazy(() =>
   import('../../features/settings/pages/SessionsPage').then((m) => ({ default: m.SessionsPage }))
 );
 
+// Integrations settings page (Gap 83-1 — Airbnb OAuth & Sync) — lazy-loaded.
+const IntegrationsPage = lazy(() =>
+  import('../../features/settings').then((m) => ({ default: m.IntegrationsPage }))
+);
+
 export function Home() {
   const { t } = useTranslation();
   const { isAuthenticated, user } = useAuth();
@@ -184,6 +189,15 @@ export function settingsRoutes() {
         element={
           <ProtectedRoute>
             <SessionsPage />
+          </ProtectedRoute>
+        }
+      />
+      {/* External integrations — Airbnb OAuth & Sync (Gap 83-1) */}
+      <Route
+        path="/settings/integrations"
+        element={
+          <ProtectedRoute>
+            <IntegrationsPage />
           </ProtectedRoute>
         }
       />

--- a/frontend/apps/ppt-web/src/test/sitemap-routes.test.ts
+++ b/frontend/apps/ppt-web/src/test/sitemap-routes.test.ts
@@ -45,7 +45,7 @@ describe('PPT-Web Route Definitions', () => {
     });
 
     it('should have correct route count', () => {
-      expect(sitemap.routes[app].length).toBe(18);
+      expect(sitemap.routes[app].length).toBe(19);
     });
   });
 

--- a/frontend/packages/sitemap/src/data/ppt-web/index.ts
+++ b/frontend/packages/sitemap/src/data/ppt-web/index.ts
@@ -174,6 +174,17 @@ export const pptWebRoutes: FrontendRoute[] = [
     tags: ['settings', 'protected'],
   },
   {
+    id: 'ppt-settings-integrations',
+    app: 'ppt-web',
+    path: '/settings/integrations',
+    name: 'Integrations',
+    description: 'External channel integrations — Airbnb OAuth connect & sync',
+    auth: { required: true, tenantContext: { required: true } },
+    component: 'IntegrationsPage',
+    feature: 'Epic-83',
+    tags: ['settings', 'integrations', 'airbnb', 'protected'],
+  },
+  {
     id: 'ppt-settings-notifications',
     app: 'ppt-web',
     path: '/settings/notifications',

--- a/frontend/packages/sitemap/src/json/sitemap.json
+++ b/frontend/packages/sitemap/src/json/sitemap.json
@@ -11,7 +11,10 @@
           "required": false
         },
         "component": "Home",
-        "tags": ["navigation", "public"]
+        "tags": [
+          "navigation",
+          "public"
+        ]
       },
       {
         "id": "ppt-login",
@@ -22,10 +25,36 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": ["auth_login"],
+        "apiEndpoints": [
+          "auth_login"
+        ],
         "component": "LoginPage",
         "feature": "UC-14",
-        "tags": ["auth", "public"]
+        "tags": [
+          "auth",
+          "public"
+        ]
+      },
+      {
+        "id": "ppt-auth-callback",
+        "app": "ppt-web",
+        "path": "/auth/callback",
+        "name": "SSO Callback",
+        "description": "OAuth / SSO provider redirect landing page — exchanges code for PPT JWT tokens",
+        "auth": {
+          "required": false
+        },
+        "apiEndpoints": [
+          "auth_sso_callback"
+        ],
+        "component": "AuthCallbackPage",
+        "parentId": "ppt-login",
+        "feature": "UC-14",
+        "tags": [
+          "auth",
+          "public",
+          "sso"
+        ]
       },
       {
         "id": "ppt-documents",
@@ -35,15 +64,25 @@
         "description": "Document management dashboard",
         "auth": {
           "required": true,
-          "roles": ["owner", "tenant", "manager", "organization_admin"],
+          "roles": [
+            "owner",
+            "tenant",
+            "manager",
+            "organization_admin"
+          ],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": ["documents_list"],
+        "apiEndpoints": [
+          "documents_list"
+        ],
         "component": "DocumentsPage",
         "feature": "Epic-39",
-        "tags": ["documents", "protected"]
+        "tags": [
+          "documents",
+          "protected"
+        ]
       },
       {
         "id": "ppt-document-upload",
@@ -53,16 +92,26 @@
         "description": "Document upload page",
         "auth": {
           "required": true,
-          "roles": ["owner", "manager", "organization_admin"],
+          "roles": [
+            "owner",
+            "manager",
+            "organization_admin"
+          ],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": ["documents_upload"],
+        "apiEndpoints": [
+          "documents_upload"
+        ],
         "component": "DocumentUploadPage",
         "parentId": "ppt-documents",
         "feature": "Epic-39",
-        "tags": ["documents", "protected", "create"]
+        "tags": [
+          "documents",
+          "protected",
+          "create"
+        ]
       },
       {
         "id": "ppt-document-detail",
@@ -84,11 +133,18 @@
             "required": true
           }
         },
-        "apiEndpoints": ["documents_get", "documents_get_versions"],
+        "apiEndpoints": [
+          "documents_get",
+          "documents_get_versions"
+        ],
         "component": "DocumentDetailPage",
         "parentId": "ppt-documents",
         "feature": "Epic-39",
-        "tags": ["documents", "protected", "detail"]
+        "tags": [
+          "documents",
+          "protected",
+          "detail"
+        ]
       },
       {
         "id": "ppt-news",
@@ -102,10 +158,15 @@
             "required": true
           }
         },
-        "apiEndpoints": ["news_list"],
+        "apiEndpoints": [
+          "news_list"
+        ],
         "component": "NewsListPage",
         "feature": "Epic-59",
-        "tags": ["news", "protected"]
+        "tags": [
+          "news",
+          "protected"
+        ]
       },
       {
         "id": "ppt-news-detail",
@@ -127,11 +188,17 @@
             "required": true
           }
         },
-        "apiEndpoints": ["news_get"],
+        "apiEndpoints": [
+          "news_get"
+        ],
         "component": "ArticleDetailPage",
         "parentId": "ppt-news",
         "feature": "Epic-59",
-        "tags": ["news", "protected", "detail"]
+        "tags": [
+          "news",
+          "protected",
+          "detail"
+        ]
       },
       {
         "id": "ppt-emergency",
@@ -145,10 +212,15 @@
             "required": true
           }
         },
-        "apiEndpoints": ["emergency_list"],
+        "apiEndpoints": [
+          "emergency_list"
+        ],
         "component": "EmergencyContactDirectoryPage",
         "feature": "Epic-62",
-        "tags": ["emergency", "protected"]
+        "tags": [
+          "emergency",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-accessibility",
@@ -161,7 +233,10 @@
         },
         "component": "AccessibilitySettingsPage",
         "feature": "Epic-60",
-        "tags": ["settings", "protected"]
+        "tags": [
+          "settings",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-privacy",
@@ -174,7 +249,70 @@
         },
         "component": "PrivacySettingsPage",
         "feature": "Epic-63",
-        "tags": ["settings", "protected"]
+        "tags": [
+          "settings",
+          "protected"
+        ]
+      },
+      {
+        "id": "ppt-settings-integrations",
+        "app": "ppt-web",
+        "path": "/settings/integrations",
+        "name": "Integrations",
+        "description": "External channel integrations — Airbnb OAuth connect & sync",
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
+        "component": "IntegrationsPage",
+        "feature": "Epic-83",
+        "tags": [
+          "settings",
+          "integrations",
+          "airbnb",
+          "protected"
+        ]
+      },
+      {
+        "id": "ppt-settings-notifications",
+        "app": "ppt-web",
+        "path": "/settings/notifications",
+        "name": "Notification Settings",
+        "description": "Channel-level notification toggles (push / email / in-app)",
+        "auth": {
+          "required": true
+        },
+        "apiEndpoints": [
+          "notification_preferences_list",
+          "notification_preference_update"
+        ],
+        "component": "NotificationSettingsPage",
+        "feature": "Epic-8A",
+        "tags": [
+          "settings",
+          "notifications",
+          "protected"
+        ]
+      },
+      {
+        "id": "ppt-settings-notifications-advanced",
+        "app": "ppt-web",
+        "path": "/settings/notifications/advanced",
+        "name": "Advanced Notification Settings",
+        "description": "Per-category preferences, digests, quiet hours and grouping",
+        "auth": {
+          "required": true
+        },
+        "component": "AdvancedNotificationSettingsPage",
+        "parentId": "ppt-settings-notifications",
+        "feature": "Epic-40",
+        "tags": [
+          "settings",
+          "notifications",
+          "protected"
+        ]
       },
       {
         "id": "ppt-disputes",
@@ -188,10 +326,15 @@
             "required": true
           }
         },
-        "apiEndpoints": ["disputes_list"],
+        "apiEndpoints": [
+          "disputes_list"
+        ],
         "component": "DisputesPage",
         "feature": "Epic-77",
-        "tags": ["disputes", "protected"]
+        "tags": [
+          "disputes",
+          "protected"
+        ]
       },
       {
         "id": "ppt-dispute-new",
@@ -201,16 +344,26 @@
         "description": "File a new dispute",
         "auth": {
           "required": true,
-          "roles": ["owner", "tenant", "resident"],
+          "roles": [
+            "owner",
+            "tenant",
+            "resident"
+          ],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": ["disputes_create"],
+        "apiEndpoints": [
+          "disputes_create"
+        ],
         "component": "FileDisputePage",
         "parentId": "ppt-disputes",
         "feature": "Epic-77",
-        "tags": ["disputes", "protected", "create"]
+        "tags": [
+          "disputes",
+          "protected",
+          "create"
+        ]
       },
       {
         "id": "ppt-dispute-detail",
@@ -232,11 +385,67 @@
             "required": true
           }
         },
-        "apiEndpoints": ["disputes_get"],
+        "apiEndpoints": [
+          "disputes_get"
+        ],
         "component": "DisputeDetailPage",
         "parentId": "ppt-disputes",
         "feature": "Epic-77",
-        "tags": ["disputes", "protected", "detail"]
+        "tags": [
+          "disputes",
+          "protected",
+          "detail"
+        ]
+      },
+      {
+        "id": "ppt-ai-sentiment",
+        "app": "ppt-web",
+        "path": "/ai/sentiment",
+        "name": "Tenant Sentiment",
+        "description": "AI-derived sentiment trends and alerts from tenant communications",
+        "auth": {
+          "required": true,
+          "roles": [
+            "manager",
+            "organization_admin"
+          ],
+          "tenantContext": {
+            "required": true
+          }
+        },
+        "component": "SentimentDashboardPage",
+        "feature": "Epic-13",
+        "tags": [
+          "ai",
+          "sentiment",
+          "protected",
+          "dashboard"
+        ]
+      },
+      {
+        "id": "ppt-ai-predictive-maintenance",
+        "app": "ppt-web",
+        "path": "/ai/predictive-maintenance",
+        "name": "Predictive Maintenance",
+        "description": "AI-powered equipment health monitoring and failure predictions",
+        "auth": {
+          "required": true,
+          "roles": [
+            "manager",
+            "organization_admin"
+          ],
+          "tenantContext": {
+            "required": true
+          }
+        },
+        "component": "PredictiveMaintenancePage",
+        "feature": "Epic-13",
+        "tags": [
+          "ai",
+          "predictive-maintenance",
+          "protected",
+          "dashboard"
+        ]
       }
     ],
     "reality-web": [
@@ -250,7 +459,10 @@
           "required": false
         },
         "component": "HomePage",
-        "tags": ["navigation", "public"]
+        "tags": [
+          "navigation",
+          "public"
+        ]
       },
       {
         "id": "reality-listings",
@@ -299,9 +511,15 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": ["listings_search"],
+        "apiEndpoints": [
+          "listings_search"
+        ],
         "component": "ListingsPage",
-        "tags": ["listings", "public", "search"]
+        "tags": [
+          "listings",
+          "public",
+          "search"
+        ]
       },
       {
         "id": "reality-listing-detail",
@@ -320,10 +538,16 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": ["listings_get"],
+        "apiEndpoints": [
+          "listings_get"
+        ],
         "component": "ListingDetailPage",
         "parentId": "reality-listings",
-        "tags": ["listings", "public", "detail"]
+        "tags": [
+          "listings",
+          "public",
+          "detail"
+        ]
       },
       {
         "id": "reality-favorites",
@@ -334,9 +558,14 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["favorites_list"],
+        "apiEndpoints": [
+          "favorites_list"
+        ],
         "component": "FavoritesPage",
-        "tags": ["favorites", "protected"]
+        "tags": [
+          "favorites",
+          "protected"
+        ]
       },
       {
         "id": "reality-saved-searches",
@@ -347,9 +576,14 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["saved_searches_list"],
+        "apiEndpoints": [
+          "saved_searches_list"
+        ],
         "component": "SavedSearchesPage",
-        "tags": ["saved-searches", "protected"]
+        "tags": [
+          "saved-searches",
+          "protected"
+        ]
       },
       {
         "id": "reality-inquiries",
@@ -360,9 +594,14 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["inquiries_list"],
+        "apiEndpoints": [
+          "inquiries_list"
+        ],
         "component": "InquiriesPage",
-        "tags": ["inquiries", "protected"]
+        "tags": [
+          "inquiries",
+          "protected"
+        ]
       },
       {
         "id": "reality-auth-callback",
@@ -374,7 +613,10 @@
           "required": false
         },
         "component": "OAuthCallbackPage",
-        "tags": ["auth", "public"]
+        "tags": [
+          "auth",
+          "public"
+        ]
       },
       {
         "id": "reality-agency",
@@ -384,12 +626,20 @@
         "description": "Agency management dashboard",
         "auth": {
           "required": true,
-          "roles": ["real_estate_agent", "organization_admin"]
+          "roles": [
+            "real_estate_agent",
+            "organization_admin"
+          ]
         },
-        "apiEndpoints": ["agencies_get"],
+        "apiEndpoints": [
+          "agencies_get"
+        ],
         "component": "AgencyPage",
         "feature": "Epic-32",
-        "tags": ["agency", "protected"]
+        "tags": [
+          "agency",
+          "protected"
+        ]
       },
       {
         "id": "reality-compare",
@@ -401,7 +651,10 @@
           "required": false
         },
         "component": "ComparePage",
-        "tags": ["compare", "public"]
+        "tags": [
+          "compare",
+          "public"
+        ]
       }
     ]
   },
@@ -418,9 +671,15 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["dashboard_get"],
+        "apiEndpoints": [
+          "dashboard_get"
+        ],
         "component": "DashboardScreen",
-        "tags": ["dashboard", "protected", "navigation"]
+        "tags": [
+          "dashboard",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-faults-list",
@@ -433,10 +692,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["faults_list"],
+        "apiEndpoints": [
+          "faults_list"
+        ],
         "component": "FaultsListScreen",
         "feature": "UC-03",
-        "tags": ["faults", "protected", "navigation"]
+        "tags": [
+          "faults",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-report-fault",
@@ -448,13 +713,23 @@
         "tabIcon": "🔧",
         "auth": {
           "required": true,
-          "roles": ["owner", "tenant", "resident"]
+          "roles": [
+            "owner",
+            "tenant",
+            "resident"
+          ]
         },
-        "apiEndpoints": ["faults_create"],
+        "apiEndpoints": [
+          "faults_create"
+        ],
         "component": "ReportFaultScreen",
         "feature": "UC-03",
         "stack": "Faults",
-        "tags": ["faults", "protected", "create"]
+        "tags": [
+          "faults",
+          "protected",
+          "create"
+        ]
       },
       {
         "id": "mobile-announcements",
@@ -467,10 +742,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["announcements_list"],
+        "apiEndpoints": [
+          "announcements_list"
+        ],
         "component": "AnnouncementsScreen",
         "feature": "Epic-6",
-        "tags": ["announcements", "protected", "navigation"]
+        "tags": [
+          "announcements",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-voting",
@@ -483,10 +764,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["voting_list"],
+        "apiEndpoints": [
+          "voting_list"
+        ],
         "component": "VotingScreen",
         "feature": "UC-04",
-        "tags": ["voting", "protected", "navigation"]
+        "tags": [
+          "voting",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-documents",
@@ -499,10 +786,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["documents_list"],
+        "apiEndpoints": [
+          "documents_list"
+        ],
         "component": "DocumentsScreen",
         "feature": "Epic-7",
-        "tags": ["documents", "protected", "navigation"]
+        "tags": [
+          "documents",
+          "protected",
+          "navigation"
+        ]
       }
     ]
   },
@@ -514,7 +807,9 @@
         "method": "GET",
         "path": "/health",
         "description": "Health check endpoint",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -531,7 +826,9 @@
         "method": "POST",
         "path": "/api/v1/auth/login",
         "description": "Login with email and password",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "requestBody": {
           "ref": "Auth.LoginRequest",
           "contentType": "application/json",
@@ -559,7 +856,9 @@
         "method": "POST",
         "path": "/api/v1/auth/register",
         "description": "Register new user account",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "requestBody": {
           "ref": "Auth.RegisterRequest",
           "contentType": "application/json",
@@ -590,7 +889,9 @@
         "method": "POST",
         "path": "/api/v1/auth/logout",
         "description": "Logout user",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -608,7 +909,9 @@
         "method": "POST",
         "path": "/api/v1/auth/refresh",
         "description": "Refresh access token",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -625,12 +928,170 @@
         "feature": "UC-14"
       },
       {
+        "operationId": "auth_sso_callback",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/auth/sso/callback",
+        "description": "Exchange SSO authorization code for PPT JWT tokens (backend stub — not yet implemented)",
+        "tags": [
+          "Authentication",
+          "SSO"
+        ],
+        "requestBody": {
+          "ref": "Auth.SsoCallbackRequest",
+          "contentType": "application/json",
+          "required": true
+        },
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "SSO login successful",
+            "ref": "Auth.LoginResponse"
+          },
+          {
+            "statusCode": 400,
+            "description": "Invalid code or state"
+          },
+          {
+            "statusCode": 401,
+            "description": "SSO provider rejected the code"
+          }
+        ],
+        "auth": {
+          "required": false
+        },
+        "feature": "UC-14"
+      },
+      {
+        "operationId": "auth_mfa_setup",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/auth/mfa/setup",
+        "description": "Begin TOTP MFA setup — returns secret and QR URI",
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "MFA setup initiated"
+          },
+          {
+            "statusCode": 409,
+            "description": "MFA already enabled"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-9-1"
+      },
+      {
+        "operationId": "auth_mfa_verify",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/auth/mfa/verify",
+        "description": "Verify TOTP code to complete MFA setup",
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "MFA verified and enabled"
+          },
+          {
+            "statusCode": 400,
+            "description": "Invalid code"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-9-1"
+      },
+      {
+        "operationId": "auth_mfa_disable",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/auth/mfa/disable",
+        "description": "Disable MFA for the authenticated user",
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "MFA disabled"
+          },
+          {
+            "statusCode": 400,
+            "description": "Invalid confirmation code"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-9-1"
+      },
+      {
+        "operationId": "auth_mfa_status",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/auth/mfa/status",
+        "description": "Get current MFA status for the authenticated user",
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "MFA status"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-9-1"
+      },
+      {
+        "operationId": "auth_mfa_backup_codes_regenerate",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/auth/mfa/backup-codes/regenerate",
+        "description": "Regenerate MFA backup codes",
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "New backup codes"
+          },
+          {
+            "statusCode": 400,
+            "description": "MFA not enabled"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-9-1"
+      },
+      {
         "operationId": "documents_list",
         "server": "api-server",
         "method": "GET",
         "path": "/api/v1/documents",
         "description": "List documents",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -665,7 +1126,9 @@
         "method": "GET",
         "path": "/api/v1/documents/:id",
         "description": "Get document details",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -697,7 +1160,9 @@
         "method": "POST",
         "path": "/api/v1/documents",
         "description": "Upload a new document",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "requestBody": {
           "contentType": "multipart/form-data",
           "required": true
@@ -726,7 +1191,9 @@
         "method": "GET",
         "path": "/api/v1/documents/:id/versions",
         "description": "Get document versions",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -754,7 +1221,9 @@
         "method": "GET",
         "path": "/api/v1/faults",
         "description": "List faults",
-        "tags": ["Faults"],
+        "tags": [
+          "Faults"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -794,7 +1263,9 @@
         "method": "GET",
         "path": "/api/v1/faults/:id",
         "description": "Get fault details",
-        "tags": ["Faults"],
+        "tags": [
+          "Faults"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -826,7 +1297,9 @@
         "method": "POST",
         "path": "/api/v1/faults",
         "description": "Report a new fault",
-        "tags": ["Faults"],
+        "tags": [
+          "Faults"
+        ],
         "requestBody": {
           "ref": "Faults.CreateRequest",
           "contentType": "application/json",
@@ -856,7 +1329,9 @@
         "method": "GET",
         "path": "/api/v1/voting",
         "description": "List votes",
-        "tags": ["Voting"],
+        "tags": [
+          "Voting"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -896,7 +1371,9 @@
         "method": "GET",
         "path": "/api/v1/voting/:id",
         "description": "Get vote details",
-        "tags": ["Voting"],
+        "tags": [
+          "Voting"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -928,7 +1405,9 @@
         "method": "POST",
         "path": "/api/v1/voting/:id/cast",
         "description": "Cast a vote",
-        "tags": ["Voting"],
+        "tags": [
+          "Voting"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -969,7 +1448,9 @@
         "method": "GET",
         "path": "/api/v1/announcements",
         "description": "List announcements",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1004,7 +1485,9 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id",
         "description": "Get announcement details",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1036,10 +1519,28 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/read",
         "description": "Mark announcement as read by current user",
-        "tags": ["Announcements"],
-        "pathParams": [{ "name": "id", "type": "uuid", "required": true }],
-        "responses": [{ "statusCode": 200, "description": "Marked as read" }],
-        "auth": { "required": true, "tenantContext": { "required": true } },
+        "tags": [
+          "Announcements"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Marked as read"
+          }
+        ],
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
         "feature": "Epic-6"
       },
       {
@@ -1048,10 +1549,28 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/acknowledge",
         "description": "Acknowledge an announcement",
-        "tags": ["Announcements"],
-        "pathParams": [{ "name": "id", "type": "uuid", "required": true }],
-        "responses": [{ "statusCode": 200, "description": "Acknowledged" }],
-        "auth": { "required": true, "tenantContext": { "required": true } },
+        "tags": [
+          "Announcements"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Acknowledged"
+          }
+        ],
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
         "feature": "Epic-6"
       },
       {
@@ -1060,10 +1579,28 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id/acknowledgments",
         "description": "Get acknowledgment stats for an announcement",
-        "tags": ["Announcements"],
-        "pathParams": [{ "name": "id", "type": "uuid", "required": true }],
-        "responses": [{ "statusCode": 200, "description": "Acknowledgment stats" }],
-        "auth": { "required": true, "tenantContext": { "required": true } },
+        "tags": [
+          "Announcements"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Acknowledgment stats"
+          }
+        ],
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
         "feature": "Epic-6"
       },
       {
@@ -1072,10 +1609,28 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id/comments",
         "description": "List comments for an announcement",
-        "tags": ["Announcements"],
-        "pathParams": [{ "name": "id", "type": "uuid", "required": true }],
-        "responses": [{ "statusCode": 200, "description": "Comment list" }],
-        "auth": { "required": true, "tenantContext": { "required": true } },
+        "tags": [
+          "Announcements"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Comment list"
+          }
+        ],
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
         "feature": "Epic-6"
       },
       {
@@ -1084,13 +1639,32 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/comments",
         "description": "Post a comment on an announcement",
-        "tags": ["Announcements"],
-        "pathParams": [{ "name": "id", "type": "uuid", "required": true }],
-        "responses": [
-          { "statusCode": 201, "description": "Comment created" },
-          { "statusCode": 400, "description": "Invalid input" }
+        "tags": [
+          "Announcements"
         ],
-        "auth": { "required": true, "tenantContext": { "required": true } },
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 201,
+            "description": "Comment created"
+          },
+          {
+            "statusCode": 400,
+            "description": "Invalid input"
+          }
+        ],
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
         "feature": "Epic-6"
       },
       {
@@ -1099,17 +1673,41 @@
         "method": "DELETE",
         "path": "/api/v1/announcements/:id/comments/:commentId",
         "description": "Delete a comment on an announcement",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
-          { "name": "id", "type": "uuid", "required": true },
-          { "name": "commentId", "type": "uuid", "required": true }
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          },
+          {
+            "name": "commentId",
+            "type": "uuid",
+            "required": true
+          }
         ],
         "responses": [
-          { "statusCode": 200, "description": "Comment deleted" },
-          { "statusCode": 403, "description": "Forbidden" },
-          { "statusCode": 404, "description": "Not found" }
+          {
+            "statusCode": 200,
+            "description": "Comment deleted"
+          },
+          {
+            "statusCode": 403,
+            "description": "Forbidden"
+          },
+          {
+            "statusCode": 404,
+            "description": "Not found"
+          }
         ],
-        "auth": { "required": true, "tenantContext": { "required": true } },
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
         "feature": "Epic-6"
       },
       {
@@ -1118,7 +1716,9 @@
         "method": "GET",
         "path": "/api/v1/news",
         "description": "List news articles",
-        "tags": ["News"],
+        "tags": [
+          "News"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1153,7 +1753,9 @@
         "method": "GET",
         "path": "/api/v1/news/:id",
         "description": "Get news article details",
-        "tags": ["News"],
+        "tags": [
+          "News"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1185,7 +1787,9 @@
         "method": "GET",
         "path": "/api/v1/emergency",
         "description": "List emergency contacts",
-        "tags": ["Emergency"],
+        "tags": [
+          "Emergency"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1206,7 +1810,9 @@
         "method": "GET",
         "path": "/api/v1/disputes",
         "description": "List disputes",
-        "tags": ["Disputes"],
+        "tags": [
+          "Disputes"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1246,7 +1852,9 @@
         "method": "GET",
         "path": "/api/v1/disputes/:id",
         "description": "Get dispute details",
-        "tags": ["Disputes"],
+        "tags": [
+          "Disputes"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1278,7 +1886,9 @@
         "method": "POST",
         "path": "/api/v1/disputes",
         "description": "File a new dispute",
-        "tags": ["Disputes"],
+        "tags": [
+          "Disputes"
+        ],
         "requestBody": {
           "ref": "Disputes.CreateRequest",
           "contentType": "application/json",
@@ -1308,7 +1918,9 @@
         "method": "GET",
         "path": "/api/v1/dashboard",
         "description": "Get dashboard data",
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1321,6 +1933,1070 @@
             "required": true
           }
         }
+      },
+      {
+        "operationId": "list_oauth_clients",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/admin/oauth/clients",
+        "description": "List all registered OAuth clients",
+        "tags": [
+          "OAuth"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "List of OAuth clients"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-2"
+      },
+      {
+        "operationId": "get_oauth_client",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/admin/oauth/clients/:clientId",
+        "description": "Get a single OAuth client by ID",
+        "tags": [
+          "OAuth"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "OAuth client"
+          },
+          {
+            "statusCode": 404,
+            "description": "Client not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-2"
+      },
+      {
+        "operationId": "register_oauth_client",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/admin/oauth/clients",
+        "description": "Register a new OAuth client",
+        "tags": [
+          "OAuth"
+        ],
+        "requestBody": {
+          "ref": "OAuth.RegisterClientRequest",
+          "contentType": "application/json",
+          "required": true
+        },
+        "responses": [
+          {
+            "statusCode": 201,
+            "description": "Client registered"
+          },
+          {
+            "statusCode": 400,
+            "description": "Invalid input"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-2"
+      },
+      {
+        "operationId": "update_oauth_client",
+        "server": "api-server",
+        "method": "PATCH",
+        "path": "/api/v1/admin/oauth/clients/:clientId",
+        "description": "Update OAuth client name, description, scopes, or status",
+        "tags": [
+          "OAuth"
+        ],
+        "requestBody": {
+          "ref": "OAuth.UpdateClientRequest",
+          "contentType": "application/json",
+          "required": true
+        },
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Client updated"
+          },
+          {
+            "statusCode": 404,
+            "description": "Client not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-2"
+      },
+      {
+        "operationId": "revoke_oauth_client",
+        "server": "api-server",
+        "method": "DELETE",
+        "path": "/api/v1/admin/oauth/clients/:clientId",
+        "description": "Revoke (deactivate) an OAuth client",
+        "tags": [
+          "OAuth"
+        ],
+        "responses": [
+          {
+            "statusCode": 204,
+            "description": "Client revoked"
+          },
+          {
+            "statusCode": 404,
+            "description": "Client not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-2"
+      },
+      {
+        "operationId": "regenerate_oauth_client_secret",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/admin/oauth/clients/:clientId/secret",
+        "description": "Regenerate the client secret for an OAuth client",
+        "tags": [
+          "OAuth"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "New client secret"
+          },
+          {
+            "statusCode": 404,
+            "description": "Client not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-2"
+      },
+      {
+        "operationId": "list_organizations",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/organizations",
+        "description": "List all organizations with metrics (platform admin view)",
+        "tags": [
+          "Platform Admin"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Organizations retrieved"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-1"
+      },
+      {
+        "operationId": "get_organization",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/organizations/:id",
+        "description": "Get organization details with members, buildings, usage metrics, billing status",
+        "tags": [
+          "Platform Admin"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Organization retrieved"
+          },
+          {
+            "statusCode": 404,
+            "description": "Organization not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-1"
+      },
+      {
+        "operationId": "suspend_organization",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/platform-admin/organizations/:id/suspend",
+        "description": "Suspend an organization (cascade-invalidates all org sessions)",
+        "tags": [
+          "Platform Admin"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Organization suspended"
+          },
+          {
+            "statusCode": 404,
+            "description": "Organization not found"
+          },
+          {
+            "statusCode": 409,
+            "description": "Organization already suspended"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-1"
+      },
+      {
+        "operationId": "reactivate_organization",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/platform-admin/organizations/:id/reactivate",
+        "description": "Reactivate a suspended organization",
+        "tags": [
+          "Platform Admin"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Organization reactivated"
+          },
+          {
+            "statusCode": 404,
+            "description": "Organization not found"
+          },
+          {
+            "statusCode": 409,
+            "description": "Organization not suspended"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-1"
+      },
+      {
+        "operationId": "get_platform_stats",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/stats",
+        "description": "Get platform-wide statistics (org counts, member counts, usage)",
+        "tags": [
+          "Platform Admin"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Platform stats retrieved"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-1"
+      },
+      {
+        "operationId": "get_health_dashboard",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/health/dashboard",
+        "description": "Get platform health dashboard (current metrics, active alerts, thresholds)",
+        "tags": [
+          "Health"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Health dashboard"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-3"
+      },
+      {
+        "operationId": "get_health_alerts",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/health/alerts",
+        "description": "List metric alerts with optional active-only filter",
+        "tags": [
+          "Health"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "List of alerts"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-3"
+      },
+      {
+        "operationId": "acknowledge_health_alert",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/platform-admin/health/alerts/:alertId/acknowledge",
+        "description": "Acknowledge an active metric alert",
+        "tags": [
+          "Health"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Alert acknowledged"
+          },
+          {
+            "statusCode": 404,
+            "description": "Alert not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-3"
+      },
+      {
+        "operationId": "get_metric_history",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/health/metrics/:name/history",
+        "description": "Get time-series history for a specific metric",
+        "tags": [
+          "Health"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Metric history with data points and stats"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-3"
+      },
+      {
+        "operationId": "update_health_threshold",
+        "server": "api-server",
+        "method": "PUT",
+        "path": "/api/v1/platform-admin/health/thresholds/:name",
+        "description": "Update warning and critical thresholds for a metric",
+        "tags": [
+          "Health"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Updated threshold"
+          },
+          {
+            "statusCode": 404,
+            "description": "Threshold not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-3"
+      },
+      {
+        "operationId": "list_user_grants",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/oauth/grants",
+        "description": "List all OAuth grants for the authenticated user",
+        "tags": [
+          "OAuth"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "List of OAuth grants"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-3"
+      },
+      {
+        "operationId": "revoke_user_grant",
+        "server": "api-server",
+        "method": "DELETE",
+        "path": "/api/v1/oauth/grants/:clientId",
+        "description": "Revoke a specific OAuth grant for the authenticated user",
+        "tags": [
+          "OAuth"
+        ],
+        "responses": [
+          {
+            "statusCode": 204,
+            "description": "Grant revoked"
+          },
+          {
+            "statusCode": 404,
+            "description": "Grant not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10A-3"
+      },
+      {
+        "operationId": "list_system_announcements",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/announcements",
+        "description": "List all platform-wide system announcements",
+        "tags": [
+          "SystemAnnouncements"
+        ],
+        "queryParams": [
+          {
+            "name": "include_deleted",
+            "type": "string",
+            "required": false,
+            "defaultValue": "false"
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "List of system announcements"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-4"
+      },
+      {
+        "operationId": "get_system_announcement",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/announcements/:id",
+        "description": "Get a single system announcement by ID",
+        "tags": [
+          "SystemAnnouncements"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "System announcement"
+          },
+          {
+            "statusCode": 404,
+            "description": "Not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-4"
+      },
+      {
+        "operationId": "create_system_announcement",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/platform-admin/announcements",
+        "description": "Create a new platform-wide system announcement",
+        "tags": [
+          "SystemAnnouncements"
+        ],
+        "requestBody": {
+          "ref": "SystemAnnouncements.CreateRequest",
+          "contentType": "application/json",
+          "required": true
+        },
+        "responses": [
+          {
+            "statusCode": 201,
+            "description": "Announcement created"
+          },
+          {
+            "statusCode": 400,
+            "description": "Invalid input"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-4"
+      },
+      {
+        "operationId": "update_system_announcement",
+        "server": "api-server",
+        "method": "PUT",
+        "path": "/api/v1/platform-admin/announcements/:id",
+        "description": "Update an existing system announcement",
+        "tags": [
+          "SystemAnnouncements"
+        ],
+        "requestBody": {
+          "ref": "SystemAnnouncements.UpdateRequest",
+          "contentType": "application/json",
+          "required": true
+        },
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Announcement updated"
+          },
+          {
+            "statusCode": 404,
+            "description": "Not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-4"
+      },
+      {
+        "operationId": "delete_system_announcement",
+        "server": "api-server",
+        "method": "DELETE",
+        "path": "/api/v1/platform-admin/announcements/:id",
+        "description": "Soft-delete a system announcement",
+        "tags": [
+          "SystemAnnouncements"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "uuid",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 204,
+            "description": "Announcement deleted"
+          },
+          {
+            "statusCode": 404,
+            "description": "Not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-4"
+      },
+      {
+        "operationId": "get_onboarding_status",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/onboarding/status",
+        "description": "Get onboarding status with the list of tours and per-tour progress",
+        "tags": [
+          "Onboarding"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Onboarding status"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-6"
+      },
+      {
+        "operationId": "get_onboarding_tours",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/onboarding/tours",
+        "description": "List onboarding tours for the authenticated user",
+        "tags": [
+          "Onboarding"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "List of tours with progress"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-6"
+      },
+      {
+        "operationId": "start_onboarding_tour",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/onboarding/tours/:tourId/start",
+        "description": "Start an onboarding tour for the authenticated user",
+        "tags": [
+          "Onboarding"
+        ],
+        "pathParams": [
+          {
+            "name": "tourId",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Tour progress"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-6"
+      },
+      {
+        "operationId": "complete_onboarding_step",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/onboarding/tours/:tourId/steps/:stepId/complete",
+        "description": "Mark a single onboarding step as complete",
+        "tags": [
+          "Onboarding"
+        ],
+        "pathParams": [
+          {
+            "name": "tourId",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "stepId",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Updated tour progress"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-6"
+      },
+      {
+        "operationId": "complete_onboarding_tour",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/onboarding/tours/:tourId/complete",
+        "description": "Mark an onboarding tour as complete",
+        "tags": [
+          "Onboarding"
+        ],
+        "pathParams": [
+          {
+            "name": "tourId",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Updated tour progress"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-6"
+      },
+      {
+        "operationId": "skip_onboarding_tour",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/onboarding/tours/:tourId/skip",
+        "description": "Skip an onboarding tour",
+        "tags": [
+          "Onboarding"
+        ],
+        "pathParams": [
+          {
+            "name": "tourId",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Updated tour progress"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-6"
+      },
+      {
+        "operationId": "reset_onboarding_tour",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/onboarding/tours/:tourId/reset",
+        "description": "Reset onboarding tour progress to the beginning",
+        "tags": [
+          "Onboarding"
+        ],
+        "pathParams": [
+          {
+            "name": "tourId",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Updated tour progress"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-6"
+      },
+      {
+        "operationId": "list_feature_flags",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/feature-flags",
+        "description": "List all feature flags (platform admin)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "List of feature flags"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "create_feature_flag",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/platform-admin/feature-flags",
+        "description": "Create a new feature flag (platform admin)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "responses": [
+          {
+            "statusCode": 201,
+            "description": "Feature flag created"
+          },
+          {
+            "statusCode": 400,
+            "description": "Invalid input"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "get_feature_flag",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/platform-admin/feature-flags/:id",
+        "description": "Get a single feature flag with its overrides (platform admin)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Feature flag with overrides"
+          },
+          {
+            "statusCode": 404,
+            "description": "Feature flag not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "update_feature_flag",
+        "server": "api-server",
+        "method": "PUT",
+        "path": "/api/v1/platform-admin/feature-flags/:id",
+        "description": "Update a feature flag (platform admin)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Feature flag updated"
+          },
+          {
+            "statusCode": 404,
+            "description": "Feature flag not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "delete_feature_flag",
+        "server": "api-server",
+        "method": "DELETE",
+        "path": "/api/v1/platform-admin/feature-flags/:id",
+        "description": "Delete a feature flag (platform admin)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 204,
+            "description": "Feature flag deleted"
+          },
+          {
+            "statusCode": 404,
+            "description": "Feature flag not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "toggle_feature_flag",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/platform-admin/feature-flags/:id/toggle",
+        "description": "Toggle a feature flag on/off (platform admin, audit-logged)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Feature flag toggled"
+          },
+          {
+            "statusCode": 404,
+            "description": "Feature flag not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "create_feature_flag_override",
+        "server": "api-server",
+        "method": "POST",
+        "path": "/api/v1/platform-admin/feature-flags/:id/overrides",
+        "description": "Create a per-scope override for a feature flag (platform admin)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 201,
+            "description": "Override created"
+          },
+          {
+            "statusCode": 404,
+            "description": "Feature flag not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "delete_feature_flag_override",
+        "server": "api-server",
+        "method": "DELETE",
+        "path": "/api/v1/platform-admin/feature-flags/:id/overrides/:override_id",
+        "description": "Delete a per-scope override from a feature flag (platform admin)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "pathParams": [
+          {
+            "name": "id",
+            "type": "string",
+            "required": true
+          },
+          {
+            "name": "override_id",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 204,
+            "description": "Override deleted"
+          },
+          {
+            "statusCode": 404,
+            "description": "Override not found"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "get_resolved_feature_flags",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/feature-flags",
+        "description": "Get resolved feature flags for the current caller (org/user/role overrides applied)",
+        "tags": [
+          "Feature Flags"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Resolved feature flags"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-10B-2"
+      },
+      {
+        "operationId": "notification_preferences_list",
+        "server": "api-server",
+        "method": "GET",
+        "path": "/api/v1/users/me/notification-preferences",
+        "description": "Get all notification channel preferences for the current user",
+        "tags": [
+          "Notification Preferences"
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Preferences retrieved"
+          },
+          {
+            "statusCode": 401,
+            "description": "Not authenticated"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-8A"
+      },
+      {
+        "operationId": "notification_preference_update",
+        "server": "api-server",
+        "method": "PATCH",
+        "path": "/api/v1/users/me/notification-preferences/:channel",
+        "description": "Enable/disable a single notification channel (push / email / in_app); requires confirmDisableAll to turn off the last active channel",
+        "tags": [
+          "Notification Preferences"
+        ],
+        "pathParams": [
+          {
+            "name": "channel",
+            "type": "string",
+            "required": true
+          }
+        ],
+        "responses": [
+          {
+            "statusCode": 200,
+            "description": "Preference updated"
+          },
+          {
+            "statusCode": 401,
+            "description": "Not authenticated"
+          },
+          {
+            "statusCode": 409,
+            "description": "Confirmation required to disable all channels"
+          }
+        ],
+        "auth": {
+          "required": true
+        },
+        "feature": "Epic-8A"
       }
     ],
     "reality-server": [
@@ -1330,7 +3006,9 @@
         "method": "GET",
         "path": "/health",
         "description": "Health check endpoint",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1347,7 +3025,9 @@
         "method": "GET",
         "path": "/api/v1/listings",
         "description": "Search property listings",
-        "tags": ["Listings"],
+        "tags": [
+          "Listings"
+        ],
         "queryParams": [
           {
             "name": "type",
@@ -1420,7 +3100,9 @@
         "method": "GET",
         "path": "/api/v1/listings/:slug",
         "description": "Get listing details by slug",
-        "tags": ["Listings"],
+        "tags": [
+          "Listings"
+        ],
         "pathParams": [
           {
             "name": "slug",
@@ -1449,7 +3131,9 @@
         "method": "GET",
         "path": "/api/v1/listings/suggestions",
         "description": "Get search suggestions",
-        "tags": ["Listings"],
+        "tags": [
+          "Listings"
+        ],
         "queryParams": [
           {
             "name": "q",
@@ -1474,7 +3158,9 @@
         "method": "GET",
         "path": "/api/v1/favorites",
         "description": "List user's favorites",
-        "tags": ["Favorites"],
+        "tags": [
+          "Favorites"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1491,7 +3177,9 @@
         "method": "POST",
         "path": "/api/v1/favorites",
         "description": "Add to favorites",
-        "tags": ["Favorites"],
+        "tags": [
+          "Favorites"
+        ],
         "requestBody": {
           "ref": "Favorites.AddRequest",
           "contentType": "application/json",
@@ -1517,7 +3205,9 @@
         "method": "DELETE",
         "path": "/api/v1/favorites/:id",
         "description": "Remove from favorites",
-        "tags": ["Favorites"],
+        "tags": [
+          "Favorites"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1545,7 +3235,9 @@
         "method": "GET",
         "path": "/api/v1/saved-searches",
         "description": "List saved searches",
-        "tags": ["SavedSearches"],
+        "tags": [
+          "SavedSearches"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1562,7 +3254,9 @@
         "method": "POST",
         "path": "/api/v1/saved-searches",
         "description": "Create saved search",
-        "tags": ["SavedSearches"],
+        "tags": [
+          "SavedSearches"
+        ],
         "requestBody": {
           "ref": "SavedSearches.CreateRequest",
           "contentType": "application/json",
@@ -1584,7 +3278,9 @@
         "method": "DELETE",
         "path": "/api/v1/saved-searches/:id",
         "description": "Delete saved search",
-        "tags": ["SavedSearches"],
+        "tags": [
+          "SavedSearches"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1608,7 +3304,9 @@
         "method": "GET",
         "path": "/api/v1/inquiries",
         "description": "List inquiries",
-        "tags": ["Inquiries"],
+        "tags": [
+          "Inquiries"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1625,7 +3323,9 @@
         "method": "POST",
         "path": "/api/v1/inquiries/contact/:listing_id",
         "description": "Send contact message",
-        "tags": ["Inquiries"],
+        "tags": [
+          "Inquiries"
+        ],
         "pathParams": [
           {
             "name": "listing_id",
@@ -1655,7 +3355,9 @@
         "method": "POST",
         "path": "/api/v1/inquiries/viewing/:listing_id",
         "description": "Request viewing",
-        "tags": ["Inquiries"],
+        "tags": [
+          "Inquiries"
+        ],
         "pathParams": [
           {
             "name": "listing_id",
@@ -1685,7 +3387,9 @@
         "method": "GET",
         "path": "/api/v1/sso/login",
         "description": "Initiate SSO login",
-        "tags": ["SSO"],
+        "tags": [
+          "SSO"
+        ],
         "responses": [
           {
             "statusCode": 302,
@@ -1703,7 +3407,9 @@
         "method": "GET",
         "path": "/api/v1/sso/callback",
         "description": "SSO callback",
-        "tags": ["SSO"],
+        "tags": [
+          "SSO"
+        ],
         "responses": [
           {
             "statusCode": 302,
@@ -1721,7 +3427,9 @@
         "method": "GET",
         "path": "/api/v1/sso/session",
         "description": "Get current session",
-        "tags": ["SSO"],
+        "tags": [
+          "SSO"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1739,7 +3447,9 @@
         "method": "GET",
         "path": "/api/v1/agencies/:id",
         "description": "Get agency details",
-        "tags": ["Agencies"],
+        "tags": [
+          "Agencies"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1768,7 +3478,9 @@
         "method": "POST",
         "path": "/api/v1/agencies",
         "description": "Create agency",
-        "tags": ["Agencies"],
+        "tags": [
+          "Agencies"
+        ],
         "requestBody": {
           "ref": "Agencies.CreateRequest",
           "contentType": "application/json",
@@ -1782,7 +3494,9 @@
         ],
         "auth": {
           "required": true,
-          "roles": ["organization_admin"]
+          "roles": [
+            "organization_admin"
+          ]
         },
         "feature": "Epic-32"
       }
@@ -1792,11 +3506,16 @@
     {
       "id": "flow-login-basic",
       "name": "Basic Login Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User logs in with email and password",
       "category": "authentication",
       "requiredRole": "anonymous",
-      "useCases": ["UC-14.1"],
+      "useCases": [
+        "UC-14.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -1878,16 +3597,25 @@
         "authenticated": true,
         "redirectedTo": "/"
       },
-      "tags": ["auth", "critical", "smoke"]
+      "tags": [
+        "auth",
+        "critical",
+        "smoke"
+      ]
     },
     {
       "id": "flow-logout",
       "name": "Logout Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User logs out of the system",
       "category": "authentication",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
       "steps": [
         {
           "order": 1,
@@ -1929,17 +3657,27 @@
         "authenticated": false,
         "redirectedTo": "/login"
       },
-      "tags": ["auth", "smoke"]
+      "tags": [
+        "auth",
+        "smoke"
+      ]
     },
     {
       "id": "flow-document-upload",
       "name": "Document Upload Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User uploads a new document",
       "category": "documents",
       "requiredRole": "owner",
-      "prerequisites": ["flow-login-basic"],
-      "useCases": ["UC-08.1"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
+      "useCases": [
+        "UC-08.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -2015,16 +3753,25 @@
       "expectedOutcome": {
         "documentUploaded": true
       },
-      "tags": ["documents", "upload", "smoke"]
+      "tags": [
+        "documents",
+        "upload",
+        "smoke"
+      ]
     },
     {
       "id": "flow-document-view",
       "name": "Document View Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User views document details",
       "category": "documents",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
       "steps": [
         {
           "order": 1,
@@ -2066,17 +3813,27 @@
       "expectedOutcome": {
         "documentViewed": true
       },
-      "tags": ["documents", "view"]
+      "tags": [
+        "documents",
+        "view"
+      ]
     },
     {
       "id": "flow-report-fault",
       "name": "Report Fault Flow",
-      "apps": ["mobile", "api-server"],
+      "apps": [
+        "mobile",
+        "api-server"
+      ],
       "description": "User reports a new fault",
       "category": "fault_management",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
-      "useCases": ["UC-03.1"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
+      "useCases": [
+        "UC-03.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -2128,16 +3885,25 @@
       "expectedOutcome": {
         "faultCreated": true
       },
-      "tags": ["faults", "create", "smoke"]
+      "tags": [
+        "faults",
+        "create",
+        "smoke"
+      ]
     },
     {
       "id": "flow-file-dispute",
       "name": "File Dispute Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User files a new dispute",
       "category": "disputes",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
       "steps": [
         {
           "order": 1,
@@ -2195,17 +3961,28 @@
       "expectedOutcome": {
         "disputeFiled": true
       },
-      "tags": ["disputes", "create", "smoke"]
+      "tags": [
+        "disputes",
+        "create",
+        "smoke"
+      ]
     },
     {
       "id": "flow-cast-vote",
       "name": "Cast Vote Flow",
-      "apps": ["mobile", "api-server"],
+      "apps": [
+        "mobile",
+        "api-server"
+      ],
       "description": "User casts a vote on a poll",
       "category": "voting",
       "requiredRole": "owner",
-      "prerequisites": ["flow-login-basic"],
-      "useCases": ["UC-04.1"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
+      "useCases": [
+        "UC-04.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -2253,12 +4030,19 @@
       "expectedOutcome": {
         "voteCast": true
       },
-      "tags": ["voting", "cast", "smoke"]
+      "tags": [
+        "voting",
+        "cast",
+        "smoke"
+      ]
     },
     {
       "id": "flow-search-listings",
       "name": "Search Listings Flow",
-      "apps": ["reality-web", "reality-server"],
+      "apps": [
+        "reality-web",
+        "reality-server"
+      ],
       "description": "User searches for property listings",
       "category": "listings",
       "requiredRole": "anonymous",
@@ -2321,16 +4105,25 @@
         "searchPerformed": true,
         "resultsDisplayed": true
       },
-      "tags": ["listings", "search", "smoke"]
+      "tags": [
+        "listings",
+        "search",
+        "smoke"
+      ]
     },
     {
       "id": "flow-add-favorite",
       "name": "Add to Favorites Flow",
-      "apps": ["reality-web", "reality-server"],
+      "apps": [
+        "reality-web",
+        "reality-server"
+      ],
       "description": "User adds a listing to favorites",
       "category": "listings",
       "requiredRole": "portal_user",
-      "prerequisites": ["flow-search-listings"],
+      "prerequisites": [
+        "flow-search-listings"
+      ],
       "steps": [
         {
           "order": 1,
@@ -2373,17 +4166,20 @@
       "expectedOutcome": {
         "favoriteAdded": true
       },
-      "tags": ["favorites", "add"]
+      "tags": [
+        "favorites",
+        "add"
+      ]
     }
   ],
   "metadata": {
-    "generated_at": "2026-01-02T12:05:07.763Z",
+    "generated_at": "2026-07-08T22:20:18.727Z",
     "version": "1.0.0",
     "stats": {
-      "ppt_web_routes": 13,
+      "ppt_web_routes": 19,
       "reality_web_routes": 9,
       "mobile_screens": 6,
-      "api_server_endpoints": 24,
+      "api_server_endpoints": 77,
       "reality_server_endpoints": 18,
       "flows": 9
     }

--- a/frontend/packages/sitemap/src/json/sitemap.json
+++ b/frontend/packages/sitemap/src/json/sitemap.json
@@ -11,10 +11,7 @@
           "required": false
         },
         "component": "Home",
-        "tags": [
-          "navigation",
-          "public"
-        ]
+        "tags": ["navigation", "public"]
       },
       {
         "id": "ppt-login",
@@ -25,15 +22,10 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": [
-          "auth_login"
-        ],
+        "apiEndpoints": ["auth_login"],
         "component": "LoginPage",
         "feature": "UC-14",
-        "tags": [
-          "auth",
-          "public"
-        ]
+        "tags": ["auth", "public"]
       },
       {
         "id": "ppt-auth-callback",
@@ -44,17 +36,11 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": [
-          "auth_sso_callback"
-        ],
+        "apiEndpoints": ["auth_sso_callback"],
         "component": "AuthCallbackPage",
         "parentId": "ppt-login",
         "feature": "UC-14",
-        "tags": [
-          "auth",
-          "public",
-          "sso"
-        ]
+        "tags": ["auth", "public", "sso"]
       },
       {
         "id": "ppt-documents",
@@ -64,25 +50,15 @@
         "description": "Document management dashboard",
         "auth": {
           "required": true,
-          "roles": [
-            "owner",
-            "tenant",
-            "manager",
-            "organization_admin"
-          ],
+          "roles": ["owner", "tenant", "manager", "organization_admin"],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": [
-          "documents_list"
-        ],
+        "apiEndpoints": ["documents_list"],
         "component": "DocumentsPage",
         "feature": "Epic-39",
-        "tags": [
-          "documents",
-          "protected"
-        ]
+        "tags": ["documents", "protected"]
       },
       {
         "id": "ppt-document-upload",
@@ -92,26 +68,16 @@
         "description": "Document upload page",
         "auth": {
           "required": true,
-          "roles": [
-            "owner",
-            "manager",
-            "organization_admin"
-          ],
+          "roles": ["owner", "manager", "organization_admin"],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": [
-          "documents_upload"
-        ],
+        "apiEndpoints": ["documents_upload"],
         "component": "DocumentUploadPage",
         "parentId": "ppt-documents",
         "feature": "Epic-39",
-        "tags": [
-          "documents",
-          "protected",
-          "create"
-        ]
+        "tags": ["documents", "protected", "create"]
       },
       {
         "id": "ppt-document-detail",
@@ -133,18 +99,11 @@
             "required": true
           }
         },
-        "apiEndpoints": [
-          "documents_get",
-          "documents_get_versions"
-        ],
+        "apiEndpoints": ["documents_get", "documents_get_versions"],
         "component": "DocumentDetailPage",
         "parentId": "ppt-documents",
         "feature": "Epic-39",
-        "tags": [
-          "documents",
-          "protected",
-          "detail"
-        ]
+        "tags": ["documents", "protected", "detail"]
       },
       {
         "id": "ppt-news",
@@ -158,15 +117,10 @@
             "required": true
           }
         },
-        "apiEndpoints": [
-          "news_list"
-        ],
+        "apiEndpoints": ["news_list"],
         "component": "NewsListPage",
         "feature": "Epic-59",
-        "tags": [
-          "news",
-          "protected"
-        ]
+        "tags": ["news", "protected"]
       },
       {
         "id": "ppt-news-detail",
@@ -188,17 +142,11 @@
             "required": true
           }
         },
-        "apiEndpoints": [
-          "news_get"
-        ],
+        "apiEndpoints": ["news_get"],
         "component": "ArticleDetailPage",
         "parentId": "ppt-news",
         "feature": "Epic-59",
-        "tags": [
-          "news",
-          "protected",
-          "detail"
-        ]
+        "tags": ["news", "protected", "detail"]
       },
       {
         "id": "ppt-emergency",
@@ -212,15 +160,10 @@
             "required": true
           }
         },
-        "apiEndpoints": [
-          "emergency_list"
-        ],
+        "apiEndpoints": ["emergency_list"],
         "component": "EmergencyContactDirectoryPage",
         "feature": "Epic-62",
-        "tags": [
-          "emergency",
-          "protected"
-        ]
+        "tags": ["emergency", "protected"]
       },
       {
         "id": "ppt-settings-accessibility",
@@ -233,10 +176,7 @@
         },
         "component": "AccessibilitySettingsPage",
         "feature": "Epic-60",
-        "tags": [
-          "settings",
-          "protected"
-        ]
+        "tags": ["settings", "protected"]
       },
       {
         "id": "ppt-settings-privacy",
@@ -249,10 +189,7 @@
         },
         "component": "PrivacySettingsPage",
         "feature": "Epic-63",
-        "tags": [
-          "settings",
-          "protected"
-        ]
+        "tags": ["settings", "protected"]
       },
       {
         "id": "ppt-settings-integrations",
@@ -268,12 +205,7 @@
         },
         "component": "IntegrationsPage",
         "feature": "Epic-83",
-        "tags": [
-          "settings",
-          "integrations",
-          "airbnb",
-          "protected"
-        ]
+        "tags": ["settings", "integrations", "airbnb", "protected"]
       },
       {
         "id": "ppt-settings-notifications",
@@ -284,17 +216,10 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "notification_preferences_list",
-          "notification_preference_update"
-        ],
+        "apiEndpoints": ["notification_preferences_list", "notification_preference_update"],
         "component": "NotificationSettingsPage",
         "feature": "Epic-8A",
-        "tags": [
-          "settings",
-          "notifications",
-          "protected"
-        ]
+        "tags": ["settings", "notifications", "protected"]
       },
       {
         "id": "ppt-settings-notifications-advanced",
@@ -308,11 +233,7 @@
         "component": "AdvancedNotificationSettingsPage",
         "parentId": "ppt-settings-notifications",
         "feature": "Epic-40",
-        "tags": [
-          "settings",
-          "notifications",
-          "protected"
-        ]
+        "tags": ["settings", "notifications", "protected"]
       },
       {
         "id": "ppt-disputes",
@@ -326,15 +247,10 @@
             "required": true
           }
         },
-        "apiEndpoints": [
-          "disputes_list"
-        ],
+        "apiEndpoints": ["disputes_list"],
         "component": "DisputesPage",
         "feature": "Epic-77",
-        "tags": [
-          "disputes",
-          "protected"
-        ]
+        "tags": ["disputes", "protected"]
       },
       {
         "id": "ppt-dispute-new",
@@ -344,26 +260,16 @@
         "description": "File a new dispute",
         "auth": {
           "required": true,
-          "roles": [
-            "owner",
-            "tenant",
-            "resident"
-          ],
+          "roles": ["owner", "tenant", "resident"],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": [
-          "disputes_create"
-        ],
+        "apiEndpoints": ["disputes_create"],
         "component": "FileDisputePage",
         "parentId": "ppt-disputes",
         "feature": "Epic-77",
-        "tags": [
-          "disputes",
-          "protected",
-          "create"
-        ]
+        "tags": ["disputes", "protected", "create"]
       },
       {
         "id": "ppt-dispute-detail",
@@ -385,17 +291,11 @@
             "required": true
           }
         },
-        "apiEndpoints": [
-          "disputes_get"
-        ],
+        "apiEndpoints": ["disputes_get"],
         "component": "DisputeDetailPage",
         "parentId": "ppt-disputes",
         "feature": "Epic-77",
-        "tags": [
-          "disputes",
-          "protected",
-          "detail"
-        ]
+        "tags": ["disputes", "protected", "detail"]
       },
       {
         "id": "ppt-ai-sentiment",
@@ -405,22 +305,14 @@
         "description": "AI-derived sentiment trends and alerts from tenant communications",
         "auth": {
           "required": true,
-          "roles": [
-            "manager",
-            "organization_admin"
-          ],
+          "roles": ["manager", "organization_admin"],
           "tenantContext": {
             "required": true
           }
         },
         "component": "SentimentDashboardPage",
         "feature": "Epic-13",
-        "tags": [
-          "ai",
-          "sentiment",
-          "protected",
-          "dashboard"
-        ]
+        "tags": ["ai", "sentiment", "protected", "dashboard"]
       },
       {
         "id": "ppt-ai-predictive-maintenance",
@@ -430,22 +322,14 @@
         "description": "AI-powered equipment health monitoring and failure predictions",
         "auth": {
           "required": true,
-          "roles": [
-            "manager",
-            "organization_admin"
-          ],
+          "roles": ["manager", "organization_admin"],
           "tenantContext": {
             "required": true
           }
         },
         "component": "PredictiveMaintenancePage",
         "feature": "Epic-13",
-        "tags": [
-          "ai",
-          "predictive-maintenance",
-          "protected",
-          "dashboard"
-        ]
+        "tags": ["ai", "predictive-maintenance", "protected", "dashboard"]
       }
     ],
     "reality-web": [
@@ -459,10 +343,7 @@
           "required": false
         },
         "component": "HomePage",
-        "tags": [
-          "navigation",
-          "public"
-        ]
+        "tags": ["navigation", "public"]
       },
       {
         "id": "reality-listings",
@@ -511,15 +392,9 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": [
-          "listings_search"
-        ],
+        "apiEndpoints": ["listings_search"],
         "component": "ListingsPage",
-        "tags": [
-          "listings",
-          "public",
-          "search"
-        ]
+        "tags": ["listings", "public", "search"]
       },
       {
         "id": "reality-listing-detail",
@@ -538,16 +413,10 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": [
-          "listings_get"
-        ],
+        "apiEndpoints": ["listings_get"],
         "component": "ListingDetailPage",
         "parentId": "reality-listings",
-        "tags": [
-          "listings",
-          "public",
-          "detail"
-        ]
+        "tags": ["listings", "public", "detail"]
       },
       {
         "id": "reality-favorites",
@@ -558,14 +427,9 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "favorites_list"
-        ],
+        "apiEndpoints": ["favorites_list"],
         "component": "FavoritesPage",
-        "tags": [
-          "favorites",
-          "protected"
-        ]
+        "tags": ["favorites", "protected"]
       },
       {
         "id": "reality-saved-searches",
@@ -576,14 +440,9 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "saved_searches_list"
-        ],
+        "apiEndpoints": ["saved_searches_list"],
         "component": "SavedSearchesPage",
-        "tags": [
-          "saved-searches",
-          "protected"
-        ]
+        "tags": ["saved-searches", "protected"]
       },
       {
         "id": "reality-inquiries",
@@ -594,14 +453,9 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "inquiries_list"
-        ],
+        "apiEndpoints": ["inquiries_list"],
         "component": "InquiriesPage",
-        "tags": [
-          "inquiries",
-          "protected"
-        ]
+        "tags": ["inquiries", "protected"]
       },
       {
         "id": "reality-auth-callback",
@@ -613,10 +467,7 @@
           "required": false
         },
         "component": "OAuthCallbackPage",
-        "tags": [
-          "auth",
-          "public"
-        ]
+        "tags": ["auth", "public"]
       },
       {
         "id": "reality-agency",
@@ -626,20 +477,12 @@
         "description": "Agency management dashboard",
         "auth": {
           "required": true,
-          "roles": [
-            "real_estate_agent",
-            "organization_admin"
-          ]
+          "roles": ["real_estate_agent", "organization_admin"]
         },
-        "apiEndpoints": [
-          "agencies_get"
-        ],
+        "apiEndpoints": ["agencies_get"],
         "component": "AgencyPage",
         "feature": "Epic-32",
-        "tags": [
-          "agency",
-          "protected"
-        ]
+        "tags": ["agency", "protected"]
       },
       {
         "id": "reality-compare",
@@ -651,10 +494,7 @@
           "required": false
         },
         "component": "ComparePage",
-        "tags": [
-          "compare",
-          "public"
-        ]
+        "tags": ["compare", "public"]
       }
     ]
   },
@@ -671,15 +511,9 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "dashboard_get"
-        ],
+        "apiEndpoints": ["dashboard_get"],
         "component": "DashboardScreen",
-        "tags": [
-          "dashboard",
-          "protected",
-          "navigation"
-        ]
+        "tags": ["dashboard", "protected", "navigation"]
       },
       {
         "id": "mobile-faults-list",
@@ -692,16 +526,10 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "faults_list"
-        ],
+        "apiEndpoints": ["faults_list"],
         "component": "FaultsListScreen",
         "feature": "UC-03",
-        "tags": [
-          "faults",
-          "protected",
-          "navigation"
-        ]
+        "tags": ["faults", "protected", "navigation"]
       },
       {
         "id": "mobile-report-fault",
@@ -713,23 +541,13 @@
         "tabIcon": "🔧",
         "auth": {
           "required": true,
-          "roles": [
-            "owner",
-            "tenant",
-            "resident"
-          ]
+          "roles": ["owner", "tenant", "resident"]
         },
-        "apiEndpoints": [
-          "faults_create"
-        ],
+        "apiEndpoints": ["faults_create"],
         "component": "ReportFaultScreen",
         "feature": "UC-03",
         "stack": "Faults",
-        "tags": [
-          "faults",
-          "protected",
-          "create"
-        ]
+        "tags": ["faults", "protected", "create"]
       },
       {
         "id": "mobile-announcements",
@@ -742,16 +560,10 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "announcements_list"
-        ],
+        "apiEndpoints": ["announcements_list"],
         "component": "AnnouncementsScreen",
         "feature": "Epic-6",
-        "tags": [
-          "announcements",
-          "protected",
-          "navigation"
-        ]
+        "tags": ["announcements", "protected", "navigation"]
       },
       {
         "id": "mobile-voting",
@@ -764,16 +576,10 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "voting_list"
-        ],
+        "apiEndpoints": ["voting_list"],
         "component": "VotingScreen",
         "feature": "UC-04",
-        "tags": [
-          "voting",
-          "protected",
-          "navigation"
-        ]
+        "tags": ["voting", "protected", "navigation"]
       },
       {
         "id": "mobile-documents",
@@ -786,16 +592,10 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": [
-          "documents_list"
-        ],
+        "apiEndpoints": ["documents_list"],
         "component": "DocumentsScreen",
         "feature": "Epic-7",
-        "tags": [
-          "documents",
-          "protected",
-          "navigation"
-        ]
+        "tags": ["documents", "protected", "navigation"]
       }
     ]
   },
@@ -807,9 +607,7 @@
         "method": "GET",
         "path": "/health",
         "description": "Health check endpoint",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": [
           {
             "statusCode": 200,
@@ -826,9 +624,7 @@
         "method": "POST",
         "path": "/api/v1/auth/login",
         "description": "Login with email and password",
-        "tags": [
-          "Authentication"
-        ],
+        "tags": ["Authentication"],
         "requestBody": {
           "ref": "Auth.LoginRequest",
           "contentType": "application/json",
@@ -856,9 +652,7 @@
         "method": "POST",
         "path": "/api/v1/auth/register",
         "description": "Register new user account",
-        "tags": [
-          "Authentication"
-        ],
+        "tags": ["Authentication"],
         "requestBody": {
           "ref": "Auth.RegisterRequest",
           "contentType": "application/json",
@@ -889,9 +683,7 @@
         "method": "POST",
         "path": "/api/v1/auth/logout",
         "description": "Logout user",
-        "tags": [
-          "Authentication"
-        ],
+        "tags": ["Authentication"],
         "responses": [
           {
             "statusCode": 200,
@@ -909,9 +701,7 @@
         "method": "POST",
         "path": "/api/v1/auth/refresh",
         "description": "Refresh access token",
-        "tags": [
-          "Authentication"
-        ],
+        "tags": ["Authentication"],
         "responses": [
           {
             "statusCode": 200,
@@ -933,10 +723,7 @@
         "method": "POST",
         "path": "/api/v1/auth/sso/callback",
         "description": "Exchange SSO authorization code for PPT JWT tokens (backend stub — not yet implemented)",
-        "tags": [
-          "Authentication",
-          "SSO"
-        ],
+        "tags": ["Authentication", "SSO"],
         "requestBody": {
           "ref": "Auth.SsoCallbackRequest",
           "contentType": "application/json",
@@ -968,10 +755,7 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/setup",
         "description": "Begin TOTP MFA setup — returns secret and QR URI",
-        "tags": [
-          "Authentication",
-          "MFA"
-        ],
+        "tags": ["Authentication", "MFA"],
         "responses": [
           {
             "statusCode": 200,
@@ -993,10 +777,7 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/verify",
         "description": "Verify TOTP code to complete MFA setup",
-        "tags": [
-          "Authentication",
-          "MFA"
-        ],
+        "tags": ["Authentication", "MFA"],
         "responses": [
           {
             "statusCode": 200,
@@ -1018,10 +799,7 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/disable",
         "description": "Disable MFA for the authenticated user",
-        "tags": [
-          "Authentication",
-          "MFA"
-        ],
+        "tags": ["Authentication", "MFA"],
         "responses": [
           {
             "statusCode": 200,
@@ -1043,10 +821,7 @@
         "method": "GET",
         "path": "/api/v1/auth/mfa/status",
         "description": "Get current MFA status for the authenticated user",
-        "tags": [
-          "Authentication",
-          "MFA"
-        ],
+        "tags": ["Authentication", "MFA"],
         "responses": [
           {
             "statusCode": 200,
@@ -1064,10 +839,7 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/backup-codes/regenerate",
         "description": "Regenerate MFA backup codes",
-        "tags": [
-          "Authentication",
-          "MFA"
-        ],
+        "tags": ["Authentication", "MFA"],
         "responses": [
           {
             "statusCode": 200,
@@ -1089,9 +861,7 @@
         "method": "GET",
         "path": "/api/v1/documents",
         "description": "List documents",
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "queryParams": [
           {
             "name": "page",
@@ -1126,9 +896,7 @@
         "method": "GET",
         "path": "/api/v1/documents/:id",
         "description": "Get document details",
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "pathParams": [
           {
             "name": "id",
@@ -1160,9 +928,7 @@
         "method": "POST",
         "path": "/api/v1/documents",
         "description": "Upload a new document",
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "requestBody": {
           "contentType": "multipart/form-data",
           "required": true
@@ -1191,9 +957,7 @@
         "method": "GET",
         "path": "/api/v1/documents/:id/versions",
         "description": "Get document versions",
-        "tags": [
-          "Documents"
-        ],
+        "tags": ["Documents"],
         "pathParams": [
           {
             "name": "id",
@@ -1221,9 +985,7 @@
         "method": "GET",
         "path": "/api/v1/faults",
         "description": "List faults",
-        "tags": [
-          "Faults"
-        ],
+        "tags": ["Faults"],
         "queryParams": [
           {
             "name": "page",
@@ -1263,9 +1025,7 @@
         "method": "GET",
         "path": "/api/v1/faults/:id",
         "description": "Get fault details",
-        "tags": [
-          "Faults"
-        ],
+        "tags": ["Faults"],
         "pathParams": [
           {
             "name": "id",
@@ -1297,9 +1057,7 @@
         "method": "POST",
         "path": "/api/v1/faults",
         "description": "Report a new fault",
-        "tags": [
-          "Faults"
-        ],
+        "tags": ["Faults"],
         "requestBody": {
           "ref": "Faults.CreateRequest",
           "contentType": "application/json",
@@ -1329,9 +1087,7 @@
         "method": "GET",
         "path": "/api/v1/voting",
         "description": "List votes",
-        "tags": [
-          "Voting"
-        ],
+        "tags": ["Voting"],
         "queryParams": [
           {
             "name": "page",
@@ -1371,9 +1127,7 @@
         "method": "GET",
         "path": "/api/v1/voting/:id",
         "description": "Get vote details",
-        "tags": [
-          "Voting"
-        ],
+        "tags": ["Voting"],
         "pathParams": [
           {
             "name": "id",
@@ -1405,9 +1159,7 @@
         "method": "POST",
         "path": "/api/v1/voting/:id/cast",
         "description": "Cast a vote",
-        "tags": [
-          "Voting"
-        ],
+        "tags": ["Voting"],
         "pathParams": [
           {
             "name": "id",
@@ -1448,9 +1200,7 @@
         "method": "GET",
         "path": "/api/v1/announcements",
         "description": "List announcements",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "queryParams": [
           {
             "name": "page",
@@ -1485,9 +1235,7 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id",
         "description": "Get announcement details",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "pathParams": [
           {
             "name": "id",
@@ -1519,9 +1267,7 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/read",
         "description": "Mark announcement as read by current user",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "pathParams": [
           {
             "name": "id",
@@ -1549,9 +1295,7 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/acknowledge",
         "description": "Acknowledge an announcement",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "pathParams": [
           {
             "name": "id",
@@ -1579,9 +1323,7 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id/acknowledgments",
         "description": "Get acknowledgment stats for an announcement",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "pathParams": [
           {
             "name": "id",
@@ -1609,9 +1351,7 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id/comments",
         "description": "List comments for an announcement",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "pathParams": [
           {
             "name": "id",
@@ -1639,9 +1379,7 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/comments",
         "description": "Post a comment on an announcement",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "pathParams": [
           {
             "name": "id",
@@ -1673,9 +1411,7 @@
         "method": "DELETE",
         "path": "/api/v1/announcements/:id/comments/:commentId",
         "description": "Delete a comment on an announcement",
-        "tags": [
-          "Announcements"
-        ],
+        "tags": ["Announcements"],
         "pathParams": [
           {
             "name": "id",
@@ -1716,9 +1452,7 @@
         "method": "GET",
         "path": "/api/v1/news",
         "description": "List news articles",
-        "tags": [
-          "News"
-        ],
+        "tags": ["News"],
         "queryParams": [
           {
             "name": "page",
@@ -1753,9 +1487,7 @@
         "method": "GET",
         "path": "/api/v1/news/:id",
         "description": "Get news article details",
-        "tags": [
-          "News"
-        ],
+        "tags": ["News"],
         "pathParams": [
           {
             "name": "id",
@@ -1787,9 +1519,7 @@
         "method": "GET",
         "path": "/api/v1/emergency",
         "description": "List emergency contacts",
-        "tags": [
-          "Emergency"
-        ],
+        "tags": ["Emergency"],
         "responses": [
           {
             "statusCode": 200,
@@ -1810,9 +1540,7 @@
         "method": "GET",
         "path": "/api/v1/disputes",
         "description": "List disputes",
-        "tags": [
-          "Disputes"
-        ],
+        "tags": ["Disputes"],
         "queryParams": [
           {
             "name": "page",
@@ -1852,9 +1580,7 @@
         "method": "GET",
         "path": "/api/v1/disputes/:id",
         "description": "Get dispute details",
-        "tags": [
-          "Disputes"
-        ],
+        "tags": ["Disputes"],
         "pathParams": [
           {
             "name": "id",
@@ -1886,9 +1612,7 @@
         "method": "POST",
         "path": "/api/v1/disputes",
         "description": "File a new dispute",
-        "tags": [
-          "Disputes"
-        ],
+        "tags": ["Disputes"],
         "requestBody": {
           "ref": "Disputes.CreateRequest",
           "contentType": "application/json",
@@ -1918,9 +1642,7 @@
         "method": "GET",
         "path": "/api/v1/dashboard",
         "description": "Get dashboard data",
-        "tags": [
-          "Dashboard"
-        ],
+        "tags": ["Dashboard"],
         "responses": [
           {
             "statusCode": 200,
@@ -1940,9 +1662,7 @@
         "method": "GET",
         "path": "/api/v1/admin/oauth/clients",
         "description": "List all registered OAuth clients",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "responses": [
           {
             "statusCode": 200,
@@ -1960,9 +1680,7 @@
         "method": "GET",
         "path": "/api/v1/admin/oauth/clients/:clientId",
         "description": "Get a single OAuth client by ID",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "responses": [
           {
             "statusCode": 200,
@@ -1984,9 +1702,7 @@
         "method": "POST",
         "path": "/api/v1/admin/oauth/clients",
         "description": "Register a new OAuth client",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "requestBody": {
           "ref": "OAuth.RegisterClientRequest",
           "contentType": "application/json",
@@ -2013,9 +1729,7 @@
         "method": "PATCH",
         "path": "/api/v1/admin/oauth/clients/:clientId",
         "description": "Update OAuth client name, description, scopes, or status",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "requestBody": {
           "ref": "OAuth.UpdateClientRequest",
           "contentType": "application/json",
@@ -2042,9 +1756,7 @@
         "method": "DELETE",
         "path": "/api/v1/admin/oauth/clients/:clientId",
         "description": "Revoke (deactivate) an OAuth client",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "responses": [
           {
             "statusCode": 204,
@@ -2066,9 +1778,7 @@
         "method": "POST",
         "path": "/api/v1/admin/oauth/clients/:clientId/secret",
         "description": "Regenerate the client secret for an OAuth client",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "responses": [
           {
             "statusCode": 200,
@@ -2090,9 +1800,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/organizations",
         "description": "List all organizations with metrics (platform admin view)",
-        "tags": [
-          "Platform Admin"
-        ],
+        "tags": ["Platform Admin"],
         "responses": [
           {
             "statusCode": 200,
@@ -2110,9 +1818,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/organizations/:id",
         "description": "Get organization details with members, buildings, usage metrics, billing status",
-        "tags": [
-          "Platform Admin"
-        ],
+        "tags": ["Platform Admin"],
         "responses": [
           {
             "statusCode": 200,
@@ -2134,9 +1840,7 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/organizations/:id/suspend",
         "description": "Suspend an organization (cascade-invalidates all org sessions)",
-        "tags": [
-          "Platform Admin"
-        ],
+        "tags": ["Platform Admin"],
         "responses": [
           {
             "statusCode": 200,
@@ -2162,9 +1866,7 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/organizations/:id/reactivate",
         "description": "Reactivate a suspended organization",
-        "tags": [
-          "Platform Admin"
-        ],
+        "tags": ["Platform Admin"],
         "responses": [
           {
             "statusCode": 200,
@@ -2190,9 +1892,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/stats",
         "description": "Get platform-wide statistics (org counts, member counts, usage)",
-        "tags": [
-          "Platform Admin"
-        ],
+        "tags": ["Platform Admin"],
         "responses": [
           {
             "statusCode": 200,
@@ -2210,9 +1910,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/health/dashboard",
         "description": "Get platform health dashboard (current metrics, active alerts, thresholds)",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": [
           {
             "statusCode": 200,
@@ -2230,9 +1928,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/health/alerts",
         "description": "List metric alerts with optional active-only filter",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": [
           {
             "statusCode": 200,
@@ -2250,9 +1946,7 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/health/alerts/:alertId/acknowledge",
         "description": "Acknowledge an active metric alert",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": [
           {
             "statusCode": 200,
@@ -2274,9 +1968,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/health/metrics/:name/history",
         "description": "Get time-series history for a specific metric",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": [
           {
             "statusCode": 200,
@@ -2294,9 +1986,7 @@
         "method": "PUT",
         "path": "/api/v1/platform-admin/health/thresholds/:name",
         "description": "Update warning and critical thresholds for a metric",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": [
           {
             "statusCode": 200,
@@ -2318,9 +2008,7 @@
         "method": "GET",
         "path": "/api/v1/oauth/grants",
         "description": "List all OAuth grants for the authenticated user",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "responses": [
           {
             "statusCode": 200,
@@ -2338,9 +2026,7 @@
         "method": "DELETE",
         "path": "/api/v1/oauth/grants/:clientId",
         "description": "Revoke a specific OAuth grant for the authenticated user",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "responses": [
           {
             "statusCode": 204,
@@ -2362,9 +2048,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/announcements",
         "description": "List all platform-wide system announcements",
-        "tags": [
-          "SystemAnnouncements"
-        ],
+        "tags": ["SystemAnnouncements"],
         "queryParams": [
           {
             "name": "include_deleted",
@@ -2390,9 +2074,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/announcements/:id",
         "description": "Get a single system announcement by ID",
-        "tags": [
-          "SystemAnnouncements"
-        ],
+        "tags": ["SystemAnnouncements"],
         "pathParams": [
           {
             "name": "id",
@@ -2421,9 +2103,7 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/announcements",
         "description": "Create a new platform-wide system announcement",
-        "tags": [
-          "SystemAnnouncements"
-        ],
+        "tags": ["SystemAnnouncements"],
         "requestBody": {
           "ref": "SystemAnnouncements.CreateRequest",
           "contentType": "application/json",
@@ -2450,9 +2130,7 @@
         "method": "PUT",
         "path": "/api/v1/platform-admin/announcements/:id",
         "description": "Update an existing system announcement",
-        "tags": [
-          "SystemAnnouncements"
-        ],
+        "tags": ["SystemAnnouncements"],
         "requestBody": {
           "ref": "SystemAnnouncements.UpdateRequest",
           "contentType": "application/json",
@@ -2479,9 +2157,7 @@
         "method": "DELETE",
         "path": "/api/v1/platform-admin/announcements/:id",
         "description": "Soft-delete a system announcement",
-        "tags": [
-          "SystemAnnouncements"
-        ],
+        "tags": ["SystemAnnouncements"],
         "pathParams": [
           {
             "name": "id",
@@ -2510,9 +2186,7 @@
         "method": "GET",
         "path": "/api/v1/onboarding/status",
         "description": "Get onboarding status with the list of tours and per-tour progress",
-        "tags": [
-          "Onboarding"
-        ],
+        "tags": ["Onboarding"],
         "responses": [
           {
             "statusCode": 200,
@@ -2530,9 +2204,7 @@
         "method": "GET",
         "path": "/api/v1/onboarding/tours",
         "description": "List onboarding tours for the authenticated user",
-        "tags": [
-          "Onboarding"
-        ],
+        "tags": ["Onboarding"],
         "responses": [
           {
             "statusCode": 200,
@@ -2550,9 +2222,7 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/start",
         "description": "Start an onboarding tour for the authenticated user",
-        "tags": [
-          "Onboarding"
-        ],
+        "tags": ["Onboarding"],
         "pathParams": [
           {
             "name": "tourId",
@@ -2577,9 +2247,7 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/steps/:stepId/complete",
         "description": "Mark a single onboarding step as complete",
-        "tags": [
-          "Onboarding"
-        ],
+        "tags": ["Onboarding"],
         "pathParams": [
           {
             "name": "tourId",
@@ -2609,9 +2277,7 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/complete",
         "description": "Mark an onboarding tour as complete",
-        "tags": [
-          "Onboarding"
-        ],
+        "tags": ["Onboarding"],
         "pathParams": [
           {
             "name": "tourId",
@@ -2636,9 +2302,7 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/skip",
         "description": "Skip an onboarding tour",
-        "tags": [
-          "Onboarding"
-        ],
+        "tags": ["Onboarding"],
         "pathParams": [
           {
             "name": "tourId",
@@ -2663,9 +2327,7 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/reset",
         "description": "Reset onboarding tour progress to the beginning",
-        "tags": [
-          "Onboarding"
-        ],
+        "tags": ["Onboarding"],
         "pathParams": [
           {
             "name": "tourId",
@@ -2690,9 +2352,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/feature-flags",
         "description": "List all feature flags (platform admin)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "responses": [
           {
             "statusCode": 200,
@@ -2710,9 +2370,7 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/feature-flags",
         "description": "Create a new feature flag (platform admin)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "responses": [
           {
             "statusCode": 201,
@@ -2734,9 +2392,7 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/feature-flags/:id",
         "description": "Get a single feature flag with its overrides (platform admin)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "pathParams": [
           {
             "name": "id",
@@ -2765,9 +2421,7 @@
         "method": "PUT",
         "path": "/api/v1/platform-admin/feature-flags/:id",
         "description": "Update a feature flag (platform admin)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "pathParams": [
           {
             "name": "id",
@@ -2796,9 +2450,7 @@
         "method": "DELETE",
         "path": "/api/v1/platform-admin/feature-flags/:id",
         "description": "Delete a feature flag (platform admin)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "pathParams": [
           {
             "name": "id",
@@ -2827,9 +2479,7 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/feature-flags/:id/toggle",
         "description": "Toggle a feature flag on/off (platform admin, audit-logged)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "pathParams": [
           {
             "name": "id",
@@ -2858,9 +2508,7 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/feature-flags/:id/overrides",
         "description": "Create a per-scope override for a feature flag (platform admin)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "pathParams": [
           {
             "name": "id",
@@ -2889,9 +2537,7 @@
         "method": "DELETE",
         "path": "/api/v1/platform-admin/feature-flags/:id/overrides/:override_id",
         "description": "Delete a per-scope override from a feature flag (platform admin)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "pathParams": [
           {
             "name": "id",
@@ -2925,9 +2571,7 @@
         "method": "GET",
         "path": "/api/v1/feature-flags",
         "description": "Get resolved feature flags for the current caller (org/user/role overrides applied)",
-        "tags": [
-          "Feature Flags"
-        ],
+        "tags": ["Feature Flags"],
         "responses": [
           {
             "statusCode": 200,
@@ -2945,9 +2589,7 @@
         "method": "GET",
         "path": "/api/v1/users/me/notification-preferences",
         "description": "Get all notification channel preferences for the current user",
-        "tags": [
-          "Notification Preferences"
-        ],
+        "tags": ["Notification Preferences"],
         "responses": [
           {
             "statusCode": 200,
@@ -2969,9 +2611,7 @@
         "method": "PATCH",
         "path": "/api/v1/users/me/notification-preferences/:channel",
         "description": "Enable/disable a single notification channel (push / email / in_app); requires confirmDisableAll to turn off the last active channel",
-        "tags": [
-          "Notification Preferences"
-        ],
+        "tags": ["Notification Preferences"],
         "pathParams": [
           {
             "name": "channel",
@@ -3006,9 +2646,7 @@
         "method": "GET",
         "path": "/health",
         "description": "Health check endpoint",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": [
           {
             "statusCode": 200,
@@ -3025,9 +2663,7 @@
         "method": "GET",
         "path": "/api/v1/listings",
         "description": "Search property listings",
-        "tags": [
-          "Listings"
-        ],
+        "tags": ["Listings"],
         "queryParams": [
           {
             "name": "type",
@@ -3100,9 +2736,7 @@
         "method": "GET",
         "path": "/api/v1/listings/:slug",
         "description": "Get listing details by slug",
-        "tags": [
-          "Listings"
-        ],
+        "tags": ["Listings"],
         "pathParams": [
           {
             "name": "slug",
@@ -3131,9 +2765,7 @@
         "method": "GET",
         "path": "/api/v1/listings/suggestions",
         "description": "Get search suggestions",
-        "tags": [
-          "Listings"
-        ],
+        "tags": ["Listings"],
         "queryParams": [
           {
             "name": "q",
@@ -3158,9 +2790,7 @@
         "method": "GET",
         "path": "/api/v1/favorites",
         "description": "List user's favorites",
-        "tags": [
-          "Favorites"
-        ],
+        "tags": ["Favorites"],
         "responses": [
           {
             "statusCode": 200,
@@ -3177,9 +2807,7 @@
         "method": "POST",
         "path": "/api/v1/favorites",
         "description": "Add to favorites",
-        "tags": [
-          "Favorites"
-        ],
+        "tags": ["Favorites"],
         "requestBody": {
           "ref": "Favorites.AddRequest",
           "contentType": "application/json",
@@ -3205,9 +2833,7 @@
         "method": "DELETE",
         "path": "/api/v1/favorites/:id",
         "description": "Remove from favorites",
-        "tags": [
-          "Favorites"
-        ],
+        "tags": ["Favorites"],
         "pathParams": [
           {
             "name": "id",
@@ -3235,9 +2861,7 @@
         "method": "GET",
         "path": "/api/v1/saved-searches",
         "description": "List saved searches",
-        "tags": [
-          "SavedSearches"
-        ],
+        "tags": ["SavedSearches"],
         "responses": [
           {
             "statusCode": 200,
@@ -3254,9 +2878,7 @@
         "method": "POST",
         "path": "/api/v1/saved-searches",
         "description": "Create saved search",
-        "tags": [
-          "SavedSearches"
-        ],
+        "tags": ["SavedSearches"],
         "requestBody": {
           "ref": "SavedSearches.CreateRequest",
           "contentType": "application/json",
@@ -3278,9 +2900,7 @@
         "method": "DELETE",
         "path": "/api/v1/saved-searches/:id",
         "description": "Delete saved search",
-        "tags": [
-          "SavedSearches"
-        ],
+        "tags": ["SavedSearches"],
         "pathParams": [
           {
             "name": "id",
@@ -3304,9 +2924,7 @@
         "method": "GET",
         "path": "/api/v1/inquiries",
         "description": "List inquiries",
-        "tags": [
-          "Inquiries"
-        ],
+        "tags": ["Inquiries"],
         "responses": [
           {
             "statusCode": 200,
@@ -3323,9 +2941,7 @@
         "method": "POST",
         "path": "/api/v1/inquiries/contact/:listing_id",
         "description": "Send contact message",
-        "tags": [
-          "Inquiries"
-        ],
+        "tags": ["Inquiries"],
         "pathParams": [
           {
             "name": "listing_id",
@@ -3355,9 +2971,7 @@
         "method": "POST",
         "path": "/api/v1/inquiries/viewing/:listing_id",
         "description": "Request viewing",
-        "tags": [
-          "Inquiries"
-        ],
+        "tags": ["Inquiries"],
         "pathParams": [
           {
             "name": "listing_id",
@@ -3387,9 +3001,7 @@
         "method": "GET",
         "path": "/api/v1/sso/login",
         "description": "Initiate SSO login",
-        "tags": [
-          "SSO"
-        ],
+        "tags": ["SSO"],
         "responses": [
           {
             "statusCode": 302,
@@ -3407,9 +3019,7 @@
         "method": "GET",
         "path": "/api/v1/sso/callback",
         "description": "SSO callback",
-        "tags": [
-          "SSO"
-        ],
+        "tags": ["SSO"],
         "responses": [
           {
             "statusCode": 302,
@@ -3427,9 +3037,7 @@
         "method": "GET",
         "path": "/api/v1/sso/session",
         "description": "Get current session",
-        "tags": [
-          "SSO"
-        ],
+        "tags": ["SSO"],
         "responses": [
           {
             "statusCode": 200,
@@ -3447,9 +3055,7 @@
         "method": "GET",
         "path": "/api/v1/agencies/:id",
         "description": "Get agency details",
-        "tags": [
-          "Agencies"
-        ],
+        "tags": ["Agencies"],
         "pathParams": [
           {
             "name": "id",
@@ -3478,9 +3084,7 @@
         "method": "POST",
         "path": "/api/v1/agencies",
         "description": "Create agency",
-        "tags": [
-          "Agencies"
-        ],
+        "tags": ["Agencies"],
         "requestBody": {
           "ref": "Agencies.CreateRequest",
           "contentType": "application/json",
@@ -3494,9 +3098,7 @@
         ],
         "auth": {
           "required": true,
-          "roles": [
-            "organization_admin"
-          ]
+          "roles": ["organization_admin"]
         },
         "feature": "Epic-32"
       }
@@ -3506,16 +3108,11 @@
     {
       "id": "flow-login-basic",
       "name": "Basic Login Flow",
-      "apps": [
-        "ppt-web",
-        "api-server"
-      ],
+      "apps": ["ppt-web", "api-server"],
       "description": "User logs in with email and password",
       "category": "authentication",
       "requiredRole": "anonymous",
-      "useCases": [
-        "UC-14.1"
-      ],
+      "useCases": ["UC-14.1"],
       "steps": [
         {
           "order": 1,
@@ -3597,25 +3194,16 @@
         "authenticated": true,
         "redirectedTo": "/"
       },
-      "tags": [
-        "auth",
-        "critical",
-        "smoke"
-      ]
+      "tags": ["auth", "critical", "smoke"]
     },
     {
       "id": "flow-logout",
       "name": "Logout Flow",
-      "apps": [
-        "ppt-web",
-        "api-server"
-      ],
+      "apps": ["ppt-web", "api-server"],
       "description": "User logs out of the system",
       "category": "authentication",
       "requiredRole": "tenant",
-      "prerequisites": [
-        "flow-login-basic"
-      ],
+      "prerequisites": ["flow-login-basic"],
       "steps": [
         {
           "order": 1,
@@ -3657,27 +3245,17 @@
         "authenticated": false,
         "redirectedTo": "/login"
       },
-      "tags": [
-        "auth",
-        "smoke"
-      ]
+      "tags": ["auth", "smoke"]
     },
     {
       "id": "flow-document-upload",
       "name": "Document Upload Flow",
-      "apps": [
-        "ppt-web",
-        "api-server"
-      ],
+      "apps": ["ppt-web", "api-server"],
       "description": "User uploads a new document",
       "category": "documents",
       "requiredRole": "owner",
-      "prerequisites": [
-        "flow-login-basic"
-      ],
-      "useCases": [
-        "UC-08.1"
-      ],
+      "prerequisites": ["flow-login-basic"],
+      "useCases": ["UC-08.1"],
       "steps": [
         {
           "order": 1,
@@ -3753,25 +3331,16 @@
       "expectedOutcome": {
         "documentUploaded": true
       },
-      "tags": [
-        "documents",
-        "upload",
-        "smoke"
-      ]
+      "tags": ["documents", "upload", "smoke"]
     },
     {
       "id": "flow-document-view",
       "name": "Document View Flow",
-      "apps": [
-        "ppt-web",
-        "api-server"
-      ],
+      "apps": ["ppt-web", "api-server"],
       "description": "User views document details",
       "category": "documents",
       "requiredRole": "tenant",
-      "prerequisites": [
-        "flow-login-basic"
-      ],
+      "prerequisites": ["flow-login-basic"],
       "steps": [
         {
           "order": 1,
@@ -3813,27 +3382,17 @@
       "expectedOutcome": {
         "documentViewed": true
       },
-      "tags": [
-        "documents",
-        "view"
-      ]
+      "tags": ["documents", "view"]
     },
     {
       "id": "flow-report-fault",
       "name": "Report Fault Flow",
-      "apps": [
-        "mobile",
-        "api-server"
-      ],
+      "apps": ["mobile", "api-server"],
       "description": "User reports a new fault",
       "category": "fault_management",
       "requiredRole": "tenant",
-      "prerequisites": [
-        "flow-login-basic"
-      ],
-      "useCases": [
-        "UC-03.1"
-      ],
+      "prerequisites": ["flow-login-basic"],
+      "useCases": ["UC-03.1"],
       "steps": [
         {
           "order": 1,
@@ -3885,25 +3444,16 @@
       "expectedOutcome": {
         "faultCreated": true
       },
-      "tags": [
-        "faults",
-        "create",
-        "smoke"
-      ]
+      "tags": ["faults", "create", "smoke"]
     },
     {
       "id": "flow-file-dispute",
       "name": "File Dispute Flow",
-      "apps": [
-        "ppt-web",
-        "api-server"
-      ],
+      "apps": ["ppt-web", "api-server"],
       "description": "User files a new dispute",
       "category": "disputes",
       "requiredRole": "tenant",
-      "prerequisites": [
-        "flow-login-basic"
-      ],
+      "prerequisites": ["flow-login-basic"],
       "steps": [
         {
           "order": 1,
@@ -3961,28 +3511,17 @@
       "expectedOutcome": {
         "disputeFiled": true
       },
-      "tags": [
-        "disputes",
-        "create",
-        "smoke"
-      ]
+      "tags": ["disputes", "create", "smoke"]
     },
     {
       "id": "flow-cast-vote",
       "name": "Cast Vote Flow",
-      "apps": [
-        "mobile",
-        "api-server"
-      ],
+      "apps": ["mobile", "api-server"],
       "description": "User casts a vote on a poll",
       "category": "voting",
       "requiredRole": "owner",
-      "prerequisites": [
-        "flow-login-basic"
-      ],
-      "useCases": [
-        "UC-04.1"
-      ],
+      "prerequisites": ["flow-login-basic"],
+      "useCases": ["UC-04.1"],
       "steps": [
         {
           "order": 1,
@@ -4030,19 +3569,12 @@
       "expectedOutcome": {
         "voteCast": true
       },
-      "tags": [
-        "voting",
-        "cast",
-        "smoke"
-      ]
+      "tags": ["voting", "cast", "smoke"]
     },
     {
       "id": "flow-search-listings",
       "name": "Search Listings Flow",
-      "apps": [
-        "reality-web",
-        "reality-server"
-      ],
+      "apps": ["reality-web", "reality-server"],
       "description": "User searches for property listings",
       "category": "listings",
       "requiredRole": "anonymous",
@@ -4105,25 +3637,16 @@
         "searchPerformed": true,
         "resultsDisplayed": true
       },
-      "tags": [
-        "listings",
-        "search",
-        "smoke"
-      ]
+      "tags": ["listings", "search", "smoke"]
     },
     {
       "id": "flow-add-favorite",
       "name": "Add to Favorites Flow",
-      "apps": [
-        "reality-web",
-        "reality-server"
-      ],
+      "apps": ["reality-web", "reality-server"],
       "description": "User adds a listing to favorites",
       "category": "listings",
       "requiredRole": "portal_user",
-      "prerequisites": [
-        "flow-search-listings"
-      ],
+      "prerequisites": ["flow-search-listings"],
       "steps": [
         {
           "order": 1,
@@ -4166,10 +3689,7 @@
       "expectedOutcome": {
         "favoriteAdded": true
       },
-      "tags": [
-        "favorites",
-        "add"
-      ]
+      "tags": ["favorites", "add"]
     }
   ],
   "metadata": {

--- a/frontend/packages/sitemap/tests/sitemap.test.ts
+++ b/frontend/packages/sitemap/tests/sitemap.test.ts
@@ -13,7 +13,7 @@ import { buildUrl, SitemapTestHelper } from '../src/utils';
 describe('Sitemap Data', () => {
   describe('Routes', () => {
     it('should have ppt-web routes', () => {
-      expect(sitemap.routes['ppt-web'].length).toBe(13);
+      expect(sitemap.routes['ppt-web'].length).toBe(19);
     });
 
     it('should have reality-web routes', () => {


### PR DESCRIPTION
## Task
frontend integrations UI not wired: the settings/integrations screen is not routed in ppt-web (83-1-airbnb-integration Airbnb OAuth and Sync). Wire the integrations settings UI route so it is reachable and renders the integrations management surface.

## Owner
pm-backend (label is stale — this is a frontend/ppt-web task; specialist: react-web)

## What & why
The `@ppt/api-client` `integrations` module (Epic 61 + Gap 83) already shipped live Airbnb hooks — `useAirbnbStatus`, `useConnectAirbnb`, `useSyncAirbnb`, `useDisconnectAirbnb`, `useAirbnbListingMappings` — wired to `/api/v1/integrations/organizations/{org}/airbnb/*`, but **no ppt-web route rendered them**, so the integrations management surface was unreachable.

This PR:
- Adds `IntegrationsPage` under `features/settings/integrations/` — renders the Airbnb card with live connection status, the OAuth **connect** flow (redirects to the backend-returned `auth_url`), **sync now**, **disconnect**, and listing mappings. Uses `useAuth()` for the org id and `useToast()` for feedback (no `alert()`), matching repo conventions.
- Mounts it at `/settings/integrations` in `routes/groups/core.tsx` (`settingsRoutes`, `<ProtectedRoute>`), lazy-loaded.
- Registers the `ppt-settings-integrations` entry in `@ppt/sitemap` (data + regenerated `sitemap.json`).
- Adds the screen-map `docs/screens/ppt/settings-integrations.md` (`/screens validate` clean).
- Adds a regression test (`IntegrationsPage.test.tsx`) pinning the render + connect/sync wiring — this fails on `dev` because the page/route did not exist there.

No new API/client code was added — this is pure UI wiring over existing hooks. `integrations` is not in the `UNWIRED_FEATURES` guard (it was retired in PAP-33), so no guard conflict.

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 **only because the owner label is stale** — every changed file is frontend/ppt-web + its screen-map + sitemap, which are exactly the `react-web` specialist's owned areas. `scope-check.sh --owner pm-frontend` (the correct owner) exits 0 (clean). No genuine drift.

## Code-reuse review
`reuse-grep.sh --specialist react-web` — no warnings. Reuses existing `@ppt/api-client` integrations hooks, `useAuth`, `useToast`.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` — exit 0
- `biome check` (repo lint standard) on all changed files — exit 0
  - Note: the `@ppt/web` `lint` script points at ESLint, which has no `eslint.config.js` (pre-existing repo breakage, unrelated to this change). Ran Biome, which is the repo's configured linter/formatter (root `check`/`lint`/`format` scripts).
- `vitest run IntegrationsPage.test.tsx` — 3 passed
- `vitest run unwired-features.test.ts` — 12 passed
- `pnpm --filter @ppt/sitemap test` — 18 passed (see Notes: fixed a pre-existing stale count assertion)
- `/screens validate` — 0 errors, 0 warnings (163 screen-maps)

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) — exit 0. Warnings are pre-existing (chunk size / ineffective-dynamic-import), not introduced here.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (UI route wiring; no security/auth/billing/data-integrity logic — the OAuth handshake itself is backend-owned and unchanged).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- **Pre-existing stale test fixed:** `packages/sitemap/tests/sitemap.test.ts` asserted `routes['ppt-web'].length === 13`, but `origin/dev` already had **18** routes (test was red on dev). Updated to **19** to reflect reality after adding this route.
- Screen-map `endpoints: []` — the Airbnb integration endpoints are not (yet) catalogued in `@ppt/sitemap`'s endpoint list; documented in the screen-map prose instead to keep `/screens validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8C3Dzk4WRi9KCcXxo68xS

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8C3Dzk4WRi9KCcXxo68xS)_