### PR TITLE
fix(common): unblock CI — update stale sitemap test_metadata route count (13→19)

### DIFF
--- a/backend/crates/common/src/sitemap/mod.rs
+++ b/backend/crates/common/src/sitemap/mod.rs
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn test_metadata() {
         let sitemap = Sitemap::load();
-        assert_eq!(sitemap.metadata.stats.ppt_web_routes, 13);
+        assert_eq!(sitemap.metadata.stats.ppt_web_routes, 19);
         assert_eq!(sitemap.metadata.stats.reality_web_routes, 9);
         assert_eq!(sitemap.metadata.stats.mobile_screens, 6);
     }


### PR DESCRIPTION
## Problem

The backend `test` job (specifically the `test-rest` leg) is **failing on every open PR**, which has stalled the entire merge pipeline — 11 approved / in-review `auto-impl/*` PRs have been unable to merge for ~2 days.

Root cause is a single stale unit-test assertion:

```
thread 'sitemap::tests::test_metadata' panicked at crates/common/src/sitemap/mod.rs:315:9:
assertion `left == right` failed
test result: FAILED. 111 passed; 1 failed
```

`sitemap::tests::test_metadata` hardcodes `ppt_web_routes == 13`, but `Sitemap::load()` deserializes `frontend/packages/sitemap/src/json/sitemap.json` directly, and that file's `metadata.stats.ppt_web_routes` is now **19** (the count is generated from `routes['ppt-web'].length` by `generate.ts`). The route count grew when the integrations settings UI route was added in #2184.

Because that route change landed via a **non-backend path**, `backend.yml` never ran on `dev` to catch the drift — so `dev`'s own last backend run was green, but every PR that runs the backend suite now fails on this assertion.

## Fix

Update the expected `ppt_web_routes` count `13 → 19` to match the authoritative sitemap stats. `reality_web_routes` (9) and `mobile_screens` (6) are unchanged and still correct. One line, no production-code change.

## Impact

Merging this makes `test-rest` green and unblocks the stalled `auto-impl/*` PR pipeline. It should be prioritised ahead of the blocked PRs (or they can rebase onto it once merged).

## Verification

- Confirmed `sitemap.json` `metadata.stats.ppt_web_routes == 19` (authoritative embedded source).
- Confirmed this is the only assertion of that value in the repo (`grep ppt_web_routes`).
- Diff is `+1/-1`, test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S8pBdHYtu22pVZYC7mstzK)_