### PR TITLE
gh-issue-2277: reality-web AgencyDashboard shows misleading "No Agency Found" on any API error

### DIFF
--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -16,6 +16,8 @@
     "formPlaceholderTitle": "Senior realitní makléř",
     "inviteError": "Chyba při odesílání pozvánky. Zkuste to znovu.",
     "inviteRealtor": "Pozvat makléře",
+    "loadErrorMessage": "Při načítání panelu agentury došlo k chybě. Zkuste to prosím znovu.",
+    "loadErrorTitle": "Nepodařilo se načíst vaši agenturu",
     "manageRealtors": "Spravovat makléře",
     "performanceOverview": "Přehled výkonnosti",
     "period1y": "1 rok",
@@ -23,6 +25,8 @@
     "period7d": "7 dní",
     "period90d": "90 dní",
     "quickActions": "Rychlé akce",
+    "retry": "Zkusit znovu",
+    "sectionLoadError": "Tuto sekci se nepodařilo načíst.",
     "topRealtors": "Nejlepší makléři",
     "viewAll": "Zobrazit vše"
   },

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -16,6 +16,8 @@
     "formPlaceholderTitle": "Senior Immobilienmakler",
     "inviteError": "Fehler beim Senden der Einladung. Bitte versuchen Sie es erneut.",
     "inviteRealtor": "Makler einladen",
+    "loadErrorMessage": "Beim Laden des Agentur-Dashboards ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.",
+    "loadErrorTitle": "Ihre Agentur konnte nicht geladen werden",
     "manageRealtors": "Makler verwalten",
     "performanceOverview": "Leistungsübersicht",
     "period1y": "1 Jahr",
@@ -23,6 +25,8 @@
     "period7d": "7 Tage",
     "period90d": "90 Tage",
     "quickActions": "Schnellaktionen",
+    "retry": "Erneut versuchen",
+    "sectionLoadError": "Dieser Abschnitt konnte nicht geladen werden.",
     "topRealtors": "Top-Makler",
     "viewAll": "Alle anzeigen"
   },

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -16,6 +16,8 @@
     "formPlaceholderTitle": "Senior Real Estate Agent",
     "inviteError": "Failed to send the invitation. Please try again.",
     "inviteRealtor": "Invite Realtor",
+    "loadErrorMessage": "Something went wrong while loading your agency dashboard. Please try again.",
+    "loadErrorTitle": "Couldn't load your agency",
     "manageRealtors": "Manage Realtors",
     "performanceOverview": "Performance Overview",
     "period1y": "1 Year",
@@ -23,6 +25,8 @@
     "period7d": "7 Days",
     "period90d": "90 Days",
     "quickActions": "Quick Actions",
+    "retry": "Retry",
+    "sectionLoadError": "Couldn't load this section.",
     "topRealtors": "Top Realtors",
     "viewAll": "View All"
   },

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -16,6 +16,8 @@
     "formPlaceholderTitle": "Senior ingatlanügynök",
     "inviteError": "Hiba a meghívó küldésekor. Kérjük, próbálja újra.",
     "inviteRealtor": "Ügynök meghívása",
+    "loadErrorMessage": "Hiba történt az ügynökségi irányítópult betöltésekor. Kérjük, próbálja újra.",
+    "loadErrorTitle": "Nem sikerült betölteni az ügynökségét",
     "manageRealtors": "Ügynökök kezelése",
     "performanceOverview": "Teljesítmény áttekintés",
     "period1y": "1 év",
@@ -23,6 +25,8 @@
     "period7d": "7 nap",
     "period90d": "90 nap",
     "quickActions": "Gyors műveletek",
+    "retry": "Újrapróbálkozás",
+    "sectionLoadError": "Ezt a szakaszt nem sikerült betölteni.",
     "topRealtors": "Legjobb ügynökök",
     "viewAll": "Összes megtekintése"
   },

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -16,6 +16,8 @@
     "formPlaceholderTitle": "Starszy agent nieruchomości",
     "inviteError": "Błąd podczas wysyłania zaproszenia. Spróbuj ponownie.",
     "inviteRealtor": "Zaproś agenta",
+    "loadErrorMessage": "Podczas ładowania panelu agencji wystąpił błąd. Spróbuj ponownie.",
+    "loadErrorTitle": "Nie udało się załadować Twojej agencji",
     "manageRealtors": "Zarządzaj agentami",
     "performanceOverview": "Przegląd wydajności",
     "period1y": "1 rok",
@@ -23,6 +25,8 @@
     "period7d": "7 dni",
     "period90d": "90 dni",
     "quickActions": "Szybkie akcje",
+    "retry": "Spróbuj ponownie",
+    "sectionLoadError": "Nie udało się załadować tej sekcji.",
     "topRealtors": "Najlepsi agenci",
     "viewAll": "Zobacz wszystkie"
   },

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -16,6 +16,8 @@
     "formPlaceholderTitle": "Senior realitný maklér",
     "inviteError": "Chyba pri odosielaní pozvánky. Skúste to znova.",
     "inviteRealtor": "Pozvať makléra",
+    "loadErrorMessage": "Pri načítaní panela agentúry sa vyskytla chyba. Skúste to znova.",
+    "loadErrorTitle": "Nepodarilo sa načítať vašu agentúru",
     "manageRealtors": "Spravovať maklérov",
     "performanceOverview": "Prehľad výkonnosti",
     "period1y": "1 rok",
@@ -23,6 +25,8 @@
     "period7d": "7 dní",
     "period90d": "90 dní",
     "quickActions": "Rýchle akcie",
+    "retry": "Skúsiť znova",
+    "sectionLoadError": "Túto sekciu sa nepodarilo načítať.",
     "topRealtors": "Najlepší makléri",
     "viewAll": "Zobraziť všetko"
   },

--- a/frontend/apps/reality-web/src/components/agency/AgencyDashboard.test.tsx
+++ b/frontend/apps/reality-web/src/components/agency/AgencyDashboard.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * AgencyDashboard Component Tests
+ *
+ * Regression for Issue #2277: on an API failure `useMyAgency` settles with
+ * `isLoading=false` and `data=undefined`. The dashboard used to fall through
+ * to <NoAgencyMessage /> ("No Agency Found / Create Agency"), showing an actual
+ * agency owner a misleading empty state. It must now render a distinct
+ * error/retry state instead, and only show "No Agency Found" when the query
+ * genuinely succeeds with no agency.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock @ppt/reality-api-client before importing the component.
+vi.mock('@ppt/reality-api-client', () => ({
+  useMyAgency: vi.fn(),
+  useAgencyStats: vi.fn(() => ({ data: undefined, isLoading: false, isError: false })),
+  useAgencyPerformance: vi.fn(() => ({ data: undefined, isError: false })),
+  useRealtors: vi.fn(() => ({ data: [], isError: false })),
+}));
+
+import { useMyAgency } from '@ppt/reality-api-client';
+import { AgencyDashboard } from './AgencyDashboard';
+
+const mockUseMyAgency = vi.mocked(useMyAgency);
+
+describe('AgencyDashboard — agency load error handling (Issue #2277)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the error/retry state (not "No Agency Found") when the agency query fails', () => {
+    mockUseMyAgency.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMyAgency>);
+
+    render(<AgencyDashboard />);
+
+    // The distinct error state is present…
+    expect(screen.getByRole('alert')).toHaveTextContent('loadErrorTitle');
+    // …and the misleading empty-state must NOT be shown on a fetch failure.
+    expect(screen.queryByText(/No Agency Found/i)).not.toBeInTheDocument();
+  });
+
+  it('calls refetch when the retry button is clicked', () => {
+    const refetch = vi.fn();
+    mockUseMyAgency.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch,
+    } as unknown as ReturnType<typeof useMyAgency>);
+
+    render(<AgencyDashboard />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'retry' }));
+    expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  it('still shows the "No Agency Found" empty state when the query succeeds with no agency', () => {
+    mockUseMyAgency.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMyAgency>);
+
+    render(<AgencyDashboard />);
+
+    expect(screen.getByText(/No Agency Found/i)).toBeInTheDocument();
+    expect(screen.queryByText('loadErrorTitle')).not.toBeInTheDocument();
+  });
+
+  it('renders the dashboard when the agency loads successfully', () => {
+    mockUseMyAgency.mockReturnValue({
+      data: { id: 'agency-1', name: 'Acme Realty' },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMyAgency>);
+
+    render(<AgencyDashboard />);
+
+    expect(screen.getByRole('heading', { name: 'Acme Realty' })).toBeInTheDocument();
+    expect(screen.queryByText(/No Agency Found/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/reality-web/src/components/agency/AgencyDashboard.tsx
+++ b/frontend/apps/reality-web/src/components/agency/AgencyDashboard.tsx
@@ -22,18 +22,35 @@ type PeriodType = '7d' | '30d' | '90d' | '12m';
 export function AgencyDashboard() {
   const t = useTranslations('agency');
   const [period, setPeriod] = useState<PeriodType>('30d');
-  const { data: agency, isLoading: agencyLoading } = useMyAgency();
-  const { data: stats, isLoading: statsLoading } = useAgencyStats(agency?.id || '', period);
-  const { data: performance } = useAgencyPerformance(
+  const {
+    data: agency,
+    isLoading: agencyLoading,
+    isError: agencyError,
+    refetch: refetchAgency,
+  } = useMyAgency();
+  const {
+    data: stats,
+    isLoading: statsLoading,
+    isError: statsError,
+  } = useAgencyStats(agency?.id || '', period);
+  const { data: performance, isError: performanceError } = useAgencyPerformance(
     agency?.id || '',
     undefined,
     undefined,
     'week'
   );
-  const { data: realtors } = useRealtors(agency?.id || '');
+  const { data: realtors, isError: realtorsError } = useRealtors(agency?.id || '');
 
   if (agencyLoading) {
     return <DashboardSkeleton />;
+  }
+
+  // Distinguish a failed fetch from a genuine "no agency" state. Without this
+  // branch, a 500/network error settles as `agency === undefined` and falls
+  // through to <NoAgencyMessage />, showing an actual agency owner the
+  // misleading "No Agency Found / Create Agency" screen (Issue #2277).
+  if (agencyError) {
+    return <AgencyLoadError onRetry={() => refetchAgency()} />;
   }
 
   if (!agency) {
@@ -69,14 +86,24 @@ export function AgencyDashboard() {
       </div>
 
       {/* Stats Cards */}
-      {statsLoading ? <StatsCardsSkeleton /> : stats ? <StatsCards stats={stats} /> : null}
+      {statsError ? (
+        <SectionError message={t('sectionLoadError')} />
+      ) : statsLoading ? (
+        <StatsCardsSkeleton />
+      ) : stats ? (
+        <StatsCards stats={stats} />
+      ) : null}
 
       {/* Main Content Grid */}
       <div className="content-grid">
         {/* Performance Chart */}
         <div className="section chart-section">
           <h2 className="section-title">{t('performanceOverview')}</h2>
-          {performance && <PerformanceChart data={performance} />}
+          {performanceError ? (
+            <SectionError message={t('sectionLoadError')} />
+          ) : (
+            performance && <PerformanceChart data={performance} />
+          )}
         </div>
 
         {/* Realtor Leaderboard */}
@@ -87,14 +114,18 @@ export function AgencyDashboard() {
               {t('viewAll')}
             </Link>
           </div>
-          <RealtorLeaderboard
-            realtors={
-              realtors
-                ?.filter((r) => r.status === 'active')
-                .sort((a, b) => b.totalSales - a.totalSales)
-                .slice(0, 5) || []
-            }
-          />
+          {realtorsError ? (
+            <SectionError message={t('sectionLoadError')} />
+          ) : (
+            <RealtorLeaderboard
+              realtors={
+                realtors
+                  ?.filter((r) => r.status === 'active')
+                  .sort((a, b) => b.totalSales - a.totalSales)
+                  .slice(0, 5) || []
+              }
+            />
+          )}
         </div>
       </div>
 
@@ -888,6 +919,80 @@ function NoAgencyMessage() {
         }
         .create-button:hover {
           background: var(--ppt-color-primary-hover);
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function AgencyLoadError({ onRetry }: { onRetry: () => void }) {
+  const t = useTranslations('agency');
+  return (
+    <div className="agency-error" role="alert">
+      <svg
+        width="64"
+        height="64"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="var(--ppt-color-danger, #ef4444)"
+        strokeWidth="1.5"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+      <h2>{t('loadErrorTitle')}</h2>
+      <p>{t('loadErrorMessage')}</p>
+      <button type="button" className="retry-button" onClick={onRetry}>
+        {t('retry')}
+      </button>
+      <style jsx>{`
+        .agency-error {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          padding: 64px 24px;
+          text-align: center;
+          min-height: 50vh;
+        }
+        h2 {
+          font-size: 1.5rem;
+          color: var(--ppt-fg-primary);
+          margin: 24px 0 8px;
+        }
+        p {
+          color: var(--ppt-fg-muted);
+          margin: 0 0 24px;
+        }
+        .retry-button {
+          padding: 12px 24px;
+          background: var(--ppt-color-primary);
+          color: var(--ppt-fg-on-accent);
+          border: none;
+          border-radius: 8px;
+          font-weight: 500;
+          cursor: pointer;
+        }
+        .retry-button:hover {
+          background: var(--ppt-color-primary-hover);
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function SectionError({ message }: { message: string }) {
+  return (
+    <div className="section-error" role="alert">
+      <span>{message}</span>
+      <style jsx>{`
+        .section-error {
+          padding: 24px;
+          text-align: center;
+          color: var(--ppt-fg-muted);
+          font-size: 14px;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Task
reality-web AgencyDashboard shows misleading "No Agency Found" screen to owners on any API error (no isError branch) (Closes #2277)

Closes #2277

## Root cause
`AgencyDashboard` destructured `useMyAgency()` for `{ data: agency, isLoading }` only — `isError` was ignored. On a 500/network failure the query settles with `isLoading=false` and `agency=undefined`, so the `if (!agency) return <NoAgencyMessage />` branch fired and showed an actual agency owner the misleading "No Agency Found / Create Agency" screen.

## Fix
- Destructure `isError` + `refetch` from `useMyAgency()` and render a distinct `<AgencyLoadError onRetry={refetch} />` state (error icon, message, Retry button) **before** the `!agency` empty-state check, so a fetch failure is no longer conflated with "no agency exists".
- Also surface the sibling hooks' error states (`useAgencyStats` / `useAgencyPerformance` / `useRealtors`) as inline `<SectionError />` messages instead of blank/empty content (the realtor leaderboard previously showed a misleading "No active realtors yet" on fetch failure).
- Added 4 i18n keys (`loadErrorTitle`, `loadErrorMessage`, `retry`, `sectionLoadError`) to all 6 locales (en, sk, cs, de, hu, pl) — real copy for every locale.

## Owner
pm-frontend

## Tested (Band A — fast check)
- `pnpm -F reality-web test -- --run src/components/agency/AgencyDashboard.test.tsx` → exit 0 (4 passed). New TDD regression test (red on `dev` — the `isError` branch didn't exist): asserts the error/retry state renders and the "No Agency Found" empty state does NOT on a fetch failure; that "No Agency Found" still shows on a genuine no-agency success; and that Retry calls `refetch`.
- `pnpm -F reality-web typecheck` (`tsc --noEmit`) → exit 0.
- Lint: the specialist's `pnpm -F reality-web lint` script (`next lint`) is broken repo-wide (Next 16 removed `next lint`) — unrelated to this change. Ran the actual CI linter instead: `npx biome check` on all changed files → exit 0, no fixes.

## Built (Band B — full build)
- `pnpm -F reality-web build` (Next production build) → exit 0.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (public read-only dashboard UI; no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. All changes under `frontend/apps/reality-web/`.

## Code-reuse review
None — `reuse-grep.sh --specialist nextjs-web` exit 0.

## Notes
- IG goal-check: IG3 (TDD test:/fix: commit pair) passes. IG1 (`.research/plan` file) and IG2 (`impl/<slug>` branch name) are structurally inapplicable to this GitHub-issue-driven task — there is no research plan, and the branch name (`auto-impl/gh-issue-2277-086d651e`) was mandated by the dispatcher.
- Draft PR per implementer contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1UNnSzQTBDfWwwvwab4Mr)_