### PR TITLE
gh-issue-2276: reality-web listing detail crashes SSR (500) on a partial 200 body

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
@@ -9,7 +9,7 @@
 
 import type { ListingDetail } from '@ppt/reality-api-client';
 import { describe, expect, it } from 'vitest';
-import { buildListingJsonLd } from './jsonLd';
+import { buildListingJsonLd, isRenderableListing } from './jsonLd';
 
 const validListing: ListingDetail = {
   id: 'listing-1',
@@ -117,5 +117,53 @@ describe('buildListingJsonLd', () => {
     expect('offers' in jsonLd).toBe(false);
     expect('numberOfRooms' in jsonLd).toBe(false);
     expect('floorSize' in jsonLd).toBe(false);
+  });
+});
+
+describe('isRenderableListing', () => {
+  it('accepts a valid listing', () => {
+    expect(isRenderableListing(validListing)).toBe(true);
+  });
+
+  it('accepts a minimal body with title, slug and a well-formed address', () => {
+    expect(
+      isRenderableListing({
+        title: 'Minimal',
+        slug: 'minimal',
+        address: { city: 'Bratislava', country: 'SK' },
+      })
+    ).toBe(true);
+  });
+
+  // These are exactly the partial 200 bodies getListing must reject so the
+  // request falls back to ListingNotFound instead of crashing SSR (#2276).
+  it('rejects null / undefined', () => {
+    expect(isRenderableListing(null)).toBe(false);
+    expect(isRenderableListing(undefined)).toBe(false);
+  });
+
+  it('rejects an empty object', () => {
+    expect(isRenderableListing({})).toBe(false);
+  });
+
+  it('rejects a body missing address', () => {
+    expect(isRenderableListing({ title: 't', slug: 's' })).toBe(false);
+  });
+
+  it('rejects a body whose address is missing city or country', () => {
+    expect(isRenderableListing({ title: 't', slug: 's', address: { city: 'X' } })).toBe(false);
+    expect(isRenderableListing({ title: 't', slug: 's', address: { country: 'SK' } })).toBe(false);
+  });
+
+  it('rejects a body missing title or slug', () => {
+    const addr = { city: 'X', country: 'SK' };
+    expect(isRenderableListing({ slug: 's', address: addr })).toBe(false);
+    expect(isRenderableListing({ title: 't', address: addr })).toBe(false);
+  });
+
+  it('rejects non-object bodies', () => {
+    expect(isRenderableListing('oops')).toBe(false);
+    expect(isRenderableListing(42)).toBe(false);
+    expect(isRenderableListing([])).toBe(false);
   });
 });

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.ts
@@ -9,33 +9,53 @@
 import type { ListingDetail } from '@ppt/reality-api-client';
 
 /**
- * Build the RealEstateListing JSON-LD object defensively.
+ * Type-guard for the minimum shape the listing detail page can render.
  *
  * `getListing` returns the raw JSON body of any 200 response, so a malformed
- * or partial 200 (e.g. `{}`, or a body missing `address` / `photos`) is truthy
- * but does not match `ListingDetail`. Dereferencing nested fields off such a
- * body (`listing.photos.map`, `listing.address.street`) would throw during SSR
- * and crash the request. Treat the body as `unknown`, require the minimum set
- * of fields, and return `null` whenever a required field is missing or has the
- * wrong shape. Optional fields (`photos`, `price`, `rooms`, `area`, …) are
- * emitted only when present.
+ * or partial 200 (e.g. `{}`, or a body missing `address`) is truthy but does
+ * not match `ListingDetail`. Dereferencing nested fields off such a body
+ * (`listing.address.city`, `Object.entries(listing.features)`) throws during
+ * SSR and crashes the request with a 500. This predicate requires the minimum
+ * set of fields — title, slug, and a well-formed `address` with `city` and
+ * `country` — and is the single source of truth for "is this body renderable".
+ * It is consumed both by `buildListingJsonLd` (below) and by `getListing`, so
+ * a body that fails validation falls back to `ListingNotFound` instead of
+ * crashing SSR.
+ */
+export function isRenderableListing(listing: unknown): listing is ListingDetail {
+  if (!listing || typeof listing !== 'object') {
+    return false;
+  }
+
+  const l = listing as Partial<ListingDetail>;
+  const address = l.address;
+
+  return (
+    typeof l.title === 'string' &&
+    typeof l.slug === 'string' &&
+    !!address &&
+    typeof address === 'object' &&
+    typeof address.city === 'string' &&
+    typeof address.country === 'string'
+  );
+}
+
+/**
+ * Build the RealEstateListing JSON-LD object defensively.
+ *
+ * Reuses {@link isRenderableListing} for the required-field check, then emits
+ * optional fields (`photos`, `price`, `rooms`, `area`, …) only when present.
+ * Returns `null` whenever a required field is missing or has the wrong shape.
  */
 export function buildListingJsonLd(listing: unknown): object | null {
-  if (!listing || typeof listing !== 'object') {
+  if (!isRenderableListing(listing)) {
     return null;
   }
 
   const l = listing as Partial<ListingDetail>;
   const address = l.address;
 
-  if (
-    typeof l.title !== 'string' ||
-    typeof l.slug !== 'string' ||
-    !address ||
-    typeof address !== 'object' ||
-    typeof address.city !== 'string' ||
-    typeof address.country !== 'string'
-  ) {
+  if (!address) {
     return null;
   }
 

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
@@ -12,7 +12,7 @@ import type { ListingDetail } from '@ppt/reality-api-client';
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { ListingDetailContent, ListingNotFound } from '@/components/listings';
-import { buildListingJsonLd } from './jsonLd';
+import { buildListingJsonLd, isRenderableListing } from './jsonLd';
 import { buildListingMetadata } from './metadata';
 
 function inferApiBaseFromHost(host: string): string | null {
@@ -74,7 +74,14 @@ async function getListing(slug: string, host: string): Promise<ListingDetail | n
       next: { revalidate: 60, tags },
     });
     if (!response.ok) return null;
-    return response.json();
+    // A 200 does not guarantee a well-formed body: an upstream/proxy partial
+    // response or a malformed listing is truthy but may be missing required
+    // nested fields (`address.city`, …). Rendering such a body crashes SSR
+    // with a 500. Validate the shape here — reusing the same required-field
+    // predicate as `buildListingJsonLd` — so a bad body falls back to
+    // `ListingNotFound` (404-style) instead of taking the request down.
+    const body: unknown = await response.json();
+    return isRenderableListing(body) ? body : null;
   } catch {
     return null;
   }

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * ListingDetailContent Tests
+ *
+ * Regression guard for the SSR 500 where a partial/malformed 200 listing body
+ * (truthy but missing nested fields) crashed rendering while dereferencing
+ * `listing.address.city` or `Object.entries(listing.features)`. The component
+ * must render such bodies without throwing (issue #2276).
+ */
+
+import type { ListingDetail } from '@ppt/reality-api-client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ListingDetailContent } from './ListingDetailContent';
+
+// ContactForm (rendered in the sidebar) uses a TanStack Query mutation hook.
+// Stub the API client so the component tree renders without a QueryClient.
+vi.mock('@ppt/reality-api-client', () => ({
+  useCreateInquiry: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    isError: false,
+  }),
+}));
+
+// Header/Footer pull in the i18n routing + auth-context tree, which is
+// irrelevant to the partial-body render behaviour under test.
+vi.mock('@/components/ui', () => ({
+  Header: () => null,
+  Footer: () => null,
+}));
+
+const validListing: ListingDetail = {
+  id: 'listing-1',
+  slug: 'beautiful-apartment',
+  title: 'Beautiful Apartment',
+  propertyType: 'apartment',
+  transactionType: 'sale',
+  status: 'active',
+  price: 150000,
+  currency: 'EUR',
+  area: 75,
+  rooms: 3,
+  address: {
+    street: 'Main St 1',
+    city: 'Bratislava',
+    district: 'Old Town',
+    postalCode: '81101',
+    country: 'SK',
+  },
+  isFeatured: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  description: 'A lovely place to live.',
+  features: { balcony: true, parking: false },
+  photos: [
+    {
+      id: 'p1',
+      url: 'https://cdn.example.com/p1.jpg',
+      thumbnailUrl: 'https://cdn.example.com/p1-thumb.jpg',
+      isPrimary: true,
+      order: 0,
+    },
+  ],
+  agent: { id: 'a1', name: 'Agent', email: 'a@example.com' },
+  viewCount: 0,
+  favoriteCount: 0,
+  primaryPhoto: {
+    id: 'p1',
+    url: 'https://cdn.example.com/p1.jpg',
+    thumbnailUrl: 'https://cdn.example.com/p1-thumb.jpg',
+    isPrimary: true,
+    order: 0,
+  },
+};
+
+describe('ListingDetailContent', () => {
+  it('renders a valid listing', () => {
+    render(<ListingDetailContent listing={validListing} />);
+    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
+  });
+
+  it('renders ListingNotFound when listing is null', () => {
+    render(<ListingDetailContent listing={null} />);
+    // next-intl is mocked to echo the key.
+    expect(screen.getByText('notFound')).toBeInTheDocument();
+  });
+
+  // Core regression: partial 200 bodies must NOT throw during (SSR) render.
+  it('does not throw when features is missing (Object.entries crash)', () => {
+    const partial = {
+      ...validListing,
+      features: undefined as unknown as ListingDetail['features'],
+    };
+    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
+    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
+  });
+
+  it('does not throw when photos is missing (PhotoGallery crash)', () => {
+    const partial = {
+      ...validListing,
+      photos: undefined as unknown as ListingDetail['photos'],
+    };
+    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
+    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
+  });
+
+  it('does not throw when address is missing (address.city crash)', () => {
+    const partial = {
+      ...validListing,
+      address: undefined as unknown as ListingDetail['address'],
+    };
+    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
+    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
+  });
+
+  it('does not throw on a near-empty body missing all nested fields', () => {
+    const partial = {
+      id: 'x',
+      slug: 'x',
+      title: 'Bare Listing',
+    } as unknown as ListingDetail;
+    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
+    expect(screen.getByText('Bare Listing')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
@@ -18,11 +18,18 @@ interface ListingDetailContentProps {
 }
 
 function formatPrice(price: number, currency: string) {
+  const value = Number.isFinite(price) ? price : 0;
+  // A partial 200 body can omit `currency`; `Intl.NumberFormat` with
+  // `style: 'currency'` throws ("Currency code is required…") on a missing
+  // code, which would crash SSR. Fall back to a plain decimal format.
+  if (typeof currency !== 'string' || currency.length === 0) {
+    return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value);
+  }
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
     currency: currency,
     maximumFractionDigits: 0,
-  }).format(price);
+  }).format(value);
 }
 
 export function ListingNotFound() {
@@ -90,7 +97,12 @@ export function ListingDetailContent({ listing, jsonLd }: ListingDetailContentPr
     return tFeatures(key);
   };
 
-  const activeFeatures = Object.entries(listing.features)
+  // `listing.features` / `listing.photos` are validated as present for bodies
+  // that reach here via `getListing`, but this component is exported and may
+  // receive a partial body from other callers. Guard the unguarded derefs so a
+  // missing `features` (Object.entries) or `photos` (PhotoGallery) can never
+  // crash SSR with a 500.
+  const activeFeatures = Object.entries(listing.features ?? {})
     .filter(([, value]) => value === true)
     .map(([key]) => key as keyof ListingFeatures);
 
@@ -113,14 +125,14 @@ export function ListingDetailContent({ listing, jsonLd }: ListingDetailContentPr
             <span className="separator">/</span>
             <a href="/listings">{tNav('allListings')}</a>
             <span className="separator">/</span>
-            <span className="current">{listing.address.city}</span>
+            <span className="current">{listing.address?.city}</span>
           </nav>
 
           <div className="content-grid">
             {/* Main Content */}
             <div className="main-content">
               {/* Photo Gallery */}
-              <PhotoGallery photos={listing.photos} title={listing.title} />
+              <PhotoGallery photos={listing.photos ?? []} title={listing.title} />
 
               {/* Header */}
               <div className="listing-header">
@@ -144,9 +156,9 @@ export function ListingDetailContent({ listing, jsonLd }: ListingDetailContentPr
                     <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
                     <circle cx="12" cy="10" r="3" />
                   </svg>
-                  {listing.address.street && `${listing.address.street}, `}
-                  {listing.address.city}
-                  {listing.address.district && `, ${listing.address.district}`}
+                  {listing.address?.street && `${listing.address.street}, `}
+                  {listing.address?.city}
+                  {listing.address?.district && `, ${listing.address.district}`}
                 </p>
                 <div className="price-row">
                   <span className="price">{formatPrice(listing.price, listing.currency)}</span>
@@ -325,7 +337,10 @@ export function ListingDetailContent({ listing, jsonLd }: ListingDetailContentPr
 
             {/* Sidebar */}
             <div className="sidebar">
-              <ContactForm listingId={listing.id} agent={listing.agent} />
+              {/* `agent` is not guaranteed on a partial 200 body; ContactForm
+                  dereferences `agent.name` / `agent.avatarUrl`, so only render
+                  it when the agent is present to avoid crashing SSR. */}
+              {listing.agent && <ContactForm listingId={listing.id} agent={listing.agent} />}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Task
reality-web listing detail crashes SSR (500) on a partial 200 body — unguarded address/features deref (Closes #2276)

Closes #2276

## Root cause
`ListingDetailContent.tsx` dereferenced `listing.address.city`/`.street`/`.district` and called `Object.entries(listing.features)` with no null-checks, and `getListing()` in `page.tsx` returned the raw JSON of any 200 with no shape validation. A partial/malformed 200 body (truthy but missing nested fields) therefore crashed SSR → 500 on the public listing detail page.

## Fix
Belt-and-suspenders, covering both suggestions in the issue:

1. **Validate the body in `getListing()`** — extracted `isRenderableListing()` from `buildListingJsonLd`'s required-field checks into `jsonLd.ts` (single source of truth: title, slug, well-formed `address` with `city`+`country`). `getListing()` now returns `null` on a malformed body → falls back to `ListingNotFound` instead of crashing.
2. **Guard the remaining unguarded derefs in `ListingDetailContent`** — fields the predicate doesn't cover:
   - `Object.entries(listing.features ?? {})`
   - optional-chained address (`listing.address?.city`, `?.street`, `?.district`)
   - `PhotoGallery photos={listing.photos ?? []}`
   - currency-safe `formatPrice` (a missing `currency` made `Intl.NumberFormat({ style: 'currency' })` throw — surfaced by the near-empty-body test)
   - render `ContactForm` only when `listing.agent` is present (it derefs `agent.name`/`agent.avatarUrl`)

## Owner
pm-frontend

## Tested (Band A — fast check)
- `pnpm -F reality-web typecheck` → exit 0
- `pnpm -F reality-web` Biome check on changed files (`biome check …`) → exit 0 (repo lint gate is Biome per CLAUDE.md; the package's `next lint` script is non-functional in CI-less env)
- `vitest run` on `ListingDetailContent.test.tsx` + `jsonLd.test.ts` → 22 passed
  - New component tests assert partial-body render behaviour (missing features / photos / address / currency / agent → no throw); these fail on the pre-fix code.

## Built (Band B — full build)
- `pnpm -F reality-web build` (Next.js production build) → exit 0; `/[locale]/listings/[slug]` compiles as a dynamic SSR route.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
false — `scope-check.sh --owner pm-frontend` exit 0. All changes under `frontend/apps/reality-web/`.

## Code-reuse review
none — `reuse-grep.sh --specialist nextjs-web` emitted no warnings. The fix reuses/extracts the existing `buildListingJsonLd` validation rather than adding a parallel checker.

## Notes
- `isRenderableListing` is now the shared predicate for both `buildListingJsonLd` and `getListing`.
- Goal-check IG1/IG2 report "plan absent" / branch-name mismatch — expected for a GitHub-issue task on the dispatcher-assigned `auto-impl/*` branch (no `.research/plans/` file; `.research/**` intentionally untouched). IG3 (regression test present) passes.
- The TDD test/fix split existed on the local branch; the MCP `push_files` path collapses it into a single commit on the remote, but both the regression tests and the fix are in this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1UNnSzQTBDfWwwvwab4Mr

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1UNnSzQTBDfWwwvwab4Mr)_