### PR TITLE
security-forgot-password-no-rate-limit: rate-limit /forgot-password and /resend-verification

### DIFF
--- a/backend/servers/api-server/src/routes/auth.rs
+++ b/backend/servers/api-server/src/routes/auth.rs
@@ -10,10 +10,84 @@ use axum::{
 use common::errors::{ErrorResponse, ValidationError};
 use db::models::{AuditAction, CreateAuditLog, CreateUser, Locale, UpdateUser};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
 use utoipa::ToSchema;
 
+use crate::routes::rate_limit::{rate_limit_allowed, InProcessRateLimiter};
 use crate::services::AuthService;
 use crate::state::AppState;
+
+// ── Email-keyed throttle for unauthenticated email-dispatch surfaces ────────
+//
+// `POST /api/v1/auth/forgot-password` and `POST /api/v1/auth/resend-verification`
+// each send an email and rotate the recipient's outstanding token on every
+// call, with no authentication. Without a limiter an attacker can (a) mailbomb
+// a victim's inbox and (b) repeatedly clobber a pending reset/verification
+// token so a legitimate link the victim is mid-flow on stops working. Both are
+// throttled per (normalised) email using the shared in-process sliding-window
+// limiter (`routes::rate_limit`) — the same algorithm the MFA verify surfaces
+// use, keyed on `String` here instead of `user_id`.
+//
+// Keyed on email (not IP) because the abuse targets a specific mailbox, and it
+// matches the login limiter's email keying (`SessionRepository::check_rate_limit`).
+// Blocking on the email string leaks no account-existence signal: the 429 is a
+// pure function of request volume for that string, independent of whether an
+// account exists — so the anti-enumeration guarantee of these endpoints holds.
+const AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS: u32 = 5;
+const AUTH_EMAIL_DISPATCH_WINDOW: Duration = Duration::from_secs(900);
+/// Only sweep expired limiter entries once the map exceeds this size.
+const AUTH_EMAIL_DISPATCH_SWEEP_THRESHOLD: usize = 1024;
+
+static FORGOT_PASSWORD_RATE_LIMITER: LazyLock<InProcessRateLimiter<String>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+static RESEND_VERIFICATION_RATE_LIMITER: LazyLock<InProcessRateLimiter<String>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Normalise an email to its rate-limit key: trimmed + lowercased, matching the
+/// `LOWER(email)` comparison the login limiter uses so casing/whitespace can't
+/// be used to sidestep the throttle.
+fn email_rate_key(email: &str) -> String {
+    email.trim().to_lowercase()
+}
+
+/// Record a `/forgot-password` attempt for `email`; `false` once more than
+/// `AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS` land in a rolling window.
+fn forgot_password_rate_allowed(email: &str) -> bool {
+    rate_limit_allowed(
+        &FORGOT_PASSWORD_RATE_LIMITER,
+        email_rate_key(email),
+        AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS,
+        AUTH_EMAIL_DISPATCH_WINDOW,
+        AUTH_EMAIL_DISPATCH_SWEEP_THRESHOLD,
+    )
+}
+
+/// Record a `/resend-verification` attempt for `email`; `false` once more than
+/// `AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS` land in a rolling window.
+fn resend_verification_rate_allowed(email: &str) -> bool {
+    rate_limit_allowed(
+        &RESEND_VERIFICATION_RATE_LIMITER,
+        email_rate_key(email),
+        AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS,
+        AUTH_EMAIL_DISPATCH_WINDOW,
+        AUTH_EMAIL_DISPATCH_SWEEP_THRESHOLD,
+    )
+}
+
+/// Shared 429 body for the email-dispatch surfaces. Kept generic (no
+/// account-specific detail) so it does not become an enumeration oracle.
+fn email_dispatch_rate_limited() -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(ErrorResponse::new(
+            "RATE_LIMITED",
+            "Too many requests for this email. Please try again later.",
+        )),
+    )
+}
 
 /// Create auth router.
 pub fn router() -> Router<AppState> {
@@ -377,12 +451,24 @@ pub struct ResendVerificationResponse {
     request_body = ResendVerificationRequest,
     responses(
         (status = 200, description = "Verification email sent (if account exists)", body = ResendVerificationResponse),
+        (status = 429, description = "Too many requests for this email", body = ErrorResponse),
     )
 )]
 pub async fn resend_verification(
     State(state): State<AppState>,
     Json(req): Json<ResendVerificationRequest>,
-) -> Json<ResendVerificationResponse> {
+) -> Result<Json<ResendVerificationResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Throttle per email before doing any work: this endpoint sends an email
+    // and rotates the recipient's verification token on every call, so it is a
+    // mailbomb / token-clobber surface (see limiter docs above).
+    if !resend_verification_rate_allowed(&req.email) {
+        tracing::warn!(
+            email_hash = %common::email_log_hash(&req.email),
+            "resend-verification blocked due to rate limiting"
+        );
+        return Err(email_dispatch_rate_limited());
+    }
+
     // Always return success to prevent email enumeration
     let response = ResendVerificationResponse {
         message:
@@ -407,7 +493,7 @@ pub async fn resend_verification(
                 .await
             {
                 tracing::error!(error = %e, user_id = %user.id, "Failed to create verification token");
-                return Json(response);
+                return Ok(Json(response));
             }
 
             // Send email
@@ -430,7 +516,7 @@ pub async fn resend_verification(
         }
     }
 
-    Json(response)
+    Ok(Json(response))
 }
 
 // ==================== Login (Story 1.2) ====================
@@ -1509,12 +1595,24 @@ pub struct ForgotPasswordResponse {
     request_body = ForgotPasswordRequest,
     responses(
         (status = 200, description = "Password reset email sent (if account exists)", body = ForgotPasswordResponse),
+        (status = 429, description = "Too many requests for this email", body = ErrorResponse),
     )
 )]
 pub async fn forgot_password(
     State(state): State<AppState>,
     Json(req): Json<ForgotPasswordRequest>,
-) -> Json<ForgotPasswordResponse> {
+) -> Result<Json<ForgotPasswordResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Throttle per email before doing any work: this endpoint sends an email
+    // and invalidates the recipient's outstanding reset token on every call, so
+    // it is a mailbomb / token-clobber surface (see limiter docs above).
+    if !forgot_password_rate_allowed(&req.email) {
+        tracing::warn!(
+            email_hash = %common::email_log_hash(&req.email),
+            "forgot-password blocked due to rate limiting"
+        );
+        return Err(email_dispatch_rate_limited());
+    }
+
     // Always return success to prevent email enumeration
     let response = ForgotPasswordResponse {
         message: "If an account exists with this email, a password reset link has been sent."
@@ -1545,7 +1643,7 @@ pub async fn forgot_password(
 
             if let Err(e) = state.password_reset_repo.create(create_token).await {
                 tracing::error!(error = %e, user_id = %user.id, "Failed to create password reset token");
-                return Json(response);
+                return Ok(Json(response));
             }
 
             // Send reset email
@@ -1579,7 +1677,7 @@ pub async fn forgot_password(
         }
     }
 
-    Json(response)
+    Ok(Json(response))
 }
 
 // ==================== Reset Password (Story 1.4) ====================
@@ -2716,6 +2814,67 @@ mod cookie_security_tests {
         assert_eq!(
             resolved, body_token,
             "Valid body token must be used when the cookie is present-but-empty"
+        );
+    }
+}
+
+// ==================== Email-dispatch rate-limit regression tests ============
+//
+// Guards the mailbomb / token-clobber fix: `/forgot-password` and
+// `/resend-verification` throttle per email. These exercise the exact guard
+// helpers the handlers call, so removing the limiter (or bumping the threshold
+// out of range) fails the build. Pure in-process — no DB/state needed.
+#[cfg(test)]
+mod email_dispatch_rate_limit_tests {
+    use super::{
+        forgot_password_rate_allowed, resend_verification_rate_allowed,
+        AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS,
+    };
+
+    #[test]
+    fn forgot_password_limit_trips_after_threshold() {
+        // Unique key so the process-global static is not polluted by other tests.
+        let email = "trip-fp-unique@example.test";
+        for i in 0..AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS {
+            assert!(
+                forgot_password_rate_allowed(email),
+                "attempt {i} (within the limit) must be allowed"
+            );
+        }
+        assert!(
+            !forgot_password_rate_allowed(email),
+            "the request past AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS must be blocked (429)"
+        );
+    }
+
+    #[test]
+    fn resend_verification_limit_trips_after_threshold() {
+        let email = "trip-rv-unique@example.test";
+        for i in 0..AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS {
+            assert!(
+                resend_verification_rate_allowed(email),
+                "attempt {i} (within the limit) must be allowed"
+            );
+        }
+        assert!(
+            !resend_verification_rate_allowed(email),
+            "the request past AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS must be blocked (429)"
+        );
+    }
+
+    /// The key is normalised (trim + lowercase) so casing / whitespace can't be
+    /// used to sidestep the throttle — the login limiter keys the same way.
+    #[test]
+    fn email_key_normalisation_prevents_case_bypass() {
+        let base = "Case-Bypass-Unique@Example.Test";
+        for _ in 0..AUTH_EMAIL_DISPATCH_MAX_ATTEMPTS {
+            assert!(forgot_password_rate_allowed(base));
+        }
+        // A different casing / surrounding whitespace maps to the same key and
+        // must remain blocked rather than resetting the counter.
+        assert!(
+            !forgot_password_rate_allowed("  case-bypass-unique@example.test  "),
+            "case/whitespace variant must hit the same throttle bucket"
         );
     }
 }

--- a/backend/servers/api-server/src/routes/mfa.rs
+++ b/backend/servers/api-server/src/routes/mfa.rs
@@ -14,65 +14,22 @@ use serde::{Deserialize, Serialize};
 use sqlx::Acquire;
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use utoipa::ToSchema;
 
+use crate::routes::rate_limit::{rate_limit_allowed, InProcessRateLimiter};
 use crate::state::AppState;
 
 // ── Generic per-user in-process brute-force throttle ────────────────────────
 //
 // Both the recovery-code verify (GH #1523/#1583) and the MFA setup-verify
 // (issue #2159) endpoints are bearer-authenticated brute-force surfaces keyed
-// on the authenticated `user_id`. They share one sliding-window limiter,
-// differing only in their backing map + tuning constants. This mirrors the
-// per-key in-process limiter in `routes/caddy_ask.rs`. NOTE: the counter is
-// per-process; a Redis-backed counter (the sessions Redis is already in the
-// stack) would hold the limit across instances — tracked as a follow-up.
+// on the authenticated `user_id`. They share one sliding-window limiter
+// (`routes::rate_limit`), differing only in their backing map + tuning
+// constants. The same limiter also guards the email-keyed
+// `/forgot-password` + `/resend-verification` surfaces in `routes::auth`.
 
-struct RateLimitEntry {
-    count: u32,
-    window_start: Instant,
-}
-
-type UserRateLimiter = Mutex<HashMap<uuid::Uuid, RateLimitEntry>>;
-
-/// Record an attempt for `user_id` in `limiter` and report whether it is within
-/// the limit. Returns `false` once more than `max_attempts` attempts occur in a
-/// rolling `window`.
-///
-/// Expired entries are evicted (GH #1583), but only once the map exceeds
-/// `sweep_threshold`, so the `retain` walk is amortized rather than run on every
-/// request. This matters because these maps are keyed on the whole user
-/// population on auth paths: without eviction an attacker enumerating user_ids
-/// could grow the map without bound (slow memory-exhaustion DoS).
-fn rate_limit_allowed(
-    limiter: &UserRateLimiter,
-    user_id: uuid::Uuid,
-    max_attempts: u32,
-    window: Duration,
-    sweep_threshold: usize,
-) -> bool {
-    let mut map = match limiter.lock() {
-        Ok(m) => m,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    let now = Instant::now();
-
-    if map.len() > sweep_threshold {
-        map.retain(|_, e| now.duration_since(e.window_start) < window);
-    }
-
-    let entry = map.entry(user_id).or_insert(RateLimitEntry {
-        count: 0,
-        window_start: now,
-    });
-    if now.duration_since(entry.window_start) >= window {
-        entry.count = 0;
-        entry.window_start = now;
-    }
-    entry.count += 1;
-    entry.count <= max_attempts
-}
+type UserRateLimiter = InProcessRateLimiter<uuid::Uuid>;
 
 // ── Brute-force throttle for recovery-code verification (GH #1523) ──────────
 //

--- a/backend/servers/api-server/src/routes/mod.rs
+++ b/backend/servers/api-server/src/routes/mod.rs
@@ -40,6 +40,7 @@ pub mod my_units;
 pub mod neighbors;
 pub mod notification_preferences;
 pub mod push_tokens;
+pub mod rate_limit;
 // Epic 8A, Story 8A.3 — WebSocket realtime notification sync
 pub mod oauth;
 pub mod onboarding;

--- a/backend/servers/api-server/src/routes/rate_limit.rs
+++ b/backend/servers/api-server/src/routes/rate_limit.rs
@@ -1,0 +1,126 @@
+//! Generic in-process sliding-window rate limiter shared by auth-surface
+//! routes.
+//!
+//! This is the single implementation of the per-key brute-force / abuse
+//! throttle that previously lived (Uuid-keyed) inside `routes::mfa` and
+//! (IP-keyed) inside `routes::caddy_ask`. Extracting it here lets the
+//! auth email-keyed surfaces (`/forgot-password`, `/resend-verification`)
+//! reuse the exact same, already-reviewed algorithm instead of growing a
+//! third copy.
+//!
+//! Semantics (unchanged from the original mfa limiter):
+//! - A rolling `window` per key; once more than `max_attempts` attempts land
+//!   in the current window the key is blocked until the window rolls over.
+//! - Expired entries are evicted, but only once the map exceeds
+//!   `sweep_threshold`, so the `retain` walk is amortized rather than run on
+//!   every request. This bounds memory on auth paths where the key space is
+//!   the whole user/email population (a slow memory-exhaustion DoS otherwise).
+//! - The counter is per-process; a Redis-backed counter (the sessions Redis is
+//!   already in the stack) would hold the limit across instances — tracked as a
+//!   follow-up.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// One key's attempt counter within the current rolling window.
+pub struct RateLimitEntry {
+    count: u32,
+    window_start: Instant,
+}
+
+/// A process-global limiter keyed on `K` (e.g. `uuid::Uuid` for authenticated
+/// user surfaces, `String` for email-keyed unauthenticated surfaces).
+pub type InProcessRateLimiter<K> = Mutex<HashMap<K, RateLimitEntry>>;
+
+/// Record an attempt for `key` in `limiter` and report whether it is within
+/// the limit. Returns `false` once more than `max_attempts` attempts occur in a
+/// rolling `window`.
+///
+/// See the module docs for the eviction / memory-bound rationale behind
+/// `sweep_threshold`.
+pub fn rate_limit_allowed<K: Eq + Hash>(
+    limiter: &InProcessRateLimiter<K>,
+    key: K,
+    max_attempts: u32,
+    window: Duration,
+    sweep_threshold: usize,
+) -> bool {
+    let mut map = match limiter.lock() {
+        Ok(m) => m,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let now = Instant::now();
+
+    if map.len() > sweep_threshold {
+        map.retain(|_, e| now.duration_since(e.window_start) < window);
+    }
+
+    let entry = map.entry(key).or_insert(RateLimitEntry {
+        count: 0,
+        window_start: now,
+    });
+    if now.duration_since(entry.window_start) >= window {
+        entry.count = 0;
+        entry.window_start = now;
+    }
+    entry.count = entry.count.saturating_add(1);
+    entry.count <= max_attempts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::LazyLock;
+
+    static TEST_LIMITER: LazyLock<InProcessRateLimiter<String>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    #[test]
+    fn allows_up_to_max_then_blocks() {
+        let key = "allows_up_to_max_then_blocks".to_string();
+        let max = 5;
+        let window = Duration::from_secs(900);
+        for i in 0..max {
+            assert!(
+                rate_limit_allowed(&TEST_LIMITER, key.clone(), max, window, 1024),
+                "attempt {i} within the limit must be allowed"
+            );
+        }
+        assert!(
+            !rate_limit_allowed(&TEST_LIMITER, key, max, window, 1024),
+            "the (max + 1)th attempt in the window must be blocked"
+        );
+    }
+
+    #[test]
+    fn separate_keys_do_not_interfere() {
+        let window = Duration::from_secs(900);
+        // Exhaust key A.
+        for _ in 0..3 {
+            assert!(rate_limit_allowed(
+                &TEST_LIMITER,
+                "iface_key_a".to_string(),
+                3,
+                window,
+                1024
+            ));
+        }
+        assert!(!rate_limit_allowed(
+            &TEST_LIMITER,
+            "iface_key_a".to_string(),
+            3,
+            window,
+            1024
+        ));
+        // A different key is unaffected.
+        assert!(rate_limit_allowed(
+            &TEST_LIMITER,
+            "iface_key_b".to_string(),
+            3,
+            window,
+            1024
+        ));
+    }
+}


### PR DESCRIPTION
## Task
`/forgot-password` and `/resend-verification` endpoints have no rate limit — vulnerable to mailbomb / token-clobber. Add rate limiting to these two auth endpoints, mirroring the rate-limiting approach already used elsewhere in the api-server (find the existing rate-limit middleware/tower layer / limiter and apply it, or extend it). Add a regression test asserting the limit trips.

## Owner
pm-security

## What changed
- **Reuse, not duplicate:** extracted the existing Uuid-keyed MFA brute-force limiter (`routes::mfa`) into a shared generic module `routes::rate_limit` (`rate_limit_allowed<K: Eq + Hash>` + `InProcessRateLimiter<K>`), preserving the exact sliding-window + amortized-sweep-eviction semantics. `routes::mfa` now consumes it (keyed on `uuid::Uuid`); `routes::auth` consumes it keyed on `String` (email). One algorithm, three call sites — no third copy.
- **New throttle** on both email-dispatch surfaces: 5 requests / 15 min per **normalised email** (trim + lowercase, matching the login limiter's `LOWER(email)` keying). The `(N+1)`th request in the window returns **429 RATE_LIMITED**.
- Both handlers changed from `Json<T>` to `Result<Json<T>, (StatusCode, Json<ErrorResponse>)>` and the `#[utoipa::path]` docs gained a `429` response.
- Keying on email leaks **no** account-existence signal: the 429 is a pure function of request volume for the email string, independent of whether an account exists — the anti-enumeration guarantee of these endpoints is preserved.

## Tested (Band A — fast check)
Local `cargo check -p api-server` / `cargo test` could **not** run to completion in this sandbox: the `utoipa-swagger-ui` build script downloads `github.com/swagger-api/swagger-ui` at build time, which is denied by this session's egress policy (195-byte policy page → `InvalidArchive`). api-server has never compiled in this environment for the same reason — this is a pre-existing infra block, not a code issue. **CI (where swagger-ui is cached) is the gate — hence draft.**

To compensate, the exact new code + the exact regression tests were compiled and run standalone with `rustc --edition 2021 --test`:
```
running 5 tests
test rate_limit::tests::allows_up_to_max_then_blocks ... ok
test rate_limit::tests::separate_keys_do_not_interfere ... ok
test email_dispatch_rate_limit_tests::forgot_password_limit_trips_after_threshold ... ok
test email_dispatch_rate_limit_tests::resend_verification_limit_trips_after_threshold ... ok
test email_dispatch_rate_limit_tests::email_key_normalisation_prevents_case_bypass ... ok
test result: ok. 5 passed; 0 failed
```
Manual review confirmed: no dangling refs after the mfa.rs refactor (removed `struct RateLimitEntry` / private `rate_limit_allowed`; imports trimmed of the now-unused `Instant`), and all existing integration tests that hit these endpoints (`auth_tests.rs`, `auth_partial_backfill_batch1_tests.rs`) issue ≤2 requests per email — comfortably under the threshold of 5, so the shared process-global limiter will not trip them.

## Built (Band B — full build)
Blocked by the same swagger-ui egress policy — deferred to CI.

## CI parity (Band C — hot-path only)
Blocked by the same swagger-ui egress policy — deferred to CI. This IS a hot-path (auth) PR; please confirm `backend.yml` (cargo fmt / clippy / test) is green before un-drafting.

## Scope drift
`scope-check.sh --owner pm-security` reports exit 2 for all four files. This is a **false positive from stale globs**: `owner-areas.json` maps pm-security to `.../src/handlers/auth/**` + `.../handlers/mfa/**`, but this repo keeps auth/MFA code under `src/routes/` (`routes/auth.rs`, `routes/mfa.rs`). All four touched files are squarely the auth/MFA security surface — pm-security's actual domain. No genuine drift. (Suggest updating `owner-areas.json` handlers→routes separately.)

## Code-reuse review
`reuse-grep.sh` — no warnings. The change consolidates the existing limiter rather than adding a duplicate helper.

## Notes
Follow-up (pre-existing, unchanged): the limiter is per-process; a Redis-backed counter (sessions Redis already in the stack) would hold the limit across instances. Tracked in the existing MFA limiter comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETgkNB3qD4N71o1c5Y2f97

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETgkNB3qD4N71o1c5Y2f97)_