### PR TITLE
gap-81-1-frontend-create-new-schedule-ui-missing: wire Create-new-schedule flow to backend

### DIFF
--- a/frontend/apps/ppt-web/src/features/reports/pages/ReportsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/pages/ReportsPage.tsx
@@ -6,6 +6,7 @@
 
 import type {
   BuildingAnalytics,
+  CreateReportSchedule,
   CronScheduleUpdateRequest,
   DataSource,
   KPIMetric,
@@ -43,7 +44,7 @@ interface ReportsPageProps {
   isLoading?: boolean;
   onCreateReport?: (data: unknown) => Promise<void>;
   onPreviewReport?: (data: unknown) => Promise<unknown>;
-  onCreateSchedule?: (data: unknown) => Promise<void>;
+  onCreateSchedule?: (data: CreateReportSchedule) => Promise<void>;
   /** gap-81-1: cron-based update (cron_expression, recipients, enabled) */
   onUpdateSchedule?: (id: string, data: CronScheduleUpdateRequest) => Promise<void>;
   onDeleteSchedule?: (id: string) => Promise<void>;

--- a/frontend/apps/ppt-web/src/routes/groups/reports.create-schedule.route.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/reports.create-schedule.route.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Route-container wiring test for the "New Schedule" create flow (gap-81-1).
+ *
+ * Before this fix `ReportsPageRoute` rendered the "+ New Schedule" button and
+ * the inline `ScheduleForm`, but never passed an `onCreateSchedule` handler and
+ * fed the form an empty `reports` list — so the create flow was inert: the
+ * report selector had no options and submitting called `undefined`.
+ *
+ * This test mounts the PRODUCTION route (`reportRoutes()` at `/reports`) and
+ * asserts the container now:
+ *   - feeds report definitions into the schedule form's report selector, and
+ *   - invokes `useCreateSchedule().mutateAsync` with the form payload on submit
+ *     and fires the success toast the route wires.
+ *
+ * Only the api-client hooks + `useToast` + `useAuth` are mocked.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { Suspense } from 'react';
+import { MemoryRouter, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reportRoutes } from './reports';
+
+const ORG_ID = 'org-1';
+
+const mockShowToast = vi.fn();
+const mockCreateMutateAsync = vi.fn();
+
+vi.mock('../../components', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../components')>()),
+  useToast: () => ({ showToast: mockShowToast }),
+  ProtectedRoute: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../../contexts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../contexts')>()),
+  useAuth: () => ({ user: { organizationId: ORG_ID } }),
+}));
+
+vi.mock('@ppt/api-client', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@ppt/api-client')>()),
+  useReports: () => ({
+    data: { reports: [{ id: 'rep-1', name: 'Monthly Revenue' }], total: 1 },
+    isLoading: false,
+  }),
+  useReportSchedules: () => ({ data: { schedules: [], total: 0 }, isLoading: false }),
+  useCreateSchedule: () => ({ mutateAsync: mockCreateMutateAsync }),
+  useReportExecutionHistory: () => ({
+    data: { executions: [], hasMore: false },
+    isLoading: false,
+    isError: false,
+  }),
+  useDownloadReport: () => ({ mutate: vi.fn() }),
+  useRetryReportExecution: () => ({ mutateAsync: vi.fn() }),
+  useUpdateScheduleCron: () => ({ mutateAsync: vi.fn() }),
+}));
+
+function renderReportsRoute() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/reports']}>
+        <Suspense fallback={<div>loading…</div>}>
+          <Routes>{reportRoutes()}</Routes>
+        </Suspense>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+describe('ReportsPageRoute create-schedule wiring (gap-81-1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a schedule via useCreateSchedule and fires the success toast', async () => {
+    mockCreateMutateAsync.mockResolvedValue({ id: 'sched-new' });
+    const user = userEvent.setup();
+
+    renderReportsRoute();
+
+    // Switch to the Schedules tab (only tab button matches while on dashboard).
+    await user.click(await screen.findByRole('button', { name: /schedules/i }, { timeout: 5000 }));
+
+    // Open the create form.
+    await user.click(await screen.findByRole('button', { name: /new schedule/i }));
+
+    // Fill the required fields. The report selector is populated from the
+    // route's useReports data — empty before this fix.
+    await user.selectOptions(screen.getByRole('combobox', { name: /report/i }), 'rep-1');
+    await user.type(screen.getByLabelText(/schedule name/i), 'Weekly Revenue Summary');
+    await user.type(screen.getByLabelText(/recipients/i), 'owner@example.com');
+
+    await user.click(screen.getByRole('button', { name: /save schedule/i }));
+
+    await waitFor(() => {
+      expect(mockCreateMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        report_id: 'rep-1',
+        name: 'Weekly Revenue Summary',
+        recipients: ['owner@example.com'],
+      })
+    );
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    });
+  });
+});

--- a/frontend/apps/ppt-web/src/routes/groups/reports.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/reports.tsx
@@ -5,14 +5,18 @@
  * Extracted from App.tsx to isolate reports work.
  */
 import type {
+  CreateReportSchedule,
   CronScheduleUpdateRequest,
   PeriodComparison,
   ReportSchedule,
   TrendAnalysis,
 } from '@ppt/api-client';
 import {
+  useCreateSchedule,
   useDownloadReport,
   useReportExecutionHistory,
+  useReportSchedules,
+  useReports,
   useRetryReportExecution,
   useUpdateScheduleCron,
 } from '@ppt/api-client';
@@ -35,6 +39,31 @@ function ReportsPageRoute() {
   const { t } = useTranslation();
   const { user } = useAuth();
   const organizationId = user?.organizationId ?? '';
+
+  // gap-81-1: report definitions + schedules feed the Schedules tab. Without
+  // the report list the "New Schedule" form's report selector is empty and a
+  // schedule can never be created.
+  const { data: reportsData, isLoading: reportsLoading } = useReports(organizationId);
+  const { data: schedulesData, isLoading: schedulesLoading } = useReportSchedules(organizationId);
+  const createScheduleMutation = useCreateSchedule(organizationId);
+
+  const handleCreateSchedule = async (data: CreateReportSchedule) => {
+    try {
+      await createScheduleMutation.mutateAsync(data);
+      showToast({
+        type: 'success',
+        title: t('common.success'),
+        message: t('reports.schedule.created', 'Schedule created successfully.'),
+      });
+    } catch (e) {
+      showToast({
+        type: 'error',
+        title: t('common.error'),
+        message: t('reports.schedule.createFailed', 'Failed to create schedule.'),
+      });
+      throw e;
+    }
+  };
 
   // gap-81-1: cron-based update (cron_expression, recipients, enabled)
   const updateScheduleCronMutation = useUpdateScheduleCron();
@@ -121,8 +150,9 @@ function ReportsPageRoute() {
     <ReportsPage
       organizationId={organizationId}
       dataSources={[]}
-      reports={[]}
-      schedules={[]}
+      reports={reportsData?.reports ?? []}
+      schedules={schedulesData?.schedules ?? []}
+      isLoading={reportsLoading || schedulesLoading}
       kpis={[]}
       buildings={[]}
       trendAnalysis={
@@ -146,6 +176,7 @@ function ReportsPageRoute() {
           difference_percentage: 0,
         } as PeriodComparison
       }
+      onCreateSchedule={handleCreateSchedule}
       onUpdateSchedule={handleUpdateSchedule}
       executions={executions}
       executionsLoading={executionsLoading}

--- a/frontend/packages/api-client/src/reports/hooks.ts
+++ b/frontend/packages/api-client/src/reports/hooks.ts
@@ -6,8 +6,11 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  createSchedule,
   getReportExecutionDownloadUrl,
   getReportExecutionHistory,
+  listReports,
+  listSchedules,
   pauseSchedule,
   resumeSchedule,
   retryReportExecution,
@@ -17,6 +20,8 @@ import {
 import type {
   CreateReportSchedule,
   CronScheduleUpdateRequest,
+  ListReportsParams,
+  ListSchedulesParams,
   ReportExecutionHistoryParams,
   ReportExecutionStatus,
 } from './types';
@@ -24,7 +29,12 @@ import type {
 // Query keys factory for cache management
 export const reportKeys = {
   all: ['reports'] as const,
+  definitions: () => [...reportKeys.all, 'definitions'] as const,
+  definitionList: (organizationId: string, filters?: Omit<ListReportsParams, 'organization_id'>) =>
+    [...reportKeys.definitions(), organizationId, filters] as const,
   schedules: () => [...reportKeys.all, 'schedules'] as const,
+  scheduleList: (organizationId: string, filters?: Omit<ListSchedulesParams, 'organization_id'>) =>
+    [...reportKeys.schedules(), 'list', organizationId, filters] as const,
   schedule: (id: string) => [...reportKeys.schedules(), id] as const,
   executions: (scheduleId: string) => [...reportKeys.schedule(scheduleId), 'executions'] as const,
   executionList: (
@@ -34,6 +44,60 @@ export const reportKeys = {
   ) => [...reportKeys.executions(scheduleId), filters, pagination] as const,
   execution: (id: string) => [...reportKeys.all, 'execution', id] as const,
 };
+
+/**
+ * Hook to list report definitions for an organization (Epic 53 / gap-81-1).
+ *
+ * Populates the report selector in the "New Schedule" form — without this the
+ * ScheduleForm dropdown is empty and a schedule can never be created.
+ */
+export function useReports(
+  organizationId: string,
+  filters?: Omit<ListReportsParams, 'organization_id'>,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: reportKeys.definitionList(organizationId, filters),
+    queryFn: () => listReports({ organization_id: organizationId, ...filters }),
+    enabled: options?.enabled !== false && !!organizationId,
+  });
+}
+
+/**
+ * Hook to list report schedules for an organization (Epic 53 / gap-81-1).
+ *
+ * Backs the Schedules tab list and lets a freshly-created schedule appear once
+ * `useCreateSchedule` invalidates the `schedules` key.
+ */
+export function useReportSchedules(
+  organizationId: string,
+  filters?: Omit<ListSchedulesParams, 'organization_id'>,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: reportKeys.scheduleList(organizationId, filters),
+    queryFn: () => listSchedules({ organization_id: organizationId, ...filters }),
+    enabled: options?.enabled !== false && !!organizationId,
+  });
+}
+
+/**
+ * Hook to create a report schedule (gap-81-1).
+ *
+ * Wires the "New Schedule" form's submit to POST /api/v1/reports/schedules.
+ * On success the `schedules` query key is invalidated so the new row shows up
+ * in the Schedules list without a manual refetch.
+ */
+export function useCreateSchedule(organizationId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateReportSchedule) => createSchedule(organizationId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: reportKeys.schedules() });
+    },
+  });
+}
 
 /**
  * Hook to update a report schedule (Story 81.1).


### PR DESCRIPTION
## Task
Frontend Create new schedule UI missing — no CreateScheduleModal/hook found (81-1-report-schedule-editing Report Schedule Editing)

## Owner
pm-backend (hint) — actual work is `react-web` (ppt-web + api-client)

## Root cause
The Schedules tab already rendered a "+ New Schedule" button and the inline `ScheduleForm` (create UI existed), but the flow was **inert**:
- `ReportsPageRoute` never passed an `onCreateSchedule` handler → submitting called `undefined`.
- The route fed `ReportsPage` a hardcoded empty `reports={[]}` list → the form's report selector had no options, so a schedule could never be created.
- No `useCreateSchedule` hook existed in `@ppt/api-client` (the `createSchedule` API fn existed but was unwired).

## Fix
- `@ppt/api-client` (`reports/hooks.ts`): add `useCreateSchedule` (POST /api/v1/reports/schedules, invalidates the `schedules` key), plus `useReports` and `useReportSchedules` query hooks (thin wrappers over the existing `listReports` / `listSchedules` API fns) to populate the report selector and schedule list.
- `ReportsPageRoute` (`routes/groups/reports.tsx`): fetch report definitions + schedules for the org, wire `onCreateSchedule` with success/error toast, pass real `reports`/`schedules`/`isLoading`.
- `ReportsPage.tsx`: tighten the `onCreateSchedule` prop type from `unknown` to `CreateReportSchedule`.
- Add a route-level regression test for the create-schedule flow.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` → exit 0 (tsc)
- `pnpm -F @ppt/web exec tsc --noEmit` (typecheck) → exit 0
- `pnpm exec biome check <changed files>` → exit 0 (after organizeImports autofix)
- `vitest run reports.create-schedule.route.test.tsx` → exit 0 (1 passed)
- Full reports suite (route + feature): `vitest run src/routes/groups/reports.* src/features/reports` → 64 passed / 6 files

Note: the app's `lint` script invokes ESLint with a missing flat config (pre-existing repo breakage unrelated to this change); the repo's actual linter is Biome (`pnpm check`), which passes.

## IG3 — failing-on-main evidence
With `routes/groups/reports.tsx` reverted to its pre-fix state, the new test **fails** (report selector empty → `selectOptions('rep-1')` cannot find the option). With the fix applied it passes. Verified via `git stash`.

## Built (Band B — full build)
Skipped: change is a focused wiring slice (hooks + route props); Band A typecheck + api-client `tsc` build already cover import-time/type errors. No Vite-only import surface changed.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). `just` not installed in this sandbox.

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-backend` → exit 2. The task's `owner_role` hint is `pm-backend`, but this is a frontend task (dispatcher confirmed). All changed paths are frontend and outside pm-backend's owner areas:
- `frontend/apps/ppt-web/src/routes/groups/reports.tsx`
- `frontend/apps/ppt-web/src/routes/groups/reports.create-schedule.route.test.tsx`
- `frontend/apps/ppt-web/src/features/reports/pages/ReportsPage.tsx`
- `frontend/packages/api-client/src/reports/hooks.ts`

## Code-reuse review
`reuse-grep.sh` emitted two WARNs — both spurious (truncated prefixes `useC` / `useR` matched unrelated files `screen-map/tests/grouping.test.ts` and `reality-api-client/.../favorites/hooks.ts`). The new hooks reuse the existing `createSchedule` / `listReports` / `listSchedules` API functions rather than reimplementing transport logic.

## Notes
- The report selector / schedule list now fetch live data for the org; previously hardcoded empty.
- Follow-up (out of scope): delete/toggle/run-now schedule actions in `ScheduleList` are still unwired in the route (`onDeleteSchedule`/`onToggleSchedule`/`onRunScheduleNow` not passed) — separate gaps.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G2P58GaUkoshGjPj5nN5aK)_