### PR TITLE
gap-screens-link-uc-33: link UC-33 (Tenant Screening) to lease-application screen-maps

### DIFF
--- a/docs/screens/ppt/lease-application-detail.md
+++ b/docs/screens/ppt/lease-application-detail.md
@@ -13,7 +13,8 @@ endpoints: []
 relatedScreens: []
 sharedComponents: []
 diagrams: []
-useCases: []
+useCases:
+  - UC-33
 epics: []
 designSources: []
 owner: pm-frontend
@@ -34,8 +35,14 @@ already built but unrouted; this screen is now reachable on web.
 ## Notes
 
 ### Specific (recent)
+- 2026-07-09 — Linked UC-33 (Tenant Screening). This detail screen is the
+  screening workspace for a single application: request background check
+  (UC-33.1), verify income (UC-33.2), view credit score (UC-33.4), generate
+  the screening report (UC-33.6), and approve/reject the application
+  (UC-33.7/33.8) with GDPR-compliant consent handling (UC-33.11/33.12).
 - 2026-06-08 — PAP-20: mounted route group; renders against the dev stack with
   stub/empty data pending the meters+leases api-client module.
 
 ## Agent Log
+- 2026-07-09 — agent: linked UC-33 (Tenant Screening) to useCases frontmatter — screening actions live on the application-detail screen.
 - 2026-06-08 — CTO: created on route mount (PAP-20, Epic 19).

--- a/docs/screens/ppt/lease-applications.md
+++ b/docs/screens/ppt/lease-applications.md
@@ -13,7 +13,8 @@ endpoints: []
 relatedScreens: []
 sharedComponents: []
 diagrams: []
-useCases: []
+useCases:
+  - UC-33
 epics: []
 designSources: []
 owner: pm-frontend
@@ -34,8 +35,13 @@ already built but unrouted; this screen is now reachable on web.
 ## Notes
 
 ### Specific (recent)
+- 2026-07-09 — Linked UC-33 (Tenant Screening). The applications list is where
+  a screener compares multiple tenant applications side by side (UC-33.10)
+  before drilling into a single application for the full screening flow on
+  `ppt/lease-application-detail`.
 - 2026-06-08 — PAP-20: mounted route group; renders against the dev stack with
   stub/empty data pending the meters+leases api-client module.
 
 ## Agent Log
+- 2026-07-09 — agent: linked UC-33 (Tenant Screening) to useCases frontmatter — list-level compare (UC-33.10) belongs here; detail screening on lease-application-detail.
 - 2026-06-08 — CTO: created on route mount (PAP-20, Epic 19).


### PR DESCRIPTION
## Task
Link UC-33 to a screen-map (appears in stories but no screen-map use-cases frontmatter)

UC-33 (Tenant Screening) is defined in `docs/use-cases.md` (12 stories, ppt-web + mobile) but was not referenced by any screen-map's `useCases` frontmatter. This links it to the two tenant-application screens that host the screening workflow:

- **`ppt/lease-application-detail`** — the per-application screening workspace: request background check (UC-33.1), verify income (UC-33.2), view credit score (UC-33.4), generate screening report (UC-33.6), approve/reject (UC-33.7/33.8), GDPR-compliant consent (UC-33.11/33.12).
- **`ppt/lease-applications`** — list-level side-by-side comparison of applications (UC-33.10).

Both screen-maps also get an Agent Log entry and a `Notes > Specific (recent)` line per the screen-map self-management protocol.

## Owner
pm-frontend

## Tested (Band A — fast check)
Docs-only change (screen-map frontmatter). The applicable gate is the screen-map validator:
```
pnpm --filter @ppt/screen-map cli validate --root <repo>
-> Validated 163 screen-maps: 0 errors, 0 warnings.
   ok  docs/screens/ppt/lease-application-detail.md
   ok  docs/screens/ppt/lease-applications.md
```
Exit 0. `UC-33` is a known UC id (extracted from `docs/use-cases.md`), so referential integrity holds.

## Built (Band B — full build)
skipped: docs-only change (no code, no public API/config touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Scope-drift check (`scope-check.sh --owner pm-frontend --base origin/dev`) exit 0 — both files are `owner: pm-frontend` screen-maps. scope_drift=false.
- Code-reuse pre-flight: N/A (no helpers/code added). code_reuse_warn=none.
- IG1–IG8 goal-check (Step 3.5) is for plan-flow tasks (requires `.research/plans/<slug>.md` + `impl/<slug>` branch); this is a dispatcher gap/docs task with no plan file and IG3/IG7/IG8 do not apply to a docs-only change — the screen-map validator is the correct gate here and it is green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgCM6zeKqst4zEugA1SM3f)_