### PR TITLE
gh-issue-2249: reality-server SSO exchange must not trust client-supplied roles (Closes #2249)

### DIFF
--- a/backend/servers/reality-server/src/routes/sso.rs
+++ b/backend/servers/reality-server/src/routes/sso.rs
@@ -919,10 +919,10 @@ pub async fn exchange_pm_token(
             )
         })?;
 
-    // Get PM roles from token scope or fetch from PM API
-    let pm_roles = extract_roles_from_scope(token_info.scope.as_deref())
-        .or_else(|| request.roles.clone())
-        .unwrap_or_default();
+    // Derive PM roles authoritatively from the introspected token scope.
+    // Client-supplied `request.roles` may only narrow this set, never expand
+    // it (security #2249 — portal privilege escalation).
+    let pm_roles = derive_pm_roles(token_info.scope.as_deref(), request.roles.as_deref());
 
     // Map PM roles to portal role (use highest privilege)
     let portal_role = pm_roles
@@ -1308,6 +1308,134 @@ fn extract_roles_from_scope(scope: Option<&str>) -> Option<Vec<String>> {
             .map(|part| part.strip_prefix("role:").unwrap_or(part).to_string())
             .collect()
     })
+}
+
+/// Derive the caller's authoritative PM roles for portal-role mapping.
+///
+/// Security (#2249 — portal privilege escalation): roles are derived **only**
+/// from the introspected PM token's OAuth `scope`. Client-supplied `requested`
+/// roles (`ExchangeTokenRequest.roles`) may only ever *narrow* (intersect) that
+/// authoritative set — they can never expand it, nor act as a fallback source
+/// when the scope carries no roles.
+///
+/// Previously the handler used
+/// `extract_roles_from_scope(scope).or_else(|| requested)`, which turned the
+/// client-supplied filter into a role *source*: a holder of any active but
+/// role-less PM token could self-assign an elevated portal role simply by
+/// sending `roles: ["agent"]`. The intersection below closes that hole while
+/// preserving the intended "client may filter down to a subset" behaviour.
+fn derive_pm_roles(scope: Option<&str>, requested: Option<&[String]>) -> Vec<String> {
+    let scope_roles = extract_roles_from_scope(scope).unwrap_or_default();
+    match requested {
+        // Narrowing filter: keep only authoritative roles the client also asked
+        // for. An empty or non-overlapping filter yields an empty set (→ lowest
+        // privilege), never an expansion.
+        Some(filter) => scope_roles
+            .into_iter()
+            .filter(|r| filter.iter().any(|f| f == r))
+            .collect(),
+        // No filter supplied: use the authoritative scope roles as-is.
+        None => scope_roles,
+    }
+}
+
+// ============ PM-role derivation security tests (#2249) ============
+
+#[cfg(test)]
+mod pm_role_derivation_tests {
+    use super::derive_pm_roles;
+    use super::role_mapping::{self, portal_roles};
+
+    fn scope(roles: &[&str]) -> String {
+        roles
+            .iter()
+            .map(|r| format!("role:{r}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Map the derived PM roles to a portal role the same way the handler does
+    /// (highest privilege wins), so the tests assert on the security-relevant
+    /// outcome — the granted portal role — not just the raw role list.
+    fn portal_role_for(roles: &[String]) -> &'static str {
+        roles
+            .iter()
+            .map(|r| role_mapping::map_pm_role_to_portal(r))
+            .max_by_key(|r| match *r {
+                portal_roles::AGENT => 4,
+                portal_roles::PROPERTY_OWNER => 3,
+                portal_roles::VERIFIED_USER => 2,
+                _ => 1,
+            })
+            .unwrap_or(portal_roles::USER)
+    }
+
+    /// Regression (#2249): an active but role-less PM token (empty scope) must
+    /// NOT let a client self-assign an elevated role via `request.roles`. The
+    /// old `.or_else(|| request.roles)` fallback made this an escalation vector
+    /// — `real_estate_agent` maps to the highest-privilege AGENT portal role.
+    #[test]
+    fn client_roles_cannot_expand_empty_scope() {
+        let requested = vec!["real_estate_agent".to_string()];
+        let derived = derive_pm_roles(None, Some(&requested));
+        assert!(
+            derived.is_empty(),
+            "client-supplied roles must not seed roles from an empty scope: {derived:?}"
+        );
+        assert_eq!(
+            portal_role_for(&derived),
+            portal_roles::USER,
+            "empty scope + client agent request must map to the lowest-privilege USER role"
+        );
+    }
+
+    /// A token whose scope does not carry `real_estate_agent` must not be
+    /// upgradable to the AGENT portal role by the client asking for it — the
+    /// client set can only intersect, never union.
+    #[test]
+    fn client_roles_cannot_add_unheld_role() {
+        let token_scope = scope(&["manager"]);
+        let requested = vec!["real_estate_agent".to_string(), "manager".to_string()];
+        let derived = derive_pm_roles(Some(&token_scope), Some(&requested));
+        assert_eq!(derived, vec!["manager".to_string()]);
+        assert_ne!(
+            portal_role_for(&derived),
+            portal_roles::AGENT,
+            "client must not be able to add the higher-privilege agent role"
+        );
+        assert_eq!(portal_role_for(&derived), portal_roles::PROPERTY_OWNER);
+    }
+
+    /// Intended behaviour is preserved: the client MAY narrow the authoritative
+    /// scope set to a lower-privilege subset.
+    #[test]
+    fn client_roles_may_narrow_scope() {
+        let token_scope = scope(&["real_estate_agent", "manager"]);
+        let requested = vec!["manager".to_string()];
+        let derived = derive_pm_roles(Some(&token_scope), Some(&requested));
+        assert_eq!(derived, vec!["manager".to_string()]);
+        assert_eq!(portal_role_for(&derived), portal_roles::PROPERTY_OWNER);
+    }
+
+    /// With no client filter, the authoritative scope roles pass through intact.
+    #[test]
+    fn no_client_filter_uses_scope_roles() {
+        let token_scope = scope(&["real_estate_agent"]);
+        let derived = derive_pm_roles(Some(&token_scope), None);
+        assert_eq!(derived, vec!["real_estate_agent".to_string()]);
+        assert_eq!(portal_role_for(&derived), portal_roles::AGENT);
+    }
+
+    /// An empty client filter intersects to nothing (defensive: no accidental
+    /// "empty means all" behaviour).
+    #[test]
+    fn empty_client_filter_yields_no_roles() {
+        let token_scope = scope(&["real_estate_agent"]);
+        let requested: Vec<String> = vec![];
+        let derived = derive_pm_roles(Some(&token_scope), Some(&requested));
+        assert!(derived.is_empty(), "empty filter must intersect to nothing");
+        assert_eq!(portal_role_for(&derived), portal_roles::USER);
+    }
 }
 
 // ==================== Cookie security unit tests (P0-12) ====================


### PR DESCRIPTION
## Task
security: reality-server SSO exchange trusts client-supplied roles → portal privilege escalation (Closes #2249)

`exchange_pm_token` derived PM roles as
`extract_roles_from_scope(token_info.scope.as_deref()).or_else(|| request.roles.clone())`.
`request.roles` is client-supplied (`ExchangeTokenRequest`). When the introspected PM token's scope carried no recognizable roles, the code trusted the client-provided `roles` verbatim and mapped the highest-privilege value to a portal role — so a holder of any active-but-role-less PM token could self-assign an elevated portal role by sending e.g. `roles: ["real_estate_agent"]` (→ AGENT). Introspection only checked `token_info.active`.

## Fix
Roles are now derived **only** from the introspected token scope (authoritative). Client-supplied `request.roles` may only *intersect* (narrow) that set — never union, never act as a fallback source. Extracted `derive_pm_roles(scope, requested)`:
- `requested = Some(filter)` → keep only authoritative scope roles that also appear in `filter` (narrowing).
- `requested = None` → authoritative scope roles pass through unchanged.
- empty/non-overlapping filter → empty set → lowest-privilege USER.

## Owner
pm-security

## Specialist
rust-backend

## Scope drift
`scope-check.sh --owner pm-security` reports exit 2: the only changed file is
`backend/servers/reality-server/src/routes/sso.rs`, which sits outside pm-security's
mapped areas (api-server auth/mfa + auth crates). The drift is inherent to the fix —
the vulnerability lives in reality-server's SSO consumer route. No other files touched.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. `derive_pm_roles` composes the
existing `extract_roles_from_scope` helper rather than reimplementing scope parsing.

## Tested (Band A — fast check)
- `cargo check -p reality-server` → exit 0 (`Finished dev profile ... in 3m 32s`).
- `cargo test -p reality-server pm_role_derivation` → exit 0. lib unittests:
  `test result: ok. 5 passed; 0 failed`. Cases:
  - `client_roles_cannot_expand_empty_scope` (regression #2249: empty scope + `roles:["real_estate_agent"]` → USER, not AGENT)
  - `client_roles_cannot_add_unheld_role` (scope `manager` + requested `real_estate_agent` → PROPERTY_OWNER, never AGENT)
  - `client_roles_may_narrow_scope` (intended narrowing preserved)
  - `no_client_filter_uses_scope_roles`
  - `empty_client_filter_yields_no_roles`

> Note: this sandbox blocks `github.com` archive downloads, so `utoipa-swagger-ui`'s
> build script was fed an equivalent `swagger-ui-dist@5.17.14` archive rebuilt from the
> allowlisted npm registry via `SWAGGER_UI_DOWNLOAD_URL=file://…`. Build-only shim; no
> source change. CI (with normal egress) builds unmodified.

## Built (Band B — full build)
Skipped: change is ~132 LOC but confined to one route module; no public API/config/migration
surface change (request/response schemas unchanged). Band A `cargo check` + tests cover it.

## CI parity (Band C — hot-path only)
Hot-path (auth/privilege). Replicated the relevant CI step locally: `cargo check` + targeted
`cargo test` both green (above). `act` not installed; ran the equivalent workflow commands manually.

## Remote-tested
skipped

## Notes
Behaviour change is intentionally one-directional: clients can still filter down to a
lower-privilege subset, but can never gain a role the PM token's scope didn't already grant.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVhai7xvTd9W38AZuujQqr)_