### PR TITLE
gh-issue-2247: sitemap test_metadata consistency check instead of hard-coded counts

### DIFF
--- a/backend/crates/common/src/sitemap/mod.rs
+++ b/backend/crates/common/src/sitemap/mod.rs
@@ -312,8 +312,24 @@ mod tests {
     #[test]
     fn test_metadata() {
         let sitemap = Sitemap::load();
-        assert_eq!(sitemap.metadata.stats.ppt_web_routes, 19);
-        assert_eq!(sitemap.metadata.stats.reality_web_routes, 9);
-        assert_eq!(sitemap.metadata.stats.mobile_screens, 6);
+        // Assert internal consistency: stats must match the actual arrays that
+        // generate.ts derives them from.  This never goes stale on route
+        // additions and catches any hand-edit or generator bug where the stats
+        // block diverges from the real arrays.
+        assert_eq!(
+            sitemap.metadata.stats.ppt_web_routes,
+            sitemap.routes.ppt_web.len(),
+            "metadata.stats.ppt_web_routes does not match routes.ppt_web.len()"
+        );
+        assert_eq!(
+            sitemap.metadata.stats.reality_web_routes,
+            sitemap.routes.reality_web.len(),
+            "metadata.stats.reality_web_routes does not match routes.reality_web.len()"
+        );
+        assert_eq!(
+            sitemap.metadata.stats.mobile_screens,
+            sitemap.screens.mobile.len(),
+            "metadata.stats.mobile_screens does not match screens.mobile.len()"
+        );
     }
 }


### PR DESCRIPTION
Replace the brittle hard-coded route-count literals in `sitemap::tests::test_metadata` with consistency assertions against the loaded sitemap collections (`ppt_web_routes == routes.ppt_web.len()` etc.), so future route additions can't break CI with stale magic numbers (the #2225 failure mode).

Local gates: `cargo test -p common sitemap` (6 pass), fmt, clippy `-D warnings` — all green.

Closes #2247.

(Replaces #2258, which was opened from a wrong head branch.)