### PR TITLE
gap-84-3-no-mobile-native-price-tracking-surface: mobile-native price-tracking surface for favorites

### DIFF
--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
@@ -85,6 +85,83 @@ data class AddFavoriteResponse(
     @SerialName("created_at") val createdAt: String,
 )
 
+// ============================================
+// Price-tracking alerts (favorites) — gap-84-3
+// ============================================
+
+/**
+ * A single favorite alert as returned by `GET /api/v1/favorites/alerts`.
+ *
+ * Mirrors the reality-server `FavoriteAlert` DTO (see
+ * `backend/crates/db/src/models/reality_portal.rs`). These are the in-app
+ * delivery view of the price-tracking pipeline: the `FavoriteAlertWorker`
+ * enqueues a row whenever a favorited listing's price (or status) changes, and
+ * this feed is how the mobile Price-Tracking surface retrieves them.
+ *
+ * Wire notes:
+ * - `alert_type` is `"price_change"` or `"status_change"`. Use [isPriceChange].
+ * - Monetary fields (`old_price` / `new_price`) are whole-currency numbers on
+ *   the wire — mapped to `Long?` to match the rest of the portal models
+ *   ([FavoriteEntry.currentPrice], `ListingSummary.price`). They are `null` for
+ *   status-only alerts.
+ * - `change_percentage` is a signed fractional number (negative = price drop),
+ *   mapped to `Double?` to match [FavoriteEntry.priceChangePercentage].
+ * - `status` is the delivery state: `"pending"` (unread) | `"sent"` (read) |
+ *   `"failed"`. Use [isUnread].
+ */
+@Serializable
+data class FavoriteAlert(
+    val id: String,
+    @SerialName("favorite_id") val favoriteId: String,
+    @SerialName("listing_id") val listingId: String,
+    val title: String,
+    @SerialName("alert_type") val alertType: String,
+    @SerialName("old_price") val oldPrice: Long? = null,
+    @SerialName("new_price") val newPrice: Long? = null,
+    val currency: String? = null,
+    @SerialName("change_percentage") val changePercentage: Double? = null,
+    @SerialName("previous_status") val previousStatus: String? = null,
+    @SerialName("new_status") val newStatus: String? = null,
+    val status: String,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("processed_at") val processedAt: String? = null,
+) {
+    /** True when this alert reports a price movement (vs a listing-status change). */
+    val isPriceChange: Boolean
+        get() = alertType == "price_change"
+
+    /** True while the alert is still pending in-app delivery (i.e. unread). */
+    val isUnread: Boolean
+        get() = status == "pending"
+
+    /** True when the price moved down (a drop) — only meaningful for price alerts. */
+    val isPriceDrop: Boolean
+        get() = isPriceChange && (changePercentage ?: 0.0) < 0.0
+}
+
+/**
+ * Response body for `GET /api/v1/favorites/alerts`.
+ *
+ * Mirrors the reality-server `FavoriteAlertsResponse`: the newest-first page of
+ * alerts plus the total unread count (independent of the page window) and the
+ * echoed `limit` / `offset`.
+ */
+@Serializable
+data class FavoriteAlertsResponse(
+    val alerts: List<FavoriteAlert> = emptyList(),
+    @SerialName("unread_count") val unreadCount: Long = 0,
+    val limit: Long = 0,
+    val offset: Long = 0,
+)
+
+/**
+ * Response body for `POST /api/v1/favorites/alerts/read-all`.
+ *
+ * Mirrors the reality-server `MarkAllFavoriteAlertsReadResponse`.
+ */
+@Serializable
+data class MarkAllFavoriteAlertsReadResponse(@SerialName("marked_read") val markedRead: Long = 0)
+
 /** Saved search. */
 @Serializable
 data class SavedSearch(

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModels.kt
@@ -93,21 +93,19 @@ data class AddFavoriteResponse(
  * A single favorite alert as returned by `GET /api/v1/favorites/alerts`.
  *
  * Mirrors the reality-server `FavoriteAlert` DTO (see
- * `backend/crates/db/src/models/reality_portal.rs`). These are the in-app
- * delivery view of the price-tracking pipeline: the `FavoriteAlertWorker`
- * enqueues a row whenever a favorited listing's price (or status) changes, and
- * this feed is how the mobile Price-Tracking surface retrieves them.
+ * `backend/crates/db/src/models/reality_portal.rs`). These are the in-app delivery view of the
+ * price-tracking pipeline: the `FavoriteAlertWorker` enqueues a row whenever a favorited listing's
+ * price (or status) changes, and this feed is how the mobile Price-Tracking surface retrieves them.
  *
  * Wire notes:
  * - `alert_type` is `"price_change"` or `"status_change"`. Use [isPriceChange].
- * - Monetary fields (`old_price` / `new_price`) are whole-currency numbers on
- *   the wire — mapped to `Long?` to match the rest of the portal models
- *   ([FavoriteEntry.currentPrice], `ListingSummary.price`). They are `null` for
- *   status-only alerts.
- * - `change_percentage` is a signed fractional number (negative = price drop),
- *   mapped to `Double?` to match [FavoriteEntry.priceChangePercentage].
- * - `status` is the delivery state: `"pending"` (unread) | `"sent"` (read) |
- *   `"failed"`. Use [isUnread].
+ * - Monetary fields (`old_price` / `new_price`) are whole-currency numbers on the wire — mapped to
+ *   `Long?` to match the rest of the portal models ([FavoriteEntry.currentPrice],
+ *   `ListingSummary.price`). They are `null` for status-only alerts.
+ * - `change_percentage` is a signed fractional number (negative = price drop), mapped to `Double?`
+ *   to match [FavoriteEntry.priceChangePercentage].
+ * - `status` is the delivery state: `"pending"` (unread) | `"sent"` (read) | `"failed"`. Use
+ *   [isUnread].
  */
 @Serializable
 data class FavoriteAlert(
@@ -142,9 +140,8 @@ data class FavoriteAlert(
 /**
  * Response body for `GET /api/v1/favorites/alerts`.
  *
- * Mirrors the reality-server `FavoriteAlertsResponse`: the newest-first page of
- * alerts plus the total unread count (independent of the page window) and the
- * echoed `limit` / `offset`.
+ * Mirrors the reality-server `FavoriteAlertsResponse`: the newest-first page of alerts plus the
+ * total unread count (independent of the page window) and the echoed `limit` / `offset`.
  */
 @Serializable
 data class FavoriteAlertsResponse(

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
@@ -133,12 +133,15 @@ class FavoritesRepository(
     /**
      * Fetch the authenticated user's favorite price-tracking alerts (newest first).
      *
-     * Endpoint: `GET /api/v1/favorites/alerts?limit&offset`. The server clamps `limit` to
-     * `[1, 200]` and floors `offset` at 0, and returns the page plus the total `unread_count`
+     * Endpoint: `GET /api/v1/favorites/alerts?limit&offset`. The server clamps `limit` to `[1,
+     * 200]` and floors `offset` at 0, and returns the page plus the total `unread_count`
      * (independent of the page window). Requires auth — unauthenticated callers get a 401 which is
      * surfaced as a [FavoritesException] so the UI can prompt sign-in.
      */
-    suspend fun getFavoriteAlerts(limit: Int = 100, offset: Int = 0): Result<FavoriteAlertsResponse> {
+    suspend fun getFavoriteAlerts(
+        limit: Int = 100,
+        offset: Int = 0,
+    ): Result<FavoriteAlertsResponse> {
         return try {
             val response =
                 client.get("$baseUrl/api/v1/favorites/alerts") {
@@ -152,7 +155,9 @@ class FavoritesRepository(
             } else if (response.status == HttpStatusCode.Unauthorized) {
                 Result.failure(FavoritesException("Please sign in to view price alerts"))
             } else {
-                Result.failure(FavoritesException("Failed to load price alerts: ${response.status}"))
+                Result.failure(
+                    FavoritesException("Failed to load price alerts: ${response.status}")
+                )
             }
         } catch (e: Exception) {
             Result.failure(e)
@@ -169,9 +174,7 @@ class FavoritesRepository(
     suspend fun markFavoriteAlertRead(alertId: String): Result<Unit> {
         return try {
             val response =
-                client.post(
-                    "$baseUrl/api/v1/favorites/alerts/${alertId.asPathSegment()}/read"
-                ) {
+                client.post("$baseUrl/api/v1/favorites/alerts/${alertId.asPathSegment()}/read") {
                     configureRequest()
                 }
 

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/FavoritesRepository.kt
@@ -128,6 +128,91 @@ class FavoritesRepository(
         }
     }
 
+    // --- Price-tracking alerts (gap-84-3) ---
+
+    /**
+     * Fetch the authenticated user's favorite price-tracking alerts (newest first).
+     *
+     * Endpoint: `GET /api/v1/favorites/alerts?limit&offset`. The server clamps `limit` to
+     * `[1, 200]` and floors `offset` at 0, and returns the page plus the total `unread_count`
+     * (independent of the page window). Requires auth — unauthenticated callers get a 401 which is
+     * surfaced as a [FavoritesException] so the UI can prompt sign-in.
+     */
+    suspend fun getFavoriteAlerts(limit: Int = 100, offset: Int = 0): Result<FavoriteAlertsResponse> {
+        return try {
+            val response =
+                client.get("$baseUrl/api/v1/favorites/alerts") {
+                    configureRequest()
+                    parameter("limit", limit)
+                    parameter("offset", offset)
+                }
+
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else if (response.status == HttpStatusCode.Unauthorized) {
+                Result.failure(FavoritesException("Please sign in to view price alerts"))
+            } else {
+                Result.failure(FavoritesException("Failed to load price alerts: ${response.status}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Mark a single favorite alert as read.
+     *
+     * Endpoint: `POST /api/v1/favorites/alerts/{alert_id}/read`. Idempotent on the server — an
+     * already-read alert still returns 204 — so a 2xx is the only success signal. A 404 means the
+     * alert doesn't exist or isn't owned by the caller.
+     */
+    suspend fun markFavoriteAlertRead(alertId: String): Result<Unit> {
+        return try {
+            val response =
+                client.post(
+                    "$baseUrl/api/v1/favorites/alerts/${alertId.asPathSegment()}/read"
+                ) {
+                    configureRequest()
+                }
+
+            if (response.status.isSuccess()) {
+                Result.success(Unit)
+            } else if (response.status == HttpStatusCode.Unauthorized) {
+                Result.failure(FavoritesException("Please sign in to manage price alerts"))
+            } else if (response.status == HttpStatusCode.NotFound) {
+                Result.failure(FavoritesException("Alert not found"))
+            } else {
+                Result.failure(FavoritesException("Failed to mark alert read: ${response.status}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Mark all of the authenticated user's pending favorite alerts as read.
+     *
+     * Endpoint: `POST /api/v1/favorites/alerts/read-all`. Returns the count that were flipped.
+     */
+    suspend fun markAllFavoriteAlertsRead(): Result<MarkAllFavoriteAlertsReadResponse> {
+        return try {
+            val response =
+                client.post("$baseUrl/api/v1/favorites/alerts/read-all") { configureRequest() }
+
+            if (response.status.isSuccess()) {
+                Result.success(response.body())
+            } else if (response.status == HttpStatusCode.Unauthorized) {
+                Result.failure(FavoritesException("Please sign in to manage price alerts"))
+            } else {
+                Result.failure(
+                    FavoritesException("Failed to mark all alerts read: ${response.status}")
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     // --- Saved Searches ---
 
     /** Get user's saved searches. */

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModel.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModel.kt
@@ -10,11 +10,10 @@ import kotlinx.coroutines.launch
 /**
  * Immutable UI state for the Price-Tracking surface.
  *
- * The screen renders two things off this single value: the user's favorited
- * listings annotated with their price movement (so a card can show a "was
- * €X → now €Y" badge), and the reverse-chronological feed of price-change
- * alerts the server has queued for the user. Everything the Compose (Android)
- * or SwiftUI (iOS) surface needs is derived here so the screen stays a pure
+ * The screen renders two things off this single value: the user's favorited listings annotated with
+ * their price movement (so a card can show a "was €X → now €Y" badge), and the
+ * reverse-chronological feed of price-change alerts the server has queued for the user. Everything
+ * the Compose (Android) or SwiftUI (iOS) surface needs is derived here so the screen stays a pure
  * `collectAsState()` render + intent wiring — mirroring [ListingDetailUiState].
  */
 data class PriceTrackingUiState(
@@ -53,9 +52,9 @@ data class PriceTrackingUiState(
  * price tracking on favorited listings (gap-84-3).
  *
  * It loads the user's favorites (each embeds `price_changed` / `price_change_percentage` /
- * `price_alert_enabled`) together with the queued favorite-alert feed
- * (`GET /api/v1/favorites/alerts`), and owns the optimistic mark-read / mark-all-read writes
- * (`POST /api/v1/favorites/alerts/{id}/read`, `.../read-all`).
+ * `price_alert_enabled`) together with the queued favorite-alert feed (`GET
+ * /api/v1/favorites/alerts`), and owns the optimistic mark-read / mark-all-read writes (`POST
+ * /api/v1/favorites/alerts/{id}/read`, `.../read-all`).
  *
  * Like [ListingDetailViewModel] it is a plain, framework-agnostic state-holder (no
  * `androidx.lifecycle` / Android types) so it lives in `commonMain`, is unit-testable off a
@@ -64,8 +63,8 @@ data class PriceTrackingUiState(
  * token, so it is rebuilt (not the whole view-model) on a session change — see [updateAuth].
  *
  * @param favoritesRepositoryFactory builds a [FavoritesRepository] carrying the given session
- *   token. Held as a factory so [updateAuth] can rebuild the auth-scoped repository on
- *   login/logout without re-creating the view-model.
+ *   token. Held as a factory so [updateAuth] can rebuild the auth-scoped repository on login/logout
+ *   without re-creating the view-model.
  * @param scope the coroutine scope loads/writes launch into (a `rememberCoroutineScope()` on
  *   Android; the `TestScope` from `runTest` in tests).
  * @param initialSessionToken the session token at construction time (`null` == unauthenticated).
@@ -170,7 +169,8 @@ class PriceTrackingViewModel(
     /**
      * Optimistically mark a single alert read: flip it to `sent` and decrement the unread count
      * immediately, then reconcile with the server. On failure the change rolls back so the badge
-     * never lies. No-op when unauthenticated, when the alert is unknown, or when it is already read.
+     * never lies. No-op when unauthenticated, when the alert is unknown, or when it is already
+     * read.
      */
     fun onMarkAlertRead(alertId: String) {
         if (currentSessionToken == null) return
@@ -195,7 +195,11 @@ class PriceTrackingViewModel(
             if (currentSessionToken != tokenAtLaunch) return@launch
             _state.update {
                 if (result.isFailure) {
-                    it.copy(alerts = previousAlerts, unreadCount = previousUnread, isMutating = false)
+                    it.copy(
+                        alerts = previousAlerts,
+                        unreadCount = previousUnread,
+                        isMutating = false,
+                    )
                 } else {
                     it.copy(isMutating = false)
                 }

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModel.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModel.kt
@@ -1,0 +1,257 @@
+package three.two.bit.ppt.reality.favorites
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Immutable UI state for the Price-Tracking surface.
+ *
+ * The screen renders two things off this single value: the user's favorited
+ * listings annotated with their price movement (so a card can show a "was
+ * €X → now €Y" badge), and the reverse-chronological feed of price-change
+ * alerts the server has queued for the user. Everything the Compose (Android)
+ * or SwiftUI (iOS) surface needs is derived here so the screen stays a pure
+ * `collectAsState()` render + intent wiring — mirroring [ListingDetailUiState].
+ */
+data class PriceTrackingUiState(
+    val isLoading: Boolean = true,
+    val errorMessage: String? = null,
+    /** `false` once we learn there is no session — favorites/alerts require auth. */
+    val isAuthenticated: Boolean = true,
+    /** All favorites (each carries the embedded flat listing summary + price fields). */
+    val favorites: List<FavoriteEntry> = emptyList(),
+    /** Newest-first feed of favorite price/status alerts. */
+    val alerts: List<FavoriteAlert> = emptyList(),
+    /** Total pending (unread) alerts, independent of the loaded page window. */
+    val unreadCount: Long = 0,
+    /** True while a mark-read / mark-all-read write is in flight. */
+    val isMutating: Boolean = false,
+) {
+    /** Favorites whose price moved since they were saved — the price-tracking highlights. */
+    val priceChangedFavorites: List<FavoriteEntry>
+        get() = favorites.filter { it.priceChanged }
+
+    /** How many favorites have price-drop alerts armed. */
+    val priceAlertEnabledCount: Int
+        get() = favorites.count { it.priceAlertEnabled }
+
+    /** The alert feed narrowed to price movements (drops/rises), excluding status-only alerts. */
+    val priceAlerts: List<FavoriteAlert>
+        get() = alerts.filter { it.isPriceChange }
+
+    /** True when there is nothing to track and no alerts — drives the empty state. */
+    val isEmpty: Boolean
+        get() = favorites.isEmpty() && alerts.isEmpty()
+}
+
+/**
+ * State-holder / view-model for the Reality-portal Price-Tracking screen — the mobile surface for
+ * price tracking on favorited listings (gap-84-3).
+ *
+ * It loads the user's favorites (each embeds `price_changed` / `price_change_percentage` /
+ * `price_alert_enabled`) together with the queued favorite-alert feed
+ * (`GET /api/v1/favorites/alerts`), and owns the optimistic mark-read / mark-all-read writes
+ * (`POST /api/v1/favorites/alerts/{id}/read`, `.../read-all`).
+ *
+ * Like [ListingDetailViewModel] it is a plain, framework-agnostic state-holder (no
+ * `androidx.lifecycle` / Android types) so it lives in `commonMain`, is unit-testable off a
+ * `TestScope`, and is reused as-is by the iOS target. DI is by constructor injection; [create]
+ * keeps repository construction out of the UI layer. The favorites repository carries the bearer
+ * token, so it is rebuilt (not the whole view-model) on a session change — see [updateAuth].
+ *
+ * @param favoritesRepositoryFactory builds a [FavoritesRepository] carrying the given session
+ *   token. Held as a factory so [updateAuth] can rebuild the auth-scoped repository on
+ *   login/logout without re-creating the view-model.
+ * @param scope the coroutine scope loads/writes launch into (a `rememberCoroutineScope()` on
+ *   Android; the `TestScope` from `runTest` in tests).
+ * @param initialSessionToken the session token at construction time (`null` == unauthenticated).
+ * @param errorMapper maps a caught [Throwable] to a user-facing message — injected because the
+ *   Android strings come from `stringResource(...)`, unreachable from `commonMain`.
+ * @param alertsPageLimit page size requested from `GET /api/v1/favorites/alerts` (server clamps to
+ *   `[1, 200]`).
+ */
+class PriceTrackingViewModel(
+    private val favoritesRepositoryFactory: (sessionToken: String?) -> FavoritesRepository,
+    private val scope: CoroutineScope,
+    initialSessionToken: String?,
+    private val errorMapper: (Throwable) -> String,
+    private val alertsPageLimit: Int = 100,
+) {
+    private val _state =
+        MutableStateFlow(PriceTrackingUiState(isAuthenticated = initialSessionToken != null))
+    val state: StateFlow<PriceTrackingUiState> = _state.asStateFlow()
+
+    private var currentSessionToken: String? = initialSessionToken
+    private var favoritesRepository: FavoritesRepository =
+        favoritesRepositoryFactory(initialSessionToken)
+
+    private var started = false
+
+    /**
+     * Kick off the initial load. Idempotent per instance so it can be safely driven from a
+     * `LaunchedEffect(viewModel)`.
+     */
+    fun start() {
+        if (started) return
+        started = true
+        load()
+    }
+
+    /** Pull-to-refresh: reload favorites + alerts. */
+    fun refresh() = load()
+
+    /** Retry after a failed load. */
+    fun retry() = load()
+
+    private fun load() {
+        if (currentSessionToken == null) {
+            // Favorites/alerts require auth; render the signed-out empty state rather than firing
+            // requests that will only 401.
+            _state.update {
+                it.copy(
+                    isLoading = false,
+                    isAuthenticated = false,
+                    favorites = emptyList(),
+                    alerts = emptyList(),
+                    unreadCount = 0,
+                    errorMessage = null,
+                )
+            }
+            return
+        }
+        _state.update { it.copy(isLoading = true, errorMessage = null, isAuthenticated = true) }
+        val tokenAtLaunch = currentSessionToken
+        val repositoryAtLaunch = favoritesRepository
+        scope.launch {
+            val favoritesResult = repositoryAtLaunch.getFavorites()
+            val alertsResult = repositoryAtLaunch.getFavoriteAlerts(limit = alertsPageLimit)
+
+            // A session change mid-flight supersedes this load; don't clobber the new session.
+            if (currentSessionToken != tokenAtLaunch) return@launch
+
+            favoritesResult.fold(
+                onSuccess = { favorites ->
+                    // Favorites are the primary payload. Alerts are best-effort: a failure there
+                    // shouldn't blank the whole screen, so we keep whatever we last had.
+                    val alerts = alertsResult.getOrNull()
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = null,
+                            favorites = favorites.favorites,
+                            alerts = alerts?.alerts ?: it.alerts,
+                            unreadCount = alerts?.unreadCount ?: it.unreadCount,
+                        )
+                    }
+                },
+                onFailure = { e ->
+                    _state.update { it.copy(isLoading = false, errorMessage = errorMapper(e)) }
+                },
+            )
+        }
+    }
+
+    /**
+     * React to a session change (login / logout): rebuild the auth-scoped repository with the new
+     * token and reload. A no-op when the token is unchanged, so it is safe to drive from a
+     * `LaunchedEffect(sessionToken)` (which also fires on first composition).
+     */
+    fun updateAuth(sessionToken: String?) {
+        if (sessionToken == currentSessionToken) return
+        currentSessionToken = sessionToken
+        favoritesRepository = favoritesRepositoryFactory(sessionToken)
+        load()
+    }
+
+    /**
+     * Optimistically mark a single alert read: flip it to `sent` and decrement the unread count
+     * immediately, then reconcile with the server. On failure the change rolls back so the badge
+     * never lies. No-op when unauthenticated, when the alert is unknown, or when it is already read.
+     */
+    fun onMarkAlertRead(alertId: String) {
+        if (currentSessionToken == null) return
+        val current = _state.value
+        val target = current.alerts.firstOrNull { it.id == alertId } ?: return
+        if (!target.isUnread) return
+
+        val previousAlerts = current.alerts
+        val previousUnread = current.unreadCount
+        val tokenAtLaunch = currentSessionToken
+        val repositoryAtLaunch = favoritesRepository
+
+        _state.update {
+            it.copy(
+                alerts = it.alerts.map { a -> if (a.id == alertId) a.copy(status = "sent") else a },
+                unreadCount = (it.unreadCount - 1).coerceAtLeast(0L),
+                isMutating = true,
+            )
+        }
+        scope.launch {
+            val result = repositoryAtLaunch.markFavoriteAlertRead(alertId)
+            if (currentSessionToken != tokenAtLaunch) return@launch
+            _state.update {
+                if (result.isFailure) {
+                    it.copy(alerts = previousAlerts, unreadCount = previousUnread, isMutating = false)
+                } else {
+                    it.copy(isMutating = false)
+                }
+            }
+        }
+    }
+
+    /**
+     * Optimistically mark every pending alert read. On failure it reloads from the server rather
+     * than trying to reconstruct the prior per-alert state.
+     */
+    fun onMarkAllRead() {
+        if (currentSessionToken == null) return
+        val current = _state.value
+        if (current.unreadCount == 0L && current.alerts.none { it.isUnread }) return
+
+        val tokenAtLaunch = currentSessionToken
+        val repositoryAtLaunch = favoritesRepository
+
+        _state.update {
+            it.copy(
+                alerts = it.alerts.map { a -> if (a.isUnread) a.copy(status = "sent") else a },
+                unreadCount = 0,
+                isMutating = true,
+            )
+        }
+        scope.launch {
+            val result = repositoryAtLaunch.markAllFavoriteAlertsRead()
+            if (currentSessionToken != tokenAtLaunch) return@launch
+            if (result.isFailure) {
+                _state.update { it.copy(isMutating = false) }
+                load()
+            } else {
+                _state.update { it.copy(isMutating = false) }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Builds the view-model together with its [FavoritesRepository], keeping repository
+         * construction out of the UI layer. `sessionToken == null` is treated as unauthenticated.
+         */
+        fun create(
+            baseUrl: String,
+            sessionToken: String?,
+            scope: CoroutineScope,
+            errorMapper: (Throwable) -> String,
+        ): PriceTrackingViewModel =
+            PriceTrackingViewModel(
+                favoritesRepositoryFactory = { token ->
+                    FavoritesRepository(baseUrl = baseUrl, sessionToken = token)
+                },
+                scope = scope,
+                initialSessionToken = sessionToken,
+                errorMapper = errorMapper,
+            )
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoriteAlertsRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoriteAlertsRepositoryTest.kt
@@ -1,0 +1,144 @@
+package three.two.bit.ppt.reality.favorites
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Repository-level coroutine tests for the favorite price-tracking alert calls added in gap-84-3:
+ * [FavoritesRepository.getFavoriteAlerts], [FavoritesRepository.markFavoriteAlertRead] and
+ * [FavoritesRepository.markAllFavoriteAlertsRead].
+ *
+ * Pins the reality-server contract for `/api/v1/favorites/alerts*`:
+ * - the list endpoint returns `{alerts, unread_count, limit, offset}` (200);
+ * - `.../{id}/read` returns 204 (idempotent — already-read still 204);
+ * - `.../read-all` returns 200 `{marked_read}`;
+ * - 401 surfaces as a [FavoritesException] so the UI can prompt sign-in.
+ */
+class FavoriteAlertsRepositoryTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private fun repoWith(status: HttpStatusCode, body: String): FavoritesRepository {
+        val engine = MockEngine {
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return FavoritesRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    private val alertsBody =
+        """
+        {
+          "alerts": [
+            {
+              "id": "al-1",
+              "favorite_id": "fav-1",
+              "listing_id": "lst-1",
+              "title": "Bright 2br in Old Town",
+              "alert_type": "price_change",
+              "old_price": 200000,
+              "new_price": 185000,
+              "currency": "EUR",
+              "change_percentage": -7.5,
+              "status": "pending",
+              "created_at": "2026-07-10T10:00:00Z"
+            },
+            {
+              "id": "al-2",
+              "favorite_id": "fav-2",
+              "listing_id": "lst-2",
+              "title": "Studio near the river",
+              "alert_type": "status_change",
+              "previous_status": "active",
+              "new_status": "sold",
+              "status": "sent",
+              "created_at": "2026-07-09T09:00:00Z",
+              "processed_at": "2026-07-09T09:05:00Z"
+            }
+          ],
+          "unread_count": 1,
+          "limit": 100,
+          "offset": 0
+        }
+        """
+            .trimIndent()
+
+    @Test
+    fun getFavoriteAlerts_decodes_alerts_and_unread_count() = runTest {
+        val repo = repoWith(HttpStatusCode.OK, alertsBody)
+        val result = repo.getFavoriteAlerts()
+        assertTrue(result.isSuccess, "expected success, got $result")
+        val body = result.getOrNull()!!
+        assertEquals(2, body.alerts.size)
+        assertEquals(1L, body.unreadCount)
+
+        val price = body.alerts[0]
+        assertEquals("al-1", price.id)
+        assertTrue(price.isPriceChange, "al-1 is a price_change alert")
+        assertTrue(price.isUnread, "al-1 status is pending → unread")
+        assertTrue(price.isPriceDrop, "al-1 has a negative change_percentage → drop")
+        assertEquals(200000L, price.oldPrice)
+        assertEquals(185000L, price.newPrice)
+        assertEquals(-7.5, price.changePercentage)
+
+        val status = body.alerts[1]
+        assertFalse(status.isPriceChange, "al-2 is a status_change alert")
+        assertFalse(status.isUnread, "al-2 status is sent → read")
+        assertEquals("sold", status.newStatus)
+    }
+
+    @Test
+    fun getFavoriteAlerts_maps_unauthorized_to_failure() = runTest {
+        val repo = repoWith(HttpStatusCode.Unauthorized, """{"error":"unauthenticated"}""")
+        val result = repo.getFavoriteAlerts()
+        assertTrue(result.isFailure, "401 should surface as failure, got $result")
+        assertTrue(result.exceptionOrNull() is FavoritesException)
+    }
+
+    @Test
+    fun markFavoriteAlertRead_returns_success_on_204() = runTest {
+        val repo = repoWith(HttpStatusCode.NoContent, "")
+        val result = repo.markFavoriteAlertRead("al-1")
+        assertTrue(result.isSuccess, "204 should map to success, got $result")
+    }
+
+    @Test
+    fun markFavoriteAlertRead_returns_failure_on_404() = runTest {
+        val repo = repoWith(HttpStatusCode.NotFound, """{"error":"not found"}""")
+        val result = repo.markFavoriteAlertRead("al-x")
+        assertTrue(result.isFailure, "404 should surface as failure, got $result")
+        assertTrue(result.exceptionOrNull() is FavoritesException)
+    }
+
+    @Test
+    fun markAllFavoriteAlertsRead_decodes_marked_read_count() = runTest {
+        val repo = repoWith(HttpStatusCode.OK, """{"marked_read": 3}""")
+        val result = repo.markAllFavoriteAlertsRead()
+        assertTrue(result.isSuccess, "expected success, got $result")
+        assertEquals(3L, result.getOrNull()!!.markedRead)
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoriteAlertsRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoriteAlertsRepositoryTest.kt
@@ -7,6 +7,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModelsContractTest.kt
@@ -239,4 +239,76 @@ class FavoritesModelsContractTest {
         val decoded: SavedSearchesResponse = json.decodeFromString(json.encodeToString(resp))
         assertEquals(resp, decoded)
     }
+
+    /**
+     * Pin the `FavoriteAlertsResponse` / `FavoriteAlert` snake_case wire shape returned by
+     * `GET /api/v1/favorites/alerts` (gap-84-3). Monetary fields are whole-currency numbers and
+     * `change_percentage` is a signed fraction — matching the rest of the portal price models.
+     */
+    @Test
+    fun favoriteAlertsResponse_decodes_snake_case_price_change_shape() {
+        val raw =
+            """
+            {
+              "alerts": [
+                {
+                  "id": "al-1",
+                  "favorite_id": "fav-1",
+                  "listing_id": "lst-1",
+                  "title": "Bright 2br in Old Town",
+                  "alert_type": "price_change",
+                  "old_price": 200000,
+                  "new_price": 185000,
+                  "currency": "EUR",
+                  "change_percentage": -7.5,
+                  "status": "pending",
+                  "created_at": "2026-07-10T10:00:00Z"
+                }
+              ],
+              "unread_count": 1,
+              "limit": 100,
+              "offset": 0
+            }
+            """
+                .trimIndent()
+        val resp: FavoriteAlertsResponse = json.decodeFromString(raw)
+        assertEquals(1L, resp.unreadCount)
+        assertEquals(1, resp.alerts.size)
+        val alert = resp.alerts.first()
+        assertEquals("fav-1", alert.favoriteId)
+        assertEquals("lst-1", alert.listingId)
+        assertEquals(200000L, alert.oldPrice)
+        assertEquals(185000L, alert.newPrice)
+        assertEquals(-7.5, alert.changePercentage)
+        assertTrue(alert.isPriceChange)
+        assertTrue(alert.isUnread)
+        assertTrue(alert.isPriceDrop)
+    }
+
+    /** Status-only alerts omit the price fields entirely; they must still decode. */
+    @Test
+    fun favoriteAlert_decodes_status_change_without_price_fields() {
+        val raw =
+            """
+            {
+              "id": "al-2",
+              "favorite_id": "fav-2",
+              "listing_id": "lst-2",
+              "title": "Studio near the river",
+              "alert_type": "status_change",
+              "previous_status": "active",
+              "new_status": "sold",
+              "status": "sent",
+              "created_at": "2026-07-09T09:00:00Z"
+            }
+            """
+                .trimIndent()
+        val alert: FavoriteAlert = json.decodeFromString(raw)
+        assertNull(alert.oldPrice)
+        assertNull(alert.newPrice)
+        assertNull(alert.changePercentage)
+        assertEquals("sold", alert.newStatus)
+        assertTrue(!alert.isPriceChange)
+        assertTrue(!alert.isUnread)
+    }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/FavoritesModelsContractTest.kt
@@ -241,8 +241,8 @@ class FavoritesModelsContractTest {
     }
 
     /**
-     * Pin the `FavoriteAlertsResponse` / `FavoriteAlert` snake_case wire shape returned by
-     * `GET /api/v1/favorites/alerts` (gap-84-3). Monetary fields are whole-currency numbers and
+     * Pin the `FavoriteAlertsResponse` / `FavoriteAlert` snake_case wire shape returned by `GET
+     * /api/v1/favorites/alerts` (gap-84-3). Monetary fields are whole-currency numbers and
      * `change_percentage` is a signed fraction — matching the rest of the portal price models.
      */
     @Test

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModelTest.kt
@@ -1,0 +1,232 @@
+package three.two.bit.ppt.reality.favorites
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Unit tests for [PriceTrackingViewModel] — the mobile price-tracking surface added in gap-84-3.
+ *
+ * The favorites HTTP layer is driven through a real [FavoritesRepository] over a path-routing Ktor
+ * [MockEngine], mirroring the [ListingDetailViewModel] test harness. The view-model runs on the
+ * `runTest` [StandardTestDispatcher] with `backgroundScope`; because [MockEngine] resumes calls off
+ * the virtual scheduler, completion is awaited by suspending on the observable outcome via
+ * `state.first { … }` rather than `advanceUntilIdle()`.
+ */
+class PriceTrackingViewModelTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private val favoritesBody =
+        """
+        {
+          "favorites": [
+            {
+              "id": "fav-1",
+              "listing_id": "lst-1",
+              "created_at": "2026-07-01T10:00:00Z",
+              "title": "Bright 2br in Old Town",
+              "current_price": 185000,
+              "currency": "EUR",
+              "city": "Bratislava",
+              "price_changed": true,
+              "price_change_percentage": -7.5,
+              "price_alert_enabled": true
+            },
+            {
+              "id": "fav-2",
+              "listing_id": "lst-2",
+              "created_at": "2026-07-02T10:00:00Z",
+              "title": "Studio near the river",
+              "current_price": 120000,
+              "currency": "EUR",
+              "city": "Kosice",
+              "price_changed": false,
+              "price_alert_enabled": false
+            }
+          ]
+        }
+        """
+            .trimIndent()
+
+    private val alertsBody =
+        """
+        {
+          "alerts": [
+            {
+              "id": "al-1",
+              "favorite_id": "fav-1",
+              "listing_id": "lst-1",
+              "title": "Bright 2br in Old Town",
+              "alert_type": "price_change",
+              "old_price": 200000,
+              "new_price": 185000,
+              "currency": "EUR",
+              "change_percentage": -7.5,
+              "status": "pending",
+              "created_at": "2026-07-10T10:00:00Z"
+            },
+            {
+              "id": "al-2",
+              "favorite_id": "fav-2",
+              "listing_id": "lst-2",
+              "title": "Studio near the river",
+              "alert_type": "status_change",
+              "previous_status": "active",
+              "new_status": "sold",
+              "status": "sent",
+              "created_at": "2026-07-09T09:00:00Z"
+            }
+          ],
+          "unread_count": 1,
+          "limit": 100,
+          "offset": 0
+        }
+        """
+            .trimIndent()
+
+    /**
+     * A [FavoritesRepository] whose responses are routed by request path, so a single instance can
+     * serve the favorites load, the alerts load, and the mark-read writes the view-model fires.
+     */
+    private fun routingRepo(
+        token: String? = "test-token",
+        readStatus: HttpStatusCode = HttpStatusCode.NoContent,
+    ): FavoritesRepository {
+        val engine = MockEngine { request ->
+            val path = request.url.encodedPath
+            val jsonHeaders = headersOf(HttpHeaders.ContentType, "application/json")
+            when {
+                path.endsWith("/favorites/alerts/read-all") ->
+                    respond("""{"marked_read": 1}""", HttpStatusCode.OK, jsonHeaders)
+                path.endsWith("/read") -> respond("", readStatus, jsonHeaders)
+                path.endsWith("/favorites/alerts") ->
+                    respond(alertsBody, HttpStatusCode.OK, jsonHeaders)
+                path.endsWith("/favorites") -> respond(favoritesBody, HttpStatusCode.OK, jsonHeaders)
+                else -> respond("{}", HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return FavoritesRepository(baseUrl = "https://example.test", sessionToken = token, client = client)
+    }
+
+    private fun viewModel(
+        repo: FavoritesRepository,
+        scope: CoroutineScope,
+        token: String? = "test-token",
+    ) =
+        PriceTrackingViewModel(
+            favoritesRepositoryFactory = { repo },
+            scope = scope,
+            initialSessionToken = token,
+            errorMapper = { it.message ?: "error" },
+        )
+
+    @Test
+    fun start_loads_favorites_alerts_and_derives_price_changes() =
+        runTest(StandardTestDispatcher()) {
+            val vm = viewModel(routingRepo(), scope = backgroundScope)
+            vm.start()
+
+            vm.state.first { !it.isLoading }
+            val s = vm.state.value
+
+            assertEquals(2, s.favorites.size)
+            assertEquals(2, s.alerts.size)
+            assertEquals(1L, s.unreadCount)
+            // Derived views used by the surface.
+            assertEquals(1, s.priceChangedFavorites.size, "only fav-1 has price_changed=true")
+            assertEquals("lst-1", s.priceChangedFavorites.first().listingId)
+            assertEquals(1, s.priceAlertEnabledCount)
+            assertEquals(1, s.priceAlerts.size, "one price_change alert, one status_change alert")
+            assertFalse(s.isEmpty)
+            assertTrue(s.errorMessage == null)
+        }
+
+    @Test
+    fun markAlertRead_is_optimistic_and_decrements_unread() =
+        runTest(StandardTestDispatcher()) {
+            val vm = viewModel(routingRepo(), scope = backgroundScope)
+            vm.start()
+            vm.state.first { !it.isLoading }
+            assertEquals(1L, vm.state.value.unreadCount)
+
+            vm.onMarkAlertRead("al-1")
+
+            // Optimistic: alert flips to read and the unread badge drops immediately.
+            val optimistic = vm.state.value
+            assertEquals(0L, optimistic.unreadCount)
+            assertFalse(optimistic.alerts.first { it.id == "al-1" }.isUnread)
+
+            vm.state.first { !it.isMutating }
+            // 204 confirms — stays read.
+            assertEquals(0L, vm.state.value.unreadCount)
+            assertFalse(vm.state.value.alerts.first { it.id == "al-1" }.isUnread)
+        }
+
+    @Test
+    fun markAlertRead_rolls_back_on_failure() =
+        runTest(StandardTestDispatcher()) {
+            val repo = routingRepo(readStatus = HttpStatusCode.InternalServerError)
+            val vm = viewModel(repo, scope = backgroundScope)
+            vm.start()
+            vm.state.first { !it.isLoading }
+
+            vm.onMarkAlertRead("al-1")
+            // Optimistic drop first…
+            assertEquals(0L, vm.state.value.unreadCount)
+
+            vm.state.first { !it.isMutating }
+            // …then rollback to the pre-write state on the 500.
+            assertEquals(1L, vm.state.value.unreadCount, "failed mark-read must roll back the badge")
+            assertTrue(vm.state.value.alerts.first { it.id == "al-1" }.isUnread)
+        }
+
+    @Test
+    fun markAllRead_clears_unread_optimistically() =
+        runTest(StandardTestDispatcher()) {
+            val vm = viewModel(routingRepo(), scope = backgroundScope)
+            vm.start()
+            vm.state.first { !it.isLoading }
+
+            vm.onMarkAllRead()
+            assertEquals(0L, vm.state.value.unreadCount)
+            assertTrue(vm.state.value.alerts.none { it.isUnread })
+
+            vm.state.first { !it.isMutating }
+            assertEquals(0L, vm.state.value.unreadCount)
+        }
+
+    @Test
+    fun start_when_unauthenticated_renders_signed_out_empty_state() =
+        runTest(StandardTestDispatcher()) {
+            val vm = viewModel(routingRepo(token = null), scope = backgroundScope, token = null)
+            vm.start()
+
+            // No network is fired; state resolves synchronously to the signed-out empty state.
+            val s = vm.state.value
+            assertFalse(s.isLoading)
+            assertFalse(s.isAuthenticated)
+            assertTrue(s.favorites.isEmpty())
+            assertTrue(s.alerts.isEmpty())
+            assertEquals(0L, s.unreadCount)
+        }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModelTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/favorites/PriceTrackingViewModelTest.kt
@@ -7,7 +7,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
-import io.ktor.utils.io.ByteReadChannel
+import io.ktor.serialization.kotlinx.json.json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -120,12 +120,17 @@ class PriceTrackingViewModelTest {
                 path.endsWith("/read") -> respond("", readStatus, jsonHeaders)
                 path.endsWith("/favorites/alerts") ->
                     respond(alertsBody, HttpStatusCode.OK, jsonHeaders)
-                path.endsWith("/favorites") -> respond(favoritesBody, HttpStatusCode.OK, jsonHeaders)
+                path.endsWith("/favorites") ->
+                    respond(favoritesBody, HttpStatusCode.OK, jsonHeaders)
                 else -> respond("{}", HttpStatusCode.OK, jsonHeaders)
             }
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
-        return FavoritesRepository(baseUrl = "https://example.test", sessionToken = token, client = client)
+        return FavoritesRepository(
+            baseUrl = "https://example.test",
+            sessionToken = token,
+            client = client,
+        )
     }
 
     private fun viewModel(
@@ -196,7 +201,11 @@ class PriceTrackingViewModelTest {
 
             vm.state.first { !it.isMutating }
             // …then rollback to the pre-write state on the 500.
-            assertEquals(1L, vm.state.value.unreadCount, "failed mark-read must roll back the badge")
+            assertEquals(
+                1L,
+                vm.state.value.unreadCount,
+                "failed mark-read must roll back the badge",
+            )
             assertTrue(vm.state.value.alerts.first { it.id == "al-1" }.isUnread)
         }
 


### PR DESCRIPTION
## Task
No mobile-native price tracking surface (84-3-price-tracking Price Tracking for Favorites). Add a price-tracking surface to the mobile app for favorited listings.

## Target app — decision
Favorites/price-tracking is a **Reality Portal** feature (reality-server, `/api/v1/favorites*`). The Reality Portal mobile app is the **KMP app under `mobile-native/`** — `frontend/apps/mobile` (React Native) is the *Property Management* app and has no favorites/listings code at all (verified: no `favorite` references there; favorites live in `mobile-native/shared/.../favorites/` + `iosApp/.../Favorites/` and `frontend/apps/reality-web`). So the surface belongs in `mobile-native/`. Specialist: `kotlin-mp`.

## What changed (shared KMP layer — consumed by both Android Compose & iOS SwiftUI)
- **Models** (`FavoritesModels.kt`): `FavoriteAlert`, `FavoriteAlertsResponse`, `MarkAllFavoriteAlertsReadResponse` mirroring the reality-server DTOs (`backend/crates/db/src/models/reality_portal.rs`), with `isPriceChange` / `isUnread` / `isPriceDrop` helpers. Monetary fields map to `Long?` and `change_percentage` to `Double?`, matching the existing portal price convention (`FavoriteEntry.currentPrice`, `ListingSummary.price`).
- **Repository** (`FavoritesRepository.kt`): `getFavoriteAlerts(limit, offset)`, `markFavoriteAlertRead(id)`, `markAllFavoriteAlertsRead()` wrapping `GET /api/v1/favorites/alerts`, `POST .../alerts/{id}/read`, `POST .../alerts/read-all`.
- **`PriceTrackingViewModel`** — a `commonMain` framework-agnostic state-holder (mirrors the established `ListingDetailViewModel` pattern): loads favorites + the alert feed, derives `priceChangedFavorites` / `priceAlertEnabledCount` / `priceAlerts`, and owns optimistic mark-read / mark-all-read with rollback and session-change guards. `create()` keeps repo construction out of the UI layer.
- **Tests** (`commonTest`): `FavoriteAlertsRepositoryTest` (contract + status mapping), `FavoritesModelsContractTest` (+2 wire-shape cases), `PriceTrackingViewModelTest` (load/derive, optimistic mark-read + rollback, mark-all, signed-out empty state).

## Owner
pm-backend (frontend/mobile surface)

## Tested (Band A — fast check)
**Could NOT run locally — status partial.** The mandatory KMP verify (`./gradlew :shared:compileKotlinJvm` / host test) cannot run in this cloud sandbox:
- `./gradlew` → Gradle distribution download blocked by the agent proxy: `HTTP 403 for https://services.gradle.org/distributions/gradle-9.6.1-bin.zip` (exit 1).
- No Android SDK (`ANDROID_HOME` empty), no Kotlin/Native toolchain, no Gradle cache — the AGP-9 `androidLibrary` + iOS targets can't even configure.

Mitigation — rigorous static verification performed:
- Symbols/imports checked against existing sibling code (`FavoritesRepository`, `NotificationRepository`, `ListingDetailViewModel`); same Ktor/coroutine APIs, all `commonMain`-safe (no Android/JVM-only types).
- Caught & fixed the Int-vs-Long `assertEquals` boxing pitfall: all assertions against `Long` fields (`unreadCount`, prices, `markedRead`) use `L` literals.
- `scope-check.sh --owner pm-backend` → exit 0 (no drift). `reuse-grep.sh --specialist kotlin-mp` → no warnings.

**CI `mobile-native.yml` must green this** (Gradle build + unit tests) — kept as a draft PR so it can't merge on an unverified local build.

## Built (Band B — full build)
Skipped: cannot build KMP in sandbox (see above).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Scope is intentionally the **shared surface** (models + repository + view-model + tests) — the reusable price-tracking layer both platforms consume, matching how `ListingDetailViewModel` landed. Wiring the visible **Android Compose screen** (`androidApp/`) and **iOS SwiftUI view** (`iosApp/`) is a natural follow-up that requires an Android-SDK / macOS build to verify and was deliberately deferred rather than shipped unverified (false-green risk).
- `Decimal` wire format: resolved to numeric (not string) by matching the whole-codebase convention — every KMP model maps `Decimal`→`Long`/`Double` and the listing/search flow (exercised end-to-end) uses `price: Long`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CPM5sCMGCGLFEBCNvanapx)_