### PR TITLE
gh-issue-2237: lock pgvector clamp-panic fix with tests + cover KMP favorites path encoders

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -1040,8 +1040,7 @@ impl LlmDocumentRepository {
         // Over-fetch when a provenance filter is active so post-filtering still
         // returns up to `limit` compatible rows (capped to avoid unbounded scans).
         let fetch_limit = if model_filter.is_some() {
-            // Not `clamp(limit, 200)`: that panics (min > max) when limit > 200.
-            limit.saturating_mul(4).min(200).max(limit)
+            over_fetch_limit(limit, 4, 200)
         } else {
             limit
         };
@@ -2081,6 +2080,22 @@ impl LlmDocumentRepository {
 // Story 97.2: RAG Helper Functions
 // =============================================================================
 
+/// Widen a top-k `limit` into an over-fetch window for provenance-filtered
+/// pgvector search, then cap it to bound the scan.
+///
+/// `search_documents_pgvector` over-fetches when a `model_filter` is active so
+/// that dropping provenance-mismatched rows still leaves up to `limit`
+/// compatible results. The window is `limit * multiplier`, capped at `cap`,
+/// but never smaller than `limit` itself.
+///
+/// Written as `.min(cap).max(limit)` on purpose — NOT `clamp(limit, cap)`:
+/// `i32::clamp(min, max)` panics when `min > max`, which happens whenever
+/// `limit > cap`. This ordering is panic-free for every `i32` input, and
+/// `saturating_mul` guards the multiply against overflow. See #2237.
+fn over_fetch_limit(limit: i32, multiplier: i32, cap: i32) -> i32 {
+    limit.saturating_mul(multiplier).min(cap).max(limit)
+}
+
 /// Calculate cosine similarity between two vectors.
 /// Returns a value between -1.0 (opposite) and 1.0 (identical).
 /// Used for semantic similarity search in RAG.
@@ -2162,5 +2177,49 @@ mod tests {
         let similarity = cosine_similarity(&a, &b);
         // Should be very similar (close to 1.0)
         assert!(similarity > 0.99);
+    }
+
+    // -------------------------------------------------------------------------
+    // #2237: regression guard for the pgvector over-fetch clamp-panic.
+    //
+    // The provenance-filter over-fetch used to be `clamp(limit, 200)`, which
+    // panics (`min > max`) whenever `limit > 200`. `search_documents_pgvector`
+    // is reached from RAG retrieval paths that don't pre-clamp `limit`, so a
+    // caller-supplied `limit > 200` would crash the request. These pin the
+    // boundary that used to panic and stop a refactor reintroducing `clamp`.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn over_fetch_limit_widens_below_cap() {
+        // Headroom below the cap: limit * multiplier, untouched by min/max.
+        assert_eq!(over_fetch_limit(10, 4, 200), 40);
+    }
+
+    #[test]
+    fn over_fetch_limit_caps_at_ceiling() {
+        // limit * multiplier exceeds the cap → capped, still >= limit.
+        assert_eq!(over_fetch_limit(60, 4, 200), 200);
+    }
+
+    #[test]
+    fn over_fetch_limit_never_panics_when_limit_exceeds_cap() {
+        // The historical panic: limit > cap. `clamp(limit, cap)` would panic
+        // here (min=limit > max=cap); the `.min().max()` ordering returns
+        // `limit` unharmed.
+        assert_eq!(over_fetch_limit(250, 4, 200), 250);
+    }
+
+    #[test]
+    fn over_fetch_limit_handles_multiply_overflow() {
+        // saturating_mul must not panic/wrap on a huge limit; result is still
+        // clamped up to at least `limit`.
+        assert_eq!(over_fetch_limit(i32::MAX, 4, 200), i32::MAX);
+    }
+
+    #[test]
+    fn over_fetch_limit_matches_the_call_site_arguments() {
+        // Guards the exact (multiplier=4, cap=200) contract used by
+        // search_documents_pgvector for a typical top-k of 10.
+        assert_eq!(over_fetch_limit(10, 4, 200), 40);
     }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryPathEncodingTest.kt
@@ -4,9 +4,12 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
@@ -50,7 +53,14 @@ class FavoritesRepositoryPathEncodingTest {
                 headers = headersOf(HttpHeaders.ContentType, "application/json"),
             )
         }
-        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        val client =
+            HttpClient(engine) {
+                install(ContentNegotiation) { json(json) }
+                // Mirror HttpClientProvider: updateSavedSearch calls setBody without an explicit
+                // contentType, relying on the default JSON content type — without it the request
+                // never leaves the client and the captured method/path stay null.
+                defaultRequest { contentType(ContentType.Application.Json) }
+            }
         return FavoritesRepository(
             baseUrl = "https://example.test",
             sessionToken = "test-token",

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryPathEncodingTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryPathEncodingTest.kt
@@ -1,0 +1,105 @@
+package three.two.bit.ppt.reality.favorites
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Security regression (#2237): favorites + saved-search ids are deep-link / nav-sourced and are
+ * spliced into the request path, so they must be percent-encoded via the shared
+ * `String.asPathSegment()` helper — a `/`, `?`, `#`, or `..`-bearing value must NOT escape its path
+ * segment (path-injection).
+ *
+ * PR #2226 refactored [FavoritesRepository] off its private `pathSegment` copy onto the shared
+ * helper but left those already-encoded call sites (addFavorite / removeFavorite / isFavorite /
+ * updateSavedSearch / deleteSavedSearch) with no direct coverage. This mirrors
+ * [three.two.bit.ppt.reality.agency.AgencyRepositoryPathEncodingTest] and closes that gap so a
+ * future edit to any of these splices can't silently regress the `..%2F` behavior.
+ */
+class FavoritesRepositoryPathEncodingTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+    }
+
+    private fun repoCapturing(captured: Captured): FavoritesRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            respond(
+                content = ByteReadChannel("{}"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return FavoritesRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    // A hostile id that would path-traverse if spliced raw. `..%2Fadmin%2Fsecret` is the
+    // percent-encoded expectation: the `/` characters stay inside the segment.
+    private val hostileId = "../admin/secret"
+    private val encodedId = "..%2Fadmin%2Fsecret"
+
+    @Test
+    fun addFavorite_encodes_listing_id_path_segment() = runTest {
+        val cap = Captured()
+        repoCapturing(cap).addFavorite(hostileId)
+        assertEquals(HttpMethod.Post, cap.method)
+        assertEquals("/api/v1/favorites/$encodedId", cap.path)
+    }
+
+    @Test
+    fun removeFavorite_encodes_listing_id_path_segment() = runTest {
+        val cap = Captured()
+        repoCapturing(cap).removeFavorite(hostileId)
+        assertEquals(HttpMethod.Delete, cap.method)
+        assertEquals("/api/v1/favorites/$encodedId", cap.path)
+    }
+
+    @Test
+    fun isFavorite_encodes_listing_id_path_segment() = runTest {
+        val cap = Captured()
+        repoCapturing(cap).isFavorite(hostileId)
+        assertEquals(HttpMethod.Get, cap.method)
+        assertEquals("/api/v1/favorites/$encodedId/check", cap.path)
+    }
+
+    @Test
+    fun updateSavedSearch_encodes_search_id_path_segment() = runTest {
+        val cap = Captured()
+        repoCapturing(cap).updateSavedSearch(hostileId, UpdateSavedSearchRequest(name = "x"))
+        assertEquals(HttpMethod.Patch, cap.method)
+        assertEquals("/api/v1/saved-searches/$encodedId", cap.path)
+    }
+
+    @Test
+    fun deleteSavedSearch_encodes_search_id_path_segment() = runTest {
+        val cap = Captured()
+        repoCapturing(cap).deleteSavedSearch(hostileId)
+        assertEquals(HttpMethod.Delete, cap.method)
+        assertEquals("/api/v1/saved-searches/$encodedId", cap.path)
+    }
+}


### PR DESCRIPTION
## Task

Follow-up: lock the pgvector clamp-panic fix with a test + cover refactored KMP path encoders (PR #2226). Closes #2237.

Two non-blocking, constructive follow-ups spotted during post-merge review of PR #2226:

1. **`test-coverage` (medium)** — the pgvector over-fetch clamp-panic fix in `search_documents_pgvector` shipped without a regression test. The old `clamp(limit, 200)` panicked (`min > max`) whenever `limit > 200`; this repo is reached from RAG retrieval paths that don't pre-clamp `limit`.
2. **`test-coverage` (low)** — PR #2226 moved `FavoritesRepository` onto the shared `String.asPathSegment()` helper but left those call sites without direct encoding coverage.

## Changes

**Backend (`rust-backend`)** — `backend/crates/db/src/repositories/llm_document.rs`
- Extracted the provenance-filter over-fetch computation into a pure, testable helper `over_fetch_limit(limit, multiplier, cap) -> i32` (`limit.saturating_mul(multiplier).min(cap).max(limit)`), replacing the inline expression at the `search_documents_pgvector` call site.
- Added 5 unit tests pinning the below-cap / at-cap / `limit > cap` (the historical panic) / `i32::MAX` overflow / call-site-args boundaries, so a refactor can't reintroduce `clamp(limit, cap)`.

**Mobile-native (`kotlin-mp`)** — new `FavoritesRepositoryPathEncodingTest.kt`
- Mirrors the existing `AgencyRepositoryPathEncodingTest`: drives `addFavorite` / `removeFavorite` / `isFavorite` / `updateSavedSearch` / `deleteSavedSearch` with a `../admin/secret` id and asserts the `..%2F` single-segment encoding via `MockEngine` `encodedPath` capture.
- `ApiClient*PathEncodingTest` (marked optional in the issue) was intentionally not added: `ApiClient` consumes the non-injectable `HttpClientProvider.client` singleton, so a clean `MockEngine` test would require refactoring production code (scope creep). `ApiClient` funnels through the same `asPathSegment()` helper, now covered transitively.

## Owner

`pm-tech-lead` (task owner). Actual implementation lands in `rust-backend` (db repo) + `kotlin-mp` (mobile test) areas — see Scope drift.

## Tested (Band A — fast check)

- `cargo check -p db` → exit 0
- `cargo test -p db --lib over_fetch_limit` → **5 passed; 0 failed**
  - `over_fetch_limit_widens_below_cap`, `over_fetch_limit_caps_at_ceiling`, `over_fetch_limit_never_panics_when_limit_exceeds_cap`, `over_fetch_limit_handles_multiply_overflow`, `over_fetch_limit_matches_the_call_site_arguments`

**KMP verify — environment-limited:** this runner has no Android SDK, no Xcode (Linux), and the Gradle distribution download is proxy-blocked (403), so `mobile-native`'s Android/iOS test targets cannot execute here. The new test is a 1:1 structural mirror of the already-passing `AgencyRepositoryPathEncodingTest` — imports, `MockEngine` pattern, `FavoritesRepository(baseUrl, sessionToken, client)` constructor, and all five method signatures/expected paths were statically verified against source. **`mobile-native.yml` CI validates it on this draft before merge.**

## Built (Band B — full build)

Skipped: change is test-only + a private-helper extraction (<50 LOC substantive, no public API/config/migration touch).

## CI parity (Band C — hot-path only)

Skipped: not a hot-path change (no security/auth/billing/data-integrity behavior change — the runtime fix already shipped in #2226; this only adds regression coverage).

## Scope drift

`scope-check` (exit 2) flags both files as outside `pm-tech-lead`'s owner areas (`docs/**`, `.research/**`, `_bmad-output/**`). Expected and justified: this is a tech-lead-owned follow-up whose implementation necessarily lands in the `rust-backend` and `kotlin-mp` code areas.

- `backend/crates/db/src/repositories/llm_document.rs`
- `mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepositoryPathEncodingTest.kt`

## Code-reuse review

`reuse-grep` (rust-backend) → no warnings. `over_fetch_limit` is a new local helper with no existing equivalent (it replaces an inline expression in the same file).

## Notes

- Reviewer: please rely on `mobile-native.yml` CI green for the KMP test (local KMP toolchain unavailable in this env, as noted above).
- Diff is exactly 2 files; the runtime behavior is unchanged from #2226 — this PR only adds a pure helper + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyuZQXyfzjzt1S3SxURu8j

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyuZQXyfzjzt1S3SxURu8j)_