### PR TITLE
test-gap-hotfix-no-test-pr-1289-api-ecosystem: regression test for public-connection routing

### DIFF
--- a/backend/crates/db/tests/api_ecosystem_public_conn_routing_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_public_conn_routing_tests.rs
@@ -1,0 +1,200 @@
+//! Regression test for the api-ecosystem **public-connection routing**
+//! introduced by PR #1289 / PAP-167 (parent PAP-150).
+//!
+//! Background
+//! ----------
+//! PR #1289 reworked the api-ecosystem handlers (~162 lines) so that the
+//! global-catalog + developer-portal reads no longer run on the raw `state.db`
+//! pool. The public catalog read handlers (`list_marketplace_integrations`,
+//! `get_marketplace_integration`, …) route through `catalog_conn()`, which
+//! calls [`db::RlsPool::acquire_public`]. That helper does two things this
+//! test pins:
+//!
+//!   1. It keeps the read off the raw pool (so the RLS-enforcement CI gate
+//!      stays green) while still resolving the public catalog — the
+//!      `marketplace_integrations_read` policy is `USING (TRUE)`, so the read
+//!      must succeed on a connection carrying **no** RLS context.
+//!   2. It **clears any stale RLS context** left on a pooled connection by a
+//!      previous (authenticated / super-admin) request before reuse. This is
+//!      the tenant-isolation property the rework depends on: a public
+//!      catalog read must never inherit a prior request's org / user /
+//!      super-admin GUCs (which, once the catalog went `FORCE ROW LEVEL
+//!      SECURITY` in PAP-171, would otherwise let a leaked super-admin context
+//!      silently authorize catalog writes on the reused connection).
+//!
+//! The PR shipped without a regression test for this routing; this file adds
+//! one. It exercises the real production path (`RlsPool::acquire_public`) and
+//! the real repository method the handler calls
+//! (`ApiEcosystemRepository::list_marketplace_integrations` /
+//! `get_marketplace_integration`).
+//!
+//! Quarantine note
+//! ---------------
+//! Mirrors the sibling api-ecosystem RLS tests: `#[sqlx::test]` needs a live
+//! Postgres, which the blind-CI gate lacks (BIT-351). The `#[ignore]` keeps the
+//! suite green until the DB-backed gate is repaired (BIT-352); the test is
+//! authored to pass against a real database.
+
+use db::repositories::ApiEcosystemRepository;
+use db::RlsPool;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Seed a marketplace integration directly (as the `#[sqlx::test]` superuser,
+/// which bypasses RLS). Returns its id.
+async fn seed_integration(pool: &PgPool, slug: &str, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO marketplace_integrations (slug, name, description, vendor_name)
+        VALUES ($1, $2, 'regression fixture', 'Test Vendor')
+        RETURNING id
+        "#,
+    )
+    .bind(slug)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed marketplace integration")
+}
+
+/// Read a request-context GUC in the `missing_ok` form, mapping the empty
+/// string (what `clear_request_context()` sets) to `None`.
+async fn read_guc<'e, E>(executor: E, name: &str) -> Option<String>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Postgres>,
+{
+    let sql = format!("SELECT current_setting('{name}', true)");
+    sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(sql))
+        .fetch_one(executor)
+        .await
+        .expect("read guc")
+        .filter(|s| !s.is_empty())
+}
+
+/// (1) The public catalog read resolves on the context-cleared connection that
+/// `acquire_public()` hands back — `marketplace_integrations_read = USING(TRUE)`
+/// keeps the catalog readable with no RLS context, so the public-connection
+/// routing does not silently blank the marketplace.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
+async fn catalog_public_read_resolves_on_acquire_public_connection(pool: PgPool) {
+    let id = seed_integration(&pool, "pap167-public-read", "PAP-167 Public Read").await;
+
+    let repo = ApiEcosystemRepository::new(pool.clone());
+    let rls_pool = RlsPool::new(pool.clone());
+
+    // Real production path: the public catalog handlers call `acquire_public()`.
+    let mut public_conn = rls_pool
+        .acquire_public()
+        .await
+        .expect("acquire_public for catalog read");
+
+    // The connection carries no RLS context (acquire_public cleared it).
+    assert!(
+        read_guc(&mut **public_conn, "app.current_org_id")
+            .await
+            .is_none(),
+        "acquire_public connection must have no org context"
+    );
+
+    // List: the seeded integration is visible through the handler's repo call.
+    let query = db::models::api_ecosystem::MarketplaceIntegrationQuery {
+        category: None,
+        status: None,
+        search: None,
+        featured_only: None,
+        premium_only: None,
+        sort_by: None,
+        sort_order: None,
+        limit: None,
+        offset: None,
+    };
+    let listed = repo
+        .list_marketplace_integrations(&mut **public_conn, &query)
+        .await
+        .expect("list_marketplace_integrations on public connection");
+    assert!(
+        listed.iter().any(|i| i.id == id),
+        "the public catalog read must return the seeded integration on the \
+         context-cleared acquire_public connection"
+    );
+
+    // Get-by-id resolves too (the other public catalog read shape).
+    let fetched = repo
+        .get_marketplace_integration(&mut **public_conn, id)
+        .await
+        .expect("get_marketplace_integration on public connection");
+    assert!(
+        fetched.is_some(),
+        "get_marketplace_integration must resolve on the acquire_public connection"
+    );
+}
+
+/// (2) Tenant / RLS isolation: `acquire_public()` clears a prior request's
+/// org + user + super-admin GUCs before reuse. A public catalog read routed
+/// through it must never inherit an authenticated request's context — the core
+/// safety property the PAP-167 rework relies on.
+///
+/// Method: poison a pooled connection with a foreign super-admin context (what
+/// an authenticated request could leave), return it to the pool WITHOUT
+/// clearing (a raw `PoolConnection` drop runs no reset), then acquire it back
+/// through the production `acquire_public()` path and assert all three GUCs are
+/// cleared. Mirrors the connection-reuse discipline in `rls_context_bleed_tests.rs`.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
+async fn acquire_public_clears_stale_context_from_prior_request(pool: PgPool) {
+    let foreign_org = Uuid::new_v4();
+    let foreign_user = Uuid::new_v4();
+
+    // --- Poison a pooled connection as a prior super-admin request would. ---
+    {
+        let mut poison = pool.acquire().await.expect("acquire connection to poison");
+        sqlx::query("SELECT set_request_context($1, $2, $3)")
+            .bind(foreign_org)
+            .bind(foreign_user)
+            .bind(true) // is_super_admin — the most dangerous context to leak
+            .execute(&mut *poison)
+            .await
+            .expect("set stale context");
+
+        // Sanity: the poison actually took, so the assertions below are not vacuous.
+        assert_eq!(
+            read_guc(&mut *poison, "app.current_org_id").await.as_deref(),
+            Some(foreign_org.to_string().as_str()),
+            "precondition: stale org context must be set on the connection"
+        );
+        assert_eq!(
+            read_guc(&mut *poison, "app.is_super_admin").await.as_deref(),
+            Some("true"),
+            "precondition: stale super-admin flag must be set on the connection"
+        );
+        // `poison` drops here as a raw PoolConnection — returned to the pool
+        // WITHOUT clearing the context (no RlsGuard, no after_release reset).
+    }
+
+    // --- Re-acquire through the production public path. ---
+    let rls_pool = RlsPool::new(pool.clone());
+    let mut public_conn = rls_pool
+        .acquire_public()
+        .await
+        .expect("acquire_public after poison");
+
+    assert!(
+        read_guc(&mut **public_conn, "app.current_org_id")
+            .await
+            .is_none(),
+        "acquire_public must clear the stale org context left by the prior request"
+    );
+    assert!(
+        read_guc(&mut **public_conn, "app.current_user_id")
+            .await
+            .is_none(),
+        "acquire_public must clear the stale user context left by the prior request"
+    );
+    let admin_after = read_guc(&mut **public_conn, "app.is_super_admin").await;
+    assert!(
+        admin_after.as_deref() != Some("true"),
+        "acquire_public must clear the stale super-admin flag — a public catalog \
+         read must never inherit a prior request's super-admin context, got: {admin_after:?}"
+    );
+}

--- a/backend/crates/db/tests/api_ecosystem_public_conn_routing_tests.rs
+++ b/backend/crates/db/tests/api_ecosystem_public_conn_routing_tests.rs
@@ -159,12 +159,16 @@ async fn acquire_public_clears_stale_context_from_prior_request(pool: PgPool) {
 
         // Sanity: the poison actually took, so the assertions below are not vacuous.
         assert_eq!(
-            read_guc(&mut *poison, "app.current_org_id").await.as_deref(),
+            read_guc(&mut *poison, "app.current_org_id")
+                .await
+                .as_deref(),
             Some(foreign_org.to_string().as_str()),
             "precondition: stale org context must be set on the connection"
         );
         assert_eq!(
-            read_guc(&mut *poison, "app.is_super_admin").await.as_deref(),
+            read_guc(&mut *poison, "app.is_super_admin")
+                .await
+                .as_deref(),
             Some("true"),
             "precondition: stale super-admin flag must be set on the connection"
         );


### PR DESCRIPTION
## Task
api_ecosystem.rs RLS migration (PR #1289, PAP-167) — a 162-line handler rework — shipped without a regression test for the public-connection routing. Add a regression test covering the public-connection routing + RLS/tenant isolation for api_ecosystem.rs.

## Owner
pm-backend

## What shipped
New DB-crate test `backend/crates/db/tests/api_ecosystem_public_conn_routing_tests.rs` pinning the two contracts of the public-connection routing PR #1289 introduced (catalog reads route through `catalog_conn()` → `RlsPool::acquire_public()`):

1. `catalog_public_read_resolves_on_acquire_public_connection` — the public catalog read resolves on the context-cleared connection `acquire_public()` returns. `marketplace_integrations_read` is `USING (TRUE)`, so a future context-dependent policy / FORCE-RLS change that broke unauthenticated reads would fail this test. Exercises the real `RlsPool::acquire_public` path and the real repo methods the handlers call (`list_marketplace_integrations`, `get_marketplace_integration`).
2. `acquire_public_clears_stale_context_from_prior_request` — RLS/tenant isolation: poisons a pooled connection with a foreign super-admin + org context (as a prior authenticated request would leave), returns it to the pool without clearing, then re-acquires via `acquire_public()` and asserts all three GUCs (`app.current_org_id`, `app.current_user_id`, `app.is_super_admin`) are cleared. This is the safety property the rework relies on — a public catalog read must never inherit a prior request's super-admin/tenant context.

Both are `#[ignore]`-quarantined under BIT-351, identical to every sibling sqlx test in this directory (blind CI has no Postgres; repair tracked in BIT-352). Authored to pass against a real database.

## Tested (Band A — fast check)
`cargo test -p db --test api_ecosystem_public_conn_routing_tests --no-run` → exit 0 (compiles clean).

## Built (Band B — full build; 200 LOC)
`cargo clippy -p db --test api_ecosystem_public_conn_routing_tests -- -D warnings` → exit 0 (no warnings).

Runtime execution is not possible in this environment (no Postgres) and the tests carry the established BIT-351 `#[ignore]` quarantine, matching `api_ecosystem_developer_force_rls_tests.rs`, `api_ecosystem_rls_repo_tests.rs`, `public_plans_rls_tests.rs`, and `rls_context_bleed_tests.rs`.

## CI parity (Band C — hot-path only)
Skipped: test-only change, no production code touched.

## Scope drift
None — single test file under `backend/crates/db/tests/` (pm-backend area). `scope-check.sh --owner pm-backend` → exit 0.

## Code-reuse review
None — reuses existing `RlsPool::acquire_public`, `ApiEcosystemRepository`, and the `MarketplaceIntegrationQuery` model; adds no auth/crypto/http helper.

## Notes
Test-only PR closing the PR #1289 / PAP-167 regression-coverage gap. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CVhai7xvTd9W38AZuujQqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVhai7xvTd9W38AZuujQqr)_