### PR TITLE
refactor-churn-hotspot-backend-integrations-booking-mod: cover OtaReadRS::from_xml envelope branches

### DIFF
--- a/backend/crates/integrations/src/booking/mod.rs
+++ b/backend/crates/integrations/src/booking/mod.rs
@@ -2691,6 +2691,91 @@ mod tests {
     }
 
     // ----------------------------------------------------------------------
+    // OtaReadRS::from_xml — response-envelope classification.
+    //
+    // parse_single_reservation is covered above; these lock in the four
+    // envelope branches of from_xml (explicit <Success/>, implicit
+    // <ReservationsList>, an <Errors> response, and the indeterminate
+    // no-marker case) plus the multi-reservation fan-out. Behaviour-only
+    // characterisation — no production code changes.
+    // ----------------------------------------------------------------------
+
+    #[test]
+    fn test_from_xml_explicit_success_parses_reservation() {
+        // <Success/> present, no <ReservationsList> wrapper: the explicit
+        // success branch must still parse the embedded reservation.
+        let xml = r#"<OTA_ReadRS><Success/><HotelReservation ResStatus="Commit"><ResGlobalInfo><HotelReservationIDs><HotelReservationID ResID_Value="BK-EXPL-1"/></HotelReservationIDs></ResGlobalInfo></HotelReservation></OTA_ReadRS>"#;
+        let rs = OtaReadRS::from_xml(xml).expect("parse must not error");
+        assert!(rs.success, "explicit <Success/> is a success envelope");
+        assert!(rs.error.is_none());
+        assert_eq!(rs.reservations.len(), 1);
+        assert_eq!(rs.reservations[0].reservation_id, "BK-EXPL-1");
+        assert_eq!(
+            rs.reservations[0].status,
+            BookingReservationStatus::Confirmed
+        );
+    }
+
+    #[test]
+    fn test_from_xml_implicit_success_via_reservations_list() {
+        // No <Success/>, but a <ReservationsList> element implies success
+        // for the Booking.com variants that omit the explicit marker.
+        let xml = r#"<OTA_ReadRS><ReservationsList><HotelReservation ResStatus="Commit"><ResGlobalInfo><HotelReservationIDs><HotelReservationID ResID_Value="BK-IMPL-1"/></HotelReservationIDs></ResGlobalInfo></HotelReservation></ReservationsList></OTA_ReadRS>"#;
+        let rs = OtaReadRS::from_xml(xml).expect("parse must not error");
+        assert!(rs.success, "<ReservationsList> is an implicit success");
+        assert!(rs.error.is_none());
+        assert_eq!(rs.reservations.len(), 1);
+        assert_eq!(rs.reservations[0].reservation_id, "BK-IMPL-1");
+    }
+
+    #[test]
+    fn test_from_xml_error_response_is_unsuccessful() {
+        // An <Errors> envelope must surface success=false with the
+        // ShortText carried through as the error message, and no
+        // reservations parsed.
+        let xml = r#"<OTA_ReadRS><Errors><Error Type="1" ShortText="Authentication failed"/></Errors></OTA_ReadRS>"#;
+        let rs = OtaReadRS::from_xml(xml).expect("parse must not error");
+        assert!(!rs.success, "<Errors> envelope is not a success");
+        assert_eq!(rs.error.as_deref(), Some("Authentication failed"));
+        assert!(rs.reservations.is_empty());
+    }
+
+    #[test]
+    fn test_from_xml_indeterminate_response_is_unsuccessful() {
+        // No <Success>, no <Errors>, no <ReservationsList>: the parser must
+        // NOT silently treat this as success (that would mask a failed
+        // pull). success=false with a non-empty error and no reservations.
+        let xml = r#"<OTA_ReadRS></OTA_ReadRS>"#;
+        let rs = OtaReadRS::from_xml(xml).expect("parse must not error");
+        assert!(!rs.success, "indeterminate envelope must not be success");
+        assert!(
+            rs.error.is_some(),
+            "indeterminate response must carry an error"
+        );
+        assert!(rs.reservations.is_empty());
+    }
+
+    #[test]
+    fn test_from_xml_parses_multiple_reservations() {
+        // The parse_reservations fan-out must return one entry per
+        // <HotelReservation> element, in document order.
+        let xml = r#"<OTA_ReadRS><Success/><ReservationsList><HotelReservation ResStatus="Commit"><ResGlobalInfo><HotelReservationIDs><HotelReservationID ResID_Value="BK-A"/></HotelReservationIDs></ResGlobalInfo></HotelReservation><HotelReservation ResStatus="Cancel"><ResGlobalInfo><HotelReservationIDs><HotelReservationID ResID_Value="BK-B"/></HotelReservationIDs></ResGlobalInfo></HotelReservation></ReservationsList></OTA_ReadRS>"#;
+        let rs = OtaReadRS::from_xml(xml).expect("parse must not error");
+        assert!(rs.success);
+        assert_eq!(rs.reservations.len(), 2);
+        assert_eq!(rs.reservations[0].reservation_id, "BK-A");
+        assert_eq!(
+            rs.reservations[0].status,
+            BookingReservationStatus::Confirmed
+        );
+        assert_eq!(rs.reservations[1].reservation_id, "BK-B");
+        assert_eq!(
+            rs.reservations[1].status,
+            BookingReservationStatus::Cancelled
+        );
+    }
+
+    // ----------------------------------------------------------------------
     // OtaHotelRateAmountNotifRQ / RS typed request/response models (Story 83.2)
     // ----------------------------------------------------------------------
 


### PR DESCRIPTION
## Task
backend integrations booking/mod.rs — instability watch after PR #2176 split. Assess whether a targeted, behavior-preserving refactor or added test coverage reduces churn risk. If the module is already clean post-#2176 and no low-risk improvement exists, return no-actionable-change rather than churning it further.

## Assessment
Post-#2176 the module is structurally clean: the XML-serialisation helpers already live in the sibling `ota_xml.rs`, and `mod.rs` has strong test coverage (38 test fns). A structural re-split would be churn for its own sake and carries behaviour risk, so that was rejected.

The one genuine low-risk gap: `OtaReadRS::from_xml` — the reservation-**pull** parse entry point — had **no direct test**. Only `parse_single_reservation` was covered. `from_xml` owns the response-envelope classification (a real churn surface: implicit-success handling, error propagation, indeterminate-vs-success), so locking that behaviour in reduces future regression risk with zero production-code change.

## Change
Test-only. Added 5 characterisation tests for `OtaReadRS::from_xml`:
- explicit `<Success/>` envelope parses the embedded reservation
- implicit success via `<ReservationsList>` (no `<Success>` marker)
- `<Errors>` envelope → success=false, ShortText surfaced, no reservations
- indeterminate (no marker) → success=false with error, not silently treated as success
- multi-reservation fan-out returns one entry per `<HotelReservation>` in order

No production code touched — behaviour-preserving.

## Owner
pm-tech-lead

## Tested (Band A — fast check)
- `cargo test -p integrations --lib booking::tests::test_from_xml` → 5 passed, 0 failed (exit 0)
- `cargo test -p integrations --lib booking::` → 95 passed, 0 failed (exit 0)
- `cargo clippy -p integrations --lib` → Finished, no warnings (exit 0)

## Built (Band B — full build)
skipped: change is test-only (~85 LOC of tests), no public API / migration / config touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only, no security/auth/billing/data-integrity change).

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 for `backend/crates/integrations/src/booking/mod.rs` — the file does not map into the `pm-tech-lead` owner glob. The drift is benign and justified: this file **is** the explicit target named in the task, and the change is test-only. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings.

## Remote-tested
skipped

## Notes
Behaviour-preserving safety net for a churn hotspot; no runtime change. Draft pending reviewer sign-off.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1Vok6zpMgqMrGe6aZgTiv)_