### PR TITLE
gh-issue-2195: url-encode remaining KMP path params + shared asPathSegment helper

### DIFF
--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/agency/AgencyRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/agency/AgencyRepository.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import three.two.bit.ppt.reality.api.HttpClientProvider
+import three.two.bit.ppt.reality.api.asPathSegment
 
 /**
  * Repository for the agency directory (UC-51).
@@ -40,7 +41,10 @@ class AgencyRepository(
     /** Get a single agency by id. */
     suspend fun getAgency(agencyId: String): Result<Agency> {
         return try {
-            val response = client.get("$baseUrl/api/v1/agencies/$agencyId") { configureRequest() }
+            val response =
+                client.get("$baseUrl/api/v1/agencies/${agencyId.asPathSegment()}") {
+                    configureRequest()
+                }
             if (response.status.isSuccess()) {
                 val payload: AgencyResponse = response.body()
                 Result.success(payload.agency)
@@ -58,7 +62,9 @@ class AgencyRepository(
     suspend fun getAgencyBySlug(slug: String): Result<Agency> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/agencies/by-slug/$slug") { configureRequest() }
+                client.get("$baseUrl/api/v1/agencies/by-slug/${slug.asPathSegment()}") {
+                    configureRequest()
+                }
             if (response.status.isSuccess()) {
                 val payload: AgencyResponse = response.body()
                 Result.success(payload.agency)
@@ -76,7 +82,9 @@ class AgencyRepository(
     suspend fun listMembers(agencyId: String): Result<AgencyMembersResponse> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/agencies/$agencyId/members") { configureRequest() }
+                client.get("$baseUrl/api/v1/agencies/${agencyId.asPathSegment()}/members") {
+                    configureRequest()
+                }
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else if (response.status == HttpStatusCode.Unauthorized) {

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/ApiClient.kt
@@ -36,13 +36,6 @@ class ApiClient(
         tenantId?.let { header("X-Tenant-ID", it) }
     }
 
-    /**
-     * Percent-encode a value before splicing it into a request path so that ids containing `/`,
-     * `?`, `#`, or `..` cannot smuggle extra path segments or query parameters into the request
-     * (path-injection).
-     */
-    private fun pathSegment(value: String): String = value.encodeURLPathPart()
-
     suspend fun healthCheck(): String {
         return client.get("$baseUrl/health") { configureRequest() }.toString()
     }
@@ -81,7 +74,7 @@ class ApiClient(
     suspend fun getListing(id: String): Result<ListingDetail> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/listings/${pathSegment(id)}") { configureRequest() }
+                client.get("$baseUrl/api/v1/listings/${id.asPathSegment()}") { configureRequest() }
             if (response.status.isSuccess()) {
                 Result.success(response.body())
             } else if (response.status == HttpStatusCode.NotFound) {
@@ -125,7 +118,7 @@ class ApiClient(
     suspend fun addFavorite(listingId: String): Result<AddFavoriteResponse> {
         return try {
             val response =
-                client.post("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
+                client.post("$baseUrl/api/v1/favorites/${listingId.asPathSegment()}") {
                     configureRequest()
                     // Empty typed body — `AddFavoriteBody` serializes to `{}` via
                     // ContentNegotiation, keeping this call on the same pipeline as every other.
@@ -155,7 +148,7 @@ class ApiClient(
     suspend fun removeFavorite(listingId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
+                client.delete("$baseUrl/api/v1/favorites/${listingId.asPathSegment()}") {
                     configureRequest()
                 }
             if (response.status.isSuccess()) {

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/UrlEncoding.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/api/UrlEncoding.kt
@@ -1,0 +1,14 @@
+package three.two.bit.ppt.reality.api
+
+import io.ktor.http.*
+
+/**
+ * Percent-encode a value before splicing it into a request path so that ids containing `/`, `?`,
+ * `#`, or `..` cannot smuggle extra path segments or query parameters into the request
+ * (path-injection). Deep-link / nav-sourced ids are untrusted.
+ *
+ * [encodeURLPathPart] percent-encodes everything that is not valid inside a single path segment.
+ * This is the single shared implementation used by every reality repository — do not re-inline a
+ * private copy (see #2195).
+ */
+internal fun String.asPathSegment(): String = encodeURLPathPart()

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import three.two.bit.ppt.reality.api.HttpClientProvider
+import three.two.bit.ppt.reality.api.asPathSegment
 
 /**
  * Repository for favorites and saved searches.
@@ -20,14 +21,6 @@ class FavoritesRepository(
     private fun HttpRequestBuilder.configureRequest() {
         sessionToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
     }
-
-    /**
-     * URL-encode a value before splicing it into a request path. Without this, an attacker- or
-     * caller-supplied id containing `/`, `?`, `#`, or `..` could smuggle extra path segments or
-     * query parameters into the request (path-injection). [encodeURLPathPart] percent-encodes
-     * everything that is not valid inside a single path segment.
-     */
-    private fun pathSegment(value: String): String = value.encodeURLPathPart()
 
     // --- Favorites ---
 
@@ -57,7 +50,7 @@ class FavoritesRepository(
     suspend fun addFavorite(listingId: String): Result<AddFavoriteResponse> {
         return try {
             val response =
-                client.post("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
+                client.post("$baseUrl/api/v1/favorites/${listingId.asPathSegment()}") {
                     configureRequest()
                     // Empty typed body — server's `AddFavorite` is `{notes?: String}`; we omit it.
                     // Using the @Serializable `AddFavoriteBody` keeps the call on the
@@ -84,7 +77,7 @@ class FavoritesRepository(
     suspend fun removeFavorite(listingId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/favorites/${pathSegment(listingId)}") {
+                client.delete("$baseUrl/api/v1/favorites/${listingId.asPathSegment()}") {
                     configureRequest()
                 }
 
@@ -114,7 +107,7 @@ class FavoritesRepository(
     suspend fun isFavorite(listingId: String): Result<Boolean> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/favorites/${pathSegment(listingId)}/check") {
+                client.get("$baseUrl/api/v1/favorites/${listingId.asPathSegment()}/check") {
                     configureRequest()
                 }
 
@@ -184,7 +177,7 @@ class FavoritesRepository(
     ): Result<SavedSearch> {
         return try {
             val response =
-                client.patch("$baseUrl/api/v1/saved-searches/${pathSegment(searchId)}") {
+                client.patch("$baseUrl/api/v1/saved-searches/${searchId.asPathSegment()}") {
                     configureRequest()
                     setBody(request)
                 }
@@ -209,7 +202,7 @@ class FavoritesRepository(
     suspend fun deleteSavedSearch(searchId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/saved-searches/${pathSegment(searchId)}") {
+                client.delete("$baseUrl/api/v1/saved-searches/${searchId.asPathSegment()}") {
                     configureRequest()
                 }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepository.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import three.two.bit.ppt.reality.api.HttpClientProvider
+import three.two.bit.ppt.reality.api.asPathSegment
 
 /**
  * Repository for inquiries and viewing requests.
@@ -107,7 +108,10 @@ class InquiryRepository(
     /** Get inquiry by ID. */
     suspend fun getInquiry(inquiryId: String): Result<Inquiry> {
         return try {
-            val response = client.get("$baseUrl/api/v1/inquiries/$inquiryId") { configureRequest() }
+            val response =
+                client.get("$baseUrl/api/v1/inquiries/${inquiryId.asPathSegment()}") {
+                    configureRequest()
+                }
 
             if (response.status.isSuccess()) {
                 Result.success(response.body())
@@ -146,7 +150,7 @@ class InquiryRepository(
     suspend fun replyToInquiry(inquiryId: String, message: String): Result<InquiryResponse> {
         return try {
             val response =
-                client.post("$baseUrl/api/v1/inquiries/$inquiryId/replies") {
+                client.post("$baseUrl/api/v1/inquiries/${inquiryId.asPathSegment()}/replies") {
                     configureRequest()
                     setBody(ReplyToInquiryRequest(message))
                 }
@@ -209,7 +213,9 @@ class InquiryRepository(
     suspend fun cancelViewing(viewingId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/viewings/$viewingId") { configureRequest() }
+                client.delete("$baseUrl/api/v1/viewings/${viewingId.asPathSegment()}") {
+                    configureRequest()
+                }
 
             if (response.status.isSuccess()) {
                 Result.success(Unit)

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/listing/ListingRepository.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import three.two.bit.ppt.reality.api.HttpClientProvider
+import three.two.bit.ppt.reality.api.asPathSegment
 
 /**
  * Repository for listing operations.
@@ -20,13 +21,6 @@ class ListingRepository(
     private fun HttpRequestBuilder.configureRequest() {
         sessionToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
     }
-
-    /**
-     * Percent-encode a value before splicing it into a request path so that ids containing `/`,
-     * `?`, `#`, or `..` cannot smuggle extra path segments or query parameters into the request
-     * (path-injection). Deep-link / nav-sourced ids are untrusted.
-     */
-    private fun pathSegment(value: String): String = value.encodeURLPathPart()
 
     /** Search listings with filters and pagination. */
     suspend fun searchListings(request: ListingSearchRequest): Result<ListingSearchResponse> {
@@ -51,7 +45,7 @@ class ListingRepository(
     suspend fun getListingDetail(listingId: String): Result<ListingDetail> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/listings/${pathSegment(listingId)}") {
+                client.get("$baseUrl/api/v1/listings/${listingId.asPathSegment()}") {
                     configureRequest()
                 }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/notifications/NotificationRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/notifications/NotificationRepository.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import three.two.bit.ppt.reality.api.HttpClientProvider
+import three.two.bit.ppt.reality.api.asPathSegment
 
 /**
  * Repository for notifications and alerts.
@@ -77,7 +78,9 @@ class NotificationRepository(
     suspend fun markAsRead(notificationId: String): Result<Unit> {
         return try {
             val response =
-                client.post("$baseUrl/api/v1/notifications/$notificationId/read") {
+                client.post(
+                    "$baseUrl/api/v1/notifications/${notificationId.asPathSegment()}/read"
+                ) {
                     configureRequest()
                 }
 
@@ -113,7 +116,7 @@ class NotificationRepository(
     suspend fun deleteNotification(notificationId: String): Result<Unit> {
         return try {
             val response =
-                client.delete("$baseUrl/api/v1/notifications/$notificationId") {
+                client.delete("$baseUrl/api/v1/notifications/${notificationId.asPathSegment()}") {
                     configureRequest()
                 }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/RealtorRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/RealtorRepository.kt
@@ -5,6 +5,7 @@ import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import three.two.bit.ppt.reality.api.HttpClientProvider
+import three.two.bit.ppt.reality.api.asPathSegment
 
 /**
  * Repository for realtor profiles (UC-49).
@@ -46,7 +47,9 @@ class RealtorRepository(
     suspend fun getProfile(userId: String): Result<RealtorProfile> {
         return try {
             val response =
-                client.get("$baseUrl/api/v1/realtors/$userId/profile") { configureRequest() }
+                client.get("$baseUrl/api/v1/realtors/${userId.asPathSegment()}/profile") {
+                    configureRequest()
+                }
             if (response.status.isSuccess()) {
                 val payload: RealtorProfileResponse = response.body()
                 Result.success(payload.profile)

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/agency/AgencyRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/agency/AgencyRepositoryPathEncodingTest.kt
@@ -18,8 +18,9 @@ import kotlinx.serialization.json.Json
 /**
  * Security regression (#2195): agency ids and slugs are deep-link / nav-sourced and are spliced
  * into the request path, so they must be percent-encoded via the shared `String.asPathSegment()`
- * helper — a `/`, `?`, `#`, or `..`-bearing value must NOT escape its path segment (path-injection).
- * Mirrors `ListingDetailRepositoryTest.getListingDetail_url_encodes_listing_id_path_segment`.
+ * helper — a `/`, `?`, `#`, or `..`-bearing value must NOT escape its path segment
+ * (path-injection). Mirrors
+ * `ListingDetailRepositoryTest.getListingDetail_url_encodes_listing_id_path_segment`.
  */
 class AgencyRepositoryPathEncodingTest {
 

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/agency/AgencyRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/agency/AgencyRepositoryPathEncodingTest.kt
@@ -1,0 +1,69 @@
+package three.two.bit.ppt.reality.agency
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Security regression (#2195): agency ids and slugs are deep-link / nav-sourced and are spliced
+ * into the request path, so they must be percent-encoded via the shared `String.asPathSegment()`
+ * helper — a `/`, `?`, `#`, or `..`-bearing value must NOT escape its path segment (path-injection).
+ * Mirrors `ListingDetailRepositoryTest.getListingDetail_url_encodes_listing_id_path_segment`.
+ */
+class AgencyRepositoryPathEncodingTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+    }
+
+    private fun repoCapturing(captured: Captured): AgencyRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            respond(
+                content = ByteReadChannel("{}"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return AgencyRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    @Test
+    fun agency_id_and_slug_path_segments_are_percent_encoded() = runTest {
+        val getAgency = Captured()
+        repoCapturing(getAgency).getAgency("../admin/secret")
+        assertEquals("/api/v1/agencies/..%2Fadmin%2Fsecret", getAgency.path)
+
+        val bySlug = Captured()
+        repoCapturing(bySlug).getAgencyBySlug("../admin/secret")
+        assertEquals("/api/v1/agencies/by-slug/..%2Fadmin%2Fsecret", bySlug.path)
+
+        val members = Captured()
+        repoCapturing(members).listMembers("../admin/secret")
+        assertEquals("/api/v1/agencies/..%2Fadmin%2Fsecret/members", members.path)
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepositoryPathEncodingTest.kt
@@ -1,0 +1,69 @@
+package three.two.bit.ppt.reality.inquiry
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Security regression (#2195): inquiry and viewing ids are spliced into the request path, so they
+ * must be percent-encoded via the shared `String.asPathSegment()` helper — a `/`, `?`, `#`, or
+ * `..`-bearing id must NOT escape its path segment (path-injection). Mirrors
+ * `ListingDetailRepositoryTest.getListingDetail_url_encodes_listing_id_path_segment`.
+ */
+class InquiryRepositoryPathEncodingTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+    }
+
+    private fun repoCapturing(captured: Captured): InquiryRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            respond(
+                content = ByteReadChannel("{}"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return InquiryRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    @Test
+    fun inquiry_and_viewing_id_path_segments_are_percent_encoded() = runTest {
+        val getInquiry = Captured()
+        repoCapturing(getInquiry).getInquiry("../admin/secret")
+        assertEquals("/api/v1/inquiries/..%2Fadmin%2Fsecret", getInquiry.path)
+
+        val reply = Captured()
+        repoCapturing(reply).replyToInquiry("../admin/secret", "hello")
+        assertEquals("/api/v1/inquiries/..%2Fadmin%2Fsecret/replies", reply.path)
+
+        val cancel = Captured()
+        repoCapturing(cancel).cancelViewing("../admin/secret")
+        assertEquals("/api/v1/viewings/..%2Fadmin%2Fsecret", cancel.path)
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/inquiry/InquiryRepositoryPathEncodingTest.kt
@@ -4,9 +4,12 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
@@ -44,7 +47,14 @@ class InquiryRepositoryPathEncodingTest {
                 headers = headersOf(HttpHeaders.ContentType, "application/json"),
             )
         }
-        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        val client =
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(json) }
+                // The production HttpClientProvider sets this too; without it Ktor cannot
+                // serialize the @Serializable request body passed to setBody() (replyToInquiry),
+                // the request never reaches the engine, and the captured path stays null.
+                defaultRequest { contentType(ContentType.Application.Json) }
+            }
         return InquiryRepository(
             baseUrl = "https://example.test",
             sessionToken = "test-token",

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/notifications/NotificationRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/notifications/NotificationRepositoryPathEncodingTest.kt
@@ -1,0 +1,65 @@
+package three.two.bit.ppt.reality.notifications
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Security regression (#2195): the notificationId is spliced into the request path, so it must be
+ * percent-encoded via the shared `String.asPathSegment()` helper — a `/`, `?`, `#`, or `..`-bearing
+ * id must not escape its path segment (path-injection). Mirrors
+ * `ListingDetailRepositoryTest.getListingDetail_url_encodes_listing_id_path_segment`.
+ */
+class NotificationRepositoryPathEncodingTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+    }
+
+    private fun repoCapturing(captured: Captured): NotificationRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            respond(
+                content = ByteReadChannel("{}"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return NotificationRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    @Test
+    fun notification_id_path_segments_are_percent_encoded() = runTest {
+        val read = Captured()
+        repoCapturing(read).markAsRead("../admin/secret")
+        assertEquals("/api/v1/notifications/..%2Fadmin%2Fsecret/read", read.path)
+
+        val delete = Captured()
+        repoCapturing(delete).deleteNotification("../admin/secret")
+        assertEquals("/api/v1/notifications/..%2Fadmin%2Fsecret", delete.path)
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/realtor/RealtorRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/realtor/RealtorRepositoryPathEncodingTest.kt
@@ -1,0 +1,61 @@
+package three.two.bit.ppt.reality.realtor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Security regression (#2195): the realtor userId is deep-link / nav-sourced and is spliced into
+ * the request path, so it must be percent-encoded via the shared `String.asPathSegment()` helper —
+ * a `/`, `?`, `#`, or `..`-bearing id must NOT escape its path segment (path-injection). Mirrors
+ * `ListingDetailRepositoryTest.getListingDetail_url_encodes_listing_id_path_segment`.
+ */
+class RealtorRepositoryPathEncodingTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+    }
+
+    private fun repoCapturing(captured: Captured): RealtorRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            respond(
+                content = ByteReadChannel("{}"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return RealtorRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    @Test
+    fun realtor_user_id_path_segment_is_percent_encoded() = runTest {
+        val cap = Captured()
+        repoCapturing(cap).getProfile("../admin/secret")
+        assertEquals("/api/v1/realtors/..%2Fadmin%2Fsecret/profile", cap.path)
+    }
+}


### PR DESCRIPTION
## Task

Follow-up: url-encode the remaining raw-spliced path params in mobile-native repositories + extract a shared `pathSegment` helper (Closes #2195).

Follow-up to merged PR #2180, which hardened `ListingRepository.getListingDetail` but left the same path-injection vector open at sibling call sites and left the helper copy-pasted 3×.

## Owner

pm-tech-lead (specialist: kotlin-mp)

## Changes

**1. SECURITY — wrap every still-raw `$id` path splice** in the shared encoder so a `/`, `?`, `#`, or `..`-bearing (deep-link / nav-sourced, untrusted) id cannot smuggle extra path segments or query params:

- `agency/AgencyRepository.kt` — `getAgency`, `getAgencyBySlug`, `listMembers`
- `realtor/RealtorRepository.kt` — `getProfile`
- `notifications/NotificationRepository.kt` — `markAsRead`, `deleteNotification`
- `inquiry/InquiryRepository.kt` — `getInquiry`, `replyToInquiry`, `cancelViewing`

**2. MAINTAINABILITY — extract one shared helper.** New top-level `internal fun String.asPathSegment(): String = encodeURLPathPart()` in `api/UrlEncoding.kt`. Every repository now calls it; the 3 private `pathSegment()` copies in `api/ApiClient.kt`, `favorites/FavoritesRepository.kt`, and `listing/ListingRepository.kt` are deleted.

**3. TESTS — one mirrored regression test per repository** (agency, realtor, notifications, inquiry), reusing the existing `Captured` / `repoCapturing` MockEngine harness from `ListingDetailRepositoryTest`. Each asserts a `../admin/secret` id stays a single percent-encoded segment (`..%2Fadmin%2Fsecret`), matching the already-merged assertion in `ListingDetailRepositoryTest`.

## Tested (Band A — fast check)

`cd mobile-native && ./gradlew :shared:test` — **environment-blocked.** The Gradle wrapper distribution (`gradle-9.6.1-bin.zip`) is denied by org egress policy (HTTP 403 from `services.gradle.org`), and the pre-installed system Gradle 8.14.3 cannot resolve this project's AGP 9.2.1 (offline, and version-incompatible). No JVM/Kotlin toolchain is available to run ktfmt/spotless or the JVM test target here.

Mitigations for the unrunnable gate:
- **Low risk:** pure mechanical refactor + security hardening that mirrors the already-merged, CI-green pattern from PR #2180 (`encodeURLPathPart` via a `pathSegment`-style helper). No behavioral change on the happy path — encoding is identity for normal ids.
- **Test-covered:** 4 new regression tests mirror the exact harness + assertion of the existing `ListingDetailRepositoryTest` security test that passes in CI today.
- **Formatting verified manually against ktfmt kotlinlangStyle (100-col):** every changed code line is ≤100 cols; over-long call sites were wrapped to the same multi-line shape ktfmt already produces elsewhere in these files. Remaining >100 lines are pre-existing/KDoc comments, which ktfmt does not reflow (the existing `FavoritesRepository.kt:55` comment at 101 cols already passes `spotlessCheck`).

CI (`mobile-native.yml`: `spotlessCheck` + `:shared:build` + `:androidApp:assembleDebug`) will exercise the real build/format/test on this PR.

## Built (Band B — full build)

Skipped — environment-blocked (same Gradle egress denial as Band A).

## CI parity (Band C — hot-path only)

Not runnable locally (Gradle blocked). This is a security-relevant change; CI `spotlessCheck` + `:shared:build` + `:shared:test` will provide parity on the PR.

## Scope drift

`scope-check.sh --owner pm-tech-lead` exits 2 because `owner-areas.json` maps `pm-tech-lead` to backend/architecture globs, not `mobile-native/`. The **actual** diff (vs `origin/dev`) is confined entirely to the KMP reality repositories and their tests — exactly the files named in issue #2195. The specialist that ran is `kotlin-mp`; the flag is an owner-glob mismatch, not genuine cross-area drift.

## Code-reuse review

`reuse-grep.sh --specialist kotlin-mp` — clean (no warnings). This PR *removes* duplication (3 private helpers → 1 shared extension) rather than adding any.

## Notes

- `api/ApiClient.kt` needs no import for `asPathSegment` — it lives in the same `three.two.bit.ppt.reality.api` package; the other repos add `import three.two.bit.ppt.reality.api.asPathSegment`.
- `encodeURLPathPart()` percent-encodes `/` → `%2F` and leaves unreserved chars (incl. `.`) as-is, so `../admin/secret` → `..%2Fadmin%2Fsecret`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dWszakBmBmTW9bvpzPUn9

---
_Generated by [Claude Code](https://claude.ai/code/session_014dWszakBmBmTW9bvpzPUn9)_