### PR TITLE
churn-hotspot: dedupe form RLS test cleanup via drop_rls_role helper

### DIFF
--- a/backend/crates/db/tests/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/form_rls_repo_tests.rs
@@ -319,21 +319,13 @@ async fn form_repo_force_rls_deny_all_and_fix(pool: PgPool) {
     }
 
     // --- Cleanup ---
-    set_ctx(&pool, None, None, true).await;
+    // Reuse the shared `drop_rls_role` helper (it re-establishes the super
+    // context, then REVOKEs every grant this test made + DROPs the role) so
+    // the REVOKE list lives in exactly one place — the write-path test below
+    // already goes through it. Keeping a hand-inlined copy here meant any new
+    // form table had to be added to the grant list twice.
     let _ = (form_b, user_b); // seeded for symmetry
-    for stmt in [
-        format!(
-            "REVOKE ALL ON forms, form_fields, form_submissions, form_downloads FROM \"{role}\""
-        ),
-        format!("REVOKE ALL ON organizations FROM \"{role}\""),
-        format!("REVOKE ALL ON users FROM \"{role}\""),
-        format!("DROP ROLE IF EXISTS \"{role}\""),
-    ] {
-        sqlx::query(sqlx::AssertSqlSafe(stmt))
-            .execute(&pool)
-            .await
-            .ok();
-    }
+    drop_rls_role(&pool, &role).await;
 }
 
 /// Write-path coverage for PAP-76 / issue #1369.


### PR DESCRIPTION
## Task
Churn hotspot — `backend/crates/db/tests/form_rls_repo_tests.rs` was touched 2x in a short window (2026-06-12→2026-06-13). Assess the file; add targeted test coverage or a behavior-preserving refactor that reduces churn/regression risk.

## Owner
pm-backend

## What changed
`form_repo_force_rls_deny_all_and_fix` hand-inlined the exact REVOKE/DROP role-cleanup sequence that the file's shared `drop_rls_role` helper already performs — and that the sibling `form_repo_force_rls_write_paths_and_cross_tenant` test already calls. Consolidated test 1 onto the same helper so the grant/revoke list lives in a single place. Adding a new form table previously required editing the REVOKE list in two spots; that duplication (the churn/regression risk) is now gone. Net: 6 insertions, 14 deletions, behavior-preserving.

Both tests remain `#[ignore]`d under the pre-existing BIT-351 quarantine (repair tracked in BIT-352) — unchanged by this PR.

## Tested (Band A — fast check)
- `cargo test -p db --test form_rls_repo_tests --no-run` → exit 0 (test target recompiles clean, `Finished` incremental in 2.88s)
- `cargo clippy -p db --test form_rls_repo_tests -- -D warnings` → exit 0 (`Finished` in 3m05s, no warnings)

The two tests require a live Postgres with `FORCE ROW LEVEL SECURITY` and are quarantined (`#[ignore]`), so runtime execution is deferred to CI/the DB gate per the env-block policy. This change is a pure consolidation onto an already-exercised helper containing identical SQL, so no behavioral delta is introduced.

## Built (Band B — full build)
skipped: <50 LOC test-only change, no public API / migration / config touch.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only refactor; no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Scope-drift check: exit 0 (`scope_drift=false`) — change is confined to a backend db test file, squarely pm-backend.
- No new helpers/symbols added, so no code-reuse concern (this PR removes a duplicate; `code_reuse_warn=none`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETgkNB3qD4N71o1c5Y2f97

---
_Generated by [Claude Code](https://claude.ai/code/session_01ETgkNB3qD4N71o1c5Y2f97)_