### PR TITLE
gh-issue-2245: wire webhook-secret envs into deployments + document second portal-receiver family

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -74,9 +74,13 @@ Key workspace dependencies:
 | `JWT_SECRET` | Yes | Secret key for JWT signing (min 32 chars) |
 | `RUST_LOG` | No | Log level (default: info) |
 | `CORS_ALLOWED_ORIGINS` | No | Comma-separated list of allowed CORS origins |
-| `PORTAL_WEBHOOK_SECRET` | If receiving portal webhooks | HMAC secret for the inbound portal webhook receiver; receiver fails closed (500 `CONFIG_ERROR`) when unset |
+| `PORTAL_WEBHOOK_SECRET` | If receiving integration-connection portal webhooks | HMAC secret for the inbound portal webhook receiver at `/api/v1/integrations/webhooks/portal/{connection_id}`; fails closed (500 `CONFIG_ERROR`) when unset |
 | `AIRBNB_WEBHOOK_SECRET` | If receiving Airbnb webhooks | HMAC secret for the inbound Airbnb webhook receiver; fails closed (500 `NOT_CONFIGURED`) when unset |
 | `STRIPE_WEBHOOK_SECRET` | If receiving Stripe webhooks | Signing secret for the Stripe payment-confirmation webhook receiver; fails closed (503 `NOT_CONFIGURED`) when unset |
+| `REALITY_PORTAL_WEBHOOK_SECRET` | If receiving reality-portal webhooks | Per-portal HMAC secret for `/api/v1/webhooks/portals/reality-portal/...`; **distinct from `PORTAL_WEBHOOK_SECRET`** — this family backs the per-portal receiver in `routes/portal_webhooks.rs`, not the integration-connection receiver. Fails closed (500 `CONFIG_ERROR`) when unset. |
+| `SREALITY_WEBHOOK_SECRET` | If receiving Sreality webhooks | Per-portal HMAC secret for `/api/v1/webhooks/portals/sreality/...`; same family as above |
+| `BEZREALITKY_WEBHOOK_SECRET` | If receiving Bezrealitky webhooks | Per-portal HMAC secret for `/api/v1/webhooks/portals/bezrealitky/...`; same family as above |
+| `NEHNUTELNOSTI_WEBHOOK_SECRET` | If receiving Nehnutelnosti webhooks | Per-portal HMAC secret for `/api/v1/webhooks/portals/nehnutelnosti/...`; same family as above |
 
 ```bash
 # Required

--- a/backend/servers/deploy-server/src/infra/blue_green.rs
+++ b/backend/servers/deploy-server/src/infra/blue_green.rs
@@ -282,6 +282,31 @@ pub fn build_service_envs(
     api_env.push(format!("INTEGRATION_ENCRYPTION_KEY={integration_key}"));
     api_env.push(format!("ESIGN_TOKEN_SECRET={esign_token_secret}"));
     api_env.push(format!("ESIGN_WEBHOOK_SECRET={esign_webhook_secret}"));
+
+    // Inbound webhook signing secrets — optional (receivers fail closed on empty
+    // secret rather than panicking at startup). Inject whatever the deploy-server's
+    // own env carries so operators can set them in /etc/ppt-deploy/secrets.env
+    // without touching this code. Missing vars are passed as empty strings,
+    // which preserves the fail-closed behaviour in each receiver.
+    //
+    // Two distinct receiver families:
+    //   1. Integration-connection receiver (/api/v1/integrations/webhooks/portal/{connection_id})
+    //      backed by PORTAL_WEBHOOK_SECRET, AIRBNB_WEBHOOK_SECRET, STRIPE_WEBHOOK_SECRET
+    //   2. Per-portal direct receiver (/api/v1/webhooks/portals/<portal>/...)
+    //      backed by <PORTAL>_WEBHOOK_SECRET (e.g. REALITY_PORTAL_WEBHOOK_SECRET)
+    for secret_key in &[
+        "PORTAL_WEBHOOK_SECRET",
+        "AIRBNB_WEBHOOK_SECRET",
+        "STRIPE_WEBHOOK_SECRET",
+        "REALITY_PORTAL_WEBHOOK_SECRET",
+        "SREALITY_WEBHOOK_SECRET",
+        "BEZREALITKY_WEBHOOK_SECRET",
+        "NEHNUTELNOSTI_WEBHOOK_SECRET",
+    ] {
+        let val = std::env::var(secret_key).unwrap_or_default();
+        api_env.push(format!("{secret_key}={val}"));
+    }
+
     api_env.push(format!("PLATFORM_HOST={platform_hosts}"));
 
     let mut reality_env = std::mem::take(&mut backend_env);

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -113,6 +113,18 @@ services:
       S3_SECRET_KEY: minioadmin123
       S3_BUCKET: ppt-documents
       S3_REGION: us-east-1
+      # Inbound webhook signing secrets — leave empty in dev unless you are
+      # tunnelling real webhook traffic in (e.g. via ngrok). Receivers fail
+      # closed when unset; setting them here enables local end-to-end testing.
+      # Integration-connection portal receiver (/api/v1/integrations/webhooks/portal/{connection_id})
+      PORTAL_WEBHOOK_SECRET: ${PORTAL_WEBHOOK_SECRET:-}
+      AIRBNB_WEBHOOK_SECRET: ${AIRBNB_WEBHOOK_SECRET:-}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+      # Per-portal receiver (/api/v1/webhooks/portals/<portal>/...)
+      REALITY_PORTAL_WEBHOOK_SECRET: ${REALITY_PORTAL_WEBHOOK_SECRET:-}
+      SREALITY_WEBHOOK_SECRET: ${SREALITY_WEBHOOK_SECRET:-}
+      BEZREALITKY_WEBHOOK_SECRET: ${BEZREALITKY_WEBHOOK_SECRET:-}
+      NEHNUTELNOSTI_WEBHOOK_SECRET: ${NEHNUTELNOSTI_WEBHOOK_SECRET:-}
     ports:
       - "127.0.0.1:8080:8080"
     volumes:

--- a/docker-compose.synology.yml
+++ b/docker-compose.synology.yml
@@ -115,6 +115,18 @@ services:
       S3_BUCKET: ${S3_BUCKET:-ppt-documents}
       S3_REGION: ${S3_REGION:-us-east-1}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      # Inbound webhook signing secrets — receiver fails closed when unset;
+      # set whichever correspond to the webhooks this environment receives.
+      # Integration-connection portal receiver (/api/v1/integrations/webhooks/portal/{connection_id})
+      PORTAL_WEBHOOK_SECRET: ${PORTAL_WEBHOOK_SECRET:-}
+      AIRBNB_WEBHOOK_SECRET: ${AIRBNB_WEBHOOK_SECRET:-}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+      # Per-portal receiver (/api/v1/webhooks/portals/<portal>/...)
+      # Each var is <PORTAL>_WEBHOOK_SECRET where portal names are uppercased with hyphens→underscores
+      REALITY_PORTAL_WEBHOOK_SECRET: ${REALITY_PORTAL_WEBHOOK_SECRET:-}
+      SREALITY_WEBHOOK_SECRET: ${SREALITY_WEBHOOK_SECRET:-}
+      BEZREALITKY_WEBHOOK_SECRET: ${BEZREALITKY_WEBHOOK_SECRET:-}
+      NEHNUTELNOSTI_WEBHOOK_SECRET: ${NEHNUTELNOSTI_WEBHOOK_SECRET:-}
     ports:
       - "8080:8080"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,18 @@ services:
       S3_BUCKET: ${S3_BUCKET:-ppt-documents}
       S3_REGION: ${S3_REGION:-us-east-1}
       CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      # Inbound webhook signing secrets — receiver fails closed when unset;
+      # set whichever correspond to the webhooks this environment receives.
+      # Integration-connection portal receiver (/api/v1/integrations/webhooks/portal/{connection_id})
+      PORTAL_WEBHOOK_SECRET: ${PORTAL_WEBHOOK_SECRET:-}
+      AIRBNB_WEBHOOK_SECRET: ${AIRBNB_WEBHOOK_SECRET:-}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+      # Per-portal receiver (/api/v1/webhooks/portals/<portal>/...)
+      # Each var is <PORTAL>_WEBHOOK_SECRET where portal names are uppercased with hyphens→underscores
+      REALITY_PORTAL_WEBHOOK_SECRET: ${REALITY_PORTAL_WEBHOOK_SECRET:-}
+      SREALITY_WEBHOOK_SECRET: ${SREALITY_WEBHOOK_SECRET:-}
+      BEZREALITKY_WEBHOOK_SECRET: ${BEZREALITKY_WEBHOOK_SECRET:-}
+      NEHNUTELNOSTI_WEBHOOK_SECRET: ${NEHNUTELNOSTI_WEBHOOK_SECRET:-}
     ports:
       - "127.0.0.1:8080:8080"
     depends_on:

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -55,6 +55,19 @@ AIRBNB_WEBHOOK_SECRET=
 # Stripe payment-confirmation webhook receiver (/api/v1/integrations/webhooks/payments/stripe)
 STRIPE_WEBHOOK_SECRET=
 
+# Per-portal direct webhook receivers (/api/v1/webhooks/portals/<portal>/...)
+# These are a SEPARATE endpoint family from PORTAL_WEBHOOK_SECRET above.
+# PORTAL_WEBHOOK_SECRET backs the integration-connection receiver at
+#   /api/v1/integrations/webhooks/portal/{connection_id}
+# while the per-portal receivers use <PORTAL>_WEBHOOK_SECRET (portal name
+# uppercased, hyphens replaced with underscores). Both receiver families
+# fail closed (500 CONFIG_ERROR) when their secret is unset.
+# Generate each with: openssl rand -base64 36
+REALITY_PORTAL_WEBHOOK_SECRET=
+SREALITY_WEBHOOK_SECRET=
+BEZREALITKY_WEBHOOK_SECRET=
+NEHNUTELNOSTI_WEBHOOK_SECRET=
+
 # =============================================================================
 # Property Management <-> Reality Portal SSO
 # =============================================================================

--- a/docker/.env.synology.example
+++ b/docker/.env.synology.example
@@ -39,6 +39,31 @@ TOTP_ENCRYPTION_KEY=your-64-hex-char-totp-encryption-key
 INTEGRATION_ENCRYPTION_KEY=your-64-hex-char-integration-encryption-key
 
 # =============================================================================
+# Inbound Webhook Signing Secrets
+# =============================================================================
+# Shared secrets used to verify the HMAC-SHA256 signature on inbound webhook
+# deliveries. Each receiver FAILS CLOSED when its secret is unset — so
+# provision these in every environment that receives the corresponding webhooks.
+# Generate each with: openssl rand -base64 36
+
+# Integration-connection portal receiver (/api/v1/integrations/webhooks/portal/{connection_id})
+PORTAL_WEBHOOK_SECRET=
+
+# Airbnb inbound webhook receiver (/api/v1/integrations/airbnb/webhook)
+AIRBNB_WEBHOOK_SECRET=
+
+# Stripe payment-confirmation webhook receiver (/api/v1/integrations/webhooks/payments/stripe)
+STRIPE_WEBHOOK_SECRET=
+
+# Per-portal direct webhook receivers (/api/v1/webhooks/portals/<portal>/...)
+# NOTE: PORTAL_WEBHOOK_SECRET (above) and these are SEPARATE receiver families.
+# The per-portal receiver uses <PORTAL>_WEBHOOK_SECRET (uppercased, hyphens→underscores).
+REALITY_PORTAL_WEBHOOK_SECRET=
+SREALITY_WEBHOOK_SECRET=
+BEZREALITKY_WEBHOOK_SECRET=
+NEHNUTELNOSTI_WEBHOOK_SECRET=
+
+# =============================================================================
 # Property Management <-> Reality Portal SSO
 # =============================================================================
 # OAuth client secret used by reality-server to authenticate to api-server


### PR DESCRIPTION
Wire `PORTAL_WEBHOOK_SECRET` and the per-portal `<PORTAL>_WEBHOOK_SECRET` family from PR #2214 docs into all deployment surfaces so `PortalAppConfig::from_env()` can actually read them.

## Findings addressed

**Finding 1 (compose deployments):** All three compose files (`docker-compose.yml`, `docker-compose.dev.yml`, `docker-compose.synology.yml`) now pass the seven webhook signing secrets into the `api-server` container via explicit `environment:` entries. Previously the compose files used an allowlist with no `env_file:`, so setting secrets in `.env` only fed compose variable interpolation — they never reached the container process.

**Finding 2 (undocumented per-portal family):** `docker/.env.example` and `backend/CLAUDE.md` now document `REALITY_PORTAL_WEBHOOK_SECRET`, `SREALITY_WEBHOOK_SECRET`, `BEZREALITKY_WEBHOOK_SECRET`, and `NEHNUTELNOSTI_WEBHOOK_SECRET` with a clear note that they back a separate receiver family (`/api/v1/webhooks/portals/<portal>/...`) distinct from `PORTAL_WEBHOOK_SECRET`.

**Finding 3 (Synology template):** `docker/.env.synology.example` now includes the full "Inbound Webhook Signing Secrets" section (both families), matching `docker/.env.example`.

**Production deploy path:** `deploy-server/blue_green.rs` `build_service_envs()` now forwards all seven secrets from the deploy-server's own env into `api_env` as optional vars (empty string when unset, preserving fail-closed behaviour).

## Changes
- `docker-compose.yml`, `docker-compose.dev.yml`, `docker-compose.synology.yml` — add 7 webhook secrets to `api-server` `environment:` block
- `docker/.env.example` — add per-portal `<PORTAL>_WEBHOOK_SECRET` family with disambiguation note
- `docker/.env.synology.example` — add complete webhook signing secrets section
- `backend/CLAUDE.md` — expand env-var table with four per-portal secrets + clarify endpoint families
- `backend/servers/deploy-server/src/infra/blue_green.rs` — forward all 7 secrets into `api_env`

## Test plan
- [ ] `cargo check -p deploy-server` passes (confirmed locally, exit 0)
- [ ] `cargo fmt --all --check` passes (confirmed locally)
- [ ] No Rust logic changes — env construction only

Closes #2245