### PR TITLE
gap-83-3: portal webhook status manager surface (ppt-web)

### DIFF
--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -83,7 +83,8 @@
     "aiChat": "AI Assistant",
     "admin": "Admin",
     "iotAlerts": "Sensor Alerts",
-    "integrations": "Integrations"
+    "integrations": "Integrations",
+    "portalWebhooks": "Portal Webhooks"
   },
   "auth": {
     "signIn": "Sign In",
@@ -3388,6 +3389,40 @@
     }
   },
   "settings": {
+    "portalWebhooks": {
+      "title": "Portal Webhooks",
+      "subtitle": "Delivery status and activity from real-estate portal webhooks — views, inquiries and sync health per portal.",
+      "noOrganization": "No organization is selected for your account, so portal webhook activity cannot be shown.",
+      "loading": "Loading portal activity…",
+      "loadError": "Failed to load portal webhook activity.",
+      "summary": {
+        "title": "Summary",
+        "active": "Active",
+        "pending": "Pending",
+        "failed": "Failed",
+        "views": "Views",
+        "inquiries": "Inquiries"
+      },
+      "byPortal": {
+        "caption": "Syndication activity by portal",
+        "portal": "Portal",
+        "empty": "No portal activity recorded yet."
+      },
+      "listings": {
+        "title": "Listings",
+        "empty": "No syndicated listings yet.",
+        "activity": "{{views}} views · {{inquiries}} inquiries",
+        "portalActivity": "{{views}} views · {{inquiries}} inquiries",
+        "lastActivity": "Last activity: {{when}}",
+        "lastError": "Last error: {{error}}"
+      },
+      "health": {
+        "healthy": "Healthy",
+        "degraded": "Degraded",
+        "unhealthy": "Unhealthy",
+        "notConfigured": "Not configured"
+      }
+    },
     "integrations": {
       "title": "Integrations",
       "subtitle": "Connect external booking channels to sync listings and reservations.",

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -134,6 +134,11 @@ function AppNavigation() {
       <Link to="/settings/integrations">
         {t('nav.integrations', { defaultValue: 'Integrations' })}
       </Link>
+      {isOperator && (
+        <Link to="/settings/portal-webhooks">
+          {t('nav.portalWebhooks', { defaultValue: 'Portal Webhooks' })}
+        </Link>
+      )}
       <Link to="/settings/accessibility">{t('nav.accessibility')}</Link>
       <Link to="/settings/privacy">{t('nav.privacy')}</Link>
       <Link to="/settings/sessions">{t('nav.sessions', { defaultValue: 'Sessions' })}</Link>

--- a/frontend/apps/ppt-web/src/features/settings/index.ts
+++ b/frontend/apps/ppt-web/src/features/settings/index.ts
@@ -4,3 +4,4 @@
 
 export { IntegrationsPage } from './integrations/IntegrationsPage';
 export { AccessibilitySettingsPage } from './pages/AccessibilitySettingsPage';
+export { PortalWebhooksPage } from './webhooks/PortalWebhooksPage';

--- a/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Regression test for the Portal Webhooks status surface (Gap 83-3 / Epic 105 —
+ * Real Estate Portal Webhooks).
+ *
+ * Inbound portal webhooks were previously inbound-only with no manager
+ * visibility. This page renders the org-scoped syndication dashboard (the
+ * downstream product of those webhooks) via the `@ppt/api-client` `syndication`
+ * module. Neither the page/route nor the `useSyndicationDashboard` hook existed
+ * on `dev`, so this test fails without the wiring in this PR.
+ */
+
+/// <reference types="vitest/globals" />
+import { render, screen, within } from '@testing-library/react';
+import { PortalWebhooksPage } from './PortalWebhooksPage';
+
+let dashboard: {
+  data?:
+    | {
+        listings: Array<{
+          listing_id: string;
+          listing_title: string;
+          listing_status: string;
+          overall_status: string;
+          total_views: number;
+          total_inquiries: number;
+          portal_statuses: Array<{
+            portal: string;
+            status: string;
+            views: number;
+            inquiries: number;
+            last_activity_at: string | null;
+            last_error: string | null;
+          }>;
+        }>;
+        total: number;
+        page: number;
+        limit: number;
+        organization_stats: {
+          total_active: number;
+          total_pending: number;
+          total_failed: number;
+          total_views: number;
+          total_inquiries: number;
+          by_portal: Array<{
+            portal: string;
+            active_count: number;
+            pending_count: number;
+            failed_count: number;
+            views: number;
+            inquiries: number;
+          }>;
+        };
+      }
+    | undefined;
+  isLoading: boolean;
+  isError: boolean;
+} = { data: undefined, isLoading: true, isError: false };
+
+vi.mock('@ppt/api-client', () => ({
+  useSyndicationDashboard: () => dashboard,
+}));
+
+vi.mock('../../../contexts', () => ({
+  useAuth: () => ({ user: { organizationId: 'org-1' } }),
+}));
+
+function loadedDashboard() {
+  return {
+    data: {
+      listings: [
+        {
+          listing_id: 'l1',
+          listing_title: 'Sunny 2BR Apartment',
+          listing_status: 'active',
+          overall_status: 'degraded',
+          total_views: 42,
+          total_inquiries: 5,
+          portal_statuses: [
+            {
+              portal: 'sreality',
+              status: 'synced',
+              views: 30,
+              inquiries: 4,
+              last_activity_at: '2026-07-10T10:00:00Z',
+              last_error: null,
+            },
+            {
+              portal: 'bezrealitky',
+              status: 'failed',
+              views: 12,
+              inquiries: 1,
+              last_activity_at: '2026-07-09T09:00:00Z',
+              last_error: 'signature mismatch',
+            },
+          ],
+        },
+      ],
+      total: 1,
+      page: 1,
+      limit: 20,
+      organization_stats: {
+        total_active: 3,
+        total_pending: 1,
+        total_failed: 1,
+        total_views: 42,
+        total_inquiries: 5,
+        by_portal: [
+          {
+            portal: 'sreality',
+            active_count: 2,
+            pending_count: 0,
+            failed_count: 0,
+            views: 30,
+            inquiries: 4,
+          },
+          {
+            portal: 'bezrealitky',
+            active_count: 1,
+            pending_count: 1,
+            failed_count: 1,
+            views: 12,
+            inquiries: 1,
+          },
+        ],
+      },
+    },
+    isLoading: false,
+    isError: false,
+  };
+}
+
+describe('PortalWebhooksPage (Gap 83-3)', () => {
+  beforeEach(() => {
+    dashboard = { data: undefined, isLoading: true, isError: false };
+  });
+
+  it('renders the portal webhooks heading', () => {
+    render(<PortalWebhooksPage />);
+    expect(screen.getByRole('heading', { level: 1, name: /portal webhooks/i })).toBeInTheDocument();
+  });
+
+  it('shows a loading state while fetching', () => {
+    render(<PortalWebhooksPage />);
+    expect(screen.getByText(/loading portal activity/i)).toBeInTheDocument();
+  });
+
+  it('shows an error state when the dashboard query fails', () => {
+    dashboard = { data: undefined, isLoading: false, isError: true };
+    render(<PortalWebhooksPage />);
+    expect(screen.getByRole('alert')).toHaveTextContent(/failed to load portal webhook activity/i);
+  });
+
+  it('renders the per-portal breakdown table with view/inquiry counts', () => {
+    dashboard = loadedDashboard();
+    render(<PortalWebhooksPage />);
+    const table = screen.getByRole('table');
+    // Both known portals appear as rows with humanized labels.
+    expect(within(table).getByText('Sreality')).toBeInTheDocument();
+    expect(within(table).getByText('Bezrealitky')).toBeInTheDocument();
+  });
+
+  it('renders per-listing syndication status, health badge and last error', () => {
+    dashboard = loadedDashboard();
+    render(<PortalWebhooksPage />);
+    expect(
+      screen.getByRole('heading', { level: 3, name: /sunny 2br apartment/i })
+    ).toBeInTheDocument();
+    // Degraded health badge is surfaced.
+    expect(screen.getByText(/degraded/i)).toBeInTheDocument();
+    // The failed portal's last error is shown to the manager.
+    expect(screen.getByText(/signature mismatch/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.tsx
+++ b/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.tsx
@@ -1,0 +1,303 @@
+/**
+ * Portal Webhooks management/status page (Gap 83-3 / Epic 105 — Real Estate
+ * Portal Webhooks).
+ *
+ * Inbound portal webhooks (`POST /api/v1/webhooks/portals/*`) record views and
+ * inquiries from external real-estate portals (Reality Portal, Sreality,
+ * Bezrealitky, Nehnutelnosti) and update per-listing syndication state. Until
+ * now there was no manager-facing surface to see any of that — the webhooks
+ * were inbound-only with zero visibility.
+ *
+ * This page renders that visibility surface from the org-scoped syndication
+ * read endpoints (via the `@ppt/api-client` `syndication` module):
+ *   GET /api/v1/listings/syndication/dashboard  — per-listing status + org stats
+ *
+ * It is read-only: the webhook receivers themselves are unauthenticated
+ * HMAC-verified endpoints owned by the portals, so there is nothing to mutate
+ * here — the manager sees delivery outcomes (views/inquiries, sync health,
+ * last activity, last error) per portal.
+ */
+
+import { useSyndicationDashboard } from '@ppt/api-client';
+import type React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '../../../contexts';
+
+/** Human-readable portal labels for the known real-estate portals. */
+const PORTAL_LABELS: Record<string, string> = {
+  reality_portal: 'Reality Portal',
+  sreality: 'Sreality',
+  bezrealitky: 'Bezrealitky',
+  nehnutelnosti: 'Nehnutelnosti',
+};
+
+function portalLabel(portal: string): string {
+  return PORTAL_LABELS[portal] ?? portal;
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString();
+}
+
+/** Tailwind classes + label for a listing's overall syndication health badge. */
+function healthBadge(
+  status: string,
+  t: (key: string, opts?: Record<string, unknown>) => string
+): { cls: string; label: string } {
+  switch (status) {
+    case 'healthy':
+      return {
+        cls: 'bg-green-100 text-green-700',
+        label: t('settings.portalWebhooks.health.healthy', { defaultValue: 'Healthy' }),
+      };
+    case 'degraded':
+      return {
+        cls: 'bg-yellow-100 text-yellow-800',
+        label: t('settings.portalWebhooks.health.degraded', { defaultValue: 'Degraded' }),
+      };
+    case 'unhealthy':
+      return {
+        cls: 'bg-red-100 text-red-700',
+        label: t('settings.portalWebhooks.health.unhealthy', { defaultValue: 'Unhealthy' }),
+      };
+    default:
+      return {
+        cls: 'bg-gray-100 text-gray-600',
+        label: t('settings.portalWebhooks.health.notConfigured', {
+          defaultValue: 'Not configured',
+        }),
+      };
+  }
+}
+
+const StatCard: React.FC<{ label: string; value: number | string }> = ({ label, value }) => (
+  <div className="rounded-lg border border-gray-200 bg-white p-4">
+    <div className="text-2xl font-bold text-gray-900">{value}</div>
+    <div className="text-xs text-gray-500">{label}</div>
+  </div>
+);
+
+export const PortalWebhooksPage: React.FC = () => {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const organizationId = user?.organizationId ?? '';
+
+  const dashboard = useSyndicationDashboard();
+  const stats = dashboard.data?.organization_stats;
+  const listings = dashboard.data?.listings ?? [];
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold">
+          {t('settings.portalWebhooks.title', { defaultValue: 'Portal Webhooks' })}
+        </h1>
+        <p className="text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          {t('settings.portalWebhooks.subtitle', {
+            defaultValue:
+              'Delivery status and activity from real-estate portal webhooks — views, inquiries and sync health per portal.',
+          })}
+        </p>
+      </header>
+
+      {!organizationId && (
+        <div
+          className="rounded-lg border border-yellow-300 bg-yellow-50 p-4 text-sm text-yellow-800"
+          role="alert"
+        >
+          {t('settings.portalWebhooks.noOrganization', {
+            defaultValue:
+              'No organization is selected for your account, so portal webhook activity cannot be shown.',
+          })}
+        </div>
+      )}
+
+      {dashboard.isLoading && (
+        <p className="text-sm text-gray-500">
+          {t('settings.portalWebhooks.loading', { defaultValue: 'Loading portal activity…' })}
+        </p>
+      )}
+
+      {dashboard.isError && (
+        <div className="rounded-md bg-red-50 p-3 text-sm text-red-700" role="alert">
+          {t('settings.portalWebhooks.loadError', {
+            defaultValue: 'Failed to load portal webhook activity.',
+          })}
+        </div>
+      )}
+
+      {/* Organization-wide summary */}
+      {stats && (
+        <section className="space-y-4" aria-labelledby="pw-summary-heading">
+          <h2 id="pw-summary-heading" className="text-lg font-semibold">
+            {t('settings.portalWebhooks.summary.title', { defaultValue: 'Summary' })}
+          </h2>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+            <StatCard
+              label={t('settings.portalWebhooks.summary.active', { defaultValue: 'Active' })}
+              value={stats.total_active}
+            />
+            <StatCard
+              label={t('settings.portalWebhooks.summary.pending', { defaultValue: 'Pending' })}
+              value={stats.total_pending}
+            />
+            <StatCard
+              label={t('settings.portalWebhooks.summary.failed', { defaultValue: 'Failed' })}
+              value={stats.total_failed}
+            />
+            <StatCard
+              label={t('settings.portalWebhooks.summary.views', { defaultValue: 'Views' })}
+              value={stats.total_views}
+            />
+            <StatCard
+              label={t('settings.portalWebhooks.summary.inquiries', { defaultValue: 'Inquiries' })}
+              value={stats.total_inquiries}
+            />
+          </div>
+
+          {/* Per-portal breakdown */}
+          <div className="overflow-x-auto rounded-lg border border-gray-200">
+            <table className="min-w-full divide-y divide-gray-200 text-sm">
+              <caption className="sr-only">
+                {t('settings.portalWebhooks.byPortal.caption', {
+                  defaultValue: 'Syndication activity by portal',
+                })}
+              </caption>
+              <thead className="bg-gray-50 text-left text-xs uppercase text-gray-500">
+                <tr>
+                  <th scope="col" className="px-4 py-2">
+                    {t('settings.portalWebhooks.byPortal.portal', { defaultValue: 'Portal' })}
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    {t('settings.portalWebhooks.summary.active', { defaultValue: 'Active' })}
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    {t('settings.portalWebhooks.summary.pending', { defaultValue: 'Pending' })}
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    {t('settings.portalWebhooks.summary.failed', { defaultValue: 'Failed' })}
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    {t('settings.portalWebhooks.summary.views', { defaultValue: 'Views' })}
+                  </th>
+                  <th scope="col" className="px-4 py-2">
+                    {t('settings.portalWebhooks.summary.inquiries', { defaultValue: 'Inquiries' })}
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 bg-white">
+                {stats.by_portal.length === 0 ? (
+                  <tr>
+                    <td className="px-4 py-3 text-gray-500" colSpan={6}>
+                      {t('settings.portalWebhooks.byPortal.empty', {
+                        defaultValue: 'No portal activity recorded yet.',
+                      })}
+                    </td>
+                  </tr>
+                ) : (
+                  stats.by_portal.map((p) => (
+                    <tr key={p.portal}>
+                      <td className="px-4 py-2 font-medium text-gray-900">
+                        {portalLabel(p.portal)}
+                      </td>
+                      <td className="px-4 py-2 text-gray-700">{p.active_count}</td>
+                      <td className="px-4 py-2 text-gray-700">{p.pending_count}</td>
+                      <td className="px-4 py-2 text-gray-700">{p.failed_count}</td>
+                      <td className="px-4 py-2 text-gray-700">{p.views}</td>
+                      <td className="px-4 py-2 text-gray-700">{p.inquiries}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      {/* Per-listing syndication status */}
+      {dashboard.data && (
+        <section className="space-y-4" aria-labelledby="pw-listings-heading">
+          <h2 id="pw-listings-heading" className="text-lg font-semibold">
+            {t('settings.portalWebhooks.listings.title', { defaultValue: 'Listings' })}
+          </h2>
+          {listings.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              {t('settings.portalWebhooks.listings.empty', {
+                defaultValue: 'No syndicated listings yet.',
+              })}
+            </p>
+          ) : (
+            <ul className="space-y-3">
+              {listings.map((listing) => {
+                const badge = healthBadge(listing.overall_status, t);
+                return (
+                  <li
+                    key={listing.listing_id}
+                    className="rounded-lg border border-gray-200 bg-white p-4 space-y-3"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <h3 className="font-semibold text-gray-900">{listing.listing_title}</h3>
+                        <p className="text-xs text-gray-500">
+                          {t('settings.portalWebhooks.listings.activity', {
+                            defaultValue: '{{views}} views · {{inquiries}} inquiries',
+                            views: listing.total_views,
+                            inquiries: listing.total_inquiries,
+                          })}
+                        </p>
+                      </div>
+                      <span
+                        className={`shrink-0 rounded-full px-3 py-1 text-xs font-medium ${badge.cls}`}
+                      >
+                        {badge.label}
+                      </span>
+                    </div>
+                    {listing.portal_statuses.length > 0 && (
+                      <ul className="divide-y divide-gray-100 rounded-md border border-gray-100">
+                        {listing.portal_statuses.map((ps) => (
+                          <li
+                            key={`${listing.listing_id}-${ps.portal}`}
+                            className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-sm"
+                          >
+                            <span className="font-medium text-gray-900">
+                              {portalLabel(ps.portal)}
+                            </span>
+                            <span className="text-gray-500">
+                              {t('settings.portalWebhooks.listings.portalActivity', {
+                                defaultValue: '{{views}} views · {{inquiries}} inquiries',
+                                views: ps.views,
+                                inquiries: ps.inquiries,
+                              })}
+                            </span>
+                            <span className="text-xs text-gray-400">
+                              {t('settings.portalWebhooks.listings.lastActivity', {
+                                defaultValue: 'Last activity: {{when}}',
+                                when: formatDate(ps.last_activity_at),
+                              })}
+                            </span>
+                            {ps.last_error && (
+                              <span className="w-full text-xs text-red-600" role="alert">
+                                {t('settings.portalWebhooks.listings.lastError', {
+                                  defaultValue: 'Last error: {{error}}',
+                                  error: ps.last_error,
+                                })}
+                              </span>
+                            )}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      )}
+    </div>
+  );
+};
+
+export default PortalWebhooksPage;

--- a/frontend/apps/ppt-web/src/routes/groups/core.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/core.tsx
@@ -49,6 +49,11 @@ const IntegrationsPage = lazy(() =>
   import('../../features/settings').then((m) => ({ default: m.IntegrationsPage }))
 );
 
+// Portal Webhooks status page (Gap 83-3 — Real Estate Portal Webhooks) — lazy-loaded.
+const PortalWebhooksPage = lazy(() =>
+  import('../../features/settings').then((m) => ({ default: m.PortalWebhooksPage }))
+);
+
 export function Home() {
   const { t } = useTranslation();
   const { isAuthenticated, user } = useAuth();
@@ -198,6 +203,15 @@ export function settingsRoutes() {
         element={
           <ProtectedRoute>
             <IntegrationsPage />
+          </ProtectedRoute>
+        }
+      />
+      {/* Portal webhook delivery status — Real Estate Portal Webhooks (Gap 83-3) */}
+      <Route
+        path="/settings/portal-webhooks"
+        element={
+          <ProtectedRoute>
+            <PortalWebhooksPage />
           </ProtectedRoute>
         }
       />

--- a/frontend/packages/api-client/src/index.ts
+++ b/frontend/packages/api-client/src/index.ts
@@ -61,6 +61,7 @@ export {
   exportReport as exportAnalyticsReport,
   type ReportType as AnalyticsReportType,
 } from './reports';
+export * from './syndication';
 export * from './templates';
 export * from './voting';
 export * from './workflow-automation';

--- a/frontend/packages/api-client/src/syndication/api.ts
+++ b/frontend/packages/api-client/src/syndication/api.ts
@@ -1,0 +1,66 @@
+/**
+ * Portal Syndication API client (Epic 105 — Real Estate Portal Webhooks).
+ *
+ * Read surface over the org-scoped syndication endpoints. These endpoints are
+ * authenticated (`TenantExtractor`) and mounted on the api-server but are not
+ * emitted into the generated OpenAPI client, so — following the `integrations`
+ * and `oauth-grants` modules — the calls are hand-written on top of the shared
+ * `authenticatedFetchJson` helper (bearer token + MFA challenge handling).
+ *
+ *   GET /api/v1/listings/syndication/dashboard        — getSyndicationDashboard
+ *   GET /api/v1/listings/syndication/stats            — getOrganizationSyndicationStats
+ *   GET /api/v1/listings/{id}/syndications            — getListingSyndications
+ *   GET /api/v1/listings/{id}/syndication/status      — getListingSyndicationStatus
+ */
+
+import { authenticatedFetchJson } from '../lib/fetch';
+import type {
+  ListingSyndication,
+  OrganizationSyndicationStats,
+  SyndicationDashboardQuery,
+  SyndicationDashboardResponse,
+  SyndicationStatusDashboard,
+} from './types';
+
+const LISTINGS_BASE = '/api/v1/listings';
+
+function buildQueryString(params: SyndicationDashboardQuery): string {
+  const search = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== null && value !== '') {
+      search.append(key, String(value));
+    }
+  }
+  const qs = search.toString();
+  return qs ? `?${qs}` : '';
+}
+
+/** Organization-wide syndication dashboard (per-listing rows + aggregate stats). */
+export async function getSyndicationDashboard(
+  query: SyndicationDashboardQuery = {}
+): Promise<SyndicationDashboardResponse> {
+  return authenticatedFetchJson<SyndicationDashboardResponse>(
+    `${LISTINGS_BASE}/syndication/dashboard${buildQueryString(query)}`
+  );
+}
+
+/** Organization-wide aggregated syndication statistics. */
+export async function getOrganizationSyndicationStats(): Promise<OrganizationSyndicationStats> {
+  return authenticatedFetchJson<OrganizationSyndicationStats>(`${LISTINGS_BASE}/syndication/stats`);
+}
+
+/** Raw syndication records for a single listing. */
+export async function getListingSyndications(listingId: string): Promise<ListingSyndication[]> {
+  return authenticatedFetchJson<ListingSyndication[]>(
+    `${LISTINGS_BASE}/${encodeURIComponent(listingId)}/syndications`
+  );
+}
+
+/** Per-portal syndication status dashboard for a single listing. */
+export async function getListingSyndicationStatus(
+  listingId: string
+): Promise<SyndicationStatusDashboard> {
+  return authenticatedFetchJson<SyndicationStatusDashboard>(
+    `${LISTINGS_BASE}/${encodeURIComponent(listingId)}/syndication/status`
+  );
+}

--- a/frontend/packages/api-client/src/syndication/hooks.ts
+++ b/frontend/packages/api-client/src/syndication/hooks.ts
@@ -1,0 +1,51 @@
+/**
+ * Portal Syndication React Query hooks (Epic 105 — Real Estate Portal Webhooks).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as api from './api';
+import type { SyndicationDashboardQuery } from './types';
+
+export const syndicationKeys = {
+  all: ['syndication'] as const,
+  dashboard: (query: SyndicationDashboardQuery) =>
+    [...syndicationKeys.all, 'dashboard', query] as const,
+  stats: () => [...syndicationKeys.all, 'stats'] as const,
+  listing: (listingId: string) => [...syndicationKeys.all, 'listing', listingId] as const,
+  listingStatus: (listingId: string) =>
+    [...syndicationKeys.all, 'listing-status', listingId] as const,
+};
+
+/** Organization syndication dashboard (per-listing rows + aggregate stats). */
+export function useSyndicationDashboard(query: SyndicationDashboardQuery = {}) {
+  return useQuery({
+    queryKey: syndicationKeys.dashboard(query),
+    queryFn: () => api.getSyndicationDashboard(query),
+  });
+}
+
+/** Organization-wide aggregated syndication statistics. */
+export function useOrganizationSyndicationStats() {
+  return useQuery({
+    queryKey: syndicationKeys.stats(),
+    queryFn: () => api.getOrganizationSyndicationStats(),
+  });
+}
+
+/** Raw syndication records for a single listing. */
+export function useListingSyndications(listingId: string) {
+  return useQuery({
+    queryKey: syndicationKeys.listing(listingId),
+    queryFn: () => api.getListingSyndications(listingId),
+    enabled: !!listingId,
+  });
+}
+
+/** Per-portal syndication status dashboard for a single listing. */
+export function useListingSyndicationStatus(listingId: string) {
+  return useQuery({
+    queryKey: syndicationKeys.listingStatus(listingId),
+    queryFn: () => api.getListingSyndicationStatus(listingId),
+    enabled: !!listingId,
+  });
+}

--- a/frontend/packages/api-client/src/syndication/index.ts
+++ b/frontend/packages/api-client/src/syndication/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Portal Syndication module (Epic 105 — Real Estate Portal Webhooks).
+ *
+ * Manager-facing read surface over listing syndication status/stats — the
+ * downstream product of inbound portal webhooks (views, inquiries, per-portal
+ * sync state).
+ */
+
+export {
+  getListingSyndicationStatus,
+  getListingSyndications,
+  getOrganizationSyndicationStats,
+  getSyndicationDashboard,
+} from './api';
+export {
+  syndicationKeys,
+  useListingSyndicationStatus,
+  useListingSyndications,
+  useOrganizationSyndicationStats,
+  useSyndicationDashboard,
+} from './hooks';
+export type {
+  ListingSyndication,
+  OrganizationSyndicationStats,
+  PortalStats,
+  PortalSyndicationStatus,
+  SyndicationDashboardQuery,
+  SyndicationDashboardResponse,
+  SyndicationHealthStatus,
+  SyndicationStatusDashboard,
+} from './types';

--- a/frontend/packages/api-client/src/syndication/types.ts
+++ b/frontend/packages/api-client/src/syndication/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Portal Syndication types (Epic 105 — Real Estate Portal Webhooks).
+ *
+ * Mirrors the backend DTOs in `backend/crates/db/src/models/listing.rs`. These
+ * back the manager-facing syndication read endpoints under
+ * `/api/v1/listings/syndication/*`, which surface the view/inquiry counts and
+ * per-portal status that inbound portal webhooks feed into. The endpoints are
+ * wired + org-scoped on the server but are not (yet) part of the generated
+ * OpenAPI client, so this module is hand-written like `integrations/` and
+ * `oauth-grants/`.
+ */
+
+/** Overall syndication health for a listing. */
+export type SyndicationHealthStatus = 'healthy' | 'degraded' | 'unhealthy' | 'not_configured';
+
+/** A single listing↔portal syndication record. */
+export interface ListingSyndication {
+  id: string;
+  listing_id: string;
+  portal: string;
+  external_id: string | null;
+  status: string;
+  last_error: string | null;
+  synced_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Syndication status + activity for one portal on one listing. */
+export interface PortalSyndicationStatus {
+  portal: string;
+  status: string;
+  external_id: string | null;
+  synced_at: string | null;
+  last_error: string | null;
+  /** Views reported by inbound portal webhooks. */
+  views: number;
+  /** Inquiries reported by inbound portal webhooks. */
+  inquiries: number;
+  last_activity_at: string | null;
+}
+
+/** Per-listing syndication dashboard row. */
+export interface SyndicationStatusDashboard {
+  listing_id: string;
+  listing_title: string;
+  listing_status: string;
+  portal_statuses: PortalSyndicationStatus[];
+  overall_status: SyndicationHealthStatus;
+  total_views: number;
+  total_inquiries: number;
+}
+
+/** Aggregated per-portal statistics across the organization. */
+export interface PortalStats {
+  portal: string;
+  active_count: number;
+  pending_count: number;
+  failed_count: number;
+  views: number;
+  inquiries: number;
+}
+
+/** Organization-wide syndication statistics. */
+export interface OrganizationSyndicationStats {
+  total_active: number;
+  total_pending: number;
+  total_failed: number;
+  total_views: number;
+  total_inquiries: number;
+  by_portal: PortalStats[];
+}
+
+/** Filter/paging parameters for the org syndication dashboard. */
+export interface SyndicationDashboardQuery {
+  portal?: string;
+  status?: string;
+  from_date?: string;
+  to_date?: string;
+  page?: number;
+  limit?: number;
+}
+
+/** Paged org syndication dashboard response. */
+export interface SyndicationDashboardResponse {
+  listings: SyndicationStatusDashboard[];
+  total: number;
+  page: number;
+  limit: number;
+  organization_stats: OrganizationSyndicationStats;
+}


### PR DESCRIPTION
## Task
No frontend screen for portal webhook management/status (inbound-only, no manager visibility surface) (83-3-portal-webhooks Real Estate Portal Webhooks)

## Owner
pm-backend (task is a frontend/ppt-web manager surface — see Scope drift)

## What & why
Inbound real-estate portal webhooks (`POST /api/v1/webhooks/portals/{reality-portal,sreality,bezrealitky,nehnutelnosti}/…`) are unauthenticated, HMAC-verified, inbound-only receivers. They record views/inquiries and drive per-listing syndication state — but there was **no manager-facing surface** to see any of it (the gap).

This PR adds that visibility surface, read-only:
- New ppt-web screen `PortalWebhooksPage` at `/settings/portal-webhooks` (manager-gated nav link). Shows an org-wide summary (active/pending/failed, total views/inquiries), a per-portal breakdown table, and per-listing syndication status with health badge, per-portal view/inquiry counts, last activity and last error.
- New hand-written `@ppt/api-client` `syndication` module (types + api + hooks + barrel), following the existing `integrations/` and `oauth-grants/` pattern (uses the shared `authenticatedFetchJson` helper).

### Why a hand-written client module (not the generated one)
The syndication **read** endpoints already exist, are mounted, and are org-scoped via `TenantExtractor` on the api-server:
- `GET /api/v1/listings/syndication/dashboard` → `SyndicationDashboardResponse` (consumed here)
- `GET /api/v1/listings/syndication/stats`, `GET /api/v1/listings/{id}/syndications`, `GET /api/v1/listings/{id}/syndication/status` (also wrapped in the module)

They have `#[utoipa::path]` annotations but are **not registered** in the api-server's OpenAPI `paths(...)` list (`servers/api-server/src/main.rs`), so they never reach the generated OpenAPI/TS client. Rather than expand into backend/contract work (out of scope for this frontend task), this PR consumes the wired endpoints via a hand-written module — the same sanctioned pattern used by `integrations`, `oauth-grants`, `packages`, etc.

> Follow-up for the backend/typespec owner: register `routes::listings::{get_syndications, get_listing_syndication_status, get_syndication_dashboard, get_organization_syndication_stats}` in the OpenAPI `paths()` and regenerate the client, then this module can be swapped for generated operations.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client typecheck` → exit 0
- `pnpm -F @ppt/web typecheck` (tsc + e2e tsconfig) → exit 0
- `biome check` on all changed files (api-client + ppt-web) → clean (after `--write` format/organize-exports)
- `pnpm -F @ppt/web test:run …/PortalWebhooksPage.test.tsx` → **5 passed** (loading / error / per-portal table / per-listing status+health+last-error / heading)

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → `✓ built in 10.86s`, exit 0 (new lazy route bundles cleanly)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (read-only UI; no security/auth/billing/data-integrity change). Auth is handled by the shared `authenticatedFetchJson` bearer/MFA path.

## Remote-tested
skipped (no ppt-bridge MCP in this session)

## Scope drift
`scope-check.sh --owner pm-backend` → exit 2 (expected). `owner_role` is `pm-backend`, but this was dispatched as a frontend/ppt-web manager-surface task, so all touched paths are under `frontend/` (ppt-web app + `@ppt/api-client`). No backend files touched.

## Code-reuse review
`reuse-grep.sh --specialist react-web` emitted 3 WARNs (`useL`, `useO`, `useS`) — all truncated-prefix false positives (e.g. `useO` matched this PR's own `useOrganizationSyndicationStats`). No real helper duplication; `authenticatedFetchJson`, `useQuery`, `useAuth`, `useTranslation` are all reused, not re-implemented.

## Notes
- i18n keys added to `messages/en.json` (`nav.portalWebhooks`, `settings.portalWebhooks.*`); every string also passes a `defaultValue`, so other locales fall back cleanly via `fallbackLng`.
- Draft — CI is the gate; not merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2P58GaUkoshGjPj5nN5aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2P58GaUkoshGjPj5nN5aK)_