### PR TITLE
gh-issue-2279: scope AI chat by-session-id handlers to owning user (within-tenant IDOR)

### DIFF
--- a/backend/crates/db/src/repositories/ai_chat.rs
+++ b/backend/crates/db/src/repositories/ai_chat.rs
@@ -80,25 +80,35 @@ impl AiChatRepository {
         .await
     }
 
-    /// Get session by ID — tenant-scoped.
+    /// Get session by ID — tenant- AND owner-scoped.
     ///
-    /// `org_id` must originate from the verified request principal.
-    /// Returns `None` for both "not found" and "belongs to another tenant"
-    /// to prevent cross-tenant ID enumeration.
+    /// `org_id` and `user_id` must originate from the verified request
+    /// principal. AI chat sessions are per-user private within an org
+    /// (`create_session` stamps the owning `user_id`, `list_user_sessions`
+    /// only returns the caller's own sessions); the `user_id` predicate keeps
+    /// the by-id path consistent so a colleague in the same org cannot read
+    /// another member's private session (within-tenant IDOR, issue #2279).
+    /// Returns `None` for "not found", "belongs to another tenant", and
+    /// "belongs to another user" alike to avoid an existence oracle.
     pub async fn find_session_by_id<'e, E>(
         &self,
         executor: E,
         id: Uuid,
         org_id: Uuid,
+        user_id: Uuid,
     ) -> Result<Option<AiChatSession>, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        sqlx::query_as("SELECT * FROM ai_chat_sessions WHERE id = $1 AND organization_id = $2")
-            .bind(id)
-            .bind(org_id)
-            .fetch_optional(executor)
-            .await
+        sqlx::query_as(
+            "SELECT * FROM ai_chat_sessions \
+             WHERE id = $1 AND organization_id = $2 AND user_id = $3",
+        )
+        .bind(id)
+        .bind(org_id)
+        .bind(user_id)
+        .fetch_optional(executor)
+        .await
     }
 
     /// List user's chat sessions.
@@ -186,16 +196,18 @@ impl AiChatRepository {
         Ok(message)
     }
 
-    /// Get messages for a session — tenant-scoped.
+    /// Get messages for a session — tenant- AND owner-scoped.
     ///
-    /// `org_id` must originate from the verified request principal.
-    /// The JOIN ensures a caller in org B cannot enumerate messages from a
-    /// session owned by org A.
+    /// `org_id` and `user_id` must originate from the verified request
+    /// principal. The JOIN predicate ensures a caller cannot enumerate
+    /// messages from a session owned by another org OR by another user in the
+    /// same org (within-tenant IDOR, issue #2279).
     pub async fn list_session_messages<'e, E>(
         &self,
         executor: E,
         session_id: Uuid,
         org_id: Uuid,
+        user_id: Uuid,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<AiChatMessage>, sqlx::Error>
@@ -206,39 +218,46 @@ impl AiChatRepository {
             r#"
             SELECT m.* FROM ai_chat_messages m
             JOIN ai_chat_sessions s ON s.id = m.session_id
-            WHERE m.session_id = $1 AND s.organization_id = $2
+            WHERE m.session_id = $1 AND s.organization_id = $2 AND s.user_id = $3
             ORDER BY m.created_at ASC
-            LIMIT $3 OFFSET $4
+            LIMIT $4 OFFSET $5
             "#,
         )
         .bind(session_id)
         .bind(org_id)
+        .bind(user_id)
         .bind(limit)
         .bind(offset)
         .fetch_all(executor)
         .await
     }
 
-    /// Delete a session and all its messages — tenant-scoped.
+    /// Delete a session and all its messages — tenant- AND owner-scoped.
     ///
-    /// `org_id` must originate from the verified request principal.
-    /// Returns `false` for both "not found" and "belongs to another tenant"
-    /// to prevent cross-tenant ID enumeration.
+    /// `org_id` and `user_id` must originate from the verified request
+    /// principal. Returns `false` for "not found", "belongs to another
+    /// tenant", and "belongs to another user" alike, so a colleague in the
+    /// same org cannot destroy another member's private session by supplying
+    /// its UUID (within-tenant IDOR, issue #2279).
     pub async fn delete_session<'e, E>(
         &self,
         executor: E,
         id: Uuid,
         org_id: Uuid,
+        user_id: Uuid,
     ) -> Result<bool, sqlx::Error>
     where
         E: Executor<'e, Database = Postgres>,
     {
-        let result =
-            sqlx::query("DELETE FROM ai_chat_sessions WHERE id = $1 AND organization_id = $2")
-                .bind(id)
-                .bind(org_id)
-                .execute(executor)
-                .await?;
+        let result = sqlx::query(
+            "DELETE FROM ai_chat_sessions \
+             WHERE id = $1 AND organization_id = $2 AND user_id = $3",
+        )
+        .bind(id)
+        .bind(org_id)
+        .bind(user_id)
+        .execute(executor)
+        .await?;
         Ok(result.rows_affected() > 0)
     }
 

--- a/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
+++ b/backend/crates/db/tests/ai_chat_rls_repo_tests.rs
@@ -149,7 +149,7 @@ async fn ai_chat_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             .expect("set role");
 
         let found = repo
-            .find_session_by_id(&mut *conn, session_a, org_a)
+            .find_session_by_id(&mut *conn, session_a, org_a, user_a)
             .await
             .expect("find_session_by_id (no ctx)");
         assert!(
@@ -183,7 +183,7 @@ async fn ai_chat_repo_force_rls_deny_all_and_fix(pool: PgPool) {
 
         // (2) Own-org row IS now visible through the repo — the fix.
         let found = repo
-            .find_session_by_id(&mut *conn, session_a, org_a)
+            .find_session_by_id(&mut *conn, session_a, org_a, user_a)
             .await
             .expect("find_session_by_id (ctx)");
         assert_eq!(
@@ -195,7 +195,7 @@ async fn ai_chat_repo_force_rls_deny_all_and_fix(pool: PgPool) {
         // (3) Org B's session stays invisible to an org-A caller — even though
         //     the SQL filter is passed org_a, RLS independently denies the row.
         let cross = repo
-            .find_session_by_id(&mut *conn, session_b, org_a)
+            .find_session_by_id(&mut *conn, session_b, org_a, user_a)
             .await
             .expect("find_session_by_id cross");
         assert!(
@@ -260,4 +260,118 @@ async fn ai_chat_repo_force_rls_deny_all_and_fix(pool: PgPool) {
             .await
             .ok();
     }
+}
+
+/// Seed a chat message on a session (as superuser, RLS-exempt).
+async fn seed_message(pool: &PgPool, session_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO ai_chat_messages (session_id, role, content)
+        VALUES ($1, 'user', 'sensitive question')
+        RETURNING id
+        "#,
+    )
+    .bind(session_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed message")
+}
+
+/// Within-tenant per-user isolation for the by-session-id AI-chat repo paths
+/// (issue #2279).
+///
+/// AI chat sessions are per-user private within an org, but the by-id repo
+/// methods used to filter by `organization_id` alone, so any colleague in the
+/// same org could read/delete/read-transcript of another member's private
+/// session by supplying its UUID. This test pins the added `user_id` predicate
+/// on `find_session_by_id`, `list_session_messages`, and `delete_session`.
+///
+/// It runs as the Postgres superuser (RLS is bypassed), so the assertions
+/// exercise the repository's SQL `WHERE` clause directly — exactly the layer
+/// the fix lives in. On the pre-fix code the org-only query returned the row to
+/// `attacker`; the `AND user_id = $n` predicate is what closes that.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn ai_chat_by_id_paths_are_owner_scoped_within_tenant(pool: PgPool) {
+    let repo = AiChatRepository::new(pool.clone());
+
+    let org = seed_org(&pool, "owner-scope").await;
+    let owner = seed_user(&pool, "owner@aichat.test").await;
+    // `attacker` is a DIFFERENT user in the SAME org.
+    let attacker = seed_user(&pool, "attacker@aichat.test").await;
+    let session = seed_session(&pool, org, owner, "owner's private session").await;
+    let _msg = seed_message(&pool, session).await;
+
+    // --- find_session_by_id: owner reads, same-org attacker is blocked. ---
+    assert!(
+        repo.find_session_by_id(&pool, session, org, owner)
+            .await
+            .expect("query ok")
+            .is_some(),
+        "the owning user must read their own session"
+    );
+    assert!(
+        repo.find_session_by_id(&pool, session, org, attacker)
+            .await
+            .expect("query ok")
+            .is_none(),
+        "#2279: a colleague in the same org must NOT read another member's session"
+    );
+    // Sanity: the org-only query (the vulnerable pre-fix path) leaks the row to
+    // any member of the same org.
+    let org_only: Option<Uuid> = sqlx::query_scalar(
+        "SELECT id FROM ai_chat_sessions WHERE id = $1 AND organization_id = $2",
+    )
+    .bind(session)
+    .bind(org)
+    .fetch_optional(&pool)
+    .await
+    .expect("query ok");
+    assert_eq!(
+        org_only,
+        Some(session),
+        "sanity: the org-only lookup (pre-fix path) does leak the session"
+    );
+
+    // --- list_session_messages: owner sees transcript, attacker sees nothing. ---
+    assert_eq!(
+        repo.list_session_messages(&pool, session, org, owner, 100, 0)
+            .await
+            .expect("query ok")
+            .len(),
+        1,
+        "the owning user must read their own transcript"
+    );
+    assert!(
+        repo.list_session_messages(&pool, session, org, attacker, 100, 0)
+            .await
+            .expect("query ok")
+            .is_empty(),
+        "#2279: a colleague must NOT read another member's transcript"
+    );
+
+    // --- delete_session: attacker cannot delete, owner can. ---
+    assert!(
+        !repo
+            .delete_session(&pool, session, org, attacker)
+            .await
+            .expect("query ok"),
+        "#2279: a colleague must NOT delete another member's session"
+    );
+    let survived: Option<Uuid> =
+        sqlx::query_scalar("SELECT id FROM ai_chat_sessions WHERE id = $1")
+            .bind(session)
+            .fetch_optional(&pool)
+            .await
+            .expect("query ok");
+    assert_eq!(
+        survived,
+        Some(session),
+        "the session must survive a cross-user delete attempt"
+    );
+    assert!(
+        repo.delete_session(&pool, session, org, owner)
+            .await
+            .expect("query ok"),
+        "the owning user must be able to delete their own session"
+    );
 }

--- a/backend/servers/api-server/src/routes/ai/sessions.rs
+++ b/backend/servers/api-server/src/routes/ai/sessions.rs
@@ -122,10 +122,14 @@ async fn get_session(
     mut rls: RlsConnection,
     Path(session_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (#2279): AI chat sessions are per-user private within an org.
+    // Scope the by-id lookup by BOTH org and owner so a colleague in the same
+    // org cannot read another member's private session by supplying its UUID.
     let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let result = state
         .ai_chat_repo
-        .find_session_by_id(&mut **rls.conn(), session_id, org_id)
+        .find_session_by_id(&mut **rls.conn(), session_id, org_id, user_id)
         .await;
     rls.release().await;
     match result {
@@ -152,10 +156,13 @@ async fn delete_session(
     mut rls: RlsConnection,
     Path(session_id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (#2279): scope the destructive delete by BOTH org and owner so
+    // a colleague in the same org cannot delete another member's session.
     let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let result = state
         .ai_chat_repo
-        .delete_session(&mut **rls.conn(), session_id, org_id)
+        .delete_session(&mut **rls.conn(), session_id, org_id, user_id)
         .await;
     rls.release().await;
     match result {
@@ -183,13 +190,17 @@ async fn list_messages(
     Path(session_id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (#2279): scope the transcript read by BOTH org and owner so a
+    // colleague in the same org cannot read another member's conversation.
     let org_id = rls.tenant_id();
+    let user_id = rls.user_id();
     let result = state
         .ai_chat_repo
         .list_session_messages(
             &mut **rls.conn(),
             session_id,
             org_id,
+            user_id,
             query.limit.unwrap_or(100),
             query.offset.unwrap_or(0),
         )
@@ -249,10 +260,12 @@ async fn send_message(
     let tenant_id = rls.tenant_id();
     let user_id = rls.user_id();
 
-    // Verify session exists and belongs to this tenant.
+    // Verify session exists and belongs to this tenant AND this user.
+    // SECURITY (#2279): AI chat sessions are per-user private; scoping by org
+    // alone let any colleague post into another member's private session.
     let _session = state
         .ai_chat_repo
-        .find_session_by_id(&mut **rls.conn(), session_id, tenant_id)
+        .find_session_by_id(&mut **rls.conn(), session_id, tenant_id, user_id)
         .await
         .map_err(|e| {
             tracing::error!("Failed to find session: {}", e);
@@ -279,6 +292,7 @@ async fn send_message(
             &mut **rls.conn(),
             session_id,
             tenant_id,
+            user_id,
             DEFAULT_HISTORY_LIMIT,
             0,
         )

--- a/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
@@ -24,6 +24,13 @@
 //! photo-enhancement read — the full LLM-document IDOR cluster from the
 //! `security-llm-doc-idor` plan.
 //!
+//! Issue #2279 extends this with WITHIN-tenant per-user isolation for the
+//! by-session-id AI-chat handlers (`get_session`, `list_messages`,
+//! `delete_session`, `send_message`): AI chat sessions are per-user private,
+//! so the by-id repo path must scope by `user_id` as well as `organization_id`
+//! — otherwise any colleague in the same org can read/delete/post into another
+//! member's private session. Tests (1b)–(1d) pin that owner predicate.
+//!
 //! Why repo-layer and not HTTP-layer: `TestApp` mounts the router WITHOUT
 //! `host_tenant_middleware`, so `RequestPrincipal` can never resolve an
 //! `effective_org` in tests (see `equipment_cross_tenant_idor_tests.rs`'s
@@ -117,9 +124,9 @@ async fn find_session_by_id_blocks_cross_tenant_read(pool: PgPool) {
     let user_a = seed_user(&pool, "sess-a@ai-idor.test").await;
     let session_in_a = seed_session(&pool, org_a, user_a).await;
 
-    // Same-org read succeeds.
+    // Same-org read succeeds (correct org + owner).
     let same_org = repo
-        .find_session_by_id(&pool, session_in_a, org_a)
+        .find_session_by_id(&pool, session_in_a, org_a, user_a)
         .await
         .expect("query ok");
     assert!(
@@ -129,7 +136,7 @@ async fn find_session_by_id_blocks_cross_tenant_read(pool: PgPool) {
 
     // Cross-org read returns None (the IDOR is blocked).
     let cross_org = repo
-        .find_session_by_id(&pool, session_in_a, org_b)
+        .find_session_by_id(&pool, session_in_a, org_b, user_a)
         .await
         .expect("query ok");
     assert!(
@@ -149,6 +156,169 @@ async fn find_session_by_id_blocks_cross_tenant_read(pool: PgPool) {
         unscoped,
         Some(session_in_a),
         "sanity: the unscoped query (the vulnerable pre-fix path) does leak the row"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (1b) Chat session read is OWNER-scoped WITHIN a tenant (issue #2279) — a
+//      colleague in the same org cannot read another member's private session
+//      by supplying its UUID. AI chat sessions are per-user private
+//      (`create_session` stamps the owner; `list_user_sessions` only returns
+//      the caller's own sessions), but the by-id path used to filter by
+//      `organization_id` alone. This pins the added `user_id` predicate.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn find_session_by_id_blocks_within_tenant_cross_user_read(pool: PgPool) {
+    let repo = AiChatRepository::new(pool.clone());
+
+    let org = seed_org(&pool, "wt-sess").await;
+    let owner = seed_user(&pool, "wt-owner@ai-idor.test").await;
+    let attacker = seed_user(&pool, "wt-attacker@ai-idor.test").await;
+    let session = seed_session(&pool, org, owner).await;
+
+    // Owner read (correct org + owner) succeeds.
+    let as_owner = repo
+        .find_session_by_id(&pool, session, org, owner)
+        .await
+        .expect("query ok");
+    assert!(
+        as_owner.is_some(),
+        "the owning user must be able to read their own chat session"
+    );
+
+    // Same-org, different-user read returns None (the within-tenant IDOR is blocked).
+    let as_attacker = repo
+        .find_session_by_id(&pool, session, org, attacker)
+        .await
+        .expect("query ok");
+    assert!(
+        as_attacker.is_none(),
+        "issue #2279: a colleague in the same org must NOT read another \
+         member's private chat session"
+    );
+
+    // Demonstrate the leak the owner predicate closes: the org-only lookup the
+    // pre-fix handler performed returns the row regardless of the caller.
+    let org_only: Option<Uuid> = sqlx::query_scalar(
+        "SELECT id FROM ai_chat_sessions WHERE id = $1 AND organization_id = $2",
+    )
+    .bind(session)
+    .bind(org)
+    .fetch_optional(&pool)
+    .await
+    .expect("query ok");
+    assert_eq!(
+        org_only,
+        Some(session),
+        "sanity: the org-only query (the vulnerable pre-fix path) does leak \
+         the row to any member of the same org"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (1c) Message-transcript read is OWNER-scoped within a tenant (issue #2279) —
+//      a colleague in the same org cannot read another member's conversation.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_session_messages_blocks_within_tenant_cross_user_read(pool: PgPool) {
+    let repo = AiChatRepository::new(pool.clone());
+
+    let org = seed_org(&pool, "wt-msg").await;
+    let owner = seed_user(&pool, "wt-msg-owner@ai-idor.test").await;
+    let attacker = seed_user(&pool, "wt-msg-attacker@ai-idor.test").await;
+    let session = seed_session(&pool, org, owner).await;
+    let _msg = seed_message(&pool, session).await;
+
+    // Owner sees the transcript.
+    let as_owner = repo
+        .list_session_messages(&pool, session, org, owner, 100, 0)
+        .await
+        .expect("query ok");
+    assert_eq!(
+        as_owner.len(),
+        1,
+        "the owning user must be able to read their own session transcript"
+    );
+
+    // Same-org, different-user read returns nothing (the IDOR is blocked).
+    let as_attacker = repo
+        .list_session_messages(&pool, session, org, attacker, 100, 0)
+        .await
+        .expect("query ok");
+    assert!(
+        as_attacker.is_empty(),
+        "issue #2279: a colleague in the same org must NOT read another \
+         member's conversation transcript"
+    );
+
+    // Sanity: the org-only join (the pre-fix path) leaks the transcript to any
+    // member of the same org.
+    let org_only: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*) FROM ai_chat_messages m
+        JOIN ai_chat_sessions s ON s.id = m.session_id
+        WHERE m.session_id = $1 AND s.organization_id = $2
+        "#,
+    )
+    .bind(session)
+    .bind(org)
+    .fetch_one(&pool)
+    .await
+    .expect("query ok");
+    assert_eq!(
+        org_only, 1,
+        "sanity: the org-only join (the vulnerable pre-fix path) does leak the \
+         transcript to any member of the same org"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (1d) Session DELETE is OWNER-scoped within a tenant (issue #2279) — a
+//      colleague in the same org cannot destroy another member's session.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_session_blocks_within_tenant_cross_user_delete(pool: PgPool) {
+    let repo = AiChatRepository::new(pool.clone());
+
+    let org = seed_org(&pool, "wt-del").await;
+    let owner = seed_user(&pool, "wt-del-owner@ai-idor.test").await;
+    let attacker = seed_user(&pool, "wt-del-attacker@ai-idor.test").await;
+    let session = seed_session(&pool, org, owner).await;
+
+    // Same-org, different-user delete affects no rows (the IDOR is blocked).
+    let attacker_deleted = repo
+        .delete_session(&pool, session, org, attacker)
+        .await
+        .expect("query ok");
+    assert!(
+        !attacker_deleted,
+        "issue #2279: a colleague in the same org must NOT delete another \
+         member's session"
+    );
+
+    let still_present: Option<Uuid> =
+        sqlx::query_scalar("SELECT id FROM ai_chat_sessions WHERE id = $1")
+            .bind(session)
+            .fetch_optional(&pool)
+            .await
+            .expect("query ok");
+    assert_eq!(
+        still_present,
+        Some(session),
+        "the session must survive a cross-user delete attempt"
+    );
+
+    // The owner can delete their own session.
+    let owner_deleted = repo
+        .delete_session(&pool, session, org, owner)
+        .await
+        .expect("query ok");
+    assert!(
+        owner_deleted,
+        "the owning user must be able to delete their own session"
     );
 }
 


### PR DESCRIPTION
## Task
AI chat sessions: within-tenant IDOR — get/list-messages/delete/send-message scope by org only, not user (Closes #2279).

The by-session-id handlers in `backend/servers/api-server/src/routes/ai/sessions.rs` (`get_session`, `list_messages`, `delete_session`, `send_message`) filtered only by `org_id`/`tenant_id`, never `user_id`. RLS scopes the connection to the org (tenant), not the user, so any authenticated member of the same org could read another member's private AI chat session and its full transcript, delete it, or post into it by supplying the session UUID.

## Fix
Threaded the verified principal's `user_id` into the three by-id repository methods and added `AND user_id = $n` to their `WHERE` clauses, matching `list_sessions`' per-user isolation (`list_user_sessions(user_id)`):

- `AiChatRepository::find_session_by_id(exec, id, org_id, user_id)`
- `AiChatRepository::list_session_messages(exec, session_id, org_id, user_id, limit, offset)`
- `AiChatRepository::delete_session(exec, id, org_id, user_id)`

Handlers now pass `rls.user_id()` alongside `rls.tenant_id()`. A non-owner lookup/delete returns `None`/`false`, surfaced to the client as `404 NOT_FOUND` (not 403 — no existence oracle), consistent with the existing tenant-miss behavior. `send_message`'s existence check (and its history read) are scoped the same way, so a colleague can no longer post into another member's session.

No admin cross-user path exists today, so none was added; the issue's "decide whether org admins get cross-user read" is left as an explicit future role-gate if needed.

## Owner
pm-security

## Scope drift
`scope-check.sh --owner pm-security` reports the 4 changed files as outside pm-security's mapped globs (auth/MFA/migrations). This is inherent to the task: the vulnerability and its fix live in the AI-chat repo + routes, not in auth code. The changed files are exactly those named in issue #2279:
- `backend/crates/db/src/repositories/ai_chat.rs` (the query fix)
- `backend/servers/api-server/src/routes/ai/sessions.rs` (handler call sites)
- `backend/crates/db/tests/ai_chat_rls_repo_tests.rs` (regression test + updated call sites)
- `backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs` (regression tests + updated call sites)

## Code-reuse review
`reuse-grep.sh` — no warnings. No new helpers added; the change reuses the existing repo-method + `rls.user_id()` idiom already used by `create_session`/`list_sessions`.

## Tested (Band A — fast check)
Run in the isolated worktree. Note: this session's egress policy blocks the GitHub repo `swagger-api/swagger-ui` (HTTP 403 "GitHub access to this repository is not enabled for this session"), which the `utoipa-swagger-ui` build script downloads, so **`api-server` cannot be compiled locally here**. No local Postgres/Docker is available either, so `#[sqlx::test]` DB tests cannot be executed locally. Both are deferred to CI (`backend.yml`), which has proper egress and a Postgres service.

- `cargo test -p db --no-run` → exit 0 (compiles the `db` lib **with the query fix** + all `db` test targets, including `ai_chat_rls_repo_tests.rs` with the new per-user regression test and updated call sites).
- `cargo test -p db --test ai_chat_rls_repo_tests --no-run` → exit 0.
- `cargo clippy -p db --tests` → exit 0 (clean, no warnings).
- `cargo fmt -p db -p api-server -- --check` → exit 0.

## Built (Band B — full build)
Deferred to CI: `api-server` release build requires the blocked Swagger UI download. The `db` crate (which carries the actual SQL predicate change) is clippy-clean above.

## CI parity (Band C — hot-path only)
This is a hot-path (within-tenant IDOR / confidentiality + integrity) change. Local CI parity is blocked by the same egress + no-DB constraints. `backend.yml` (fmt, clippy, `cargo test`) is the authoritative gate and will run the DB regression tests. **Do not merge until CI is green.**

## Regression tests (IG3)
The regression asserts per-user isolation and is designed to fail on the pre-fix org-only path:

- `db` crate — `ai_chat_by_id_paths_are_owner_scoped_within_tenant` (in `ai_chat_rls_repo_tests.rs`): seeds one org with an owner + a second same-org user, then asserts the owner can read/list-transcript/delete while the same-org non-owner is blocked on all three by-id paths; includes a sanity assertion that the org-only query still leaks the row (the vulnerable pre-fix behavior). Runs as superuser so it exercises the repository `WHERE` clause directly — the exact layer the fix lives in.
- `api-server` IDOR suite — tests `(1b)`–`(1d)` in `ai_llm_cross_tenant_idor_tests.rs` pin the same contract alongside the existing #766/#816 cross-tenant cluster.

## Notes
- Only callers of the three changed repo signatures are the AI-chat handlers and these two test files (verified by grep); the same-named `find_session_by_id`/`delete_session` on the dispute and reality-server session-token repos are unrelated (different signatures).
- Draft until CI (backend.yml) is green, since `api-server` build + DB tests could not be executed in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPM5sCMGCGLFEBCNvanapx)_