### PR TITLE
gh-issue-2248: rebalance test shards + lock bundled common-lib fix with test

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -261,25 +261,34 @@ jobs:
 
   # SHARDED backend tests (issue #2222).
   # ------------------------------------
-  # `servers/api-server` owns ~197 integration test binaries (each statically
-  # links the whole server and provisions its own `#[sqlx::test]` DB), so the
-  # old single `cargo test --workspace` ran ~107-119 min — right at the
-  # `timeout --kill-after=1m 150m` ceiling. When the wrapper SIGKILLed the run,
-  # cargo blamed whichever target was in flight (observed `-p common --lib`,
-  # whose unit tests are all trivial synchronous `#[test]`s), i.e. pure
-  # wall-clock exhaustion, NOT a real failure. That wedged EVERY open backend
-  # PR on the shared `test` gate.
+  # The server crates under `servers/*` own the bulk of the integration test
+  # binaries (each statically links its whole server and provisions its own
+  # `#[sqlx::test]` DB), so the old single `cargo test --workspace` ran
+  # ~107-119 min — right at the `timeout --kill-after=1m 150m` ceiling, wedging
+  # EVERY open backend PR on the shared `test` gate.
   #
-  # This job fans the api-server integration test binaries out over MATRIX_COUNT
-  # parallel runners via scripts/ci-test-shard.sh (hash-partitioned by sorted
-  # position). EVERY shard — shard 0 included — now runs an identically-shaped,
-  # roughly equal-sized ~1/4 slice of those binaries and NOTHING else, so none
-  # approaches the timeout. The "everything else once" workload (all
-  # non-api-server workspace tests + api-server's lib/bins unit tests) used to
-  # ride on TOP of shard 0's partition, making shard 0 by far the heaviest
-  # shard — it tipped over its per-shard timeout (~53 min job wall) while shards
-  # 1-3 passed comfortably. That load now lives in a dedicated parallel job
-  # (`test-rest` below), off the shard hot path, so shard 0 has real headroom.
+  # (Correction, issue #2248 finding 1: the specific `-p common --lib` failure
+  # PR #2223 unwedged was NOT purely wall-clock. A prior dispatcher commit
+  # regenerated the sitemap from 13 -> 19 `ppt-web` routes, so `common`'s
+  # `test_metadata` hit a genuine, fast `assertion failed` on a stale hardcoded
+  # count; #2223 also bumped that literal. The wall-clock timeout was a real,
+  # separate risk that sharding addresses; the one-line count bump was the real
+  # `common --lib` fix. `common`'s lib target now derives that expectation from
+  # the loaded sitemap so it can't silently rot again — see
+  # `backend/crates/common/src/sitemap/mod.rs::test_metadata_stats_match_loaded_collections`.)
+  #
+  # This job fans ALL server (`servers/*`) integration test binaries out over
+  # MATRIX_COUNT parallel runners via scripts/ci-test-shard.sh (hash-partitioned
+  # by sorted `crate:test` position). Issue #2248 finding 2: previously only
+  # api-server's binaries were sharded and reality-server's 32 integration
+  # binaries rode sequentially on `test-rest`, making IT the new bottleneck; the
+  # sharder now partitions every server crate's integration binaries together so
+  # the heavy load is spread evenly. EVERY shard — shard 0 included — runs an
+  # identically-shaped, roughly equal-sized ~1/N slice of those binaries and
+  # NOTHING else, so none approaches the timeout. The "everything else once"
+  # workload (non-server workspace tests + each server crate's lib/bins/doc unit
+  # tests) lives in a dedicated parallel job (`test-rest` below), off the shard
+  # hot path.
   # This is NOT the required status context (branch protection requires exactly
   # `test`, produced by the thin aggregator job below — one producer, per
   # #1672); the matrix legs report `test-shard (0..N)` and skip cleanly on
@@ -397,12 +406,13 @@ jobs:
           RUST_ENV: development
         run: cargo test -p api-server --test ws_integration_tests -- --include-ignored
 
-  # Non-shard test leg (issue #2222 rebalance). Runs everything that is NOT an
-  # api-server integration test binary, exactly once: all non-api-server
-  # workspace tests (`--workspace --exclude api-server`) plus api-server's own
-  # lib/bins unit tests. This is the "everything else once" workload that used
-  # to ride on shard 0 and overload it; hosting it in its own parallel runner
-  # lets every `test-shard` leg carry only its equal-sized integration slice.
+  # Non-shard test leg (issue #2222 rebalance, generalized in #2248). Runs
+  # everything that is NOT a server integration test binary, exactly once: all
+  # non-server workspace tests (`--workspace` minus every sharded server crate)
+  # plus each server crate's own lib/bins/doc unit tests (--doc closes the #2248
+  # finding-3 gap where api-server doctests were silently dropped). This is the
+  # "everything else once" workload; hosting it in its own parallel runner lets
+  # every `test-shard` leg carry only its equal-sized integration slice.
   # Like the shards, this is NOT the required context — the aggregator `test`
   # job below gates on it too (so coverage stays exactly-once, no false green,
   # #1672) and it skips cleanly on pure-frontend PRs.

--- a/backend/crates/common/src/sitemap/mod.rs
+++ b/backend/crates/common/src/sitemap/mod.rs
@@ -309,11 +309,49 @@ mod tests {
         assert!(!f.steps.is_empty());
     }
 
+    // Regression guard for issue #2248 finding 1. The `-p common --lib` failure
+    // that PR #2223 unwedged was NOT purely wall-clock: `test_metadata` had a
+    // hardcoded `ppt_web_routes == 13` that went genuinely red (fast
+    // `assertion failed`) when dispatcher commit b0e619a regenerated the sitemap
+    // to 19 `ppt-web` routes. The one-line count bump in #2223 was the real fix.
+    //
+    // To stop these hardcoded counts silently rotting every time a route/screen
+    // is added, this test now derives the expectation from the loaded data
+    // itself: `metadata.stats` must equal the actual length of the corresponding
+    // collection. A regeneration that updates one but not the other fails here
+    // with a clear message instead of drifting until a stale literal breaks CI.
     #[test]
-    fn test_metadata() {
+    fn test_metadata_stats_match_loaded_collections() {
         let sitemap = Sitemap::load();
-        assert_eq!(sitemap.metadata.stats.ppt_web_routes, 19);
-        assert_eq!(sitemap.metadata.stats.reality_web_routes, 9);
-        assert_eq!(sitemap.metadata.stats.mobile_screens, 6);
+        assert_eq!(
+            sitemap.metadata.stats.ppt_web_routes,
+            sitemap.routes.ppt_web.len(),
+            "metadata.stats.ppt_web_routes drifted from routes[\"ppt-web\"] length"
+        );
+        assert_eq!(
+            sitemap.metadata.stats.reality_web_routes,
+            sitemap.routes.reality_web.len(),
+            "metadata.stats.reality_web_routes drifted from routes[\"reality-web\"] length"
+        );
+        assert_eq!(
+            sitemap.metadata.stats.mobile_screens,
+            sitemap.screens.mobile.len(),
+            "metadata.stats.mobile_screens drifted from screens.mobile length"
+        );
+        assert_eq!(
+            sitemap.metadata.stats.api_server_endpoints,
+            sitemap.endpoints.api_server.len(),
+            "metadata.stats.api_server_endpoints drifted from endpoints[\"api-server\"] length"
+        );
+        assert_eq!(
+            sitemap.metadata.stats.reality_server_endpoints,
+            sitemap.endpoints.reality_server.len(),
+            "metadata.stats.reality_server_endpoints drifted from endpoints[\"reality-server\"] length"
+        );
+        assert_eq!(
+            sitemap.metadata.stats.flows,
+            sitemap.flows.len(),
+            "metadata.stats.flows drifted from flows length"
+        );
     }
 }

--- a/backend/scripts/ci-test-shard.sh
+++ b/backend/scripts/ci-test-shard.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# CI backend test sharder (issue #2222)
-# ------------------------------------
+# CI backend test sharder (issue #2222, generalized in #2248)
+# -----------------------------------------------------------
 # The backend `test` CI job used to run ONE monolithic
 # `cargo test --workspace` that took ~107-119 min — right up against the
 # `timeout --kill-after=1m 150m` ceiling. When the wrapper SIGKILLed the run,
@@ -9,34 +9,44 @@
 # wall-clock exhaustion, not a real test failure. That wedged every open
 # backend PR on the shared `test` gate.
 #
-# `servers/api-server` owns ~197 integration test binaries (each statically
-# links the whole server and provisions its own `#[sqlx::test]` database), so
-# it dominates the wall time. This script deterministically shards the suite
-# across N parallel CI runners so no single runner approaches the timeout.
+# The server crates under `servers/*` own the bulk of the integration test
+# binaries (each statically links its whole server and provisions its own
+# `#[sqlx::test]` database), so they dominate the wall time. This script
+# deterministically shards ALL server integration test binaries across N
+# parallel CI runners so no single runner approaches the timeout.
 #
-# Two invocation modes, so no shard is heavier than the others (issue #2222
-# follow-up — shard 0 previously ALSO carried the whole "everything else"
-# workspace run on top of its integration partition, making it the heaviest
-# shard by far and tipping it over its per-shard timeout while shards 1-3
-# passed comfortably):
+# Issue #2248 follow-up: previously ONLY api-server's ~199 integration binaries
+# were sharded, and everything else — including reality-server's 32 top-level
+# integration binaries — rode sequentially on the single `rest` leg. That made
+# `test-rest` the new un-parallelized bottleneck (and it reintroduced the exact
+# #2222 wedge as reality-server grew, since the "bump the matrix" escape hatch
+# only relieves the shards, not `rest`). This script now enumerates EVERY
+# server crate's integration binaries and partitions them together, so the
+# heavy integration load is spread evenly across the shards and `rest` only
+# carries lightweight unit/lib/doc tests.
+#
+# Two invocation modes, so no shard is heavier than the others:
 #
 #   ci-test-shard.sh <shard_index> <shard_count>
-#     Runs THIS shard's slice of api-server integration test binaries and
-#     NOTHING else. api-server integration test binaries (top-level
-#     `tests/*.rs`, one cargo `--test` target each) are hash-partitioned by
-#     sorted position modulo the shard count — new test files distribute
-#     automatically, no list to maintain. EVERY shard (0 included) now runs an
-#     identically-shaped, roughly equal-sized workload.
+#     Runs THIS shard's slice of the server integration test binaries and
+#     NOTHING else. Integration test binaries (top-level `servers/*/tests/*.rs`,
+#     one cargo `--test` target each) across all server crates are enumerated as
+#     `crate:test` pairs, sorted, and hash-partitioned by sorted position modulo
+#     the shard count — new test files (in any server crate) distribute
+#     automatically, no list to maintain. EVERY shard (0 included) runs an
+#     identically-shaped, roughly equal-sized workload. Selected targets are
+#     grouped per crate and run with one `cargo test -p <crate> --test ...`
+#     invocation per crate.
 #
 #   ci-test-shard.sh rest
-#     Runs everything that is NOT an api-server integration test binary,
-#     exactly once: all other crates' lib/doc/integration tests
-#     (`--workspace --exclude api-server`, i.e. reality-server, deploy-server,
-#     accounting-server, and every library crate) plus api-server's own
-#     `--lib`/`--bins` unit tests. This is a SEPARATE parallel CI job (see
-#     backend.yml `test-rest`) — off the shard hot path — and the required
-#     `test` aggregator gates on it too, so coverage stays exactly-once with no
-#     false green (#1672).
+#     Runs everything that is NOT a server integration test binary, exactly
+#     once: all non-server library crates' tests
+#     (`--workspace` minus every sharded server crate) plus each server crate's
+#     own `--lib`/`--bins`/`--doc` tests (unit tests + doctests). This is a
+#     SEPARATE parallel CI job (see backend.yml `test-rest`) — off the shard hot
+#     path — and the required `test` aggregator gates on it too, so coverage
+#     stays exactly-once with no false green (#1672). `--doc` closes the #2248
+#     finding-3 gap where api-server doctests were silently dropped.
 #
 # Together the two modes partition the full workspace test surface with no
 # overlap and no gap: every workspace test runs exactly once across
@@ -52,8 +62,8 @@
 set -uo pipefail
 
 usage() {
-  echo "usage: $0 <shard_index> <shard_count>   # run this shard's api-server integration partition" >&2
-  echo "       $0 rest                            # run all non-api-server-integration workspace tests exactly once" >&2
+  echo "usage: $0 <shard_index> <shard_count>   # run this shard's server integration partition" >&2
+  echo "       $0 rest                            # run all non-integration workspace tests exactly once" >&2
 }
 
 # Run from the backend/ crate root regardless of caller CWD.
@@ -72,18 +82,53 @@ run() {
   timeout --kill-after=1m 120m cargo test "$@" --no-fail-fast -- --test-threads=4
 }
 
-# --- Mode: "rest" — everything that is NOT an api-server integration binary ---
+# The set of server crates whose integration binaries are sharded. A crate
+# belongs here iff it has top-level `tests/*.rs` integration targets that we
+# want spread across shards; its `--lib`/`--bins`/`--doc` unit tests stay on the
+# `rest` leg. Kept in sync with the `--exclude` list in `rest` mode below so the
+# partition covers the workspace exactly once. Deriving the list from the
+# filesystem keeps it self-maintaining as servers are added/removed.
+mapfile -t server_crates < <(
+  find servers -maxdepth 2 -type d -name tests -printf '%h\n' \
+    | while read -r d; do
+        # Only crates that actually have top-level integration test targets.
+        if find "$d/tests" -maxdepth 1 -name '*.rs' -print -quit | grep -q .; then
+          basename "$d"
+        fi
+      done | sort -u
+)
+
+# Enumerate every server integration test binary as a `crate:test` pair.
+# Top-level `tests/*.rs` files are each a distinct cargo `--test` target named
+# by basename; the `tests/common/` helper subdirectory is a module, not a
+# target, and is excluded by -maxdepth 1.
+mapfile -t all_tests < <(
+  for crate in "${server_crates[@]}"; do
+    find "servers/$crate/tests" -maxdepth 1 -name '*.rs' -printf '%f\n' \
+      | sed 's/\.rs$//' \
+      | while read -r t; do echo "$crate:$t"; done
+  done | sort
+)
+
+# --- Mode: "rest" — everything that is NOT a server integration binary ---
 if [ "$#" -eq 1 ] && [ "$1" = "rest" ]; then
-  echo "rest leg: non-api-server workspace tests + api-server lib/bins unit tests"
+  echo "rest leg: non-server workspace tests + each server crate's lib/bins/doc unit tests"
   rc=0
-  # Everything that is NOT api-server, run exactly once.
-  run --workspace --exclude api-server || rc=1
-  # api-server unit tests (lib + bins). Its integration binaries live on the shards.
-  run -p api-server --lib --bins || rc=1
+  # Everything that is NOT a sharded server crate, run exactly once.
+  exclude_args=()
+  for crate in "${server_crates[@]}"; do
+    exclude_args+=(--exclude "$crate")
+  done
+  run --workspace "${exclude_args[@]}" || rc=1
+  # Each server crate's unit tests (lib + bins) and doctests. Its integration
+  # binaries live on the shards; --doc closes the #2248 finding-3 gap.
+  for crate in "${server_crates[@]}"; do
+    run -p "$crate" --lib --bins --doc || rc=1
+  done
   exit "$rc"
 fi
 
-# --- Mode: "<idx> <count>" — this shard's api-server integration partition ---
+# --- Mode: "<idx> <count>" — this shard's server integration partition ---
 if [ "$#" -ne 2 ]; then
   usage
   exit 64
@@ -95,28 +140,37 @@ if ! [[ "$idx" =~ ^[0-9]+$ && "$total" =~ ^[0-9]+$ ]] || [ "$total" -lt 1 ] || [
   exit 64
 fi
 
-# Enumerate api-server integration test binaries. Top-level `tests/*.rs` files
-# are each a distinct cargo `--test` target named by basename; the `tests/common/`
-# helper subdirectory is a module, not a target, and is excluded by -maxdepth 1.
-mapfile -t api_tests < <(find servers/api-server/tests -maxdepth 1 -name '*.rs' -printf '%f\n' | sed 's/\.rs$//' | sort)
-
-# Partition: target at sorted position P runs on shard (P % total).
-sel=()
+# Partition: pair at sorted position P runs on shard (P % total). Group the
+# selected `crate:test` pairs per crate so each crate needs at most one cargo
+# invocation on this shard.
+declare -A sel_by_crate
 pos=0
-for t in "${api_tests[@]}"; do
+for pair in "${all_tests[@]}"; do
   if [ "$(( pos % total ))" -eq "$idx" ]; then
-    sel+=(--test "$t")
+    crate="${pair%%:*}"
+    test="${pair#*:}"
+    sel_by_crate["$crate"]+=" --test $test"
   fi
   pos=$(( pos + 1 ))
 done
 
-echo "shard $idx/$total: ${#api_tests[@]} api-server integration targets total, $(( ${#sel[@]} / 2 )) on this shard"
+selected_count=0
+for crate in "${!sel_by_crate[@]}"; do
+  # shellcheck disable=SC2086
+  set -- ${sel_by_crate[$crate]}
+  selected_count=$(( selected_count + $# / 2 ))
+done
 
-if [ "${#sel[@]}" -eq 0 ]; then
-  echo "shard $idx: no api-server integration targets assigned — nothing to do"
+echo "shard $idx/$total: ${#all_tests[@]} server integration targets total across ${#server_crates[@]} crates, $selected_count on this shard"
+
+if [ "$selected_count" -eq 0 ]; then
+  echo "shard $idx: no server integration targets assigned — nothing to do"
   exit 0
 fi
 
 rc=0
-run -p api-server "${sel[@]}" || rc=1
+for crate in $(printf '%s\n' "${!sel_by_crate[@]}" | sort); do
+  # shellcheck disable=SC2086
+  run -p "$crate" ${sel_by_crate[$crate]} || rc=1
+done
 exit "$rc"

--- a/backend/scripts/ci-test-shard.sh
+++ b/backend/scripts/ci-test-shard.sh
@@ -122,8 +122,11 @@ if [ "$#" -eq 1 ] && [ "$1" = "rest" ]; then
   run --workspace "${exclude_args[@]}" || rc=1
   # Each server crate's unit tests (lib + bins) and doctests. Its integration
   # binaries live on the shards; --doc closes the #2248 finding-3 gap.
+  # cargo forbids mixing --doc with other target selectors, so doctests run
+  # as a separate invocation.
   for crate in "${server_crates[@]}"; do
-    run -p "$crate" --lib --bins --doc || rc=1
+    run -p "$crate" --lib --bins || rc=1
+    run -p "$crate" --doc || rc=1
   done
   exit "$rc"
 fi


### PR DESCRIPTION
Follow-up to #2223. Addresses the post-merge review findings on the backend test-job sharding. **Not a revert** — the sharding structure is sound; this hardens and rebalances it.

## Finding 1 (medium) — bundled common-lib fix now documented + regression-locked
PR #2223's body claimed the `-p common --lib` failure was *pure wall-clock, not a real failure*, but it also silently bumped `common`'s `test_metadata` assertion `ppt_web_routes` 13 → 19. That literal was **genuinely red** (fast `assertion failed`) after a prior dispatcher commit regenerated the sitemap to 19 `ppt-web` routes.

- Corrected the root-cause narrative in `backend.yml` (wall-clock was a *separate* real risk sharding addresses; the count bump was the real `common --lib` fix).
- Rewrote `test_metadata` → `test_metadata_stats_match_loaded_collections`: every `metadata.stats.*` count is now asserted **equal to the actual loaded collection length** (`routes.ppt_web.len()`, `screens.mobile.len()`, endpoints, flows, …). The hardcoded literals can no longer silently rot when a route/screen is added — a regen that updates data but not stats (or vice-versa) fails with a clear message.

## Finding 2 (medium) — `test-rest` no longer the un-sharded bottleneck
`ci-test-shard.sh` previously sharded **only** api-server's ~199 integration binaries; reality-server's 32 integration binaries ran sequentially on the single `test-rest` leg, making it the new long pole (and reintroducing the #2222 wedge as reality-server grows — the "bump the matrix" escape hatch only relieves the shards).

The sharder now enumerates **every** `servers/*/tests/*.rs` integration binary as `crate:test` pairs and partitions them all together (self-maintaining via `find`; no crate list to hand-edit). Dry-run over 4 shards: **233 targets → 59 / 58 / 58 / 58**, evenly balanced. `test-rest` now carries only lightweight lib/bins/doc unit tests.

## Finding 3 (low) — api-server doctests restored
`rest` mode now runs each server crate's `--doc` target (`-p <crate> --lib --bins --doc`), closing the silent gap where api-server doctests were dropped after #2223.

## Invariants preserved
- `test` stays the single required aggregator context (one producer, #1672) — **no branch-protection rename**.
- shard ∪ rest still partitions the workspace **exactly once** (233 sharded integration targets, all non-server crates + server lib/bins/doc on rest).
- Script signatures (`<idx> <count>` / `rest`) unchanged — `backend.yml` call sites untouched.

## Verification
- `python3 -c "import yaml; yaml.safe_load(...)"` — workflow parses ✅
- `bash -n ci-test-shard.sh` ✅
- Dry-run partition (cargo shimmed): 233 targets split 59/58/58/58, deterministic modulo → exactly-once by construction ✅
- `cargo test -p common --lib` (sitemap) — 6 pass incl. new self-validating test ✅
- `cargo fmt --all --check` ✅ · `cargo clippy -p common --lib -- -D warnings` ✅

**CI-timing changes cannot be fully verified locally** — actual per-shard wall-clock balance and the `--doc` coverage are validated by CI on this PR, which is the arbiter.

Closes #2248