### PR TITLE
gap-84-4: add notification-trigger management UI (ppt-web)

### DIFF
--- a/docs/screens/ppt/notification-triggers.md
+++ b/docs/screens/ppt/notification-triggers.md
@@ -1,0 +1,82 @@
+---
+id: ppt/notification-triggers
+name: Notification Triggers
+product: ppt
+implementations:
+  ppt-web:
+    route: /notifications/triggers
+    component: NotificationTriggersPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: complete
+  mobile:
+    buildStatus: n/a
+    redesignStatus: n/a
+    apiStatus: n/a
+endpoints: []
+relatedScreens:
+  - ppt/notification-analytics
+useCases:
+  - UC-01
+sharedComponents:
+  - data-table
+  - toggle
+epics: []
+diagrams: []
+owner: pm-frontend
+---
+
+## Functionality Checklist
+
+<!-- tag with [w] / [m] / [w,m] / [-] -->
+
+### Trigger list (web)
+- [x] [w] Triggers (event types) grouped by category (fault / vote / announcement / document / message / critical / finance / facility)
+- [x] [w] Per-category header shows the display name and `{enabled} of {total} enabled` rollup
+- [x] [w] Priority triggers (e.g. emergency alerts) show a "Priority" badge
+
+### Channel toggles (web)
+- [x] [w] Push / Email / In-app checkbox per trigger → `PUT …/granular/events/{eventType}`
+- [x] [w] Priority triggers keep the in-app channel forced on + disabled (backend enforces)
+- [x] [w] Row inputs disabled while its update is in flight (`savingEventType`)
+- [x] [w] Save failure surfaces an error toast; the query invalidates on success to refresh rollups
+
+### Reset (web)
+- [x] [w] "Reset to defaults" → `POST …/granular/events/reset`, success/error toast, cache updated
+
+## States
+
+- **Empty**: when `preferences` is empty, a single-line "No notification triggers are available for your account." is shown.
+- **Loading**: centered spinner with `aria-busy` while `useNotificationTriggers` is fetching.
+- **Error**: inline `role="alert"` danger tile ("Failed to load notification triggers") + `common.retry` button wired to `refetch()`.
+- **Forbidden**: a backend `401`/`403` surfaces an amber `role="alert"` access notice and no table.
+
+## Notes
+
+### Broader context
+
+User-facing management UI for the Notification Trigger System (Story 84.4). Lets
+a user choose which events notify them and on which channels, over the granular
+notification-event API (Epic 8B) at
+`/api/v1/users/me/notification-preferences/granular/events`. Closes the PM gap
+"No frontend notification-trigger management UI (84-4)". Complements the operator
+delivery dashboard at `ppt/notification-analytics`.
+
+### Specific (recent)
+
+- **Endpoint not catalogued**: the granular `/events` endpoints have no
+  `operationId` in `@ppt/sitemap` and are absent from the generated
+  `@ppt/api-client`, so `endpoints: []` here (keeps `/screens validate` green) and
+  the hooks call the REST path directly via TanStack Query — the
+  `notification-analytics` / `admin/audit` precedent.
+- **Route not in sitemap**: `/notifications/triggers` is not in `@ppt/sitemap`
+  `pptWebRoutes`, so `sitemapRefs` is omitted. It shares the `routes/groups/notifications.tsx`
+  group with `/notifications/analytics`.
+- Auth: the bearer token is read from `localStorage` (`ppt_access_token`) in the
+  fetch helpers, matching `authApiClient` / `gdprClient` / `useNotificationAnalytics`.
+
+## Agent Log
+
+<!-- newest entries on top -->
+
+- 2026-07-13 — agent: gap-84-4 (react-web) — created from scratch. New `/notifications/triggers` route + `NotificationTriggersPage` + `useNotificationTriggers` / `useUpdateNotificationTrigger` / `useResetNotificationTriggers` (direct REST over granular `/events`, analytics precedent). Category-grouped trigger list, per-channel toggles, forced-on in-app for priority triggers, reset-to-defaults, toast feedback. ppt-web buildStatus shipped / apiStatus complete; mobile n/a. 10 page tests; typecheck + biome + vitest + Vite build green.

--- a/docs/screens/ppt/notification-triggers.md
+++ b/docs/screens/ppt/notification-triggers.md
@@ -15,7 +15,8 @@ implementations:
     apiStatus: n/a
 endpoints: []
 relatedScreens:
-  - ppt/notification-analytics
+  - id: ppt/notification-analytics
+    rel: sibling
 useCases:
   - UC-01
 sharedComponents:

--- a/frontend/apps/ppt-web/src/features/notification-triggers/hooks/useNotificationTriggers.ts
+++ b/frontend/apps/ppt-web/src/features/notification-triggers/hooks/useNotificationTriggers.ts
@@ -1,0 +1,114 @@
+/**
+ * Notification trigger hooks (Story 84.4 — Notification Trigger System, PM gap 84-4).
+ *
+ * TanStack Query wrappers over the granular notification-event API:
+ *   GET  /api/v1/users/me/notification-preferences/granular/events
+ *   PUT  /api/v1/users/me/notification-preferences/granular/events/{eventType}
+ *   POST /api/v1/users/me/notification-preferences/granular/events/reset
+ *
+ * These endpoints require authentication and are absent from the generated
+ * `@ppt/api-client`, so we call the REST paths directly and read the bearer token
+ * from localStorage — the same convention as `features/notification-analytics`,
+ * `features/auth/authApiClient.ts`, and `features/privacy/gdprClient.ts`.
+ */
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { EventTriggersResponse, UpdateTriggerRequest } from '../types';
+
+const BASE_PATH = '/api/v1/users/me/notification-preferences/granular';
+const ACCESS_TOKEN_KEY = 'ppt_access_token';
+
+function readAccessToken(): string | undefined {
+  try {
+    return localStorage.getItem(ACCESS_TOKEN_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function authHeaders(): Headers {
+  const headers = new Headers({ 'Content-Type': 'application/json' });
+  const token = readAccessToken();
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return headers;
+}
+
+async function parseError(res: Response): Promise<Error & { status: number }> {
+  const body = (await res.json().catch(() => null)) as { message?: string } | null;
+  const error = new Error(body?.message || `Request failed (HTTP ${res.status})`) as Error & {
+    status: number;
+  };
+  error.status = res.status;
+  return error;
+}
+
+async function fetchTriggers(): Promise<EventTriggersResponse> {
+  const res = await fetch(`${BASE_PATH}/events`, { headers: authHeaders() });
+  if (!res.ok) {
+    throw await parseError(res);
+  }
+  return res.json() as Promise<EventTriggersResponse>;
+}
+
+async function putTrigger(eventType: string, patch: UpdateTriggerRequest): Promise<void> {
+  const res = await fetch(`${BASE_PATH}/events/${encodeURIComponent(eventType)}`, {
+    method: 'PUT',
+    headers: authHeaders(),
+    body: JSON.stringify(patch),
+  });
+  if (!res.ok) {
+    throw await parseError(res);
+  }
+}
+
+async function postReset(): Promise<EventTriggersResponse> {
+  const res = await fetch(`${BASE_PATH}/events/reset`, {
+    method: 'POST',
+    headers: authHeaders(),
+  });
+  if (!res.ok) {
+    throw await parseError(res);
+  }
+  return res.json() as Promise<EventTriggersResponse>;
+}
+
+export const notificationTriggerKeys = {
+  all: ['notification-triggers'] as const,
+  events: () => [...notificationTriggerKeys.all, 'events'] as const,
+};
+
+/** Fetch the full set of notification triggers (event types) and category rollups. */
+export function useNotificationTriggers() {
+  return useQuery({
+    queryKey: notificationTriggerKeys.events(),
+    queryFn: fetchTriggers,
+    staleTime: 30 * 1000,
+  });
+}
+
+/**
+ * Toggle a single channel on one trigger. Invalidates the trigger list on success
+ * so the category rollups (`enabledEvents`) stay in sync.
+ */
+export function useUpdateNotificationTrigger() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ eventType, patch }: { eventType: string; patch: UpdateTriggerRequest }) =>
+      putTrigger(eventType, patch),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: notificationTriggerKeys.events() });
+    },
+  });
+}
+
+/** Reset every trigger back to its role/system default and refresh the cache. */
+export function useResetNotificationTriggers() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: postReset,
+    onSuccess: (data) => {
+      queryClient.setQueryData(notificationTriggerKeys.events(), data);
+    },
+  });
+}

--- a/frontend/apps/ppt-web/src/features/notification-triggers/index.ts
+++ b/frontend/apps/ppt-web/src/features/notification-triggers/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Notification trigger management feature barrel (Story 84.4 — Notification
+ * Trigger System, PM gap 84-4). Manage which event types notify the user and on
+ * which channels, over the granular `/notification-preferences/granular/events` API.
+ */
+
+export * from './hooks/useNotificationTriggers';
+export * from './pages';
+export * from './types';

--- a/frontend/apps/ppt-web/src/features/notification-triggers/pages/NotificationTriggersPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/notification-triggers/pages/NotificationTriggersPage.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * NotificationTriggersPage tests (Story 84.4 — Notification Trigger System,
+ * PM gap 84-4). Covers forbidden/loading/error states, per-category grouping,
+ * channel toggles (incl. forced priority in-app), and the reset action.
+ */
+
+/// <reference types="vitest/globals" />
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import type { EventTriggersResponse } from '../types';
+import { NotificationTriggersPage } from './NotificationTriggersPage';
+
+const noop = () => {};
+
+const baseProps = {
+  onToggle: noop,
+};
+
+const data: EventTriggersResponse = {
+  preferences: [
+    {
+      eventType: 'fault_status_changed',
+      category: 'fault',
+      displayName: 'Fault status changed',
+      description: 'When a reported fault changes status.',
+      isPriority: false,
+      pushEnabled: true,
+      emailEnabled: false,
+      inAppEnabled: true,
+    },
+    {
+      eventType: 'emergency_alert',
+      category: 'critical',
+      displayName: 'Emergency alert',
+      isPriority: true,
+      pushEnabled: true,
+      emailEnabled: true,
+      inAppEnabled: true,
+    },
+  ],
+  categories: [
+    { category: 'fault', displayName: 'fault', totalEvents: 1, enabledEvents: 1 },
+    { category: 'critical', displayName: 'critical', totalEvents: 1, enabledEvents: 1 },
+  ],
+};
+
+describe('NotificationTriggersPage', () => {
+  it('shows the forbidden notice when isForbidden', () => {
+    render(<NotificationTriggersPage {...baseProps} isForbidden />);
+    expect(screen.getByRole('alert')).toHaveTextContent('do not have permission');
+  });
+
+  it('renders a loading spinner when isLoading', () => {
+    const { container } = render(<NotificationTriggersPage {...baseProps} isLoading />);
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+
+  it('renders an error state with a retry button', () => {
+    const onRetry = vi.fn();
+    render(<NotificationTriggersPage {...baseProps} isError onRetry={onRetry} />);
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed to load notification triggers');
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('renders the empty state when there are no triggers', () => {
+    render(<NotificationTriggersPage {...baseProps} data={{ preferences: [], categories: [] }} />);
+    expect(
+      screen.getByText('No notification triggers are available for your account.')
+    ).toBeInTheDocument();
+  });
+
+  it('groups triggers by category and shows the priority badge', () => {
+    render(<NotificationTriggersPage {...baseProps} data={data} />);
+    expect(screen.getByRole('heading', { name: 'Fault' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Critical' })).toBeInTheDocument();
+    expect(screen.getByText('Priority')).toBeInTheDocument();
+  });
+
+  it('invokes onToggle with the event type, channel, and next value', () => {
+    const onToggle = vi.fn();
+    render(<NotificationTriggersPage {...baseProps} data={data} onToggle={onToggle} />);
+    // Email is currently off for the fault trigger — clicking enables it.
+    const emailBox = screen.getByRole('checkbox', {
+      name: 'Fault status changed — Email',
+    });
+    fireEvent.click(emailBox);
+    expect(onToggle).toHaveBeenCalledWith('fault_status_changed', 'email', true);
+  });
+
+  it('forces the in-app channel on and disabled for priority triggers', () => {
+    render(<NotificationTriggersPage {...baseProps} data={data} />);
+    const inAppBox = screen.getByRole('checkbox', {
+      name: 'Emergency alert — In app',
+    }) as HTMLInputElement;
+    expect(inAppBox).toBeChecked();
+    expect(inAppBox).toBeDisabled();
+  });
+
+  it('disables a row while it is saving', () => {
+    render(
+      <NotificationTriggersPage {...baseProps} data={data} savingEventType="fault_status_changed" />
+    );
+    const pushBox = screen.getByRole('checkbox', {
+      name: 'Fault status changed — Push',
+    });
+    expect(pushBox).toBeDisabled();
+  });
+
+  it('renders the reset button and calls onReset', () => {
+    const onReset = vi.fn();
+    render(<NotificationTriggersPage {...baseProps} data={data} onReset={onReset} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to defaults' }));
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it('shows the per-category enabled count', () => {
+    render(<NotificationTriggersPage {...baseProps} data={data} />);
+    const faultSection = screen.getByRole('heading', { name: 'Fault' }).closest('section');
+    expect(faultSection).not.toBeNull();
+    expect(within(faultSection as HTMLElement).getByText('1 of 1 enabled')).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/notification-triggers/pages/NotificationTriggersPage.tsx
+++ b/frontend/apps/ppt-web/src/features/notification-triggers/pages/NotificationTriggersPage.tsx
@@ -1,0 +1,283 @@
+/**
+ * NotificationTriggersPage — manage which notification triggers (event types)
+ * fire, and on which channels (Story 84.4 — Notification Trigger System, PM gap 84-4).
+ *
+ * Presentational: query + mutation state is owned by the route wrapper
+ * (NotificationTriggersPageRoute), which drives the granular-events hooks. Each
+ * trigger row exposes push / email / in-app checkboxes; priority triggers
+ * (e.g. emergency alerts) keep the in-app channel forced on server-side, so we
+ * render it disabled here to set expectations.
+ */
+
+import { useTranslation } from 'react-i18next';
+import type {
+  CategorySummary,
+  EventTriggerPreference,
+  EventTriggersResponse,
+  TriggerChannel,
+} from '../types';
+
+export interface NotificationTriggersPageProps {
+  data?: EventTriggersResponse;
+  isLoading?: boolean;
+  isError?: boolean;
+  /** True when the backend rejected the request with 401/403. */
+  isForbidden?: boolean;
+  onRetry?: () => void;
+  /** Event type currently being persisted (disables its row's inputs). */
+  savingEventType?: string | null;
+  onToggle: (eventType: string, channel: TriggerChannel, enabled: boolean) => void;
+  onReset?: () => void;
+  isResetting?: boolean;
+}
+
+const CHANNELS: TriggerChannel[] = ['push', 'email', 'inApp'];
+
+const CHANNEL_LABEL_KEY: Record<TriggerChannel, { key: string; def: string }> = {
+  push: { key: 'notificationTriggers.channelPush', def: 'Push' },
+  email: { key: 'notificationTriggers.channelEmail', def: 'Email' },
+  inApp: { key: 'notificationTriggers.channelInApp', def: 'In app' },
+};
+
+/** Humanise a category/enum key (`in_app` → `In app`). */
+function humanise(value: string): string {
+  const s = value.replace(/_/g, ' ');
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function channelValue(pref: EventTriggerPreference, channel: TriggerChannel): boolean {
+  switch (channel) {
+    case 'push':
+      return pref.pushEnabled;
+    case 'email':
+      return pref.emailEnabled;
+    case 'inApp':
+      return pref.inAppEnabled;
+  }
+}
+
+export function NotificationTriggersPage({
+  data,
+  isLoading,
+  isError,
+  isForbidden,
+  onRetry,
+  savingEventType,
+  onToggle,
+  onReset,
+  isResetting,
+}: NotificationTriggersPageProps) {
+  const { t } = useTranslation();
+
+  if (isForbidden) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 py-8">
+        <div
+          role="alert"
+          className="border border-amber-200 bg-amber-50 text-amber-800 rounded-lg p-6 text-center"
+        >
+          <p className="font-medium">
+            {t('notificationTriggers.forbidden', {
+              defaultValue: 'You do not have permission to manage notification triggers.',
+            })}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const preferences: EventTriggerPreference[] = data?.preferences ?? [];
+  const categories: CategorySummary[] = data?.categories ?? [];
+
+  // Group triggers by category, preserving the backend category ordering.
+  const byCategory = new Map<string, EventTriggerPreference[]>();
+  for (const pref of preferences) {
+    const list = byCategory.get(pref.category) ?? [];
+    list.push(pref);
+    byCategory.set(pref.category, list);
+  }
+  const orderedCategories =
+    categories.length > 0 ? categories.map((c) => c.category) : Array.from(byCategory.keys());
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <header className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">
+            {t('notificationTriggers.title', { defaultValue: 'Notification Triggers' })}
+          </h1>
+          <p className="text-sm text-gray-500">
+            {t('notificationTriggers.subtitle', {
+              defaultValue:
+                'Choose which events notify you, and on which channels (push, email, in-app).',
+            })}
+          </p>
+        </div>
+        {onReset && (
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={isResetting || isLoading}
+            className="px-3 py-2 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+          >
+            {isResetting
+              ? t('notificationTriggers.resetting', { defaultValue: 'Resetting…' })
+              : t('notificationTriggers.resetDefaults', { defaultValue: 'Reset to defaults' })}
+          </button>
+        )}
+      </header>
+
+      {/* Loading */}
+      {isLoading && (
+        <div className="flex justify-center py-16" aria-live="polite" aria-busy="true">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600" />
+        </div>
+      )}
+
+      {/* Error */}
+      {!isLoading && isError && (
+        <div
+          role="alert"
+          className="text-center py-8 border border-red-200 bg-red-50 rounded-lg text-red-700"
+        >
+          <p className="font-medium">
+            {t('notificationTriggers.failedToLoad', {
+              defaultValue: 'Failed to load notification triggers',
+            })}
+          </p>
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="mt-3 px-3 py-1 border border-red-300 rounded hover:bg-red-100"
+            >
+              {t('common.retry', { defaultValue: 'Retry' })}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Content */}
+      {!isLoading && !isError && data && (
+        <>
+          {preferences.length === 0 ? (
+            <div className="text-center py-12 text-gray-500">
+              {t('notificationTriggers.empty', {
+                defaultValue: 'No notification triggers are available for your account.',
+              })}
+            </div>
+          ) : (
+            <div className="space-y-8">
+              {orderedCategories.map((category) => {
+                const rows = byCategory.get(category) ?? [];
+                if (rows.length === 0) {
+                  return null;
+                }
+                const summary = categories.find((c) => c.category === category);
+                return (
+                  <section
+                    key={category}
+                    className="border border-gray-200 rounded-lg overflow-hidden"
+                  >
+                    <div className="flex items-center justify-between bg-gray-50 px-4 py-3 border-b border-gray-200">
+                      <h2 className="font-semibold text-gray-800">
+                        {summary?.displayName ? humanise(summary.displayName) : humanise(category)}
+                      </h2>
+                      {summary && (
+                        <span className="text-xs text-gray-500 tabular-nums">
+                          {t('notificationTriggers.enabledCount', {
+                            defaultValue: '{{enabled}} of {{total}} enabled',
+                            enabled: summary.enabledEvents,
+                            total: summary.totalEvents,
+                          })}
+                        </span>
+                      )}
+                    </div>
+                    <div className="overflow-x-auto">
+                      <table className="min-w-full text-sm">
+                        <caption className="sr-only">
+                          {t('notificationTriggers.tableCaption', {
+                            defaultValue: 'Notification channels per trigger',
+                          })}
+                        </caption>
+                        <thead className="text-gray-600">
+                          <tr>
+                            <th scope="col" className="px-4 py-2 text-left font-semibold">
+                              {t('notificationTriggers.colTrigger', { defaultValue: 'Trigger' })}
+                            </th>
+                            {CHANNELS.map((channel) => (
+                              <th
+                                key={channel}
+                                scope="col"
+                                className="px-4 py-2 text-center font-semibold w-24"
+                              >
+                                {t(CHANNEL_LABEL_KEY[channel].key, {
+                                  defaultValue: CHANNEL_LABEL_KEY[channel].def,
+                                })}
+                              </th>
+                            ))}
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-100">
+                          {rows.map((pref) => {
+                            const rowSaving = savingEventType === pref.eventType;
+                            return (
+                              <tr key={pref.eventType} className="text-gray-800">
+                                <td className="px-4 py-3">
+                                  <div className="font-medium flex items-center gap-2">
+                                    {humanise(pref.displayName || pref.eventType)}
+                                    {pref.isPriority && (
+                                      <span className="inline-block text-[10px] uppercase tracking-wide font-semibold text-red-700 bg-red-50 border border-red-200 rounded px-1.5 py-0.5">
+                                        {t('notificationTriggers.priorityBadge', {
+                                          defaultValue: 'Priority',
+                                        })}
+                                      </span>
+                                    )}
+                                  </div>
+                                  {pref.description && (
+                                    <p className="text-xs text-gray-500 mt-0.5">
+                                      {pref.description}
+                                    </p>
+                                  )}
+                                </td>
+                                {CHANNELS.map((channel) => {
+                                  const checked = channelValue(pref, channel);
+                                  // Priority triggers keep in-app forced on by the
+                                  // backend; reflect that with a disabled, checked box.
+                                  const forced = pref.isPriority && channel === 'inApp';
+                                  const labelText = t(CHANNEL_LABEL_KEY[channel].key, {
+                                    defaultValue: CHANNEL_LABEL_KEY[channel].def,
+                                  });
+                                  return (
+                                    <td key={channel} className="px-4 py-3 text-center">
+                                      <input
+                                        type="checkbox"
+                                        className="h-4 w-4 accent-blue-600 disabled:opacity-40"
+                                        checked={forced ? true : checked}
+                                        disabled={rowSaving || forced}
+                                        aria-label={`${humanise(
+                                          pref.displayName || pref.eventType
+                                        )} — ${labelText}`}
+                                        onChange={(e) =>
+                                          onToggle(pref.eventType, channel, e.target.checked)
+                                        }
+                                      />
+                                    </td>
+                                  );
+                                })}
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                  </section>
+                );
+              })}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/notification-triggers/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/notification-triggers/pages/index.ts
@@ -1,0 +1,1 @@
+export * from './NotificationTriggersPage';

--- a/frontend/apps/ppt-web/src/features/notification-triggers/types.ts
+++ b/frontend/apps/ppt-web/src/features/notification-triggers/types.ts
@@ -1,0 +1,66 @@
+/**
+ * Notification trigger management types (Story 84.4 — Notification Trigger System,
+ * PM gap 84-4).
+ *
+ * Mirrors the granular notification-event API shipped by the backend (Epic 8B,
+ * `backend/crates/db/src/models/granular_notification.rs`) at base
+ * `/api/v1/users/me/notification-preferences/granular`. These per-event-type
+ * preferences ARE the trigger surface: each event type (trigger) fans out to the
+ * push / email / in-app channels according to the flags below.
+ *
+ * The granular endpoints are NOT in the generated `@ppt/api-client`, so — as with
+ * `features/notification-analytics` — these types are hand-authored alongside a
+ * direct-REST hook. JSON is camelCase (backend `#[serde(rename_all = "camelCase")]`).
+ */
+
+/** Delivery channels a trigger can fan out to. */
+export type TriggerChannel = 'push' | 'email' | 'inApp';
+
+/** Event categories the backend groups triggers under (snake_case on the wire). */
+export type NotificationEventCategory =
+  | 'fault'
+  | 'vote'
+  | 'announcement'
+  | 'document'
+  | 'message'
+  | 'critical'
+  | 'finance'
+  | 'facility';
+
+/**
+ * A single trigger (event type) with its per-channel delivery flags.
+ * Mirrors `EventPreferenceWithDetails`.
+ */
+export interface EventTriggerPreference {
+  eventType: string;
+  category: NotificationEventCategory;
+  displayName: string;
+  description?: string;
+  /** Priority triggers (e.g. emergencies) cannot be fully silenced. */
+  isPriority: boolean;
+  pushEnabled: boolean;
+  emailEnabled: boolean;
+  inAppEnabled: boolean;
+  updatedAt?: string;
+}
+
+/** Per-category rollup. Mirrors `CategorySummary`. */
+export interface CategorySummary {
+  category: NotificationEventCategory;
+  displayName: string;
+  totalEvents: number;
+  enabledEvents: number;
+}
+
+/** Full granular-events response. Mirrors `EventPreferencesResponse`. */
+export interface EventTriggersResponse {
+  preferences: EventTriggerPreference[];
+  categories: CategorySummary[];
+}
+
+/** Partial channel update for a single trigger. Mirrors `UpdateEventPreferenceRequest`. */
+export interface UpdateTriggerRequest {
+  pushEnabled?: boolean;
+  emailEnabled?: boolean;
+  inAppEnabled?: boolean;
+}

--- a/frontend/apps/ppt-web/src/routes/groups/notifications.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/notifications.tsx
@@ -10,12 +10,20 @@
  * `isManagerRole` (operator-equivalent); the backend remains the source of truth
  * and a 403 surfaces the forbidden notice.
  */
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Route } from 'react-router-dom';
+import { useToast } from '../../components';
 import { useAuth } from '../../contexts';
 import type { NotificationAnalyticsFilters } from '../../features/notification-analytics';
 import { useNotificationAnalytics } from '../../features/notification-analytics';
-import { NotificationAnalyticsPage } from '../lazyRoutes';
+import type { TriggerChannel } from '../../features/notification-triggers';
+import {
+  useNotificationTriggers,
+  useResetNotificationTriggers,
+  useUpdateNotificationTrigger,
+} from '../../features/notification-triggers';
+import { NotificationAnalyticsPage, NotificationTriggersPage } from '../lazyRoutes';
 import { isManagerRole } from '../shared';
 
 function NotificationAnalyticsPageRoute() {
@@ -47,11 +55,102 @@ function NotificationAnalyticsPageRoute() {
   );
 }
 
-/** Notification analytics routes (Story 2B-C.3). */
+/**
+ * Notification trigger management route (Story 84.4 — Notification Trigger System,
+ * PM gap 84-4).
+ *
+ * Owns the granular-events query + per-trigger channel mutations and the reset
+ * action, bridging them to the presentational `NotificationTriggersPage`. Any
+ * authenticated user manages their own triggers; a 401/403 surfaces the same
+ * forbidden notice. The endpoint is not in the generated client, so the hooks
+ * call the REST path directly.
+ */
+function NotificationTriggersPageRoute() {
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+
+  const { data, isLoading, error, refetch } = useNotificationTriggers();
+  const updateTrigger = useUpdateNotificationTrigger();
+  const resetTriggers = useResetNotificationTriggers();
+
+  const status = (error as (Error & { status?: number }) | null)?.status;
+  const isForbidden = status === 401 || status === 403;
+
+  const onToggle = useCallback(
+    (eventType: string, channel: TriggerChannel, enabled: boolean) => {
+      const patch =
+        channel === 'push'
+          ? { pushEnabled: enabled }
+          : channel === 'email'
+            ? { emailEnabled: enabled }
+            : { inAppEnabled: enabled };
+      updateTrigger.mutate(
+        { eventType, patch },
+        {
+          onError: (err) => {
+            showToast({
+              type: 'error',
+              title: t('notificationTriggers.saveFailed', {
+                defaultValue: 'Could not update trigger',
+              }),
+              message: err instanceof Error ? err.message : String(err),
+            });
+          },
+        }
+      );
+    },
+    [updateTrigger, showToast, t]
+  );
+
+  const onReset = useCallback(() => {
+    resetTriggers.mutate(undefined, {
+      onSuccess: () => {
+        showToast({
+          type: 'success',
+          title: t('notificationTriggers.resetDone', {
+            defaultValue: 'Triggers reset to defaults',
+          }),
+        });
+      },
+      onError: (err) => {
+        showToast({
+          type: 'error',
+          title: t('notificationTriggers.resetFailed', {
+            defaultValue: 'Could not reset triggers',
+          }),
+          message: err instanceof Error ? err.message : String(err),
+        });
+      },
+    });
+  }, [resetTriggers, showToast, t]);
+
+  const savingEventType = updateTrigger.isPending
+    ? (updateTrigger.variables?.eventType ?? null)
+    : null;
+
+  return (
+    <NotificationTriggersPage
+      data={data}
+      isLoading={isLoading}
+      isError={!!error && !isForbidden}
+      isForbidden={isForbidden}
+      onRetry={() => {
+        void refetch();
+      }}
+      savingEventType={savingEventType}
+      onToggle={onToggle}
+      onReset={onReset}
+      isResetting={resetTriggers.isPending}
+    />
+  );
+}
+
+/** Notification analytics + trigger-management routes (Stories 2B-C.3, 84.4). */
 export function notificationAnalyticsRoutes() {
   return (
     <>
       <Route path="/notifications/analytics" element={<NotificationAnalyticsPageRoute />} />
+      <Route path="/notifications/triggers" element={<NotificationTriggersPageRoute />} />
     </>
   );
 }

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -321,6 +321,13 @@ export const NotificationAnalyticsPage = lazy(() =>
   }))
 );
 
+// Notification trigger management (Story 84.4 — Notification Trigger System, PM gap 84-4)
+export const NotificationTriggersPage = lazy(() =>
+  import('../features/notification-triggers').then((m) => ({
+    default: m.NotificationTriggersPage,
+  }))
+);
+
 // Predictive Maintenance Dashboard (Epic 13, Story 13.3) — gap-sweep
 export const PredictiveMaintenancePage = lazy(() =>
   import('../features/predictive-maintenance').then((m) => ({


### PR DESCRIPTION
## Task
No frontend notification-trigger management UI (84-4-notification-triggers Notification Trigger System)

## Owner
pm-backend (hint) — but this is a **frontend** task; specialist = `react-web` (per dispatcher: "This is a frontend task").

## What
Adds a ppt-web page (`/notifications/triggers`) to manage which notification triggers (event types) fire and on which channels (push / email / in-app). Backs onto the granular notification-event API (Epic 8B, Story 84.4) at `/api/v1/users/me/notification-preferences/granular/events`:
- `GET  …/events` — list triggers grouped by category + per-category rollups
- `PUT  …/events/{eventType}` — toggle one channel on one trigger
- `POST …/events/reset` — reset all triggers to defaults

These endpoints are **not in the generated `@ppt/api-client`**, so — following the established `features/notification-analytics` / `admin/audit` precedent — types are hand-authored and the hooks call the REST path directly (bearer token from `localStorage`).

Files:
- `features/notification-triggers/` — `types.ts`, `hooks/useNotificationTriggers.ts` (list / update / reset TanStack hooks), presentational `pages/NotificationTriggersPage.tsx`, barrels, `pages/NotificationTriggersPage.test.tsx` (10 cases)
- `routes/groups/notifications.tsx` — `/notifications/triggers` wrapper wiring query + per-trigger mutations + reset with toast feedback (route registered via the existing `notificationAnalyticsRoutes()` group already called in `AppRoutes.tsx`)
- `routes/lazyRoutes.tsx` — lazy `NotificationTriggersPage`
- `docs/screens/ppt/notification-triggers.md` — screen-map

UX details: triggers grouped by category with `{enabled} of {total}` rollup; priority triggers (e.g. emergency alerts) show a "Priority" badge and keep the in-app channel forced-on + disabled (backend enforces); per-row inputs disable while saving; loading / error+retry / empty / forbidden (401/403) states.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm exec vitest run src/features/notification-triggers` → exit 0 (**10 passed**)
- `pnpm exec biome check <changed files>` → exit 0 (after `--write` format)
- Note: the app's `eslint` script is non-functional repo-wide (no flat `eslint.config.js`); Biome is the authoritative lint gate per CLAUDE.md / `frontend.yml`.

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → exit 0, ✓ built in 19.18s

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — per-user notification preferences behind existing auth).

## Remote-tested
skipped

## Scope drift
`scope-check --owner pm-backend` → exit 2, flagging all 9 changed paths (they are `frontend/**` + `docs/screens/**`). This is **expected/benign**: the `owner_role` hint was `pm-backend`, but the task is inherently frontend (dispatcher: "This is a frontend task (ppt-web or reality-web)"). Against the correct area, `scope-check --owner pm-frontend` → **exit 0 (no drift)**. No backend/API/migration files touched.

## Code-reuse review
`reuse-grep --specialist react-web` → exit 0. It emitted 3 WARN lines (`useN`/`useR`/`useU` "looks like an existing helper") — these are **spurious truncated-name substring matches** against my `useNotificationTriggers` / `useResetNotificationTriggers` / `useUpdateNotificationTrigger`, not real duplication. The hooks are net-new and mirror the sanctioned `notification-analytics` direct-REST pattern.

## Notes
- Sandbox constraint: `api-server` cannot compile locally (swagger-ui 403) — but this PR is pure frontend and touches no Rust, so nothing was deferred. `frontend.yml` (biome + typecheck + test + build) is the relevant CI gate and was replicated locally green.
- No new i18n JSON keys added: all copy uses inline `defaultValue` (same convention as `NotificationAnalyticsPage`).
- Draft — not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2P58GaUkoshGjPj5nN5aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2P58GaUkoshGjPj5nN5aK)_