### PR TITLE
gh-issue-2200: exercise ProtectedRoute /login return-URL guard

### DIFF
--- a/frontend/apps/ppt-web/src/components/ProtectedRoute.routing.test.tsx
+++ b/frontend/apps/ppt-web/src/components/ProtectedRoute.routing.test.tsx
@@ -8,7 +8,9 @@
  *   - unauthenticated users are redirected to /login (Navigate)
  *   - the `redirectTo` override targets a custom path
  *   - the current location (path + query) is persisted as the return URL
- *   - the login page itself is never stored as a return URL
+ *   - the login page itself (bare and with a ?next= query) is never stored as
+ *     a return URL — with ProtectedRoute actually mounted at /login so the
+ *     storeReturnUrl guard is exercised rather than bypassed
  *   - authenticated users pass through when no roles are required
  *   - an empty `requiredRoles` array skips the role gate
  *   - a user holding any one of several accepted roles is allowed
@@ -102,6 +104,37 @@ function renderAt(entry: string, props: { requiredRoles?: string[]; redirectTo?:
   );
 }
 
+/**
+ * Mount ProtectedRoute *itself* at `entry` so its own `storeReturnUrl` guard is
+ * actually exercised for the login path.
+ *
+ * The shared `renderAt` router wires `/login` to a sibling `<Route>`, so an
+ * entry of `/login` matches that exact route and ProtectedRoute (on `path="*"`)
+ * never mounts — the storeReturnUrl effect never runs and the "don't store
+ * /login" assertion passes trivially. Here ProtectedRoute is the element for
+ * `path="/login"`, so its effect runs with `location.pathname === '/login'`,
+ * driving the `returnUrl !== LOGIN_PATH` guard. A distinct `redirectTo`
+ * landing route absorbs the unauthenticated `Navigate` without redirect-looping
+ * back onto the path under test.
+ */
+function renderProtectedAtLogin(entry: string) {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <Routes>
+        <Route path="/landing" element={<div>Landing</div>} />
+        <Route
+          path="/login"
+          element={
+            <ProtectedRoute redirectTo="/landing">
+              <div>Secret content</div>
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 beforeEach(() => {
   // Start each test from a clean return-URL slot.
   if (typeof sessionStorage !== 'undefined') sessionStorage.clear();
@@ -144,8 +177,23 @@ describe('ProtectedRoute redirect behaviour', () => {
   });
 
   it('does not store the login page as a return URL', () => {
+    // ProtectedRoute is mounted *at* /login here (not on the catch-all), so its
+    // storeReturnUrl effect genuinely runs with pathname === '/login'. The
+    // `returnUrl !== LOGIN_PATH` guard must reject it — removing that guard
+    // flips this test red instead of leaving it trivially green.
     mockAuth = unauthenticated();
-    renderAt('/login');
+    renderProtectedAtLogin('/login');
+    expect(screen.getByText('Landing')).toBeInTheDocument();
+    expect(getAndClearReturnUrl()).toBeNull();
+  });
+
+  it('does not store the login page with a query (?next=) as a return URL', () => {
+    // Locks in the second half of the guard:
+    // `!returnUrl.startsWith(`${LOGIN_PATH}?`)`. Without it, a login URL that
+    // carries a next-hop query would be stored as its own return URL.
+    mockAuth = unauthenticated();
+    renderProtectedAtLogin('/login?next=/buildings/42');
+    expect(screen.getByText('Landing')).toBeInTheDocument();
     expect(getAndClearReturnUrl()).toBeNull();
   });
 });


### PR DESCRIPTION
## Task
Follow-up: "does not store login page as return URL" test never exercises the guard it claims to cover (PR #2177). In `ProtectedRoute.routing.test.tsx`, the `does not store the login page as a return URL` test rendered `renderAt('/login')`, where the sibling `/login` route wins over ProtectedRoute's `path="*"`, so ProtectedRoute never mounts — the `storeReturnUrl` guard (`returnUrl !== LOGIN_PATH && !returnUrl.startsWith(`${LOGIN_PATH}?`)`) was never exercised and the assertion passed trivially. Add the guarded-branch test + a `/login?next=` companion. (Closes #2200)

## Owner
pm-tech-lead (specialist: react-web)

## What changed
`frontend/apps/ppt-web/src/components/ProtectedRoute.routing.test.tsx` (test-only):
- Added `renderProtectedAtLogin()` helper that mounts `ProtectedRoute` **directly at** `path="/login"` (with a distinct `redirectTo="/landing"` landing route to absorb the unauthenticated `Navigate` without redirect-looping), so the component's `storeReturnUrl` effect actually runs with `location.pathname === '/login'`.
- Rewrote `does not store the login page as a return URL` to use it — now covers the `returnUrl !== LOGIN_PATH` half of the guard.
- Added companion `does not store the login page with a query (?next=) as a return URL` (`/login?next=/buildings/42`) — covers the previously-untested `!returnUrl.startsWith(`${LOGIN_PATH}?`)` half.
- Updated the file header docstring.

No production code changed.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web test -- ProtectedRoute.routing` → exit 0, **10 passed (10)**.
- `pnpm -F @ppt/web typecheck` (`tsc --noEmit` + e2e tsconfig) → exit 0.
- `pnpm exec biome check apps/ppt-web/src/components/ProtectedRoute.routing.test.tsx` → exit 0, no fixes. (Note: `pnpm -F @ppt/web lint` invokes ESLint but the repo has no `eslint.config.js`; the actual CI lint gate is Biome per CLAUDE.md, which is clean.)

## IG3 — improved test fails without the guard
Temporarily removed the guard in `ProtectedRoute.tsx` (`storeReturnUrl` unconditionally calls `setReturnUrl`) and re-ran:
```
FAIL > does not store the login page as a return URL
  expected '/login' to be null
FAIL > does not store the login page with a query (?next=) as a return URL
  expected '/login?next=/buildings/42' to be null
Tests  2 failed | 8 passed (10)
```
Both new tests go red on the removed guard (old tautological test stayed green in that scenario). Guard restored; `git diff` on `ProtectedRoute.tsx` is clean.

## Built (Band B — full build)
skipped: test-only change, <50 LOC, no public API/config touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only, no security/auth/billing/data-integrity production change).

## Remote-tested
skipped.

## Scope drift
None — single test file under `frontend/apps/ppt-web/`.

## Code-reuse review
None — no new helpers in security/auth/crypto/http-client paths (added helper is a test-only router harness).

## Notes
The added test harness deliberately mounts `ProtectedRoute` at `/login` rather than on the wildcard, which is the whole point of the fix; `redirectTo="/landing"` prevents a redirect loop back onto the path under test.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tw3SDxB3KEqHLjGGT1x91e)_