### PR TITLE
gap-84-3-no-dedicated-price-alert-subscription-ui: price-alert subscription surface in reality-web

### DIFF
--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -515,7 +515,8 @@
     "favorites": {
       "title": "Moje oblíbené",
       "description": "Nemovitosti, které jste si uložili.",
-      "h1": "Moje oblíbené"
+      "h1": "Moje oblíbené",
+      "priceAlertsLink": "Cenová upozornění"
     },
     "login": {
       "title": "Přihlášení",
@@ -590,6 +591,10 @@
       "description": "Porovnejte nemovitosti vedle sebe a najděte ten správný domov.",
       "h1": "Porovnat nemovitosti",
       "subtitle": "Podívejte se, jak si vaše vybrané nemovitosti stojí vedle sebe."
+    },
+    "priceAlerts": {
+      "title": "Cenová upozornění",
+      "description": "Upozornění na snížení ceny a návrat na trh pro vaše oblíbené nabídky."
     }
   },
   "search": {
@@ -637,5 +642,21 @@
     "accept": "Accept all",
     "reject": "Reject optional",
     "manage": "Cookie settings"
+  },
+  "priceAlerts": {
+    "h1": "Cenová upozornění",
+    "subtitle": "Změny cen a návrat na trh pro nabídky, které jste si označili jako oblíbené.",
+    "backToFavorites": "← Zpět na oblíbené",
+    "unread": "{count, plural, =0 {Žádná nepřečtená upozornění} one {# nepřečtené upozornění} few {# nepřečtená upozornění} other {# nepřečtených upozornění}}",
+    "markAllRead": "Označit vše jako přečtené",
+    "markRead": "Označit jako přečtené",
+    "backOnMarket": "Opět na trhu",
+    "priceChanged": "Cena se změnila",
+    "drop": "snížení o {pct}",
+    "increase": "zvýšení o {pct}",
+    "loadError": "Nepodařilo se načíst cenová upozornění. Zkuste to znovu.",
+    "emptyTitle": "Zatím žádná cenová upozornění",
+    "emptyText": "Upozorníme vás zde, když se změní ceny vašich oblíbených nabídek.",
+    "goToFavorites": "Přejít na oblíbené"
   }
 }

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -515,7 +515,8 @@
     "favorites": {
       "title": "Meine Favoriten",
       "description": "Immobilien, die Sie gespeichert haben.",
-      "h1": "Meine Favoriten"
+      "h1": "Meine Favoriten",
+      "priceAlertsLink": "Preisbenachrichtigungen"
     },
     "login": {
       "title": "Anmelden",
@@ -590,6 +591,10 @@
       "description": "Vergleichen Sie Immobilien nebeneinander und finden Sie Ihr perfektes Zuhause.",
       "h1": "Immobilien vergleichen",
       "subtitle": "Sehen Sie, wie sich Ihre ausgewählten Immobilien im Vergleich schlagen."
+    },
+    "priceAlerts": {
+      "title": "Preisbenachrichtigungen",
+      "description": "Benachrichtigungen zu Preissenkungen und Rückkehr auf den Markt für Ihre Favoriten."
     }
   },
   "search": {
@@ -637,5 +642,21 @@
     "accept": "Accept all",
     "reject": "Reject optional",
     "manage": "Cookie settings"
+  },
+  "priceAlerts": {
+    "h1": "Preisbenachrichtigungen",
+    "subtitle": "Preisänderungen und Rückkehr auf den Markt für Ihre favorisierten Angebote.",
+    "backToFavorites": "← Zurück zu Favoriten",
+    "unread": "{count, plural, =0 {Keine ungelesenen Benachrichtigungen} one {# ungelesene Benachrichtigung} other {# ungelesene Benachrichtigungen}}",
+    "markAllRead": "Alle als gelesen markieren",
+    "markRead": "Als gelesen markieren",
+    "backOnMarket": "Wieder auf dem Markt",
+    "priceChanged": "Preis geändert",
+    "drop": "{pct} Preissenkung",
+    "increase": "{pct} Erhöhung",
+    "loadError": "Preisbenachrichtigungen konnten nicht geladen werden. Bitte versuchen Sie es erneut.",
+    "emptyTitle": "Noch keine Preisbenachrichtigungen",
+    "emptyText": "Wir benachrichtigen Sie hier, wenn sich die Preise Ihrer Favoriten ändern.",
+    "goToFavorites": "Favoriten ansehen"
   }
 }

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -515,7 +515,8 @@
     "favorites": {
       "title": "My Favorites",
       "description": "Properties you have saved for later.",
-      "h1": "My Favorites"
+      "h1": "My Favorites",
+      "priceAlertsLink": "Price alerts"
     },
     "login": {
       "title": "Sign in",
@@ -590,6 +591,10 @@
       "description": "Compare properties side by side to find your perfect home.",
       "h1": "Compare properties",
       "subtitle": "See how your selected properties stack up against each other."
+    },
+    "priceAlerts": {
+      "title": "Price Alerts",
+      "description": "Price-drop and back-on-market alerts for your favorite listings."
     }
   },
   "search": {
@@ -637,5 +642,21 @@
     "accept": "Accept all",
     "reject": "Reject optional",
     "manage": "Cookie settings"
+  },
+  "priceAlerts": {
+    "h1": "Price Alerts",
+    "subtitle": "Price changes and back-on-market alerts for the listings you've favorited.",
+    "backToFavorites": "← Back to favorites",
+    "unread": "{count, plural, =0 {No unread alerts} one {# unread alert} other {# unread alerts}}",
+    "markAllRead": "Mark all read",
+    "markRead": "Mark read",
+    "backOnMarket": "Back on the market",
+    "priceChanged": "Price changed",
+    "drop": "{pct} price drop",
+    "increase": "{pct} increase",
+    "loadError": "Failed to load price alerts. Please try again.",
+    "emptyTitle": "No price alerts yet",
+    "emptyText": "We'll notify you here when prices change on your favorite listings.",
+    "goToFavorites": "Browse favorites"
   }
 }

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -514,7 +514,8 @@
     "favorites": {
       "title": "Kedvenceim",
       "description": "Az Ön által mentett ingatlanok.",
-      "h1": "Kedvenceim"
+      "h1": "Kedvenceim",
+      "priceAlertsLink": "Árriasztások"
     },
     "login": {
       "title": "Sign in",
@@ -583,6 +584,10 @@
       "requestNew": "Request a new reset link",
       "goToSignIn": "Go to sign in",
       "genericError": "Could not reset password. Please try again."
+    },
+    "priceAlerts": {
+      "title": "Árriasztások",
+      "description": "Árcsökkenési és piacra visszatérési riasztások a kedvenc hirdetéseihez."
     }
   },
   "search": {
@@ -630,5 +635,21 @@
     "accept": "Accept all",
     "reject": "Reject optional",
     "manage": "Cookie settings"
+  },
+  "priceAlerts": {
+    "h1": "Árriasztások",
+    "subtitle": "Árváltozások és piacra visszatérés a kedvencnek jelölt hirdetéseihez.",
+    "backToFavorites": "← Vissza a kedvencekhez",
+    "unread": "{count, plural, =0 {Nincs olvasatlan riasztás} other {# olvasatlan riasztás}}",
+    "markAllRead": "Összes megjelölése olvasottként",
+    "markRead": "Megjelölés olvasottként",
+    "backOnMarket": "Ismét piacon",
+    "priceChanged": "Az ár megváltozott",
+    "drop": "{pct} árcsökkenés",
+    "increase": "{pct} növekedés",
+    "loadError": "Nem sikerült betölteni az árriasztásokat. Próbálja újra.",
+    "emptyTitle": "Még nincsenek árriasztások",
+    "emptyText": "Értesítjük, ha megváltozik a kedvenc hirdetései ára.",
+    "goToFavorites": "Ugrás a kedvencekhez"
   }
 }

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -514,7 +514,8 @@
     "favorites": {
       "title": "Moje ulubione",
       "description": "Nieruchomości, które zapisałeś.",
-      "h1": "Moje ulubione"
+      "h1": "Moje ulubione",
+      "priceAlertsLink": "Alerty cenowe"
     },
     "login": {
       "title": "Sign in",
@@ -583,6 +584,10 @@
       "requestNew": "Request a new reset link",
       "goToSignIn": "Go to sign in",
       "genericError": "Could not reset password. Please try again."
+    },
+    "priceAlerts": {
+      "title": "Alerty cenowe",
+      "description": "Alerty o obniżkach cen i powrocie na rynek dla Twoich ulubionych ofert."
     }
   },
   "search": {
@@ -630,5 +635,21 @@
     "accept": "Accept all",
     "reject": "Reject optional",
     "manage": "Cookie settings"
+  },
+  "priceAlerts": {
+    "h1": "Alerty cenowe",
+    "subtitle": "Zmiany cen i powrót na rynek dla ofert dodanych do ulubionych.",
+    "backToFavorites": "← Powrót do ulubionych",
+    "unread": "{count, plural, =0 {Brak nieprzeczytanych alertów} one {# nieprzeczytany alert} few {# nieprzeczytane alerty} other {# nieprzeczytanych alertów}}",
+    "markAllRead": "Oznacz wszystkie jako przeczytane",
+    "markRead": "Oznacz jako przeczytane",
+    "backOnMarket": "Ponownie na rynku",
+    "priceChanged": "Cena się zmieniła",
+    "drop": "obniżka o {pct}",
+    "increase": "wzrost o {pct}",
+    "loadError": "Nie udało się załadować alertów cenowych. Spróbuj ponownie.",
+    "emptyTitle": "Brak alertów cenowych",
+    "emptyText": "Powiadomimy Cię tutaj, gdy zmienią się ceny Twoich ulubionych ofert.",
+    "goToFavorites": "Przejdź do ulubionych"
   }
 }

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -515,7 +515,8 @@
     "favorites": {
       "title": "Moje obľúbené",
       "description": "Nehnuteľnosti, ktoré ste si uložili.",
-      "h1": "Moje obľúbené"
+      "h1": "Moje obľúbené",
+      "priceAlertsLink": "Cenové upozornenia"
     },
     "login": {
       "title": "Prihlásenie",
@@ -590,6 +591,10 @@
       "description": "Porovnajte nehnuteľnosti vedľa seba a nájdite ten správny domov.",
       "h1": "Porovnať nehnuteľnosti",
       "subtitle": "Pozrite sa, ako si vaše vybrané nehnuteľnosti stoja vedľa seba."
+    },
+    "priceAlerts": {
+      "title": "Cenové upozornenia",
+      "description": "Upozornenia na zníženie ceny a návrat na trh pre vaše obľúbené ponuky."
     }
   },
   "search": {
@@ -637,5 +642,21 @@
     "accept": "Prijať všetky",
     "reject": "Odmietnuť voliteľné",
     "manage": "Nastavenia cookies"
+  },
+  "priceAlerts": {
+    "h1": "Cenové upozornenia",
+    "subtitle": "Zmeny cien a návrat na trh pre ponuky, ktoré ste si označili ako obľúbené.",
+    "backToFavorites": "← Späť na obľúbené",
+    "unread": "{count, plural, =0 {Žiadne neprečítané upozornenia} one {# neprečítané upozornenie} few {# neprečítané upozornenia} other {# neprečítaných upozornení}}",
+    "markAllRead": "Označiť všetky ako prečítané",
+    "markRead": "Označiť ako prečítané",
+    "backOnMarket": "Opäť na trhu",
+    "priceChanged": "Cena sa zmenila",
+    "drop": "zníženie o {pct}",
+    "increase": "zvýšenie o {pct}",
+    "loadError": "Nepodarilo sa načítať cenové upozornenia. Skúste to znova.",
+    "emptyTitle": "Zatiaľ žiadne cenové upozornenia",
+    "emptyText": "Upozorníme vás tu, keď sa zmenia ceny vašich obľúbených ponúk.",
+    "goToFavorites": "Prejsť na obľúbené"
   }
 }

--- a/frontend/apps/reality-web/src/app/[locale]/favorites/alerts/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/favorites/alerts/layout.tsx
@@ -1,0 +1,7 @@
+import { pageMetadata } from '@/lib/page-metadata';
+
+export const generateMetadata = pageMetadata('priceAlerts');
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/frontend/apps/reality-web/src/app/[locale]/favorites/alerts/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/favorites/alerts/page.tsx
@@ -1,0 +1,70 @@
+/**
+ * Price Alerts Page
+ *
+ * Dedicated price-alert subscription surface — lists price-change and
+ * back-on-market alerts for the user's favorited listings (Story 84.3).
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { ProtectedRoute } from '@/components/auth';
+import { PriceAlerts } from '@/components/favorites';
+import { Footer, Header } from '@/components/ui';
+
+export default function PriceAlertsPage() {
+  const t = useTranslations('priceAlerts');
+  return (
+    <div className="page-container">
+      <Header />
+      <main className="main">
+        <div className="container">
+          <nav className="breadcrumb">
+            <Link href="/favorites" className="crumb-link">
+              {t('backToFavorites')}
+            </Link>
+          </nav>
+          <h1 className="page-title">{t('h1')}</h1>
+          <p className="page-subtitle">{t('subtitle')}</p>
+          <ProtectedRoute>
+            <PriceAlerts />
+          </ProtectedRoute>
+        </div>
+      </main>
+      <Footer />
+
+      <style jsx>{`
+        .page-container {
+          min-height: 100vh;
+          display: flex;
+          flex-direction: column;
+          background: var(--ppt-bg-app);
+        }
+        .main { flex: 1; padding: 32px 0; }
+        .container {
+          max-width: 960px;
+          margin: 0 auto;
+          padding: 0 16px;
+        }
+        .breadcrumb { margin: 0 0 16px; }
+        .crumb-link {
+          font-size: 14px;
+          color: var(--ppt-fg-muted);
+          text-decoration: none;
+        }
+        .crumb-link:hover { text-decoration: underline; }
+        .page-title {
+          font-size: 2rem;
+          font-weight: bold;
+          color: var(--ppt-fg-primary);
+          margin: 0 0 8px;
+        }
+        .page-subtitle {
+          margin: 0 0 32px;
+          color: var(--ppt-fg-muted);
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/apps/reality-web/src/app/[locale]/favorites/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/favorites/page.tsx
@@ -202,7 +202,12 @@ export default function FavoritesPage() {
       <Header />
       <main className="main">
         <div className="container">
-          <h1 className="page-title">{t('h1')}</h1>
+          <div className="page-head">
+            <h1 className="page-title">{t('h1')}</h1>
+            <Link href="/favorites/alerts" className="alerts-link">
+              {t('priceAlertsLink')}
+            </Link>
+          </div>
           <ProtectedRoute>
             <FavoritesContent />
           </ProtectedRoute>
@@ -226,12 +231,31 @@ export default function FavoritesPage() {
           margin: 0 auto;
           padding: 0 16px;
         }
+        .page-head {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 16px;
+          flex-wrap: wrap;
+          margin: 0 0 32px;
+        }
         .page-title {
           font-size: 2rem;
           font-weight: bold;
           color: var(--ppt-fg-primary);
-          margin: 0 0 32px;
+          margin: 0;
         }
+        .alerts-link {
+          padding: 8px 16px;
+          background: var(--ppt-bg-surface);
+          border: 1px solid var(--ppt-border-default);
+          border-radius: 8px;
+          font-size: 14px;
+          font-weight: 600;
+          color: var(--ppt-fg-primary);
+          text-decoration: none;
+        }
+        .alerts-link:hover { background: var(--ppt-bg-app); }
       `}</style>
     </div>
   );

--- a/frontend/apps/reality-web/src/components/favorites/PriceAlerts.test.tsx
+++ b/frontend/apps/reality-web/src/components/favorites/PriceAlerts.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * PriceAlerts tests
+ *
+ * Regression guard for Story 84.3 (gap-84-3): before this surface existed
+ * there was no reality-web UI consuming the price-tracking feed at
+ * `GET /api/v1/favorites/alerts`. These tests pin that the dedicated
+ * price-alert surface fetches the canonical endpoint and renders the
+ * price-change alerts it returns.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PriceAlerts } from './PriceAlerts';
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const priceChangeAlert = {
+  id: 'alert-1',
+  favorite_id: 'fav-1',
+  listing_id: 'listing-1',
+  title: 'Sunny 2-bedroom apartment',
+  alert_type: 'price_change',
+  old_price: 200000,
+  new_price: 180000,
+  currency: 'EUR',
+  change_percentage: -10,
+  previous_status: null,
+  new_status: null,
+  status: 'pending',
+  created_at: '2026-07-01T00:00:00Z',
+  processed_at: null,
+};
+
+describe('PriceAlerts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches the canonical favorites alerts endpoint and renders the alert', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        alerts: [priceChangeAlert],
+        unread_count: 1,
+        limit: 100,
+        offset: 0,
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderWithClient(<PriceAlerts />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    // Regression bar: the feed must be the canonical price-tracking endpoint.
+    expect(calledUrl).toMatch(/\/api\/v1\/favorites\/alerts\?/);
+
+    await waitFor(() => expect(screen.getByText('Sunny 2-bedroom apartment')).toBeInTheDocument());
+    // Unread alert exposes a mark-read control.
+    expect(screen.getByRole('button', { name: 'markRead' })).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no alerts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ alerts: [], unread_count: 0, limit: 100, offset: 0 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderWithClient(<PriceAlerts />);
+
+    await waitFor(() => expect(screen.getByText('emptyTitle')).toBeInTheDocument());
+  });
+});

--- a/frontend/apps/reality-web/src/components/favorites/PriceAlerts.tsx
+++ b/frontend/apps/reality-web/src/components/favorites/PriceAlerts.tsx
@@ -1,0 +1,283 @@
+/**
+ * PriceAlerts
+ *
+ * Dedicated price-alert subscription surface for the Reality Portal
+ * (Story 84.3 — Price Tracking for Favorites). Consumes the existing
+ * reality-server price-tracking feed at `GET /api/v1/favorites/alerts`
+ * (populated by the `FavoriteAlertWorker`) and lets the user read /
+ * dismiss price-change and back-on-market alerts on favorited listings.
+ */
+
+'use client';
+
+import {
+  type FavoriteAlert,
+  useFavoriteAlerts,
+  useMarkAllFavoriteAlertsRead,
+  useMarkFavoriteAlertRead,
+} from '@ppt/reality-api-client';
+import Link from 'next/link';
+import { useLocale, useTranslations } from 'next-intl';
+import { formatPrice } from '@/lib/format';
+
+const UNREAD_STATUS = 'pending';
+
+function isUnread(alert: FavoriteAlert): boolean {
+  return alert.status === UNREAD_STATUS;
+}
+
+/** Price alert direction — drop is the actionable case buyers care about. */
+function priceDirection(alert: FavoriteAlert): 'drop' | 'increase' | null {
+  if (alert.old_price == null || alert.new_price == null) return null;
+  if (alert.new_price < alert.old_price) return 'drop';
+  if (alert.new_price > alert.old_price) return 'increase';
+  return null;
+}
+
+function AlertBody({ alert, locale }: { alert: FavoriteAlert; locale: string }) {
+  const t = useTranslations('priceAlerts');
+  const currency = alert.currency ?? 'EUR';
+
+  if (alert.alert_type === 'back_on_market') {
+    return <p className="alert-detail">{t('backOnMarket')}</p>;
+  }
+
+  const direction = priceDirection(alert);
+  const pct = alert.change_percentage;
+  const pctLabel =
+    pct != null
+      ? `${pct > 0 ? '+' : ''}${new Intl.NumberFormat(locale, {
+          maximumFractionDigits: 1,
+        }).format(pct)}%`
+      : null;
+
+  return (
+    <p className="alert-detail">
+      {alert.old_price != null && alert.new_price != null ? (
+        <>
+          <span className="old-price">{formatPrice(alert.old_price, locale, { currency })}</span>
+          <span aria-hidden="true" className="arrow">
+            →
+          </span>
+          <span className={`new-price ${direction ?? ''}`}>
+            {formatPrice(alert.new_price, locale, { currency })}
+          </span>
+        </>
+      ) : (
+        <span>{t('priceChanged')}</span>
+      )}
+      {pctLabel && direction && (
+        <span className={`pct ${direction}`}>
+          {direction === 'drop' ? t('drop', { pct: pctLabel }) : t('increase', { pct: pctLabel })}
+        </span>
+      )}
+    </p>
+  );
+}
+
+export function PriceAlerts() {
+  const t = useTranslations('priceAlerts');
+  const locale = useLocale();
+  const { data, isLoading, error } = useFavoriteAlerts();
+  const markRead = useMarkFavoriteAlertRead();
+  const markAllRead = useMarkAllFavoriteAlertsRead();
+
+  if (isLoading) {
+    return (
+      <div className="alerts-list loading">
+        {[1, 2, 3].map((i) => (
+          <div key={`alert-skeleton-${i}`} className="skeleton-row" />
+        ))}
+        <style jsx>{`
+          .alerts-list { display: flex; flex-direction: column; gap: 12px; }
+          .skeleton-row {
+            height: 84px;
+            background: var(--ppt-border-default);
+            border-radius: 12px;
+            animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+          }
+          @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
+        `}</style>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="error-state" role="alert">
+        <p>{t('loadError')}</p>
+        <style jsx>{`
+          .error-state {
+            padding: 48px 24px;
+            text-align: center;
+            color: var(--ppt-color-danger-hover);
+          }
+        `}</style>
+      </div>
+    );
+  }
+
+  const alerts = data?.alerts ?? [];
+  const unreadCount = data?.unread_count ?? 0;
+
+  if (alerts.length === 0) {
+    return (
+      <div className="empty-state">
+        <h2 className="empty-title">{t('emptyTitle')}</h2>
+        <p className="empty-text">{t('emptyText')}</p>
+        <Link href="/favorites" className="browse-link">
+          {t('goToFavorites')}
+        </Link>
+        <style jsx>{`
+          .empty-state {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 64px 24px;
+            text-align: center;
+            color: var(--ppt-fg-muted);
+          }
+          .empty-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: var(--ppt-fg-primary);
+            margin: 0 0 8px;
+          }
+          .empty-text { margin: 0 0 24px; max-width: 400px; }
+          .browse-link {
+            padding: 12px 24px;
+            background: var(--ppt-color-primary);
+            color: var(--ppt-fg-on-accent);
+            text-decoration: none;
+            border-radius: 8px;
+            font-weight: 600;
+          }
+          .browse-link:hover { background: var(--ppt-color-primary-hover); }
+        `}</style>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="toolbar">
+        <span className="unread-badge">{t('unread', { count: unreadCount })}</span>
+        <button
+          type="button"
+          className="mark-all"
+          disabled={unreadCount === 0 || markAllRead.isPending}
+          onClick={() => markAllRead.mutate()}
+        >
+          {t('markAllRead')}
+        </button>
+      </div>
+
+      <ul className="alerts-list">
+        {alerts.map((alert) => (
+          <li key={alert.id} className={`alert-row ${isUnread(alert) ? 'is-unread' : ''}`}>
+            <div className="alert-main">
+              <Link href={`/listings/${alert.listing_id}`} className="alert-title">
+                {alert.title}
+              </Link>
+              <AlertBody alert={alert} locale={locale} />
+            </div>
+            {isUnread(alert) && (
+              <button
+                type="button"
+                className="mark-read"
+                disabled={markRead.isPending}
+                onClick={() => markRead.mutate(alert.id)}
+              >
+                {t('markRead')}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <style jsx>{`
+        .toolbar {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 16px;
+          margin-bottom: 20px;
+        }
+        .unread-badge {
+          font-size: 14px;
+          font-weight: 600;
+          color: var(--ppt-fg-muted);
+        }
+        .mark-all {
+          padding: 8px 16px;
+          background: var(--ppt-bg-surface);
+          border: 1px solid var(--ppt-border-default);
+          border-radius: 8px;
+          font-size: 14px;
+          cursor: pointer;
+        }
+        .mark-all:disabled { opacity: 0.5; cursor: not-allowed; }
+        .mark-all:hover:not(:disabled) { background: var(--ppt-bg-app); }
+        .alerts-list {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+        }
+        .alert-row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 16px;
+          padding: 16px;
+          background: var(--ppt-bg-surface);
+          border: 1px solid var(--ppt-border-default);
+          border-radius: 12px;
+        }
+        .alert-row.is-unread {
+          border-left: 3px solid var(--ppt-color-primary);
+        }
+        .alert-main { min-width: 0; }
+        .alert-title {
+          font-weight: 600;
+          color: var(--ppt-fg-primary);
+          text-decoration: none;
+        }
+        .alert-title:hover { text-decoration: underline; }
+        .mark-read {
+          flex-shrink: 0;
+          padding: 6px 12px;
+          background: transparent;
+          border: 1px solid var(--ppt-border-default);
+          border-radius: 8px;
+          font-size: 13px;
+          cursor: pointer;
+          color: var(--ppt-fg-muted);
+        }
+        .mark-read:disabled { opacity: 0.5; cursor: not-allowed; }
+        .mark-read:hover:not(:disabled) { background: var(--ppt-bg-app); }
+      `}</style>
+      <style jsx global>{`
+        .alert-detail {
+          margin: 4px 0 0;
+          display: flex;
+          flex-wrap: wrap;
+          align-items: baseline;
+          gap: 8px;
+          font-size: 14px;
+          color: var(--ppt-fg-muted);
+        }
+        .alert-detail .old-price { text-decoration: line-through; }
+        .alert-detail .arrow { color: var(--ppt-fg-muted); }
+        .alert-detail .new-price { font-weight: 600; color: var(--ppt-fg-primary); }
+        .alert-detail .pct.drop,
+        .alert-detail .new-price.drop { color: var(--ppt-color-success, #16a34a); }
+        .alert-detail .pct.increase,
+        .alert-detail .new-price.increase { color: var(--ppt-color-danger-hover); }
+      `}</style>
+    </>
+  );
+}

--- a/frontend/apps/reality-web/src/components/favorites/index.ts
+++ b/frontend/apps/reality-web/src/components/favorites/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Favorites Components Index
+ *
+ * Favorite-listing surfaces for the Reality Portal.
+ */
+
+export { PriceAlerts } from './PriceAlerts';

--- a/frontend/apps/reality-web/src/lib/page-metadata.ts
+++ b/frontend/apps/reality-web/src/lib/page-metadata.ts
@@ -80,6 +80,7 @@ function pagePathForKey(key: string): string {
     resetPassword: '/auth/reset-password',
     login: '/auth/login',
     register: '/auth/register',
+    priceAlerts: '/favorites/alerts',
   };
   return overrides[key] ?? `/${key.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`)}`;
 }
@@ -91,6 +92,7 @@ const PRIVATE_KEYS = new Set([
   'forgotPassword',
   'resetPassword',
   'favorites',
+  'priceAlerts',
   'inquiries',
   'profile',
 ]);

--- a/frontend/packages/reality-api-client/src/favorites/hooks.ts
+++ b/frontend/packages/reality-api-client/src/favorites/hooks.ts
@@ -11,6 +11,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getApiBase } from '../config';
 import type {
   CreateSavedSearchRequest,
+  FavoriteAlertsResponse,
+  MarkAllFavoriteAlertsReadResponse,
   PaginatedFavorites,
   SavedSearch,
   UpdateSavedSearchRequest,
@@ -91,6 +93,72 @@ export function useRemoveFavorite() {
       queryClient.invalidateQueries({ queryKey: ['favorites'] });
       queryClient.invalidateQueries({ queryKey: ['favorite-ids'] });
       queryClient.invalidateQueries({ queryKey: ['listings'] });
+    },
+  });
+}
+
+// Favorite Price-Alert Hooks (Story 84.3)
+
+const FAVORITE_ALERTS_KEY = ['favorite-alerts'] as const;
+
+/**
+ * Fetch the authenticated user's favorite price / status alerts (newest first).
+ *
+ * Consumes `GET /api/v1/favorites/alerts` — the price-tracking feed populated
+ * by reality-server's `FavoriteAlertWorker`. `unread_count` reflects alerts
+ * still in `pending` status.
+ */
+export function useFavoriteAlerts(limit = 100, offset = 0) {
+  return useQuery({
+    queryKey: [...FAVORITE_ALERTS_KEY, limit, offset],
+    queryFn: async (): Promise<FavoriteAlertsResponse> => {
+      const params = new URLSearchParams();
+      params.set('limit', String(limit));
+      params.set('offset', String(offset));
+
+      const response = await fetch(`${getApiBase()}/api/v1/favorites/alerts?${params}`, {
+        credentials: 'include',
+      });
+      if (!response.ok) throw new Error('Failed to fetch favorite alerts');
+      return response.json();
+    },
+    staleTime: 30 * 1000,
+  });
+}
+
+/** Mark a single favorite alert as read (idempotent server-side). */
+export function useMarkFavoriteAlertRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (alertId: string): Promise<void> => {
+      const response = await fetch(`${getApiBase()}/api/v1/favorites/alerts/${alertId}/read`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!response.ok) throw new Error('Failed to mark favorite alert read');
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: FAVORITE_ALERTS_KEY });
+    },
+  });
+}
+
+/** Mark every pending favorite alert as read. */
+export function useMarkAllFavoriteAlertsRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (): Promise<MarkAllFavoriteAlertsReadResponse> => {
+      const response = await fetch(`${getApiBase()}/api/v1/favorites/alerts/read-all`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!response.ok) throw new Error('Failed to mark all favorite alerts read');
+      return response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: FAVORITE_ALERTS_KEY });
     },
   });
 }

--- a/frontend/packages/reality-api-client/src/favorites/types.ts
+++ b/frontend/packages/reality-api-client/src/favorites/types.ts
@@ -52,3 +52,47 @@ export interface PaginatedFavorites {
   pageSize: number;
   totalPages: number;
 }
+
+// ============================================
+// Favorite price / status alerts (Story 84.3)
+// ============================================
+
+/**
+ * A single queued favorite alert, as delivered by
+ * `GET /api/v1/favorites/alerts`.
+ *
+ * Field names mirror the reality-server `FavoriteAlert` DTO verbatim
+ * (snake_case on the wire — that DTO has no `rename_all = "camelCase"`),
+ * so this interface is the runtime-accurate shape of the response.
+ */
+export interface FavoriteAlert {
+  id: string;
+  favorite_id: string;
+  listing_id: string;
+  title: string;
+  /** `price_change` (price drop/increase) or `back_on_market`. */
+  alert_type: string;
+  old_price?: number | null;
+  new_price?: number | null;
+  currency?: string | null;
+  change_percentage?: number | null;
+  previous_status?: string | null;
+  new_status?: string | null;
+  /** `pending` (unread) or `sent` (read). */
+  status: string;
+  created_at: string;
+  processed_at?: string | null;
+}
+
+/** Response of `GET /api/v1/favorites/alerts`. */
+export interface FavoriteAlertsResponse {
+  alerts: FavoriteAlert[];
+  unread_count: number;
+  limit: number;
+  offset: number;
+}
+
+/** Response of `POST /api/v1/favorites/alerts/read-all`. */
+export interface MarkAllFavoriteAlertsReadResponse {
+  marked_read: number;
+}


### PR DESCRIPTION
## Task
No dedicated price-alert subscription UI in reality-web (84-3-price-tracking Price Tracking for Favorites). Build a price-alert subscription UI surface in reality-web that lets a user subscribe to price changes on favorited listings, consuming the existing price-tracking backend. Scope to reality-web frontend.

## Owner
pm-backend (nominal) — but this is a reality-web frontend surface; implemented by the `nextjs-web`/`react` specialist as the task itself anticipated.

## What shipped
- New dedicated **Price Alerts** page at `/[locale]/favorites/alerts` (`page.tsx` + `layout.tsx` metadata) rendering the `PriceAlerts` component.
- `PriceAlerts` component (`components/favorites/PriceAlerts.tsx`) consuming the existing reality-server price-tracking feed `GET /api/v1/favorites/alerts` (populated by `FavoriteAlertWorker`): lists price-change (old→new price, signed %, drop/increase styling) and back-on-market alerts, with per-alert **Mark read** and **Mark all read**, unread badge, loading/empty/error states.
- New `@ppt/reality-api-client` hooks + types: `useFavoriteAlerts`, `useMarkFavoriteAlertRead`, `useMarkAllFavoriteAlertsRead`, and `FavoriteAlert` / `FavoriteAlertsResponse` / `MarkAllFavoriteAlertsReadResponse` (typed to the backend's snake_case wire shape — that DTO has no `rename_all`).
- Entry point link from the Favorites page; canonical-path override + `noindex` for the new route in `page-metadata.ts`.
- i18n keys (`priceAlerts` namespace + `pages.priceAlerts` + `pages.favorites.priceAlertsLink`) across all 6 locales (en, sk, cs, de, pl, hu).
- Regression test `PriceAlerts.test.tsx` (2 tests): pins the canonical `/api/v1/favorites/alerts` fetch + render, and the empty state.

## Tested (Band A — fast check)
- `pnpm -F reality-web typecheck` → exit 0
- `biome check` on all changed paths → exit 0 (autofixed formatting)
- `pnpm -F reality-web test -- --run src/components/favorites/PriceAlerts.test.tsx` → 2 passed
- `pnpm -F @ppt/reality-api-client build` (tsc) → exit 0

> Note: repo's `reality-web` `lint` script (`next lint`) is broken in this Next 16 setup; CI lints via Biome (`biome check`), which is green here.

## Built (Band B — full build)
- `pnpm -F reality-web build` → success; new route `ƒ /[locale]/favorites/alerts` registered, no SSR/i18n key drift.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
`scope-check.sh --owner pm-backend` reports drift (exit 2): all changed paths are under `frontend/` (reality-web app + reality-api-client + messages). This is expected — the task was filed under `owner_role=pm-backend` but is explicitly a reality-web frontend surface. No backend files touched.

## Code-reuse review
`reuse-grep.sh` emitted two heuristic false positives from truncated hook-name prefixes:
- `WARN: useF ... favorites/hooks.ts` — matches existing `useFavorites`; the new `useFavoriteAlerts` is distinct.
- `WARN: useM ... favorites/hooks.ts` — no prior `useMark*` hook existed; the new mark-read hooks are new.

## Notes
- The per-favorite opt-in toggle (`price_alert_enabled`) has a backend handler (`FavoritesHandler::update_favorite`) but **no HTTP route** wired in `routes/favorites.rs` (no PATCH/PUT). Per task guidance ("wire to whatever price-tracking API exists; do not expand into backend work"), this PR consumes the fully-wired alerts feed instead. A follow-up backend task should expose a `PATCH /api/v1/favorites/{listing_id}` route so the UI can add an explicit subscribe/unsubscribe toggle per favorite (AC-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPM5sCMGCGLFEBCNvanapx

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPM5sCMGCGLFEBCNvanapx)_