### PR TITLE
gh-issue-2204: cover getAppEnv fallback + de-duplicate env resolver

### DIFF
--- a/frontend/apps/mobile/app.config.env.test.ts
+++ b/frontend/apps/mobile/app.config.env.test.ts
@@ -50,9 +50,27 @@ jest.mock('node:fs', () => {
 
 type Env = 'development' | 'staging' | 'production';
 
-function loadConfig(appEnv: Env, extraProcessEnv: Record<string, string> = {}): ExpoConfig {
+/**
+ * `appEnv` argument:
+ *   - a valid `Env` literal -> assigned to `process.env.APP_ENV`
+ *   - any other string (e.g. `'garbage'`) -> assigned verbatim so the
+ *     invalid-`APP_ENV` fallback branch of `resolveAppEnv` can be exercised
+ *   - `null` -> `APP_ENV` is left cleared (deleted in `beforeEach`), so the
+ *     `NODE_ENV`-based fallback branch is exercised
+ */
+function loadConfig(
+  appEnv: Env | 'garbage' | null,
+  extraProcessEnv: Record<string, string> = {}
+): ExpoConfig {
   jest.resetModules();
-  process.env.APP_ENV = appEnv;
+  if (appEnv === null) {
+    delete process.env.APP_ENV;
+  } else {
+    // Cast: `'garbage'` is intentionally invalid so the resolver's
+    // invalid-APP_ENV fallback branch can be exercised. `process.env.APP_ENV`
+    // is typed to the valid `Env` union via a ProcessEnv augmentation.
+    process.env.APP_ENV = appEnv as Env;
+  }
   for (const [k, v] of Object.entries(extraProcessEnv)) {
     process.env[k] = v;
   }
@@ -125,10 +143,47 @@ describe('API_BASE_URL / WS_BASE_URL resolution', () => {
     expect(extra(cfg).WS_BASE_URL).toBe('wss://api.ppt.test');
   });
 
+  // NOTE (test-fidelity, #2204): this pins the *file-wins* precedence
+  // `envVars.X ?? process.env.X` (app.config.ts). It does NOT model the
+  // documented CI production-override path: the `dotenv` mock here returns
+  // `mockParsedEnv` directly and never mutates `process.env`, whereas the real
+  // sentinel-override path (#620 / #523) rewrites `.env.production` or sets
+  // `process.env` via `eas.json env` / `eas secret:create`. A `process.env`
+  // override alone would be shadowed by any file value under this precedence —
+  // so treat this case as documenting current precedence, not the CI path.
   it('prefers the parsed .env value over process.env', () => {
     mockParsedEnv = { API_BASE_URL: 'https://from-dotenv.test' };
     const cfg = loadConfig('staging', { API_BASE_URL: 'https://from-process.test' });
     expect(extra(cfg).API_BASE_URL).toBe('https://from-dotenv.test');
+  });
+});
+
+describe('APP_ENV fallback resolution (shared resolveAppEnv)', () => {
+  // These cases drive the fallback branch of the environment resolver through
+  // the default export. app.config.ts no longer keeps a private `getAppEnv`
+  // copy — it re-uses the exported `resolveAppEnv` from withIosBuildConfig.ts
+  // (#2204), so a single tested function backs both the JS runtime surface and
+  // the native xcconfig surface. With no `ENVIRONMENT` in the parsed .env,
+  // `extra.ENVIRONMENT` reflects exactly the resolved APP_ENV.
+
+  it('falls back to production when APP_ENV is unset and NODE_ENV=production', () => {
+    const cfg = loadConfig(null, { NODE_ENV: 'production' });
+    expect(extra(cfg).ENVIRONMENT).toBe('production');
+    // Production posture propagates: debug off + iOS ATS enforces HTTPS.
+    expect(extra(cfg).DEBUG_MODE).toBe(false);
+    expect(cfg.ios?.infoPlist?.NSAppTransportSecurity).toEqual({ NSAllowsArbitraryLoads: false });
+  });
+
+  it('falls back to development when both APP_ENV and NODE_ENV are unset', () => {
+    const cfg = loadConfig(null);
+    expect(extra(cfg).ENVIRONMENT).toBe('development');
+    expect(extra(cfg).DEBUG_MODE).toBe(true);
+  });
+
+  it('treats an unrecognised APP_ENV as development', () => {
+    const cfg = loadConfig('garbage');
+    expect(extra(cfg).ENVIRONMENT).toBe('development');
+    expect(extra(cfg).DEBUG_MODE).toBe(true);
   });
 });
 

--- a/frontend/apps/mobile/app.config.ts
+++ b/frontend/apps/mobile/app.config.ts
@@ -47,7 +47,13 @@ import type { ConfigContext, ExpoConfig } from 'expo/config';
 // (ios/xcconfig/{Development,Staging,Production}.xcconfig) into the generated
 // `ios/` project at prebuild and wires it as the baseConfigurationReference of
 // every Xcode build configuration. See plugins/withIosBuildConfig.ts.
-import withIosBuildConfig from './plugins/withIosBuildConfig';
+//
+// `resolveAppEnv` is re-used here as the single source of truth for the
+// APP_ENV -> environment mapping: the JS runtime layer (this file) and the
+// native xcconfig build layer (the plugin) must never disagree about which
+// environment a build is. Previously app.config.ts kept a private byte-for-byte
+// copy (`getAppEnv`) that was untested and could silently diverge — see #2204.
+import withIosBuildConfig, { resolveAppEnv } from './plugins/withIosBuildConfig';
 // Custom Expo config plugin -- re-adds legacy storage perms with
 // maxSdkVersion=32 so they apply only on API <= 32. Issue #626.
 import withLegacyStoragePermissions from './plugins/withLegacyStoragePermissions';
@@ -148,15 +154,6 @@ function resolveIconVariant(env: AppEnvironment): IconVariant {
   return resolved;
 }
 
-function getAppEnv(): AppEnvironment {
-  const raw = process.env.APP_ENV ?? '';
-  if (raw === 'staging' || raw === 'production' || raw === 'development') {
-    return raw;
-  }
-  // Fall back to NODE_ENV-based detection
-  return process.env.NODE_ENV === 'production' ? 'production' : 'development';
-}
-
 /**
  * Sentinel value written into `.env.production` — must be overridden by CI
  * (e.g. eas.json `env` or `eas secret:create`) before a production build is
@@ -183,7 +180,7 @@ function hasGoogleServicesJson(): boolean {
 }
 
 export default ({ config }: ConfigContext): ExpoConfig => {
-  const appEnv = getAppEnv();
+  const appEnv = resolveAppEnv();
   const envVars = loadEnvFile(appEnv);
 
   // Resolved values — single source of truth is the `.env.<appEnv>` file loaded


### PR DESCRIPTION
## Task
Follow-up (Closes #2204): app.config.env test leaves getAppEnv() fallback uncovered + duplicates plugin resolver (PR #2185). In frontend/apps/mobile: (1) add test cases in app.config.env.test.ts exercising the getAppEnv() fallback branch via the default export — APP_ENV unset+NODE_ENV=production→'production', APP_ENV unset+NODE_ENV unset→'development', APP_ENV='garbage'→'development' (loadConfig must allow omitting/clearing APP_ENV); (2) de-duplicate: getAppEnv() in app.config.ts is a byte-for-byte copy of the exported resolveAppEnv() in plugins/withIosBuildConfig.ts — delete getAppEnv() and import/share resolveAppEnv so both surfaces resolve env through one tested function; (3) optionally annotate the dotenv-precedence test to note it does not model the CI process.env override path.

## Owner
pm-tech-lead (specialist: react-native)

## Changes
- `app.config.ts`: deleted the private `getAppEnv()` (functionally identical copy of the plugin's resolver) and now imports/re-uses the exported, already-tested `resolveAppEnv` from `plugins/withIosBuildConfig.ts`, so the JS runtime layer and the native xcconfig layer share one environment resolver that cannot silently diverge.
- `app.config.env.test.ts`: `loadConfig` now allows clearing (`null`) or passing an invalid (`'garbage'`) `APP_ENV`; added a `describe('APP_ENV fallback resolution …')` block with the three fallback cases. Annotated the dotenv file-wins precedence case to note it does not model the CI `process.env` sentinel-override path (#620/#523).

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `pnpm biome check apps/mobile/app.config.ts apps/mobile/app.config.env.test.ts` → exit 0 (no `lint` script on the mobile package; Biome is the workspace linter)
- `pnpm jest app.config.env.test.ts` → 24 passed (21 original + 3 new), exit 0

## Built (Band B — full build)
skipped: test-only + a private-helper removal (no public API/config output change; well under the substantive-LOC threshold).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` flagged both changed files (`frontend/apps/mobile/app.config.ts`, `app.config.env.test.ts`) as outside the `pm-tech-lead` owner-area. This is expected: `pm-tech-lead` is the PM-lens hint, while the task is explicitly a `frontend/apps/mobile` test/de-dup change handled by the `react-native` specialist. No unrelated files were touched.

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings. This change actively *removes* a duplicated helper (`getAppEnv`) in favour of the shared `resolveAppEnv`.

## Notes
The three new cases assert `extra.ENVIRONMENT` (which equals the resolved `APP_ENV` when the parsed `.env` has no `ENVIRONMENT` key) plus the derived posture (DEBUG_MODE / iOS ATS), driving the fallback branch end-to-end through the default export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DnbYV6JWXLJpjYhmVmheGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DnbYV6JWXLJpjYhmVmheGJ)_