### PR TITLE
gap-screens-link-uc-40: link UC-40 to financial-budgets screen-map

### DIFF
--- a/docs/screens/ppt/financial-budgets.md
+++ b/docs/screens/ppt/financial-budgets.md
@@ -16,7 +16,8 @@ relatedScreens:
     rel: parent
 sharedComponents: []
 diagrams: []
-useCases: []
+useCases:
+  - UC-40
 epics: []
 designSources: []
 owner: pm-frontend
@@ -30,6 +31,8 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 
 ### Specific (recent)
 - 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:534`.
+- 2026-07-09 — linked UC-40 (Budget & Planning) to this screen; the use case covers annual budgets, budget-vs-actual, capex planning, budget approval voting, reporting, forecasting, reserve-fund management, and budget history — all served by the Budget Management page.
 
 ## Agent Log
 - 2026-05-18 — agent: created stub for unmapped route.
+- 2026-07-09 — agent: linked UC-40 to useCases frontmatter (gap-screens-link-uc-40).


### PR DESCRIPTION
## Task
Link UC-40 to a screen-map (appears in stories but no screen-map use-cases frontmatter)

UC-40 (Budget & Planning) is catalogued in `docs/use-cases.md` (8 sub-use-cases: annual budget, budget-vs-actual, capex planning, budget approval voting, reporting, forecasting, reserve-fund management, budget history) but no screen-map referenced it. The `ppt/financial-budgets` (Budget Management, route `/financial/budgets`) screen-map — created as a stub in the 2026-05-18 audit — carried an empty `useCases: []`. This links UC-40 there, restoring screen-map ↔ use-case referential integrity.

## Owner
pm-frontend

## Change
- `docs/screens/ppt/financial-budgets.md`: `useCases: [UC-40]` + Agent Log / Notes entries per the screen-map self-management protocol.

Docs-only, single file. No code, API, or config surface touched.

## Tested (Band A — fast check)
- `git diff --check` → exit 0 (no whitespace errors)
- `pnpm -F @ppt/screen-map cli validate --root .` → exit 0 — `ok docs/screens/ppt/financial-budgets.md`; "Validated 163 screen-maps: 0 errors, 0 warnings."
- Scope-drift check (`scope-check.sh --owner pm-frontend --base origin/dev`) → exit 0, no drift.

## Built (Band B — full build)
skipped: docs-only change (<50 LOC, no public API/config/build output touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- Specialist: react-web by the deterministic roster rule (owner_role=pm-frontend, no ≥+3 stack signal), but the change is pure `docs/screens/` — the meaningful verification is the screen-map validator (run above), not ppt-web typecheck/lint.
- `goal-check.sh` (IG1–IG8) is plan-driven (IG1 requires a `.research/plans/<slug>.md`, IG2 an `impl/<slug>` branch); this is a planless gap task on an `auto-impl/` branch, so those IGs don't apply. IG3 (regression test) is N/A for a docs-only change.
- Code-reuse pre-flight: N/A (no new helper / security-auth-crypto code path). `code_reuse_warn=none`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgCM6zeKqst4zEugA1SM3f)_