### PR TITLE
gh-issue-2282: mobile dashboard surfaces load errors instead of silent zeros

### DIFF
--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -57,6 +57,7 @@
   },
   "dashboard": {
     "title": "Prehled",
+    "loadError": "Nepodarilo se nacist prehled. Pretazenim obnovte nebo klepnete na Opakovat.",
     "welcome": "Vitejte",
     "welcomeBack": "Vitejte zpet,",
     "recentActivity": "Posledni aktivita",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -57,6 +57,7 @@
   },
   "dashboard": {
     "title": "Dashboard",
+    "loadError": "Dashboard konnte nicht geladen werden. Zum Aktualisieren nach unten ziehen oder auf Wiederholen tippen.",
     "welcome": "Willkommen",
     "welcomeBack": "Willkommen zuruck,",
     "recentActivity": "Letzte Aktivitat",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -57,6 +57,7 @@
   },
   "dashboard": {
     "title": "Dashboard",
+    "loadError": "Couldn't load your dashboard. Pull down to refresh or tap retry.",
     "welcome": "Welcome",
     "welcomeBack": "Welcome back,",
     "recentActivity": "Recent Activity",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -57,6 +57,7 @@
   },
   "dashboard": {
     "title": "Iranyitopult",
+    "loadError": "Nem sikerult betolteni az iranyitopultot. Huzza le a frissiteshez, vagy koppintson az Ujra gombra.",
     "welcome": "Udvozoljuk",
     "welcomeBack": "Udvozoljuk ujra,",
     "recentActivity": "Legutobbi tevekenyseg",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -57,6 +57,7 @@
   },
   "dashboard": {
     "title": "Panel",
+    "loadError": "Nie udalo sie zaladowac panelu. Pociagnij, aby odswiezyc, lub dotknij Ponow.",
     "welcome": "Witaj",
     "welcomeBack": "Witaj ponownie,",
     "recentActivity": "Ostatnia aktywnosc",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -57,6 +57,7 @@
   },
   "dashboard": {
     "title": "Prehlad",
+    "loadError": "Nepodarilo sa nacitat prehlad. Potiahnutim obnovte alebo klepnite na Skusit znova.",
     "welcome": "Vitajte",
     "welcomeBack": "Vitajte spat,",
     "recentActivity": "Posledna aktivita",

--- a/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.test.tsx
+++ b/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * DashboardScreen — error-state regression test (issue #2282).
+ *
+ * The dashboard fires four independent `useApiQuery` calls (announcements,
+ * fault stats, votes, unread messages) and previously consumed only `.data`.
+ * On any failure the stat derivations coalesce to `?? 0` / `?? []`, so the
+ * screen silently rendered an all-zero dashboard indistinguishable from a
+ * genuinely-empty building. The fix destructures `isError` and renders a
+ * distinct, retryable banner (wired to the existing pull-to-refresh
+ * `onRefresh`) above the zeroed stats.
+ *
+ * These tests lock the contract: no banner when everything loads, a banner
+ * the moment ANY query errors, and a retry button that refetches all four
+ * queries. i18n `t` returns the key in tests (see src/test/setup.ts), so the
+ * banner asserts on the `dashboard.loadError` / `common.retry` keys.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { DashboardScreen } from './DashboardScreen';
+
+// --- Mocks ---
+
+jest.mock('../../hooks/useApi', () => ({
+  useApiQuery: jest.fn(),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { firstName: 'Ada', lastName: 'Byron' },
+    logout: jest.fn(),
+  }),
+}));
+
+const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
+
+// --- Fixtures ---
+
+const ANNOUNCEMENTS = {
+  announcements: [
+    {
+      id: 'a-1',
+      title: 'Lift maintenance',
+      status: 'published',
+      pinned: false,
+      created_at: '2026-06-20T10:00:00Z',
+    },
+  ],
+};
+const FAULT_STATS = { statistics: { open_count: 2, in_progress_count: 1 } };
+const VOTES = {
+  votes: [{ id: 'v-1', title: 'New bike shed', status: 'active', end_at: '2026-07-20T10:00:00Z' }],
+};
+const UNREAD = { unreadCount: 5 };
+
+interface QueryOverrides {
+  data?: unknown;
+  isError?: boolean;
+  refetch?: jest.Mock;
+}
+
+function queryResult({
+  data = undefined,
+  isError = false,
+  refetch = jest.fn(),
+}: QueryOverrides = {}) {
+  return {
+    data,
+    isLoading: false,
+    isError,
+    error: isError ? new Error('boom') : null,
+    isFetching: false,
+    refetch,
+  };
+}
+
+/**
+ * Mock the four queries in call order:
+ * announcements, faultsStats, votes, unreadMessages.
+ */
+function mockQueries(results: ReturnType<typeof queryResult>[]) {
+  mockUseApiQuery.mockReset();
+  for (const r of results) {
+    mockUseApiQuery.mockReturnValueOnce(r);
+  }
+}
+
+const allSuccess = () => [
+  queryResult({ data: ANNOUNCEMENTS }),
+  queryResult({ data: FAULT_STATS }),
+  queryResult({ data: VOTES }),
+  queryResult({ data: UNREAD }),
+];
+
+// --- Tests ---
+
+describe('DashboardScreen error state (#2282)', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders no error banner and shows real stats when all queries succeed', () => {
+    mockQueries(allSuccess());
+    render(<DashboardScreen />);
+
+    expect(screen.queryByText('dashboard.loadError')).toBeNull();
+    // pendingFaults = open_count + in_progress_count = 3
+    expect(screen.getByText('3')).toBeTruthy();
+    // unreadMessages = unreadCount = 5
+    expect(screen.getByText('5')).toBeTruthy();
+  });
+
+  it('shows the error banner when ANY query fails (not a silent all-zero state)', () => {
+    // Only the fault-stats query fails; the other three succeed. Without the
+    // fix the fault card would read 0 and the screen would look "empty".
+    mockQueries([
+      queryResult({ data: ANNOUNCEMENTS }),
+      queryResult({ isError: true }),
+      queryResult({ data: VOTES }),
+      queryResult({ data: UNREAD }),
+    ]);
+    render(<DashboardScreen />);
+
+    expect(screen.getByText('dashboard.loadError')).toBeTruthy();
+    expect(screen.getByText('common.retry')).toBeTruthy();
+  });
+
+  it('does not distinguish a genuinely-empty building from an error — empty data shows NO banner', () => {
+    // All queries succeed but return empty/zeroed payloads: this is a real
+    // empty building, so there must be no error banner.
+    mockQueries([
+      queryResult({ data: { announcements: [] } }),
+      queryResult({ data: { statistics: { open_count: 0, in_progress_count: 0 } } }),
+      queryResult({ data: { votes: [] } }),
+      queryResult({ data: { unreadCount: 0 } }),
+    ]);
+    render(<DashboardScreen />);
+
+    expect(screen.queryByText('dashboard.loadError')).toBeNull();
+  });
+
+  it('retry button refetches all four queries', () => {
+    const refetches = [jest.fn(), jest.fn(), jest.fn(), jest.fn()];
+    mockQueries([
+      queryResult({ isError: true, refetch: refetches[0] }),
+      queryResult({ data: FAULT_STATS, refetch: refetches[1] }),
+      queryResult({ data: VOTES, refetch: refetches[2] }),
+      queryResult({ data: UNREAD, refetch: refetches[3] }),
+    ]);
+    render(<DashboardScreen />);
+
+    fireEvent.press(screen.getByText('common.retry'));
+
+    for (const refetch of refetches) {
+      expect(refetch).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
@@ -134,6 +134,18 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
     votesQuery.isFetching ||
     unreadMessagesQuery.isFetching;
 
+  // If ANY of the four cards' queries failed, the stat derivations above
+  // silently coalesce to `?? 0` / `?? []`, so an error would render an
+  // all-zero dashboard indistinguishable from a genuinely empty building
+  // (#2282). Surface a distinct, retryable banner so the zeros aren't
+  // mistaken for real data. Partial data (from the queries that DID succeed)
+  // still renders beneath the banner.
+  const hasError =
+    announcementsQuery.isError ||
+    faultsStatsQuery.isError ||
+    votesQuery.isError ||
+    unreadMessagesQuery.isError;
+
   const onRefresh = useCallback(async () => {
     await Promise.all([
       announcementsQuery.refetch(),
@@ -197,6 +209,22 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
           <RefreshControl refreshing={isFetching} onRefresh={onRefresh} tintColor={colors.accent} />
         }
       >
+        {/* Error banner — shown when any card's query failed so the zeroed
+            stats below aren't mistaken for a genuinely empty building (#2282). */}
+        {hasError && (
+          <View style={styles.errorBanner} accessibilityRole="alert">
+            <Text style={styles.errorBannerIcon}>⚠️</Text>
+            <Text style={styles.errorBannerText}>{t('dashboard.loadError')}</Text>
+            <Pressable
+              style={styles.errorBannerButton}
+              onPress={onRefresh}
+              accessibilityRole="button"
+            >
+              <Text style={styles.errorBannerButtonText}>{t('common.retry')}</Text>
+            </Pressable>
+          </View>
+        )}
+
         {/* Stats Grid */}
         <View style={styles.statsGrid}>
           <Pressable style={styles.statCard} onPress={() => onNavigate?.('Faults')}>
@@ -313,6 +341,27 @@ const styles = StyleSheet.create({
   logoutButton: { padding: 8 },
   logoutText: { color: 'rgba(255, 255, 255, 0.9)', fontSize: 14 },
   scrollView: { flex: 1 },
+  errorBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginHorizontal: 16,
+    marginTop: 16,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: colors.dangerBg,
+    borderWidth: 1,
+    borderColor: colors.danger,
+  },
+  errorBannerIcon: { fontSize: 20 },
+  errorBannerText: { flex: 1, fontSize: 13, color: colors.dangerDark },
+  errorBannerButton: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: colors.danger,
+  },
+  errorBannerButtonText: { color: colors.white, fontSize: 13, fontWeight: '600' },
   statsGrid: { flexDirection: 'row', flexWrap: 'wrap', padding: 16, gap: 12 },
   statCard: {
     flex: 1,


### PR DESCRIPTION
## Task
mobile dashboard silently renders zero stats on any API error (four useApiQuery calls with no isError branch) (Closes #2282)

`frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx` fired four `useApiQuery` calls and consumed only `.data`, never `.isError`. On any failure the stat derivations coalesce to `?? 0` / `?? []`, so the dashboard silently rendered an all-zero state indistinguishable from a genuinely-empty building.

## Fix
- Destructure `isError` from all four queries into a `hasError` flag.
- Render a distinct, retryable error banner above the stats grid, wired to the existing pull-to-refresh `onRefresh`. Partial data from queries that DID succeed still renders beneath the banner.
- Add `dashboard.loadError` string across all six locales (en, cs, de, hu, pl, sk); reuse the existing `common.retry` string for the button.
- Kept scoped to the error-state fix — the optional `formatDate` `en-US` and hardcoded `'general'` category nits were left untouched.

## Owner
pm-frontend (specialist: react-native)

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `pnpm -F mobile test -- src/screens/dashboard/DashboardScreen.test.tsx` → 4 passed, exit 0
- `pnpm exec biome check <changed paths>` → exit 0 (after `--write` format)

New test suite `DashboardScreen.test.tsx` covers: no banner on all-success, banner shown when ANY query errors, no banner for a genuinely-empty building (real empty vs error distinction), and retry refetches all four queries.

## Built (Band B — full build)
skipped: change < 50 LOC of substantive logic, no public API/config/migration touch (UI + locale strings + test only).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
None. `scope-check.sh --owner pm-frontend --base origin/dev` → exit 0. All changes under `frontend/apps/mobile/src/`.

## Code-reuse review
None. `reuse-grep.sh --specialist react-native` → empty.

## Notes
- The pre-existing reusable `ErrorState` component is a full-screen centered placeholder; a top-of-screen inline banner was chosen instead so partial data from succeeding queries stays visible.
- i18n `t` returns the key in the mobile jest setup, so the test asserts on `dashboard.loadError` / `common.retry` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiHgPwpaLN2Z8DSrKrTgYT

---
_Generated by [Claude Code](https://claude.ai/code/session_01NiHgPwpaLN2Z8DSrKrTgYT)_