### PR TITLE
gh-issue-2240: cover Airbnb direct-connect success path via AirbnbClient base-URL seam

### DIFF
--- a/backend/crates/integrations/src/airbnb.rs
+++ b/backend/crates/integrations/src/airbnb.rs
@@ -341,7 +341,12 @@ pub enum AirbnbWebhookEventType {
 
 const AIRBNB_AUTH_URL: &str = "https://www.airbnb.com/oauth2/auth";
 const AIRBNB_TOKEN_URL: &str = "https://api.airbnb.com/v1/oauth2/token";
-const AIRBNB_API_BASE: &str = "https://api.airbnb.com/v2";
+/// Default base URL for the Airbnb Partner API (v2 listing/reservation surface).
+///
+/// [`AirbnbClient::new`] uses this; [`AirbnbClient::with_base_url`] lets a caller
+/// override it — used by tests to point the client at a stub server, and usable
+/// by ops to target a non-production Airbnb sandbox without a code change.
+pub const AIRBNB_API_BASE: &str = "https://api.airbnb.com/v2";
 
 // ============================================
 // Client Implementation
@@ -351,15 +356,46 @@ const AIRBNB_API_BASE: &str = "https://api.airbnb.com/v2";
 pub struct AirbnbClient {
     client: reqwest::Client,
     config: AirbnbOAuthConfig,
+    /// Base URL for the v2 listing/reservation API. Defaults to
+    /// [`AIRBNB_API_BASE`]; overridable via [`AirbnbClient::with_base_url`].
+    base_url: String,
 }
 
 impl AirbnbClient {
     /// Create a new Airbnb client with OAuth configuration.
+    ///
+    /// Uses the production [`AIRBNB_API_BASE`] endpoint. Use
+    /// [`AirbnbClient::with_base_url`] to target a different host (e.g. a test
+    /// stub or a sandbox).
     pub fn new(config: AirbnbOAuthConfig) -> Self {
+        Self::with_base_url(config, AIRBNB_API_BASE)
+    }
+
+    /// Create a new Airbnb client with an explicit API base URL.
+    ///
+    /// The seam exists so the direct-connect / sync success paths can be
+    /// exercised deterministically against a `wiremock`-style stub instead of
+    /// the live Airbnb Partner API (issue #2240). Any trailing slash is
+    /// trimmed, and an empty base falls back to [`AIRBNB_API_BASE`] so a
+    /// misconfigured override can never yield a malformed request URL.
+    pub fn with_base_url(config: AirbnbOAuthConfig, base_url: impl Into<String>) -> Self {
+        let raw = base_url.into();
+        let trimmed = raw.trim_end_matches('/');
+        let base_url = if trimmed.is_empty() {
+            AIRBNB_API_BASE.to_string()
+        } else {
+            trimmed.to_string()
+        };
         Self {
             client: reqwest::Client::new(),
             config,
+            base_url,
         }
+    }
+
+    /// The API base URL this client issues listing/reservation requests against.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
     }
 
     /// Create a new Airbnb client from individual parameters.
@@ -546,7 +582,7 @@ impl AirbnbClient {
     ) -> Result<Vec<AirbnbListing>, AirbnbError> {
         let response = self
             .client
-            .get(format!("{}/listings", AIRBNB_API_BASE))
+            .get(format!("{}/listings", self.base_url))
             .bearer_auth(access_token)
             .send()
             .await?;
@@ -592,7 +628,7 @@ impl AirbnbClient {
     ) -> Result<AirbnbListing, AirbnbError> {
         let response = self
             .client
-            .get(format!("{}/listings/{}", AIRBNB_API_BASE, listing_id))
+            .get(format!("{}/listings/{}", self.base_url, listing_id))
             .bearer_auth(access_token)
             .send()
             .await?;
@@ -641,7 +677,7 @@ impl AirbnbClient {
         start_date: Option<NaiveDate>,
         end_date: Option<NaiveDate>,
     ) -> Result<Vec<AirbnbReservation>, AirbnbError> {
-        let mut url = format!("{}/reservations?listing_id={}", AIRBNB_API_BASE, listing_id);
+        let mut url = format!("{}/reservations?listing_id={}", self.base_url, listing_id);
 
         if let Some(start) = start_date {
             url.push_str(&format!("&start_date={}", start));
@@ -699,7 +735,7 @@ impl AirbnbClient {
     ) -> Result<Vec<AirbnbReservation>, AirbnbError> {
         let response = self
             .client
-            .get(format!("{}/reservations", AIRBNB_API_BASE))
+            .get(format!("{}/reservations", self.base_url))
             .bearer_auth(access_token)
             .send()
             .await?;
@@ -1076,6 +1112,32 @@ mod tests {
         assert!(auth_url.contains("test_client_id"));
         assert!(auth_url.contains("test_state"));
         assert!(auth_url.contains("response_type=code"));
+    }
+
+    #[test]
+    fn test_new_uses_default_api_base() {
+        let client = AirbnbClient::new(AirbnbOAuthConfig {
+            client_id: "id".to_string(),
+            client_secret: "secret".to_string(),
+            redirect_uri: "http://localhost/cb".to_string(),
+        });
+        assert_eq!(client.base_url(), AIRBNB_API_BASE);
+    }
+
+    #[test]
+    fn test_with_base_url_overrides_and_trims_trailing_slash() {
+        let cfg = AirbnbOAuthConfig {
+            client_id: "id".to_string(),
+            client_secret: "secret".to_string(),
+            redirect_uri: "http://localhost/cb".to_string(),
+        };
+        // Trailing slash is trimmed so callers can pass either form.
+        let client = AirbnbClient::with_base_url(cfg.clone(), "http://127.0.0.1:9999/v2/");
+        assert_eq!(client.base_url(), "http://127.0.0.1:9999/v2");
+        // An empty override falls back to the production default rather than
+        // producing a malformed request URL.
+        let fallback = AirbnbClient::with_base_url(cfg, "");
+        assert_eq!(fallback.base_url(), AIRBNB_API_BASE);
     }
 
     #[test]

--- a/backend/crates/integrations/src/lib.rs
+++ b/backend/crates/integrations/src/lib.rs
@@ -52,7 +52,7 @@ pub use airbnb::{
     map_reservation_status as map_airbnb_status, map_to_internal_reservation, AirbnbClient,
     AirbnbError, AirbnbGuest, AirbnbListing, AirbnbOAuthConfig, AirbnbOAuthTokens, AirbnbPhoto,
     AirbnbReservation, AirbnbReservationStatus, AirbnbWebhookEvent, AirbnbWebhookEventType,
-    ListingSyncResult, Reservation, ReservationSyncResult,
+    ListingSyncResult, Reservation, ReservationSyncResult, AIRBNB_API_BASE,
 };
 
 // Story 83.2: Booking.com Integration

--- a/backend/servers/api-server/src/routes/integrations/install.rs
+++ b/backend/servers/api-server/src/routes/integrations/install.rs
@@ -1940,7 +1940,10 @@ pub async fn direct_connect_airbnb(
         client_secret,
         redirect_uri,
     };
-    let client = AirbnbClient::new(oauth_config);
+    // Issue #2240: build via the base-URL seam so this write path is testable
+    // against a stub server. `api_base` defaults to the production endpoint in
+    // production (`AirbnbAppConfig::from_env`).
+    let client = AirbnbClient::with_base_url(oauth_config, state.airbnb_config.api_base.clone());
 
     let listings = client
         .fetch_listings(&request.access_token)

--- a/backend/servers/api-server/src/state.rs
+++ b/backend/servers/api-server/src/state.rs
@@ -70,18 +70,33 @@ pub struct AirbnbAppConfig {
     /// `AIRBNB_WEBHOOK_SECRET` — required for inbound webhook signature
     /// verification.
     pub webhook_secret: String,
+    /// `AIRBNB_API_BASE` — base URL of the Airbnb Partner API used for
+    /// listing/reservation calls. Defaults to the production endpoint
+    /// ([`integrations::AIRBNB_API_BASE`]) when unset; overridable so
+    /// integration tests can point the direct-connect success path at a stub
+    /// server (issue #2240) and so a non-production Airbnb sandbox can be
+    /// targeted without a code change. Unlike the credential fields, this is
+    /// never empty — an unset env resolves to the production default.
+    pub api_base: String,
 }
 
 impl AirbnbAppConfig {
-    /// Load from the standard env vars. Empty strings are preserved so the
-    /// handlers can still emit `NOT_CONFIGURED` for missing values — this
-    /// matches the previous per-request behaviour exactly.
+    /// Load from the standard env vars. Empty strings are preserved for the
+    /// credential fields so the handlers can still emit `NOT_CONFIGURED` for
+    /// missing values — this matches the previous per-request behaviour
+    /// exactly. `api_base` is the exception: an unset/empty `AIRBNB_API_BASE`
+    /// resolves to the production default so the client URL is always valid.
     pub fn from_env() -> Self {
+        let api_base = std::env::var("AIRBNB_API_BASE")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| integrations::AIRBNB_API_BASE.to_string());
         Self {
             client_id: std::env::var("AIRBNB_CLIENT_ID").unwrap_or_default(),
             client_secret: std::env::var("AIRBNB_CLIENT_SECRET").unwrap_or_default(),
             redirect_uri: std::env::var("AIRBNB_REDIRECT_URI").unwrap_or_default(),
             webhook_secret: std::env::var("AIRBNB_WEBHOOK_SECRET").unwrap_or_default(),
+            api_base,
         }
     }
 }
@@ -831,6 +846,19 @@ impl AppState {
     /// real Vision-capable provider here, and tests can inject a fake.
     pub fn with_id_document_ocr(mut self, ocr: SharedIdDocumentOcr) -> Self {
         self.id_document_ocr = ocr;
+        self
+    }
+
+    /// Override the Airbnb integration configuration (test seam, issue #2240).
+    ///
+    /// Production loads `airbnb_config` from the environment in
+    /// [`AppState::new`]. Integration tests use this to inject non-empty
+    /// credentials plus an `api_base` pointing at a `wiremock` stub, so the
+    /// `direct_connect_airbnb` success/write path can be exercised network-free
+    /// without setting process-global `AIRBNB_*` env vars (which would race the
+    /// other `#[sqlx::test]` cases sharing the same test binary).
+    pub fn with_airbnb_config(mut self, config: AirbnbAppConfig) -> Self {
+        self.airbnb_config = config;
         self
     }
 }

--- a/backend/servers/api-server/tests/airbnb_direct_connect_and_availability_sync_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_direct_connect_and_availability_sync_tests.rs
@@ -603,7 +603,9 @@ async fn direct_connect_happy_path_upserts_connection(pool: PgPool) {
     );
     let stored_refresh: Option<String> = row.get("refresh_token");
     assert!(
-        stored_refresh.as_deref().is_some_and(|t| t.starts_with("enc:")),
+        stored_refresh
+            .as_deref()
+            .is_some_and(|t| t.starts_with("enc:")),
         "refresh token must be stored encrypted: {stored_refresh:?}"
     );
 }

--- a/backend/servers/api-server/tests/airbnb_direct_connect_and_availability_sync_tests.rs
+++ b/backend/servers/api-server/tests/airbnb_direct_connect_and_availability_sync_tests.rs
@@ -58,6 +58,9 @@ use serde_json::json;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
 use common::{seed_org, TestApp};
 
 // Must match `TestConfig::default().jwt_secret`.
@@ -453,6 +456,155 @@ async fn direct_connect_authorized_request_reaches_not_configured(pool: PgPool) 
     assert_eq!(
         count, 0,
         "no connection row should be written when Airbnb is not configured"
+    );
+}
+
+/// Happy path (issue #2240): an authorized manager on a configured org, whose
+/// supplied access token validates against a stubbed Airbnb Partner API,
+/// gets `200` + a fully-populated [`AirbnbDirectConnectResponse`] and exactly
+/// one persisted `rental_platform_connections` row with the token encrypted at
+/// rest.
+///
+/// This is the previously-missing success/write-path coverage: unlike the
+/// NOT_CONFIGURED test above, this binary injects non-empty Airbnb credentials
+/// **and** an `api_base` pointing at a `wiremock` server via
+/// `TestApp::with_airbnb_config`, so the handler runs all the way through
+/// `client.fetch_listings(...)` → `encrypt_required(...)` →
+/// `rental_repo.upsert_airbnb_connection(...)` without any live network call.
+/// The per-instance config injection (rather than process-global `AIRBNB_*`
+/// env vars) keeps the sibling NOT_CONFIGURED case — which requires the
+/// credentials to stay empty — passing under concurrent `#[sqlx::test]`
+/// execution.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn direct_connect_happy_path_upserts_connection(pool: PgPool) {
+    // `direct_connect_airbnb` encrypts the token before storage via
+    // `IntegrationCrypto::try_from_env()` and fails closed (500
+    // ENCRYPTION_REQUIRED) when `INTEGRATION_ENCRYPTION_KEY` is unset. Seed a
+    // valid 64-hex-char (32-byte) key for this binary. No sibling test in this
+    // file asserts the key is absent, so a one-time global set is safe here.
+    static ENC_KEY_ONCE: std::sync::Once = std::sync::Once::new();
+    ENC_KEY_ONCE.call_once(|| {
+        if std::env::var("INTEGRATION_ENCRYPTION_KEY").is_err() {
+            std::env::set_var("INTEGRATION_ENCRYPTION_KEY", "0".repeat(64));
+        }
+    });
+
+    // Stub the Airbnb Partner API: GET {base}/listings → two listings. The
+    // handler only counts the listings, so a minimal-but-valid `AirbnbListing`
+    // shape (required non-Option fields + empty photos/amenities) is enough.
+    let mock_server = MockServer::start().await;
+    let listings_body = json!({
+        "listings": [
+            {
+                "id": "L1", "name": "Listing One", "property_type": "apartment",
+                "room_type": "entire_home", "bedrooms": 2, "bathrooms": 1.0,
+                "person_capacity": 4, "status": "active",
+                "photos": [], "amenities": []
+            },
+            {
+                "id": "L2", "name": "Listing Two", "property_type": "house",
+                "room_type": "private_room", "bedrooms": 1, "bathrooms": 1.5,
+                "person_capacity": 2, "status": "active",
+                "photos": [], "amenities": []
+            }
+        ]
+    });
+    Mock::given(method("GET"))
+        .and(path("/listings"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(listings_body))
+        .mount(&mock_server)
+        .await;
+
+    let airbnb_config = api_server::state::AirbnbAppConfig {
+        client_id: "test-client-id".to_string(),
+        client_secret: "test-client-secret".to_string(),
+        redirect_uri: "http://localhost/callback".to_string(),
+        webhook_secret: String::new(),
+        // Point the direct-connect client at the stub; the handler appends
+        // `/listings`.
+        api_base: mock_server.uri(),
+    };
+
+    let app = TestApp::with_airbnb_config(pool.clone(), airbnb_config).await;
+    let org_id = seed_org(&pool, "dc-happy").await;
+    let user_id = Uuid::new_v4();
+    let token = mint_manager_token(user_id, org_id);
+
+    let resp = app
+        .execute(authed_request(
+            Method::POST,
+            &direct_connect_uri(org_id),
+            &token,
+            Some(json!({
+                "access_token": "valid-airbnb-token",
+                "refresh_token": "valid-airbnb-refresh",
+                "airbnb_account_id": "ACCT-1"
+            })),
+        ))
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "configured direct-connect with a valid token must be 200; got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    // Response DTO: success flag, a UUID connection_id, listings_count from the
+    // stub, and a human-readable message referencing the count.
+    let body: serde_json::Value =
+        serde_json::from_str(&resp.text()).expect("direct-connect response must be JSON");
+    assert_eq!(body["success"], true, "body: {body}");
+    assert_eq!(body["listings_count"], 2, "body: {body}");
+    let connection_id = body["connection_id"]
+        .as_str()
+        .and_then(|s| Uuid::parse_str(s).ok())
+        .expect("connection_id must be a UUID string");
+    assert!(
+        body["message"]
+            .as_str()
+            .is_some_and(|m| m.contains("2 listing")),
+        "message should reference the listing count: {body}"
+    );
+
+    // Exactly one Airbnb connection row is persisted for the org.
+    let row = sqlx::query(
+        r#"
+        SELECT id, organization_id, platform, access_token, refresh_token, is_active
+        FROM rental_platform_connections
+        WHERE organization_id = $1 AND platform = 'airbnb'
+        "#,
+    )
+    .bind(org_id)
+    .fetch_all(&pool)
+    .await
+    .expect("query connection rows");
+    assert_eq!(
+        row.len(),
+        1,
+        "exactly one airbnb connection row must be persisted"
+    );
+    let row = &row[0];
+    assert_eq!(row.get::<Uuid, _>("id"), connection_id);
+    assert_eq!(row.get::<Uuid, _>("organization_id"), org_id);
+    assert!(row.get::<bool, _>("is_active"));
+
+    // Token is encrypted at rest (Issue #765 mandatory-encryption contract):
+    // the persisted value carries the "enc:" prefix, never the plaintext token.
+    let stored_access: String = row.get("access_token");
+    assert!(
+        stored_access.starts_with("enc:"),
+        "access token must be stored encrypted, got: {stored_access}"
+    );
+    assert!(
+        !stored_access.contains("valid-airbnb-token"),
+        "plaintext token must never be persisted: {stored_access}"
+    );
+    let stored_refresh: Option<String> = row.get("refresh_token");
+    assert!(
+        stored_refresh.as_deref().is_some_and(|t| t.starts_with("enc:")),
+        "refresh token must be stored encrypted: {stored_refresh:?}"
     );
 }
 

--- a/backend/servers/api-server/tests/common/mod.rs
+++ b/backend/servers/api-server/tests/common/mod.rs
@@ -127,6 +127,66 @@ impl TestApp {
         }
     }
 
+    /// Create a test application whose `AppState` carries a custom Airbnb
+    /// integration configuration (issue #2240).
+    ///
+    /// Production loads `airbnb_config` from the environment. This lets a test
+    /// inject non-empty credentials plus an `api_base` pointing at a `wiremock`
+    /// stub so the `direct_connect_airbnb` success/write path can be driven
+    /// network-free — without setting process-global `AIRBNB_*` env vars, which
+    /// would race the sibling `#[sqlx::test]` cases in the same binary (notably
+    /// the NOT_CONFIGURED test, which requires the credentials to stay empty).
+    pub async fn with_airbnb_config(
+        pool: PgPool,
+        airbnb_config: api_server::state::AirbnbAppConfig,
+    ) -> Self {
+        use api_server::services::{EmailService, JwtService};
+        use api_server::state::AppState;
+
+        let config = TestConfig::default();
+
+        // Seed JWT_SECRET / RUST_ENV exactly like `with_config` so bearer
+        // tokens validate and `TotpService::new` doesn't panic.
+        static TEST_ENV_ONCE: std::sync::Once = std::sync::Once::new();
+        TEST_ENV_ONCE.call_once(|| {
+            if std::env::var("JWT_SECRET").is_err() {
+                std::env::set_var("JWT_SECRET", &config.jwt_secret);
+            }
+            if std::env::var("RUST_ENV").is_err() {
+                std::env::set_var("RUST_ENV", "development");
+            }
+        });
+
+        let email_service = EmailService::new(config.base_url.clone(), config.email_enabled);
+        let jwt_service =
+            JwtService::new(&config.jwt_secret).expect("Failed to create JWT service for tests");
+        let tenant_cache = std::sync::Arc::new(api_core::middleware::TenantResolutionCache::new(
+            300, 30, 10_000,
+        ));
+        let tenant_rate_limiters =
+            std::sync::Arc::new(api_core::middleware::TenantRateLimiterSet::new());
+
+        let state = AppState::new(
+            pool.clone(),
+            email_service,
+            jwt_service,
+            tenant_cache,
+            tenant_rate_limiters,
+        )
+        .with_airbnb_config(airbnb_config);
+
+        let router =
+            api_server::create_router(state).layer(axum::extract::connect_info::MockConnectInfo(
+                std::net::SocketAddr::from(([127, 0, 0, 1], 0)),
+            ));
+
+        Self {
+            router,
+            pool,
+            config,
+        }
+    }
+
     /// Create a test application whose `AppState` has a
     /// [`PreferenceEventRecorder`](api_server::state::PreferenceEventRecorder)
     /// installed, returning the app plus the recorder handle (issue #1376).


### PR DESCRIPTION
## Task

Follow-up to PR #2189 (issue #2240): `direct_connect_airbnb`'s success/write path had zero coverage — all six existing direct-connect tests stop at an auth/error branch, and the "authorized happy path" test only asserts the `500 NOT_CONFIGURED` short-circuit. Root cause: `AirbnbClient` hardcoded `AIRBNB_API_BASE` with no injection seam, so the success path (token validation via `fetch_listings` → `encrypt_required` → `upsert_airbnb_connection` → `AirbnbDirectConnectResponse`) could not be driven network-free.

This adds the seam and the missing happy-path test.

## Owner

pm-tech-lead (specialist: rust-backend)

## What changed

- **`crates/integrations/src/airbnb.rs`** — `AIRBNB_API_BASE` is now `pub`; added `AirbnbClient::with_base_url(config, base)` (trims trailing slash, empty falls back to the production default) plus a `base_url()` getter. The four `fetch_*` methods now use `self.base_url` instead of the constant. `new()` delegates to `with_base_url(config, AIRBNB_API_BASE)`, so production behaviour is unchanged. Two unit tests added.
- **`crates/integrations/src/lib.rs`** — re-export `AIRBNB_API_BASE`.
- **`servers/api-server/src/state.rs`** — `AirbnbAppConfig` gains an `api_base` field (from `AIRBNB_API_BASE` env, defaulting to the production endpoint when unset — never empty). Added a test seam `AppState::with_airbnb_config(...)`.
- **`servers/api-server/src/routes/integrations/install.rs`** — `direct_connect_airbnb` builds its client via `AirbnbClient::with_base_url(oauth_config, state.airbnb_config.api_base.clone())`.
- **`servers/api-server/tests/common/mod.rs`** — `TestApp::with_airbnb_config(...)` helper so a test injects credentials + `api_base` per-instance (no process-global `AIRBNB_*` env, which would race the sibling NOT_CONFIGURED case).
- **`servers/api-server/tests/airbnb_direct_connect_and_availability_sync_tests.rs`** — new `direct_connect_happy_path_upserts_connection`: a `wiremock` server stubs `GET /listings`; asserts `200` + `success`/`connection_id`/`listings_count`/`message`, exactly one persisted `rental_platform_connections` row, and that the stored access/refresh tokens are encrypted at rest (`enc:` prefix). Mirrors the existing `availability_sync_happy_path_enqueues_job` pattern.

## Tested (Band A — fast check)

- `cargo test -p integrations --lib airbnb` — exit 0; **21 passed** (incl. the 2 new `test_new_uses_default_api_base` / `test_with_base_url_overrides_and_trims_trailing_slash`).
- `cargo test -p api-server --test airbnb_direct_connect_and_availability_sync_tests --no-run` — exit 0; test binary (with wiremock + the new test) links cleanly.

The DB-backed `#[sqlx::test]` cases cannot execute in this sandbox (no Postgres / `DATABASE_URL`); they compile and run in CI (`backend.yml`).

## Built (Band B — full build)

- Debug build of `integrations` + `api-server` is **warning-free**.
- `cargo clippy` / `cargo fmt --check` could not run locally — the `clippy` and `rustfmt` components are absent from the sandbox toolchain (`1.94.1`). Code was hand-formatted to convention; CI enforces both.
- Note: `utoipa-swagger-ui`'s build script cannot fetch its zip from github through the sandbox proxy (repo not allowlisted); worked around locally by pointing `SWAGGER_UI_DOWNLOAD_URL` at an offline copy repackaged from the npm `swagger-ui-dist` — a sandbox-only build detail, no repo changes.

## CI parity (Band C — hot-path only)

Skipped: production behaviour is unchanged (`api_base` defaults to the live endpoint). This PR only adds a test seam + coverage; the encryption/IDOR/role gates are untouched.

## Scope drift

`scope-check.sh --owner pm-tech-lead` exits 2 because `pm-tech-lead` maps to no code area in `owner-areas.json`. The actual specialist is `rust-backend` (deterministic selection: `backend/` + `routes/` + "rust"). All touched paths are the intended `crates/integrations` + `api-server` route/state/test files named in the issue — no unrelated code.

## Code-reuse review

`reuse-grep.sh` — no warnings.

## Notes

- The base-URL seam also unblocks a future real happy-path test for the pre-existing `sync_airbnb` handler (out of scope here).

Closes #2240

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyX9hirLy6oSTDSjA7SizM)_