### PR TITLE
gh-issue-2244: record portal listing views via SECURITY DEFINER (fix analytics write path)

### DIFF
--- a/backend/crates/db/migrations/00214_portal_track_listing_view.sql
+++ b/backend/crates/db/migrations/00214_portal_track_listing_view.sql
@@ -1,0 +1,76 @@
+-- Epic 15 follow-up: fix the per-listing analytics **write** path for
+-- portal-owned listings (#2244, the write-path counterpart of #2199 / #2218).
+--
+-- Background
+-- ----------
+-- `track_listing_view` (migration 00063) is `LANGUAGE plpgsql` with no security
+-- clause, i.e. **SECURITY INVOKER**. It `INSERT … ON CONFLICT DO UPDATE`s into
+-- `listing_analytics`, which is `FORCE ROW LEVEL SECURITY` (migration 00113)
+-- whose only policy is org-scoped:
+--
+--     is_super_admin()
+--     OR EXISTS (SELECT 1 FROM listings p
+--                WHERE p.id = listing_analytics.listing_id
+--                  AND p.organization_id = get_current_org_id())
+--
+-- with **no portal-owner branch**. Portal listings carry `organization_id = NULL`
+-- (migration 00186 moved ownership to `portal_owner_id`), and the public
+-- reality-server pool is RLS-subject with no org context. So the write's
+-- `WITH CHECK` fails for portal listings exactly as the read's `USING` did
+-- (#2199): the view increment errors out (swallowed as best-effort by the
+-- route), the `listing_analytics` table stays empty for portal listings, and
+-- `GET /api/v1/my/listings/{id}/analytics` keeps returning a zeroed summary
+-- end-to-end even after the #2218 read fix. Net: reads were fixed but no data
+-- is ever recorded.
+--
+-- Fix
+-- ---
+-- Mirror the portal SECURITY DEFINER pattern (migration 00186 / 00213). Add
+-- `portal_track_listing_view(p_listing_id, p_source)`, a SECURITY DEFINER
+-- function with the same INSERT/UPSERT body as `track_listing_view` but running
+-- as the definer (a superuser), so it bypasses the org-scoped
+-- `listing_analytics` RLS policy and records the view for portal listings.
+--
+-- No ownership gate is applied (unlike the read function 00213): recording a
+-- view is an inherently public, unauthenticated action — any visitor of a
+-- public listing legitimately increments its view counter, and the function
+-- only ever touches the aggregate counters of the listing being viewed. There
+-- is no cross-tenant data exposure: the function neither returns rows nor lets
+-- the caller read another tenant's data.
+
+CREATE OR REPLACE FUNCTION portal_track_listing_view(
+    p_listing_id UUID,
+    p_source     VARCHAR DEFAULT 'website'
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+    INSERT INTO listing_analytics (listing_id, date, views, source_website, source_mobile, source_search, source_direct)
+    VALUES (
+        p_listing_id,
+        CURRENT_DATE,
+        1,
+        CASE WHEN p_source = 'website' THEN 1 ELSE 0 END,
+        CASE WHEN p_source = 'mobile' THEN 1 ELSE 0 END,
+        CASE WHEN p_source = 'search' THEN 1 ELSE 0 END,
+        CASE WHEN p_source = 'direct' THEN 1 ELSE 0 END
+    )
+    ON CONFLICT (listing_id, date) DO UPDATE SET
+        views = listing_analytics.views + 1,
+        source_website = listing_analytics.source_website + CASE WHEN p_source = 'website' THEN 1 ELSE 0 END,
+        source_mobile = listing_analytics.source_mobile + CASE WHEN p_source = 'mobile' THEN 1 ELSE 0 END,
+        source_search = listing_analytics.source_search + CASE WHEN p_source = 'search' THEN 1 ELSE 0 END,
+        source_direct = listing_analytics.source_direct + CASE WHEN p_source = 'direct' THEN 1 ELSE 0 END;
+END;
+$$;
+
+COMMENT ON FUNCTION portal_track_listing_view IS
+    'Record a listing view (INSERT/UPSERT into listing_analytics) for a portal '
+    'listing. SECURITY DEFINER bypasses the org-scoped listing_analytics RLS '
+    'policy (which has no portal-owner branch), so views on portal listings '
+    '(organization_id IS NULL) are actually recorded instead of failing the '
+    'FORCE-RLS WITH CHECK. Write-path counterpart of portal_get_listing_analytics '
+    '(migration 00213); no ownership gate — view tracking is public (#2244).';

--- a/backend/crates/db/src/repositories/reality_portal/listings.rs
+++ b/backend/crates/db/src/repositories/reality_portal/listings.rs
@@ -201,9 +201,19 @@ impl RealityPortalRepository {
     // Listing Analytics (Story 33.4)
     // ========================================================================
 
-    /// Track listing view.
+    /// Track a listing view (increment daily analytics counters).
+    ///
+    /// Routes through the SECURITY DEFINER `portal_track_listing_view` function
+    /// (migration 00214), **not** the plain `track_listing_view` (00063). The
+    /// latter is SECURITY INVOKER and its `INSERT … ON CONFLICT` into
+    /// `listing_analytics` — a `FORCE ROW LEVEL SECURITY` table with an org-only
+    /// policy and no portal-owner branch — fails the `WITH CHECK` for portal
+    /// listings (`organization_id IS NULL`) on the RLS-subject reality-server
+    /// pool, so no view was ever recorded (#2244). The definer function bypasses
+    /// that policy while only ever touching the viewed listing's aggregate
+    /// counters. View tracking is public, so there is no ownership gate.
     pub async fn track_view(&self, listing_id: Uuid, source: &str) -> Result<(), SqlxError> {
-        sqlx::query("SELECT track_listing_view($1, $2)")
+        sqlx::query("SELECT portal_track_listing_view($1, $2)")
             .bind(listing_id)
             .bind(source)
             .execute(&self.pool)

--- a/backend/crates/db/tests/portal_track_listing_view_force_rls_tests.rs
+++ b/backend/crates/db/tests/portal_track_listing_view_force_rls_tests.rs
@@ -1,0 +1,185 @@
+//! Repo/DB-level FORCE-RLS regression test for the analytics **write** path on
+//! **portal-owned** listings (#2244) — the write-path counterpart of the read
+//! test in `portal_listing_analytics_force_rls_tests.rs` (#2199 / #2218).
+//!
+//! Background
+//! ----------
+//! `track_listing_view` (migration 00063) is SECURITY INVOKER. It upserts into
+//! `listing_analytics`, a `FORCE ROW LEVEL SECURITY` table (migration 00113)
+//! with an org-only policy and no portal-owner branch. Portal listings carry
+//! `organization_id = NULL` (migration 00186), so for a portal listing run on
+//! the RLS-subject reality-server role the `WITH CHECK` fails and the view is
+//! never recorded — the table stays empty and `portal_get_listing_analytics`
+//! reads back zeros end-to-end (#2244).
+//!
+//! Migration 00214 adds `portal_track_listing_view`, a SECURITY DEFINER upsert
+//! that bypasses the org-only policy so portal views are actually recorded.
+//!
+//! This test binds a real `NOSUPERUSER NOBYPASSRLS` role — the way the
+//! production reality-server role experiences FORCE RLS — and proves:
+//!
+//! 1. **Bug proof** — the old SECURITY INVOKER `track_listing_view` raises an
+//!    RLS `WITH CHECK` violation for the portal listing under the bound role.
+//! 2. **Fix** — `portal_track_listing_view` succeeds under the same role and
+//!    each call increments `views`.
+//! 3. **End-to-end regression lock** — after the definer writes, the owner's
+//!    `portal_get_listing_analytics` reads the recorded views back non-zero
+//!    (closing the #2199 user-visible symptom for good).
+//!
+//! Assertion (2)/(3) fail on `main` (no definer write path existed there);
+//! together they are the regression lock for the write fix.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_portal_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind) \
+         VALUES ($1, 'test_hash', $2, 'active', NOW(), 'public') RETURNING id",
+    )
+    .bind(format!("{tag}@portal-track-rls.test"))
+    .bind(format!("PortalTrackRls {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_portal_user({tag}): {e}"))
+}
+
+/// Create a portal-owned listing (`organization_id IS NULL`,
+/// `portal_owner_id = user_id`) via the SECURITY DEFINER repo path.
+async fn seed_portal_listing(pool: &PgPool, user_id: Uuid, title: &str) -> Uuid {
+    let repo = db::repositories::RealityPortalRepository::new(pool.clone());
+    repo.create_portal_listing(
+        user_id,
+        title,
+        Some("desc"),
+        "apartment",
+        "sale",
+        rust_decimal::Decimal::new(100_000, 0),
+        "EUR",
+        "Test Street 1",
+        "Bratislava",
+        "81101",
+        "SK",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("seed_portal_listing")
+    .id
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn portal_view_recorded_via_security_definer_under_force_rls(pool: PgPool) {
+    let owner = seed_portal_user(&pool, "owner").await;
+    let listing_id = seed_portal_listing(&pool, owner, "track-force-rls").await;
+
+    let role = format!("portal_tr_rls_{}", &Uuid::new_v4().to_string()[..8]);
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE RLS actually binds. ---
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create test role");
+
+    // Grant everything the writes would legitimately need, so the ONLY barrier
+    // left standing is the FORCE-RLS policy itself.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT, INSERT, UPDATE ON listing_analytics TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant analytics privileges");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON listings TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant listings select");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION \
+         track_listing_view(UUID, VARCHAR), \
+         portal_track_listing_view(UUID, VARCHAR), \
+         portal_get_listing_analytics(UUID, UUID, DATE, DATE), \
+         is_super_admin(), get_current_org_id() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute");
+
+    // All role-bound work runs on ONE dedicated connection.
+    let mut conn = pool.acquire().await.expect("acquire connection");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+        .execute(&mut *conn)
+        .await
+        .expect("set role");
+
+    // --- 1. Bug proof: the SECURITY INVOKER path is blocked by FORCE RLS. ---
+    let invoker_result = sqlx::query("SELECT track_listing_view($1, 'website')")
+        .bind(listing_id)
+        .execute(&mut *conn)
+        .await;
+    assert!(
+        invoker_result.is_err(),
+        "the SECURITY INVOKER track_listing_view must fail the org-only \
+         listing_analytics WITH CHECK for a portal listing under the \
+         RLS-subject role (this is the #2244 bug)"
+    );
+
+    // --- 2. Fix: the SECURITY DEFINER path records the view. ---
+    for _ in 0..3 {
+        sqlx::query("SELECT portal_track_listing_view($1, 'website')")
+            .bind(listing_id)
+            .execute(&mut *conn)
+            .await
+            .expect("portal_track_listing_view must succeed under FORCE RLS");
+    }
+
+    // --- 3. End-to-end: the owner reads the recorded views back non-zero. ---
+    let views: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(SUM(views), 0)::bigint \
+         FROM portal_get_listing_analytics($1, $2, NULL, NULL)",
+    )
+    .bind(listing_id)
+    .bind(owner)
+    .fetch_one(&mut *conn)
+    .await
+    .expect("owner definer views");
+    assert_eq!(
+        views, 3,
+        "each portal_track_listing_view call must increment views, and the \
+         owner must read them back through portal_get_listing_analytics under \
+         FORCE RLS (#2244 end-to-end regression lock)"
+    );
+
+    sqlx::query("RESET ROLE")
+        .execute(&mut *conn)
+        .await
+        .expect("reset role");
+    drop(conn);
+
+    // --- Cleanup ---
+    for stmt in [
+        format!("REVOKE ALL ON listing_analytics, listings FROM \"{role}\""),
+        format!(
+            "REVOKE EXECUTE ON FUNCTION \
+             track_listing_view(UUID, VARCHAR), \
+             portal_track_listing_view(UUID, VARCHAR), \
+             portal_get_listing_analytics(UUID, UUID, DATE, DATE), \
+             is_super_admin(), get_current_org_id() FROM \"{role}\""
+        ),
+        format!("DROP OWNED BY \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/reality-server/src/handlers/listings/mod.rs
+++ b/backend/servers/reality-server/src/handlers/listings/mod.rs
@@ -122,14 +122,19 @@ impl ListingHandler {
     }
 
     /// Track a listing view.
-    /// Increments the view count for analytics.
-    pub async fn track_view(&self, _listing_id: Uuid, _source: &str) -> Result<(), String> {
-        // View tracking would typically:
-        // 1. Increment daily analytics counter
-        // 2. Track unique views by session/IP
-        // 3. Record source (website, mobile, search, direct)
-        tracing::debug!(listing_id = %_listing_id, source = %_source, "Tracking listing view");
-        Ok(())
+    ///
+    /// Increments the daily analytics counters for the listing. Previously a
+    /// no-op stub that never recorded anything; it now routes through the real
+    /// write path — `RealityPortalRepository::track_view`, backed by the
+    /// SECURITY DEFINER `portal_track_listing_view` function (migration 00214) —
+    /// so views on portal listings actually land in `listing_analytics` despite
+    /// its FORCE-RLS org-only policy (#2244). Best-effort at the call site.
+    pub async fn track_view(&self, listing_id: Uuid, source: &str) -> Result<(), String> {
+        tracing::debug!(%listing_id, %source, "Tracking listing view");
+        db::repositories::RealityPortalRepository::new(self.repo.pool().clone())
+            .track_view(listing_id, source)
+            .await
+            .map_err(|e| format!("Failed to track listing view: {}", e))
     }
 
     /// Get popular searches for suggestions.


### PR DESCRIPTION
## Task
Follow-up: portal analytics write path (`track_listing_view`) still blocked by FORCE RLS — reads fixed but no data is ever recorded (PR #2218). Add a SECURITY DEFINER `portal_track_listing_view` migration + wire the reality-server `track_view` path, plus a FORCE-RLS regression test.

Closes #2244

## Owner
pm-tech-lead (specialist: db-migration + rust-backend)

## What changed
`track_listing_view` (migration `00063`) is `LANGUAGE plpgsql` with no security clause → **SECURITY INVOKER**. Its `INSERT … ON CONFLICT` into `listing_analytics` (a `FORCE ROW LEVEL SECURITY` table with an org-only policy and no portal-owner branch) fails the `WITH CHECK` for portal listings (`organization_id IS NULL`) on the RLS-subject reality-server pool. The write errored (swallowed as best-effort by the route), the table stayed empty, and `GET /api/v1/my/listings/{id}/analytics` kept returning zeros end-to-end despite the #2218 read fix.

- **Migration `00214_portal_track_listing_view.sql`** — SECURITY DEFINER upsert with the same body as `track_listing_view`, `SET search_path = public`. Bypasses the org-only policy so portal views are recorded. Write-path counterpart of `portal_get_listing_analytics` (00213). **No ownership gate** — recording a view is public/unauthenticated and only touches the viewed listing's aggregate counters (no cross-tenant read).
- **`RealityPortalRepository::track_view`** now calls `portal_track_listing_view` instead of `track_listing_view`. This is the real production write path (`routes/listings.rs:380` and `:870`).
- **`ListingHandler::track_view`** (reality-server) was a no-op stub that recorded nothing; it now routes through `RealityPortalRepository::track_view` (the real write path).
- **New FORCE-RLS regression test** (`portal_track_listing_view_force_rls_tests.rs`) — mirrors the 00213 harness with a real `NOSUPERUSER NOBYPASSRLS` role: (1) the old SECURITY INVOKER path errors under FORCE RLS, (2) the definer path records views, (3) the owner reads them back non-zero via `portal_get_listing_analytics`. The true end-to-end regression lock for #2199/#2244.

Finding 2 (PUBLIC EXECUTE hardening) is intentionally **not** included — the issue marks it optional and says it should be batched across the whole `portal_*` family (00186 + 00213 + 00214) in one migration if done at all.

## Tested (Band A — fast check)
Against a real Postgres 16 (`DATABASE_URL` set, `SQLX_OFFLINE=true`):
- `cargo check -p db` → exit 0
- `cargo check -p reality-server` → build-script panic in `utoipa-swagger-ui` (downloads Swagger UI zip at build time; the sandboxed proxy corrupts it: `InvalidArchive: Could not find EOCD`). **Environmental, unrelated to this change** — the reality-server edit is a 6-line delegation to an existing `db` repo method that compiles clean. Will build in CI (network available).
- `cargo test -p db --test portal_track_listing_view_force_rls_tests --test portal_listing_analytics_force_rls_tests` → **2 passed, 0 failed** (migration applied via `db::MIGRATOR`).

## Built (Band B — full build)
- `cargo clippy -p db --tests` → exit 0, no warnings.
- Migration applied cleanly on an ephemeral DB through the sqlx test migrator.
- No `query!`/`query_as!` macros added (all runtime `sqlx::query`), so `.sqlx` offline data is unaffected — `sqlx prepare --check` unimpacted.

## CI parity (Band C — hot-path)
This is a data-integrity / RLS change. The db-crate FORCE-RLS tests (the CI-relevant surface) pass locally against a bound `NOSUPERUSER NOBYPASSRLS` role. `reality-server` compilation deferred to CI due to the Swagger-UI download sandbox limitation noted above.

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 (owner_role has no mapped code area). Files touched, all legitimately in scope for this db-migration + rust-backend task:
- `backend/crates/db/migrations/00214_portal_track_listing_view.sql`
- `backend/crates/db/src/repositories/reality_portal/listings.rs`
- `backend/crates/db/tests/portal_track_listing_view_force_rls_tests.rs`
- `backend/servers/reality-server/src/handlers/listings/mod.rs`

## Code-reuse review
`reuse-grep.sh` → no warnings. The migration deliberately reuses the exact upsert body of `track_listing_view` and mirrors the established `portal_*` SECURITY DEFINER pattern (00186 / 00213).

## Notes
- The reality-server `ListingHandler` is currently not constructed anywhere (dead code); wiring it was still done per the issue so it is no longer a misleading no-op. The live path fixed by this PR is `RealityPortalRepository::track_view` used by `routes/listings.rs`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016AKQBQvfBzAHi9hH6uP9wZ)_