### PR TITLE
gh-issue-2246: harden resolve_current_session_id user-scoping + tighten session tests

### DIFF
--- a/backend/servers/api-server/src/routes/auth.rs
+++ b/backend/servers/api-server/src/routes/auth.rs
@@ -1187,6 +1187,7 @@ fn hash_refresh_token(token: &str) -> String {
 async fn resolve_current_session_id(
     state: &AppState,
     headers: &axum::http::HeaderMap,
+    user_id: uuid::Uuid,
 ) -> Option<uuid::Uuid> {
     let token = parse_refresh_cookie(headers).or_else(|| {
         headers
@@ -1200,12 +1201,19 @@ async fn resolve_current_session_id(
 
     let token_hash = hash_refresh_token(&token);
 
+    // Defense-in-depth: `find_by_token_hash` resolves *any* user's live
+    // session by hash. Only treat it as the caller's current session when it
+    // actually belongs to the authenticated user — a stray/stale cookie
+    // belonging to a different user must not become `except_id` (which would
+    // resurface the "sign out other devices signs YOU out" failure) nor mark a
+    // foreign session `isCurrent`.
     state
         .session_repo
         .find_by_token_hash(&token_hash)
         .await
         .ok()
         .flatten()
+        .filter(|session| session.user_id == user_id)
         .map(|session| session.id)
 }
 
@@ -1985,7 +1993,7 @@ pub async fn list_sessions(
     // fall back to the `X-Refresh-Token` header (see
     // `resolve_current_session_id`). Cookie-based ppt-web clients used to
     // resolve to `None` here, so no row could ever be marked `isCurrent`.
-    let current_session_id = resolve_current_session_id(&state, &headers).await;
+    let current_session_id = resolve_current_session_id(&state, &headers, user_id).await;
 
     // Get all active sessions for user
     let sessions = match state.session_repo.find_user_sessions(user_id).await {
@@ -2174,7 +2182,7 @@ pub async fn revoke_all_sessions(
     // Cookie-based ppt-web clients used to resolve to `None` here, which made
     // `revoke_all_user_tokens(user_id, None)` revoke the caller's OWN live
     // session — "sign out other devices" signed the caller out too.
-    let current_session_id = resolve_current_session_id(&state, &headers).await;
+    let current_session_id = resolve_current_session_id(&state, &headers, user_id).await;
 
     // Revoke all sessions except current
     match state

--- a/backend/servers/api-server/tests/auth_tests.rs
+++ b/backend/servers/api-server/tests/auth_tests.rs
@@ -960,6 +960,20 @@ mod sessions {
         let (access1, refresh1) = create_authenticated_user(&app, &user).await;
         let (_access2, _refresh2) = login_again(&app, &user).await;
 
+        // Session 1 (the caller) is the earliest-created refresh_tokens row for
+        // this user; session 2 came from `login_again`. Bind `isCurrent` to
+        // that specific id so a resolver that flagged the *wrong* session would
+        // fail — a bare count assertion would not catch it.
+        let session1_id: uuid::Uuid = sqlx::query_scalar(
+            "SELECT id FROM refresh_tokens \
+             WHERE user_id = (SELECT id FROM users WHERE email = $1) \
+             ORDER BY created_at ASC LIMIT 1",
+        )
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("session 1 row");
+
         let req = app
             .get("/api/v1/auth/sessions")
             .bearer(&access1)
@@ -980,6 +994,66 @@ mod sessions {
             current.len(),
             1,
             "exactly one session must be marked current for the cookie caller"
+        );
+        assert_eq!(
+            current[0]["id"].as_str().unwrap(),
+            session1_id.to_string(),
+            "the current row must be the caller's own (session 1), not the other device"
+        );
+
+        cleanup_test_user(&pool, &user.email).await;
+    }
+
+    /// Header-based caller (mobile RN / legacy ppt-web): list-sessions must mark
+    /// exactly one row `isCurrent = true` and it must be the caller's session,
+    /// resolved via the `X-Refresh-Token` fallback. Mirrors the cookie test to
+    /// guard the header branch symmetrically with the revoke-all tests. On
+    /// `main` the header path already worked; this locks in identity, not just
+    /// count.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn list_sessions_marks_header_caller_current(pool: PgPool) {
+        let app = TestApp::new(pool.clone()).await;
+        let user = TestUser::new();
+        cleanup_test_user(&pool, &user.email).await;
+
+        let (access1, refresh1) = create_authenticated_user(&app, &user).await;
+        let (_access2, _refresh2) = login_again(&app, &user).await;
+
+        let session1_id: uuid::Uuid = sqlx::query_scalar(
+            "SELECT id FROM refresh_tokens \
+             WHERE user_id = (SELECT id FROM users WHERE email = $1) \
+             ORDER BY created_at ASC LIMIT 1",
+        )
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("session 1 row");
+
+        let req = app
+            .get("/api/v1/auth/sessions")
+            .bearer(&access1)
+            .header("X-Refresh-Token", &refresh1)
+            .build();
+        let resp = app.execute(req).await;
+        resp.assert_status(StatusCode::OK);
+
+        let json = resp.json_value();
+        let sessions = json["sessions"].as_array().unwrap();
+        assert_eq!(sessions.len(), 2, "user has two live sessions");
+
+        let current: Vec<&Value> = sessions
+            .iter()
+            .filter(|s| s["isCurrent"].as_bool().unwrap_or(false))
+            .collect();
+        assert_eq!(
+            current.len(),
+            1,
+            "exactly one session must be marked current for the header caller"
+        );
+        assert_eq!(
+            current[0]["id"].as_str().unwrap(),
+            session1_id.to_string(),
+            "the current row must be the caller's own (session 1) via the header fallback"
         );
 
         cleanup_test_user(&pool, &user.email).await;


### PR DESCRIPTION
## Summary

Security-hardening follow-up to PR #2190 (issue #2246). Two low-severity, non-blocking improvements in `backend/servers/api-server/src/routes/auth.rs` + `tests/auth_tests.rs` — no live defect fixed.

**1. Resolver user-scoping (defense-in-depth).**
`resolve_current_session_id` looked up the session globally via `find_by_token_hash`, resolving *any* user's live session by hash. Now threads the authenticated `user_id` (both call sites already have it in scope) and only returns `Some(session.id)` when `session.user_id == user_id`, via `.filter(|s| s.user_id == user_id)`. This rejects a stray/stale valid `refresh_token` cookie belonging to a different user — which would otherwise resurface the "sign out other devices signs YOU out" failure (foreign `except_id` matches none of the caller's rows) or mark a foreign session `isCurrent`. Not currently exploitable (revoke-all is `WHERE user_id = $1` scoped; list-sessions only compares against the caller's own rows), so it is pure defense-in-depth.

**2. Tighter session tests.**
- `list_sessions_marks_cookie_caller_current` now binds `isCurrent` to the caller's own row (session 1, the earliest-created `refresh_tokens` row) instead of only asserting the count is 1 — a resolver flagging the wrong session would now fail.
- Added `list_sessions_marks_header_caller_current` mirror exercising the `X-Refresh-Token` fallback branch, symmetric with the existing revoke-all cookie/header pair.

No migration, no OpenAPI/public-API change.

## Gates (local)

- `cargo fmt --all --check` — clean
- `cargo clippy -p api-server --all-targets -- -D warnings` — clean (exit 0)
- `cargo test -p api-server --test auth_tests --no-run` — compiles (exit 0)

The new/changed assertions are inside `#[sqlx::test]` DB-backed tests that cannot run locally without a database; **CI is the arbiter** for their runtime behavior.

Closes #2246