### PR TITLE
gh-issue-2236: finish env-resolver de-dup — stale getAppEnv() comment + duplicated AppEnvironment type

### DIFF
--- a/frontend/apps/mobile/app.config.ts
+++ b/frontend/apps/mobile/app.config.ts
@@ -53,13 +53,13 @@ import type { ConfigContext, ExpoConfig } from 'expo/config';
 // native xcconfig build layer (the plugin) must never disagree about which
 // environment a build is. Previously app.config.ts kept a private byte-for-byte
 // copy (`getAppEnv`) that was untested and could silently diverge — see #2204.
-import withIosBuildConfig, { resolveAppEnv } from './plugins/withIosBuildConfig';
+import withIosBuildConfig, {
+  type AppEnvironment,
+  resolveAppEnv,
+} from './plugins/withIosBuildConfig';
 // Custom Expo config plugin -- re-adds legacy storage perms with
 // maxSdkVersion=32 so they apply only on API <= 32. Issue #626.
 import withLegacyStoragePermissions from './plugins/withLegacyStoragePermissions';
-
-/** Supported environments */
-type AppEnvironment = 'development' | 'staging' | 'production';
 
 function loadEnvFile(env: AppEnvironment): dotenv.DotenvParseOutput {
   const envFile = path.resolve(__dirname, `.env.${env}`);

--- a/frontend/apps/mobile/plugins/withIosBuildConfig.ts
+++ b/frontend/apps/mobile/plugins/withIosBuildConfig.ts
@@ -50,7 +50,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { type ConfigPlugin, withDangerousMod, withXcodeProject } from '@expo/config-plugins';
 
-/** Supported environments — mirrors app.config.ts AppEnvironment. */
+/** Supported environments — single source of truth, imported by app.config.ts. */
 export type AppEnvironment = 'development' | 'staging' | 'production';
 
 /** Basename of the xcconfig copied into the generated `ios/` project. */
@@ -64,9 +64,10 @@ export const TEMPLATE_BY_ENV: Record<AppEnvironment, string> = {
 };
 
 /**
- * Resolve the active environment. Kept in lockstep with app.config.ts
- * `getAppEnv()` so the native build layer and the JS runtime layer never
- * disagree about which environment a build is.
+ * Resolve the active environment. Single source of truth for the APP_ENV ->
+ * environment mapping — imported by app.config.ts (the JS runtime layer) so it
+ * and the native xcconfig build layer can never disagree about which
+ * environment a build is.
  */
 export function resolveAppEnv(env: NodeJS.ProcessEnv = process.env): AppEnvironment {
   const raw = env.APP_ENV ?? '';


### PR DESCRIPTION
## Task
Follow-up to PR #2227 (env-resolver de-dup). Removes the two loose ends the merge left behind: the stale `getAppEnv()` doc comment and the duplicated `AppEnvironment` type. Consolidates to the single canonical definition in `plugins/withIosBuildConfig.ts`. Closes #2236.

## Changes
- `plugins/withIosBuildConfig.ts` — reworded the `resolveAppEnv` doc comment (was referencing the now-deleted `getAppEnv()`) to describe the single-source-of-truth reality; updated the `AppEnvironment` type comment (was "mirrors app.config.ts", now "single source of truth, imported by app.config.ts").
- `app.config.ts` — dropped the local `AppEnvironment` union declaration and now `import { type AppEnvironment }` from the plugin, so both surfaces share one type as well as one resolver function.

No runtime/logic change — the union values are byte-for-byte identical; this is a type/comment consolidation.

## Owner
pm-tech-lead (react-native specialist)

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0 (tsc --noEmit clean)
- `pnpm jest app.config` → exit 0 (4 suites, 48 tests passed — includes `app.config.iosBuildConfig.test.ts` which unit-tests `resolveAppEnv`)
- `pnpm biome check apps/mobile/app.config.ts apps/mobile/plugins/withIosBuildConfig.ts` → exit 0 (no fixes)

## Built (Band B — full build)
skipped: change <50 LOC, no public API/config output change (type/comment-only consolidation)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
Scope-drift check: clean (both files under `frontend/apps/mobile/`). Code-reuse: n/a — this PR *removes* a duplicate rather than adding a helper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVhai7xvTd9W38AZuujQqr)_