### PR TITLE
gap-screens-link-uc-10: link UC-10 to person-months screen-map

### DIFF
--- a/docs/screens/ppt/person-months.md
+++ b/docs/screens/ppt/person-months.md
@@ -15,7 +15,8 @@ relatedScreens:
     rel: parent
 sharedComponents: []
 diagrams: []
-useCases: []
+useCases:
+  - UC-10
 epics:
   - Epic-3-5
 designSources: []
@@ -70,3 +71,4 @@ Reachable from the building detail page via a "Person-months" quick link.
 
 ## Agent Log
 - 2026-06-22 — FrontendEngineer: created on route+api-client wiring (BIT-190).
+- 2026-07-09 — agent: linked UC-10 (Person-Months, docs/use-cases.md) in useCases frontmatter (gap-screens-link-uc-10).


### PR DESCRIPTION
## Task
Link UC-10 to a screen-map (UC-10 appears in stories but no screen-map has it in the use-cases frontmatter). Find the appropriate screen-map under docs/screens/ppt/ and add UC-10 to its use-cases frontmatter; run /screens validate.

## Owner
pm-frontend

## What changed
`docs/use-cases.md` defines **UC-10: Person-Months** (ppt-web, mobile) — add/view/edit/delete/bulk-entry/export/reminder for person-month records. No screen-map referenced it (`useCases: []`). `docs/screens/ppt/person-months.md` is the screen-map for the routed person-months pages (`PersonMonthsPage`, `BulkEntryPage`, `UnitPersonMonthsPage`, `EditPersonMonthPage`) — the obvious match by name and by the routes/components it documents. Added `UC-10` to its `useCases` frontmatter and an Agent Log entry.

## Tested (Band A — fast check)
`pnpm -C frontend --filter @ppt/screen-map cli validate --root <repo-root>`
→ `Validated 162 screen-maps: 0 errors, 0 warnings.` (exit 0)

## Built (Band B — full build)
skipped: docs-only frontmatter change, <50 LOC, no public API/config touch

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Scope-check (`scope-check.sh --owner pm-frontend`) passed clean, no drift.
- Only file touched: `docs/screens/ppt/person-months.md` (useCases frontmatter + Agent Log entry).


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8PBfSAyTVUdcHw4NGZvBp)_