### PR TITLE
gap-screens-link-uc-29: link UC-29 to a rentals-dashboard screen-map

### DIFF
--- a/docs/screens/ppt/rentals-dashboard.md
+++ b/docs/screens/ppt/rentals-dashboard.md
@@ -1,0 +1,78 @@
+---
+id: ppt/rentals-dashboard
+name: Short-Term Rentals Dashboard
+product: ppt
+implementations:
+  ppt-web:
+    route: "/rentals"
+    component: RentalsDashboardPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints: []
+relatedScreens:
+  - id: ppt/settings-integrations
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-29
+  - UC-30
+epics:
+  - Epic-18
+designSources: []
+owner: pm-frontend
+---
+
+# Short-Term Rentals Dashboard
+
+Manager-facing home for the Short-Term Rental Integration feature (Epic 18,
+UC-29 Short-term Rental Management + UC-30 Guest Registration System). The
+`/rentals` dashboard surfaces reservation statistics, upcoming/active bookings,
+and platform-connection health, and links out to the rest of the rentals
+feature. It is the canonical screen-map anchor for UC-29 — the
+`ppt/settings-integrations` screen only carries the Airbnb OAuth connect flow
+(UC-29.1 / UC-29.2), while the day-to-day rental management lives here.
+
+The rentals feature (route group `frontend/apps/ppt-web/src/routes/groups/rentals.tsx`)
+owns these routes, all rendered by pages under
+`frontend/apps/ppt-web/src/features/rentals/`:
+
+- `/rentals` — `RentalsDashboardPage` (stats, upcoming/active bookings, connection health)
+- `/rentals/connections` — `PlatformConnectionsPage` (UC-29.1/29.2 connect, UC-29.3 sync)
+- `/rentals/bookings` — `BookingsPage` (reservation list + filters)
+- `/rentals/bookings/:bookingId` — `BookingDetailPage` (UC-29.9/29.10 check-in/out)
+- `/rentals/calendar` — `CalendarPage` (UC-29.4 reservation calendar)
+- `/rentals/guests` — `GuestRegistrationPage` (UC-29.5 + UC-30 guest registration)
+- `/rentals/reports` — `TaxReportPage` (UC-29.13/29.14/29.15 statistics + tax export)
+
+Rentals calls (via `@ppt/api-client` `ShortTermRentalsService` — `rentalsApi*`):
+- `rentalsApiListReservations` — reservation list (dashboard + bookings)
+- `rentalsApiGetReservation` — single reservation (booking detail)
+- `rentalsApiListConnections` / `rentalsApiCreateConnection` — platform connections
+- `rentalsApiSyncPlatforms` — trigger a channel sync
+- `rentalsApiListGuests` — guest registrations
+- `rentalsApiCheckIn` / `rentalsApiCheckOut` — guest check-in / check-out
+
+## Notes
+
+### Specific (recent)
+- 2026-07-09 — created this screen-map to give UC-29 (and UC-30) a canonical
+  home. UC-29 had only been attached to `ppt/settings-integrations` (the Airbnb
+  connect sub-flow, gap-83-1); the primary rentals management surface at
+  `/rentals` and its sibling routes had no screen-map at all.
+- `endpoints` left empty: the rentals endpoints are not (yet) in the
+  `@ppt/sitemap` endpoint catalogue (same situation as `ppt/settings-integrations`).
+- `apiStatus: partial` — reservations / connections / guests / check-in-out are
+  live, but the calendar and tax-report routes still render with empty data
+  (no calendar or tax-report endpoint exists yet; see the route wrappers in
+  `groups/rentals.tsx`).
+- No `sitemapRefs`: the `/rentals*` routes are not present in `@ppt/sitemap`
+  (only `/settings/integrations` is). The rest of the rentals routes remain
+  unmapped in the sitemap + screen-map tree — a follow-up drift item.
+
+## Agent Log
+- 2026-07-09 — agent: gap-screens-link-uc-29 — created the Short-Term Rentals
+  Dashboard screen-map and linked UC-29 (+ UC-30) to it, giving the
+  Short-Term Rental Management use case a canonical screen-map home beyond the
+  Airbnb-connect sub-flow already tracked on ppt/settings-integrations.


### PR DESCRIPTION
## Task
Link UC-29 to a screen-map (appears in stories but no screen-map use-cases frontmatter)

## Owner
pm-frontend

## What changed
Added `docs/screens/ppt/rentals-dashboard.md` — a new screen-map for the `/rentals` Short-Term Rentals dashboard (Epic 18) that carries `UC-29` (Short-term Rental Management) and `UC-30` (Guest Registration) in its `useCases` frontmatter.

Context: UC-29's only prior screen-map link was `ppt/settings-integrations`, which is really just the Airbnb OAuth connect sub-flow (UC-29.1/29.2) added by gap-83-1. The primary rental management surface — the `/rentals` dashboard plus its `/rentals/{connections,bookings,calendar,guests,reports}` routes (`groups/rentals.tsx`, `features/rentals/`) — had no screen-map at all. This adds the canonical home for UC-29. The new screen's body documents all seven rentals routes, their pages, and the `@ppt/api-client` `rentalsApi*` calls. `ppt/settings-integrations` is left untouched (its UC-29 link for the connect flow remains valid; the two screens are cross-linked as siblings).

Docs-only change — no code, API, migration, or config touched.

## Tested (Band A — fast check)
Screen-map validate is the correct gate for a docs/screens change:
```
pnpm -F @ppt/screen-map cli validate --root <repo>
→ ok  docs/screens/ppt/rentals-dashboard.md
→ Validated 164 screen-maps: 0 errors, 0 warnings.   (exit 0)
```
Drift check confirms UC-29/UC-30 are no longer unmapped:
```
pnpm -F @ppt/screen-map cli update --root <repo>
→ UC-29 / UC-30 no longer flagged; only advisory `unknown-epic :: ppt/rentals-dashboard :: Epic-18`
```
The `unknown-epic` line is pre-existing advisory noise, not new: there is no `docs/epics/` directory, so the drift tool flags every epic reference (65 such lines across all existing screens). Epic-18 = "Short-Term Rental Integration" per `docs/EPIC_STORY_STATUS.md` and the route file header.

## Built (Band B — full build)
Skipped: docs-only change, no build output.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Scope drift
None. `scope-check.sh --owner pm-frontend --base origin/dev` → exit 0. Diff is a single file under `docs/screens/**`, which is in pm-frontend's owner area.

## Code-reuse review
None — docs-only, no helpers added.

## Notes
- goal-check.sh IG1/IG2 "fail" only because this is a dispatcher action-list gap task (branch `auto-impl/...`, no `.research/plans/<slug>.md`), not a `.research/plans/` flow task — the script expects a plan file and an `impl/<slug>` branch. No plan file was created (the dispatcher owns `.research/**`). IG3/IG7/IG8 were skipped (docs-only: no regression test applies, no archive move). The substantive verify (screen-map validate) is green.
- Follow-up (out of scope here): the `/rentals*` routes are absent from `@ppt/sitemap`, and the individual rental sub-screens (connections/bookings/calendar/guests/reports) remain unmapped — a larger screen-map + sitemap coverage task for the whole Epic 18 feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCM6zeKqst4zEugA1SM3f

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgCM6zeKqst4zEugA1SM3f)_