### PR TITLE
test(mobile): cover per-slot icon fallback in app.config.icon.test.ts

### DIFF
--- a/frontend/apps/mobile/app.config.icon.test.ts
+++ b/frontend/apps/mobile/app.config.icon.test.ts
@@ -137,6 +137,33 @@ describe('fallback when badged variant is missing', () => {
 });
 
 /**
+ * `app.config.ts` resolves the launcher icon and the Android adaptive
+ * foreground independently (two separate on-disk existence checks), so a
+ * half-present variant must degrade one slot without dragging the other back
+ * to the base asset. This pins that per-slot fallback, which the all-present /
+ * all-absent suites above cannot exercise.
+ */
+describe('per-slot fallback when only one badged asset is missing', () => {
+  it('keeps the badged launcher but falls back for the missing adaptive foreground', () => {
+    // dev launcher icon present; dev adaptive foreground absent.
+    mockIconExistsPredicate = (s) => !s.includes('adaptive-icon-dev');
+    const { launcher, adaptive } = iconSlots(loadConfig('development'));
+    expect(launcher).toContain('icon-dev.png');
+    expect(adaptive).toContain('adaptive-icon.png');
+    expect(adaptive).not.toContain('-dev');
+  });
+
+  it('keeps the badged adaptive foreground but falls back for the missing launcher', () => {
+    // dev adaptive foreground present; dev launcher icon absent.
+    mockIconExistsPredicate = (s) => s.includes('adaptive-icon-dev') || !s.includes('icon-dev');
+    const { launcher, adaptive } = iconSlots(loadConfig('development'));
+    expect(adaptive).toContain('adaptive-icon-dev.png');
+    expect(launcher).toContain('icon.png');
+    expect(launcher).not.toContain('-dev');
+  });
+});
+
+/**
  * Guard for issue #1670 (PR #1554 follow-up): the icon PNG assets referenced by
  * app.config.ts must actually exist on disk. The other suites mock
  * `fs.existsSync` (so they cannot catch a tracked-but-missing PNG); this suite


### PR DESCRIPTION
## What

Churn-hotspot follow-up on `frontend/apps/mobile/app.config.icon.test.ts` (gap-85 area). The existing suites are already well-refactored (helpers extracted, clear docstrings), so rather than churn the structure this PR closes a genuine, previously untested code path.

`app.config.ts#resolveIconVariant` resolves the launcher `icon` and the Android adaptive-icon `foregroundImage` **independently** — two separate `fs.existsSync` checks with independent fallback ternaries. The prior suites only covered:
- all badged assets present (happy path), and
- only base assets present (full fallback).

Neither exercises a **half-present** variant, where one badged slot is on disk and the other is missing — the case the independent resolution exists for.

## Change

Adds two focused tests (reusing the existing `iconSlots` helper):
1. badged launcher present, badged adaptive missing → launcher stays badged, adaptive falls back to the un-badged production asset.
2. the inverse.

No production code changes; nothing about what is under test changes. Pure coverage strengthening.

## Verify

- `pnpm --filter ./apps/mobile test` — 495 passed (was 493, +2 new).
- `biome check` on the file — clean.
- `tsc --noEmit` (mobile) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRPAT4RKJ4cikghipcp7L5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRPAT4RKJ4cikghipcp7L5)_