### PR TITLE
gh-issue-2299: tick Tasks/Subtasks in 15 reconciled done story-md files

### DIFF
--- a/_bmad-output/implementation-artifacts/stories/79-2-authentication-flow.md
+++ b/_bmad-output/implementation-artifacts/stories/79-2-authentication-flow.md
@@ -44,46 +44,46 @@ So that **I can securely access the application and my data is protected**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create AuthContext and Provider (AC: 1, 2, 3, 4, 5)
-  - [ ] 1.1 Create `/frontend/apps/ppt-web/src/contexts/AuthContext.tsx`
-  - [ ] 1.2 Define AuthState type with `user`, `isAuthenticated`, `isLoading`
-  - [ ] 1.3 Implement `login`, `logout`, `refreshToken` methods
-  - [ ] 1.4 Add token storage using httpOnly cookies or secure localStorage
-  - [ ] 1.5 Create `useAuth` hook for consuming context
+- [x] Task 1: Create AuthContext and Provider (AC: 1, 2, 3, 4, 5)
+  - [x] 1.1 Create `/frontend/apps/ppt-web/src/contexts/AuthContext.tsx`
+  - [x] 1.2 Define AuthState type with `user`, `isAuthenticated`, `isLoading`
+  - [x] 1.3 Implement `login`, `logout`, `refreshToken` methods
+  - [x] 1.4 Add token storage using httpOnly cookies or secure localStorage
+  - [x] 1.5 Create `useAuth` hook for consuming context
 
-- [ ] Task 2: Implement Login Page (AC: 1)
-  - [ ] 2.1 Create `/frontend/apps/ppt-web/src/pages/LoginPage.tsx`
-  - [ ] 2.2 Create login form with email/password fields
-  - [ ] 2.3 Add form validation (email format, password required)
-  - [ ] 2.4 Handle login errors (invalid credentials, account locked)
-  - [ ] 2.5 Show loading state during authentication
+- [x] Task 2: Implement Login Page (AC: 1)
+  - [x] 2.1 Create `/frontend/apps/ppt-web/src/pages/LoginPage.tsx`
+  - [x] 2.2 Create login form with email/password fields
+  - [x] 2.3 Add form validation (email format, password required)
+  - [x] 2.4 Handle login errors (invalid credentials, account locked)
+  - [x] 2.5 Show loading state during authentication
 
-- [ ] Task 3: Implement Token Refresh Mechanism (AC: 2)
-  - [ ] 3.1 Add axios response interceptor in `/frontend/apps/ppt-web/src/lib/api.ts`
-  - [ ] 3.2 Detect 401 responses and attempt token refresh
-  - [ ] 3.3 Queue requests during refresh to prevent race conditions
-  - [ ] 3.4 Retry failed requests after successful refresh
-  - [ ] 3.5 Clear auth state if refresh fails
+- [x] Task 3: Implement Token Refresh Mechanism (AC: 2)
+  - [x] 3.1 Add axios response interceptor in `/frontend/apps/ppt-web/src/lib/api.ts`
+  - [x] 3.2 Detect 401 responses and attempt token refresh
+  - [x] 3.3 Queue requests during refresh to prevent race conditions
+  - [x] 3.4 Retry failed requests after successful refresh
+  - [x] 3.5 Clear auth state if refresh fails
 
-- [ ] Task 4: Implement Protected Route Wrapper (AC: 3, 5)
-  - [ ] 4.1 Create `/frontend/apps/ppt-web/src/components/ProtectedRoute.tsx`
-  - [ ] 4.2 Check `isAuthenticated` from AuthContext
-  - [ ] 4.3 Store current location in sessionStorage as returnUrl
-  - [ ] 4.4 Redirect to login if not authenticated
-  - [ ] 4.5 Show loading spinner while checking auth state
+- [x] Task 4: Implement Protected Route Wrapper (AC: 3, 5)
+  - [x] 4.1 Create `/frontend/apps/ppt-web/src/components/ProtectedRoute.tsx`
+  - [x] 4.2 Check `isAuthenticated` from AuthContext
+  - [x] 4.3 Store current location in sessionStorage as returnUrl
+  - [x] 4.4 Redirect to login if not authenticated
+  - [x] 4.5 Show loading spinner while checking auth state
 
-- [ ] Task 5: Implement Logout Flow (AC: 4)
-  - [ ] 5.1 Create logout button in header/navigation
-  - [ ] 5.2 Call `/api/v1/auth/logout` on click
-  - [ ] 5.3 Clear all tokens from storage
-  - [ ] 5.4 Invalidate all React Query caches
-  - [ ] 5.5 Navigate to login page
+- [x] Task 5: Implement Logout Flow (AC: 4)
+  - [x] 5.1 Create logout button in header/navigation
+  - [x] 5.2 Call `/api/v1/auth/logout` on click
+  - [x] 5.3 Clear all tokens from storage
+  - [x] 5.4 Invalidate all React Query caches
+  - [x] 5.5 Navigate to login page
 
-- [ ] Task 6: Implement Return URL Handling (AC: 1, 3, 5)
-  - [ ] 6.1 Capture intended URL before redirect to login
-  - [ ] 6.2 Store in sessionStorage as `returnUrl`
-  - [ ] 6.3 After successful login, redirect to returnUrl or dashboard
-  - [ ] 6.4 Clear returnUrl after use
+- [x] Task 6: Implement Return URL Handling (AC: 1, 3, 5)
+  - [x] 6.1 Capture intended URL before redirect to login
+  - [x] 6.2 Store in sessionStorage as `returnUrl`
+  - [x] 6.3 After successful login, redirect to returnUrl or dashboard
+  - [x] 6.4 Clear returnUrl after use
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/79-3-error-handling-toasts.md
+++ b/_bmad-output/implementation-artifacts/stories/79-3-error-handling-toasts.md
@@ -47,48 +47,48 @@ So that **I understand the result of my interactions and can take appropriate ac
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Toast Notification System (AC: 1, 2)
-  - [ ] 1.1 Create `/frontend/apps/ppt-web/src/components/Toast/ToastProvider.tsx`
-  - [ ] 1.2 Create ToastContext with `addToast`, `removeToast` methods
-  - [ ] 1.3 Create Toast component with success, error, warning, info variants
-  - [ ] 1.4 Implement auto-dismiss with configurable duration
-  - [ ] 1.5 Add dismiss on click and close button
-  - [ ] 1.6 Support stacking up to 3 toasts
+- [x] Task 1: Create Toast Notification System (AC: 1, 2)
+  - [x] 1.1 Create `/frontend/apps/ppt-web/src/components/Toast/ToastProvider.tsx`
+  - [x] 1.2 Create ToastContext with `addToast`, `removeToast` methods
+  - [x] 1.3 Create Toast component with success, error, warning, info variants
+  - [x] 1.4 Implement auto-dismiss with configurable duration
+  - [x] 1.5 Add dismiss on click and close button
+  - [x] 1.6 Support stacking up to 3 toasts
 
-- [ ] Task 2: Create Toast Component Styles (AC: 1, 2)
-  - [ ] 2.1 Create `/frontend/apps/ppt-web/src/components/Toast/Toast.tsx`
-  - [ ] 2.2 Add icons for each toast type (check, x, warning, info)
-  - [ ] 2.3 Add slide-in/slide-out animations
-  - [ ] 2.4 Add copy button for error messages
-  - [ ] 2.5 Ensure accessible (role="alert", aria-live)
+- [x] Task 2: Create Toast Component Styles (AC: 1, 2)
+  - [x] 2.1 Create `/frontend/apps/ppt-web/src/components/Toast/Toast.tsx`
+  - [x] 2.2 Add icons for each toast type (check, x, warning, info)
+  - [x] 2.3 Add slide-in/slide-out animations
+  - [x] 2.4 Add copy button for error messages
+  - [x] 2.5 Ensure accessible (role="alert", aria-live)
 
-- [ ] Task 3: Create API Error Handler (AC: 2, 4)
-  - [ ] 3.1 Create `/frontend/apps/ppt-web/src/lib/errorHandler.ts`
-  - [ ] 3.2 Parse backend ErrorResponse format
-  - [ ] 3.3 Map error codes to user-friendly messages
-  - [ ] 3.4 Handle validation error arrays with field paths
-  - [ ] 3.5 Extract requestId for error reporting
+- [x] Task 3: Create API Error Handler (AC: 2, 4)
+  - [x] 3.1 Create `/frontend/apps/ppt-web/src/lib/errorHandler.ts`
+  - [x] 3.2 Parse backend ErrorResponse format
+  - [x] 3.3 Map error codes to user-friendly messages
+  - [x] 3.4 Handle validation error arrays with field paths
+  - [x] 3.5 Extract requestId for error reporting
 
-- [ ] Task 4: Implement Network Status Detection (AC: 3)
-  - [ ] 4.1 Create `/frontend/apps/ppt-web/src/hooks/useNetworkStatus.ts`
-  - [ ] 4.2 Add online/offline event listeners
-  - [ ] 4.3 Create NetworkStatusProvider context
-  - [ ] 4.4 Create offline indicator component for header
-  - [ ] 4.5 Queue mutations when offline
+- [x] Task 4: Implement Network Status Detection (AC: 3)
+  - [x] 4.1 Create `/frontend/apps/ppt-web/src/hooks/useNetworkStatus.ts`
+  - [x] 4.2 Add online/offline event listeners
+  - [x] 4.3 Create NetworkStatusProvider context
+  - [x] 4.4 Create offline indicator component for header
+  - [x] 4.5 Queue mutations when offline
 
-- [ ] Task 5: Implement Rate Limit Handling (AC: 5)
-  - [ ] 5.1 Add 429 handler to axios response interceptor
-  - [ ] 5.2 Parse Retry-After header
-  - [ ] 5.3 Show countdown toast
-  - [ ] 5.4 Automatically retry after delay
-  - [ ] 5.5 Disable action buttons during rate limit
+- [x] Task 5: Implement Rate Limit Handling (AC: 5)
+  - [x] 5.1 Add 429 handler to axios response interceptor
+  - [x] 5.2 Parse Retry-After header
+  - [x] 5.3 Show countdown toast
+  - [x] 5.4 Automatically retry after delay
+  - [x] 5.5 Disable action buttons during rate limit
 
-- [ ] Task 6: Wire Toast System Throughout App (AC: 1, 2, 3, 4, 5)
-  - [ ] 6.1 Add ToastProvider to App.tsx root
-  - [ ] 6.2 Create `useToast` hook for easy access
-  - [ ] 6.3 Add success toasts to all mutation onSuccess callbacks
-  - [ ] 6.4 Add error handler to global axios interceptor
-  - [ ] 6.5 Update all forms to show inline validation errors
+- [x] Task 6: Wire Toast System Throughout App (AC: 1, 2, 3, 4, 5)
+  - [x] 6.1 Add ToastProvider to App.tsx root
+  - [x] 6.2 Create `useToast` hook for easy access
+  - [x] 6.3 Add success toasts to all mutation onSuccess callbacks
+  - [x] 6.4 Add error handler to global axios interceptor
+  - [x] 6.5 Update all forms to show inline validation errors
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/79-4-websocket-realtime.md
+++ b/_bmad-output/implementation-artifacts/stories/79-4-websocket-realtime.md
@@ -45,43 +45,43 @@ So that **I always see the latest information without manually refreshing the pa
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create WebSocket Service (AC: 1, 5)
-  - [ ] 1.1 Create `/frontend/apps/ppt-web/src/lib/websocket.ts`
-  - [ ] 1.2 Implement WebSocket connection with auth token
-  - [ ] 1.3 Add automatic reconnection with exponential backoff
-  - [ ] 1.4 Create connection state machine (connecting, connected, disconnected, error)
-  - [ ] 1.5 Implement heartbeat/ping-pong mechanism
+- [x] Task 1: Create WebSocket Service (AC: 1, 5)
+  - [x] 1.1 Create `/frontend/apps/ppt-web/src/lib/websocket.ts`
+  - [x] 1.2 Implement WebSocket connection with auth token
+  - [x] 1.3 Add automatic reconnection with exponential backoff
+  - [x] 1.4 Create connection state machine (connecting, connected, disconnected, error)
+  - [x] 1.5 Implement heartbeat/ping-pong mechanism
 
-- [ ] Task 2: Create WebSocket Context and Provider (AC: 1, 2, 3, 4)
-  - [ ] 2.1 Create `/frontend/apps/ppt-web/src/contexts/WebSocketContext.tsx`
-  - [ ] 2.2 Expose connection state and methods via context
-  - [ ] 2.3 Create `useWebSocket` hook for subscribing to events
-  - [ ] 2.4 Integrate with AuthContext for auth token
+- [x] Task 2: Create WebSocket Context and Provider (AC: 1, 2, 3, 4)
+  - [x] 2.1 Create `/frontend/apps/ppt-web/src/contexts/WebSocketContext.tsx`
+  - [x] 2.2 Expose connection state and methods via context
+  - [x] 2.3 Create `useWebSocket` hook for subscribing to events
+  - [x] 2.4 Integrate with AuthContext for auth token
 
-- [ ] Task 3: Implement Message Event Handling (AC: 2)
-  - [ ] 3.1 Subscribe to `message:new` WebSocket events
-  - [ ] 3.2 Update messages query cache on new message
-  - [ ] 3.3 Update unread count in header
-  - [ ] 3.4 Play notification sound (with user preference check)
-  - [ ] 3.5 Show browser notification (if permitted)
+- [x] Task 3: Implement Message Event Handling (AC: 2)
+  - [x] 3.1 Subscribe to `message:new` WebSocket events
+  - [x] 3.2 Update messages query cache on new message
+  - [x] 3.3 Update unread count in header
+  - [x] 3.4 Play notification sound (with user preference check)
+  - [x] 3.5 Show browser notification (if permitted)
 
-- [ ] Task 4: Implement Notification Sync (AC: 3)
-  - [ ] 4.1 Update `/frontend/packages/api-client/src/notification-preferences/sync.ts`
-  - [ ] 4.2 Subscribe to `notification:*` WebSocket events
-  - [ ] 4.3 Filter events based on user preferences
-  - [ ] 4.4 Display real-time notification toasts
+- [x] Task 4: Implement Notification Sync (AC: 3)
+  - [x] 4.1 Update `/frontend/packages/api-client/src/notification-preferences/sync.ts`
+  - [x] 4.2 Subscribe to `notification:*` WebSocket events
+  - [x] 4.3 Filter events based on user preferences
+  - [x] 4.4 Display real-time notification toasts
 
-- [ ] Task 5: Implement Query Invalidation System (AC: 4)
-  - [ ] 5.1 Create event-to-query-key mapping configuration
-  - [ ] 5.2 Subscribe to entity change events (`entity:updated`, `entity:created`, `entity:deleted`)
-  - [ ] 5.3 Invalidate relevant TanStack Query caches
-  - [ ] 5.4 Add subtle "Data updated" indicator component
+- [x] Task 5: Implement Query Invalidation System (AC: 4)
+  - [x] 5.1 Create event-to-query-key mapping configuration
+  - [x] 5.2 Subscribe to entity change events (`entity:updated`, `entity:created`, `entity:deleted`)
+  - [x] 5.3 Invalidate relevant TanStack Query caches
+  - [x] 5.4 Add subtle "Data updated" indicator component
 
-- [ ] Task 6: Implement Reconnection and Sync (AC: 5)
-  - [ ] 6.1 Track last event timestamp for gap detection
-  - [ ] 6.2 Fetch missed events on reconnection via REST endpoint
-  - [ ] 6.3 Apply missed events to update local state
-  - [ ] 6.4 Show reconnection status in toast
+- [x] Task 6: Implement Reconnection and Sync (AC: 5)
+  - [x] 6.1 Track last event timestamp for gap detection
+  - [x] 6.2 Fetch missed events on reconnection via REST endpoint
+  - [x] 6.3 Apply missed events to update local state
+  - [x] 6.4 Show reconnection status in toast
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/82-1-swiftui-project-setup.md
+++ b/_bmad-output/implementation-artifacts/stories/82-1-swiftui-project-setup.md
@@ -53,38 +53,38 @@ So that **we can build the Reality Portal iOS app using shared Kotlin code**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Xcode Project (AC: 1, 4)
-  - [ ] 1.1 Create new Xcode project in `/mobile-native/iosApp/`
-  - [ ] 1.2 Configure bundle identifier: `three.two.bit.ppt.reality`
-  - [ ] 1.3 Set deployment target (iOS 15.0+)
-  - [ ] 1.4 Configure team and signing
-  - [ ] 1.5 Add app icons (1024x1024 source)
-  - [ ] 1.6 Configure launch screen storyboard or SwiftUI
+- [x] Task 1: Create Xcode Project (AC: 1, 4)
+  - [x] 1.1 Create new Xcode project in `/mobile-native/iosApp/`
+  - [x] 1.2 Configure bundle identifier: `three.two.bit.ppt.reality`
+  - [x] 1.3 Set deployment target (iOS 15.0+)
+  - [x] 1.4 Configure team and signing
+  - [x] 1.5 Add app icons (1024x1024 source)
+  - [x] 1.6 Configure launch screen storyboard or SwiftUI
 
-- [ ] Task 2: Integrate KMP Shared Module (AC: 2)
-  - [ ] 2.1 Configure Gradle for iOS framework export
-  - [ ] 2.2 Add XCFramework dependency to Xcode project
-  - [ ] 2.3 Create bridge/wrapper for Kotlin types
-  - [ ] 2.4 Verify API client is accessible from Swift
-  - [ ] 2.5 Test basic Kotlin function calls
+- [x] Task 2: Integrate KMP Shared Module (AC: 2)
+  - [x] 2.1 Configure Gradle for iOS framework export
+  - [x] 2.2 Add XCFramework dependency to Xcode project
+  - [x] 2.3 Create bridge/wrapper for Kotlin types
+  - [x] 2.4 Verify API client is accessible from Swift
+  - [x] 2.5 Test basic Kotlin function calls
 
-- [ ] Task 3: Configure Swift Package Manager (AC: 3)
-  - [ ] 3.1 Add Package.swift or use Xcode SPM integration
-  - [ ] 3.2 Add Kingfisher for image loading
-  - [ ] 3.3 Add KeychainAccess for secure storage
-  - [ ] 3.4 Configure package resolution
+- [x] Task 3: Configure Swift Package Manager (AC: 3)
+  - [x] 3.1 Add Package.swift or use Xcode SPM integration
+  - [x] 3.2 Add Kingfisher for image loading
+  - [x] 3.3 Add KeychainAccess for secure storage
+  - [x] 3.4 Configure package resolution
 
-- [ ] Task 4: Set Up Build Configurations (AC: 5)
-  - [ ] 4.1 Create Debug, Release, and Staging configurations
-  - [ ] 4.2 Add environment-specific xcconfig files
-  - [ ] 4.3 Configure API URL per environment
-  - [ ] 4.4 Create build schemes for each environment
+- [x] Task 4: Set Up Build Configurations (AC: 5)
+  - [x] 4.1 Create Debug, Release, and Staging configurations
+  - [x] 4.2 Add environment-specific xcconfig files
+  - [x] 4.3 Configure API URL per environment
+  - [x] 4.4 Create build schemes for each environment
 
-- [ ] Task 5: Configure App Permissions (AC: 4)
-  - [ ] 5.1 Add location permission for nearby listings
-  - [ ] 5.2 Add photo library permission for uploads
-  - [ ] 5.3 Add push notification entitlement
-  - [ ] 5.4 Configure App Transport Security
+- [x] Task 5: Configure App Permissions (AC: 4)
+  - [x] 5.1 Add location permission for nearby listings
+  - [x] 5.2 Add photo library permission for uploads
+  - [x] 5.3 Add push notification entitlement
+  - [x] 5.4 Configure App Transport Security
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/82-2-navigation-routing.md
+++ b/_bmad-output/implementation-artifacts/stories/82-2-navigation-routing.md
@@ -44,36 +44,36 @@ So that **I can easily access all features of the app**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Tab Bar Container (AC: 1, 4)
-  - [ ] 1.1 Create `/mobile-native/iosApp/iosApp/App/MainTabView.swift`
-  - [ ] 1.2 Define 5 tabs with icons and labels
-  - [ ] 1.3 Implement tab selection state
-  - [ ] 1.4 Style tab bar with app colors
-  - [ ] 1.5 Add badge for unread inquiries
+- [x] Task 1: Create Tab Bar Container (AC: 1, 4)
+  - [x] 1.1 Create `/mobile-native/iosApp/iosApp/App/MainTabView.swift`
+  - [x] 1.2 Define 5 tabs with icons and labels
+  - [x] 1.3 Implement tab selection state
+  - [x] 1.4 Style tab bar with app colors
+  - [x] 1.5 Add badge for unread inquiries
 
-- [ ] Task 2: Implement Navigation Stacks (AC: 2)
-  - [ ] 2.1 Create NavigationStack for each tab
-  - [ ] 2.2 Define navigation destinations
-  - [ ] 2.3 Create `Router.swift` for centralized routing
-  - [ ] 2.4 Implement NavigationPath state management
+- [x] Task 2: Implement Navigation Stacks (AC: 2)
+  - [x] 2.1 Create NavigationStack for each tab
+  - [x] 2.2 Define navigation destinations
+  - [x] 2.3 Create `Router.swift` for centralized routing
+  - [x] 2.4 Implement NavigationPath state management
 
-- [ ] Task 3: Create Navigation Coordinator (AC: 2, 3, 4)
-  - [ ] 3.1 Create `/mobile-native/iosApp/iosApp/Core/Navigation/NavigationCoordinator.swift`
-  - [ ] 3.2 Define Route enum with all destinations
-  - [ ] 3.3 Handle navigation state preservation
-  - [ ] 3.4 Implement programmatic navigation
+- [x] Task 3: Create Navigation Coordinator (AC: 2, 3, 4)
+  - [x] 3.1 Create `/mobile-native/iosApp/iosApp/Core/Navigation/NavigationCoordinator.swift`
+  - [x] 3.2 Define Route enum with all destinations
+  - [x] 3.3 Handle navigation state preservation
+  - [x] 3.4 Implement programmatic navigation
 
-- [ ] Task 4: Implement Deep Linking (AC: 3)
-  - [ ] 4.1 Configure URL schemes in Info.plist
-  - [ ] 4.2 Add Universal Links entitlement
-  - [ ] 4.3 Parse incoming URLs in App delegate
-  - [ ] 4.4 Route to appropriate screen
+- [x] Task 4: Implement Deep Linking (AC: 3)
+  - [x] 4.1 Configure URL schemes in Info.plist
+  - [x] 4.2 Add Universal Links entitlement
+  - [x] 4.3 Parse incoming URLs in App delegate
+  - [x] 4.4 Route to appropriate screen
 
-- [ ] Task 5: Add Authentication Guard (AC: 5)
-  - [ ] 5.1 Create `/mobile-native/iosApp/iosApp/Core/Navigation/AuthGuard.swift`
-  - [ ] 5.2 Check auth state before protected routes
-  - [ ] 5.3 Show login sheet when unauthenticated
-  - [ ] 5.4 Store intended destination for post-login redirect
+- [x] Task 5: Add Authentication Guard (AC: 5)
+  - [x] 5.1 Create `/mobile-native/iosApp/iosApp/Core/Navigation/AuthGuard.swift`
+  - [x] 5.2 Check auth state before protected routes
+  - [x] 5.3 Show login sheet when unauthenticated
+  - [x] 5.4 Store intended destination for post-login redirect
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/82-3-home-search-screens.md
+++ b/_bmad-output/implementation-artifacts/stories/82-3-home-search-screens.md
@@ -44,48 +44,48 @@ So that **I can discover properties that match my needs**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Home Screen (AC: 1)
-  - [ ] 1.1 Create `/mobile-native/iosApp/iosApp/Features/Home/HomeView.swift`
-  - [ ] 1.2 Create featured listings carousel component
-  - [ ] 1.3 Create listing grid section
-  - [ ] 1.4 Add quick category buttons
-  - [ ] 1.5 Implement pull-to-refresh
-  - [ ] 1.6 Create HomeViewModel using shared KMP code
+- [x] Task 1: Create Home Screen (AC: 1)
+  - [x] 1.1 Create `/mobile-native/iosApp/iosApp/Features/Home/HomeView.swift`
+  - [x] 1.2 Create featured listings carousel component
+  - [x] 1.3 Create listing grid section
+  - [x] 1.4 Add quick category buttons
+  - [x] 1.5 Implement pull-to-refresh
+  - [x] 1.6 Create HomeViewModel using shared KMP code
 
-- [ ] Task 2: Create Search Screen (AC: 2, 3)
-  - [ ] 2.1 Create `/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift`
-  - [ ] 2.2 Implement search bar with debounced input
-  - [ ] 2.3 Create SearchViewModel with KMP integration
-  - [ ] 2.4 Show search suggestions
-  - [ ] 2.5 Display recent searches
+- [x] Task 2: Create Search Screen (AC: 2, 3)
+  - [x] 2.1 Create `/mobile-native/iosApp/iosApp/Features/Search/SearchView.swift`
+  - [x] 2.2 Implement search bar with debounced input
+  - [x] 2.3 Create SearchViewModel with KMP integration
+  - [x] 2.4 Show search suggestions
+  - [x] 2.5 Display recent searches
 
-- [ ] Task 3: Create Filter Sheet (AC: 3)
-  - [ ] 3.1 Create `/mobile-native/iosApp/iosApp/Features/Search/FilterSheet.swift`
-  - [ ] 3.2 Add price range slider
-  - [ ] 3.3 Add property type picker
-  - [ ] 3.4 Add bedroom/bathroom counters
-  - [ ] 3.5 Add location radius filter
-  - [ ] 3.6 Implement apply/reset buttons
+- [x] Task 3: Create Filter Sheet (AC: 3)
+  - [x] 3.1 Create `/mobile-native/iosApp/iosApp/Features/Search/FilterSheet.swift`
+  - [x] 3.2 Add price range slider
+  - [x] 3.3 Add property type picker
+  - [x] 3.4 Add bedroom/bathroom counters
+  - [x] 3.5 Add location radius filter
+  - [x] 3.6 Implement apply/reset buttons
 
-- [ ] Task 4: Create Listing Card Component (AC: 4)
-  - [ ] 4.1 Create `/mobile-native/iosApp/iosApp/Features/Shared/ListingCard.swift`
-  - [ ] 4.2 Display listing image with async loading
-  - [ ] 4.3 Show price, title, location
-  - [ ] 4.4 Add favorite button overlay
-  - [ ] 4.5 Handle image loading states
+- [x] Task 4: Create Listing Card Component (AC: 4)
+  - [x] 4.1 Create `/mobile-native/iosApp/iosApp/Features/Shared/ListingCard.swift`
+  - [x] 4.2 Display listing image with async loading
+  - [x] 4.3 Show price, title, location
+  - [x] 4.4 Add favorite button overlay
+  - [x] 4.5 Handle image loading states
 
-- [ ] Task 5: Implement Infinite Scroll (AC: 4)
-  - [ ] 5.1 Add pagination to search results
-  - [ ] 5.2 Detect scroll to bottom
-  - [ ] 5.3 Load next page automatically
-  - [ ] 5.4 Show loading indicator at bottom
+- [x] Task 5: Implement Infinite Scroll (AC: 4)
+  - [x] 5.1 Add pagination to search results
+  - [x] 5.2 Detect scroll to bottom
+  - [x] 5.3 Load next page automatically
+  - [x] 5.4 Show loading indicator at bottom
 
-- [ ] Task 6: Add Location-based Features (AC: 5)
-  - [ ] 6.1 Request location permission
-  - [ ] 6.2 Get current location
-  - [ ] 6.3 Add "Near Me" toggle
-  - [ ] 6.4 Sort results by distance
-  - [ ] 6.5 Create map view alternative
+- [x] Task 6: Add Location-based Features (AC: 5)
+  - [x] 6.1 Request location permission
+  - [x] 6.2 Get current location
+  - [x] 6.3 Add "Near Me" toggle
+  - [x] 6.4 Sort results by distance
+  - [x] 6.5 Create map view alternative
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/82-4-listing-detail-favorites.md
+++ b/_bmad-output/implementation-artifacts/stories/82-4-listing-detail-favorites.md
@@ -46,42 +46,42 @@ So that **I can make informed decisions and track interesting properties**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Listing Detail Screen (AC: 1)
-  - [ ] 1.1 Create `/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift`
-  - [ ] 1.2 Create photo header with gallery preview
-  - [ ] 1.3 Add price and key details section
-  - [ ] 1.4 Add full description section
-  - [ ] 1.5 Add features/amenities grid
-  - [ ] 1.6 Add location map section
-  - [ ] 1.7 Add agent contact card
-  - [ ] 1.8 Create ListingDetailViewModel with KMP
+- [x] Task 1: Create Listing Detail Screen (AC: 1)
+  - [x] 1.1 Create `/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift`
+  - [x] 1.2 Create photo header with gallery preview
+  - [x] 1.3 Add price and key details section
+  - [x] 1.4 Add full description section
+  - [x] 1.5 Add features/amenities grid
+  - [x] 1.6 Add location map section
+  - [x] 1.7 Add agent contact card
+  - [x] 1.8 Create ListingDetailViewModel with KMP
 
-- [ ] Task 2: Create Photo Gallery (AC: 2)
-  - [ ] 2.1 Create `/mobile-native/iosApp/iosApp/Features/Listing/PhotoGalleryView.swift`
-  - [ ] 2.2 Implement full-screen photo viewer
-  - [ ] 2.3 Add swipe navigation between photos
-  - [ ] 2.4 Add pinch-to-zoom gesture
-  - [ ] 2.5 Add close button and photo counter
+- [x] Task 2: Create Photo Gallery (AC: 2)
+  - [x] 2.1 Create `/mobile-native/iosApp/iosApp/Features/Listing/PhotoGalleryView.swift`
+  - [x] 2.2 Implement full-screen photo viewer
+  - [x] 2.3 Add swipe navigation between photos
+  - [x] 2.4 Add pinch-to-zoom gesture
+  - [x] 2.5 Add close button and photo counter
 
-- [ ] Task 3: Implement Favorites Functionality (AC: 3)
-  - [ ] 3.1 Create `/mobile-native/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift`
-  - [ ] 3.2 Add favorite toggle mutation via KMP
-  - [ ] 3.3 Sync favorites state across views
-  - [ ] 3.4 Persist favorites locally for offline
-  - [ ] 3.5 Add haptic feedback on toggle
+- [x] Task 3: Implement Favorites Functionality (AC: 3)
+  - [x] 3.1 Create `/mobile-native/iosApp/iosApp/Features/Favorites/FavoritesViewModel.swift`
+  - [x] 3.2 Add favorite toggle mutation via KMP
+  - [x] 3.3 Sync favorites state across views
+  - [x] 3.4 Persist favorites locally for offline
+  - [x] 3.5 Add haptic feedback on toggle
 
-- [ ] Task 4: Create Favorites Screen (AC: 4)
-  - [ ] 4.1 Create `/mobile-native/iosApp/iosApp/Features/Favorites/FavoritesView.swift`
-  - [ ] 4.2 Display favorites in grid layout
-  - [ ] 4.3 Add swipe-to-delete gesture
-  - [ ] 4.4 Add empty state for no favorites
-  - [ ] 4.5 Implement pull-to-refresh
+- [x] Task 4: Create Favorites Screen (AC: 4)
+  - [x] 4.1 Create `/mobile-native/iosApp/iosApp/Features/Favorites/FavoritesView.swift`
+  - [x] 4.2 Display favorites in grid layout
+  - [x] 4.3 Add swipe-to-delete gesture
+  - [x] 4.4 Add empty state for no favorites
+  - [x] 4.5 Implement pull-to-refresh
 
-- [ ] Task 5: Implement Share Feature (AC: 5)
-  - [ ] 5.1 Create share URL generator
-  - [ ] 5.2 Add share button to listing detail
-  - [ ] 5.3 Integrate with iOS ShareLink
-  - [ ] 5.4 Include listing image in share preview
+- [x] Task 5: Implement Share Feature (AC: 5)
+  - [x] 5.1 Create share URL generator
+  - [x] 5.2 Add share button to listing detail
+  - [x] 5.3 Integrate with iOS ShareLink
+  - [x] 5.4 Include listing image in share preview
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/82-5-inquiries-account.md
+++ b/_bmad-output/implementation-artifacts/stories/82-5-inquiries-account.md
@@ -47,49 +47,49 @@ So that **I can contact property owners and control my profile settings**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Inquiry Form (AC: 1)
-  - [ ] 1.1 Create `/mobile-native/iosApp/iosApp/Features/Inquiries/NewInquirySheet.swift`
-  - [ ] 1.2 Show listing preview at top
-  - [ ] 1.3 Add message text field
-  - [ ] 1.4 Add contact preference options
-  - [ ] 1.5 Implement send mutation via KMP
-  - [ ] 1.6 Show success confirmation
+- [x] Task 1: Create Inquiry Form (AC: 1)
+  - [x] 1.1 Create `/mobile-native/iosApp/iosApp/Features/Inquiries/NewInquirySheet.swift` — shipped as `SendInquiryView.swift`; wired to `newInquiry(listingId:)` in `MainTabView.swift`
+  - [x] 1.2 Show listing preview at top
+  - [x] 1.3 Add message text field
+  - [x] 1.4 Add contact preference options
+  - [x] 1.5 Implement send mutation via KMP
+  - [x] 1.6 Show success confirmation
 
-- [ ] Task 2: Create Inquiries List (AC: 2)
-  - [ ] 2.1 Create `/mobile-native/iosApp/iosApp/Features/Inquiries/InquiriesView.swift`
-  - [ ] 2.2 Create InquiriesViewModel with KMP integration
-  - [ ] 2.3 Display inquiry cards with listing info
-  - [ ] 2.4 Show status badge (pending, replied, closed)
-  - [ ] 2.5 Add pull-to-refresh
+- [x] Task 2: Create Inquiries List (AC: 2)
+  - [x] 2.1 Create `/mobile-native/iosApp/iosApp/Features/Inquiries/InquiriesView.swift`
+  - [x] 2.2 Create InquiriesViewModel with KMP integration
+  - [x] 2.3 Display inquiry cards with listing info
+  - [x] 2.4 Show status badge (pending, replied, closed)
+  - [x] 2.5 Add pull-to-refresh
 
-- [ ] Task 3: Create Conversation View (AC: 3)
-  - [ ] 3.1 Create `/mobile-native/iosApp/iosApp/Features/Inquiries/ConversationView.swift`
-  - [ ] 3.2 Display message bubbles
-  - [ ] 3.3 Add message input field
-  - [ ] 3.4 Implement send message mutation
-  - [ ] 3.5 Auto-scroll to new messages
+- [x] Task 3: Create Conversation View (AC: 3)
+  - [x] 3.1 Create `/mobile-native/iosApp/iosApp/Features/Inquiries/ConversationView.swift` — shipped as `InquiryDetailView.swift`; wired to `inquiryDetail(id:)` in `MainTabView.swift`
+  - [x] 3.2 Display message bubbles
+  - [x] 3.3 Add message input field
+  - [x] 3.4 Implement send message mutation
+  - [x] 3.5 Auto-scroll to new messages
 
-- [ ] Task 4: Create Account Screen (AC: 4, 5)
-  - [ ] 4.1 Create `/mobile-native/iosApp/iosApp/Features/Account/AccountView.swift`
-  - [ ] 4.2 Create AccountViewModel with auth state
-  - [ ] 4.3 Display user profile info
-  - [ ] 4.4 Add edit profile button
-  - [ ] 4.5 Add settings navigation
+- [x] Task 4: Create Account Screen (AC: 4, 5)
+  - [x] 4.1 Create `/mobile-native/iosApp/iosApp/Features/Account/AccountView.swift`
+  - [x] 4.2 Create AccountViewModel with auth state
+  - [x] 4.3 Display user profile info
+  - [x] 4.4 Add edit profile button
+  - [x] 4.5 Add settings navigation
 
-- [ ] Task 5: Create Profile Edit Screen (AC: 4)
+- [ ] Task 5: Create Profile Edit Screen (AC: 4) — NOT delivered: `EditProfileView.swift` absent; `profile` route is still a stub `Text` in `MainTabView.swift` (see `docs/superpowers/plans/gap-82-1-swiftui-audit.md`)
   - [ ] 5.1 Create `/mobile-native/iosApp/iosApp/Features/Account/EditProfileView.swift`
   - [ ] 5.2 Add editable fields (name, email, phone)
   - [ ] 5.3 Add profile photo picker
   - [ ] 5.4 Implement save mutation
 
-- [ ] Task 6: Create Login/Register Screens (AC: 5)
-  - [ ] 6.1 Create `/mobile-native/iosApp/iosApp/Features/Auth/LoginView.swift`
-  - [ ] 6.2 Create `/mobile-native/iosApp/iosApp/Features/Auth/RegisterView.swift`
-  - [ ] 6.3 Integrate with KMP auth use cases
-  - [ ] 6.4 Store auth tokens in Keychain
-  - [ ] 6.5 Handle token refresh
+- [~] Task 6: Create Login/Register Screens (AC: 5) — LoginView shipped; Register not delivered
+  - [x] 6.1 Create `/mobile-native/iosApp/iosApp/Features/Auth/LoginView.swift`
+  - [ ] 6.2 Create `/mobile-native/iosApp/iosApp/Features/Auth/RegisterView.swift` — NOT delivered: `register` route is still a stub `Text` in `MainTabView.swift` (SSO-only login currently; see audit)
+  - [x] 6.3 Integrate with KMP auth use cases
+  - [x] 6.4 Store auth tokens in Keychain
+  - [x] 6.5 Handle token refresh
 
-- [ ] Task 7: Configure Push Notifications (AC: 3)
+- [ ] Task 7: Configure Push Notifications (AC: 3) — NOT delivered: no `Core/Push/PushNotificationManager.swift`; push capability not wired
   - [ ] 7.1 Add push notification capability
   - [ ] 7.2 Request notification permission
   - [ ] 7.3 Register device token with backend

--- a/_bmad-output/implementation-artifacts/stories/84-1-s3-presigned-urls.md
+++ b/_bmad-output/implementation-artifacts/stories/84-1-s3-presigned-urls.md
@@ -45,36 +45,36 @@ So that **I can access files without exposing storage credentials**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Implement S3 Presigned URL Service (AC: 1, 2, 5)
-  - [ ] 1.1 Create `/backend/crates/integrations/storage/src/presigned.rs`
-  - [ ] 1.2 Implement generate_download_url function
-  - [ ] 1.3 Configure URL expiration (default: 15 minutes)
-  - [ ] 1.4 Set Content-Type based on file extension
-  - [ ] 1.5 Set Content-Disposition for downloads
+- [x] Task 1: Implement S3 Presigned URL Service (AC: 1, 2, 5)
+  - [x] 1.1 Create `/backend/crates/integrations/storage/src/presigned.rs`
+  - [x] 1.2 Implement generate_download_url function
+  - [x] 1.3 Configure URL expiration (default: 15 minutes)
+  - [x] 1.4 Set Content-Type based on file extension
+  - [x] 1.5 Set Content-Disposition for downloads
 
-- [ ] Task 2: Update Documents Route (AC: 1, 3)
-  - [ ] 2.1 Update `/backend/servers/api-server/src/routes/documents.rs:1058`
-  - [ ] 2.2 Verify document access permissions
-  - [ ] 2.3 Generate presigned URL via storage service
-  - [ ] 2.4 Return URL and expiration to client
+- [x] Task 2: Update Documents Route (AC: 1, 3)
+  - [x] 2.1 Update `/backend/servers/api-server/src/routes/documents.rs:1058`
+  - [x] 2.2 Verify document access permissions
+  - [x] 2.3 Generate presigned URL via storage service
+  - [x] 2.4 Return URL and expiration to client
 
-- [ ] Task 3: Implement Upload Presigned URLs (AC: 4)
-  - [ ] 3.1 Update `/backend/servers/api-server/src/routes/documents.rs:1116`
-  - [ ] 3.2 Create upload request endpoint
-  - [ ] 3.3 Generate presigned PUT URL
-  - [ ] 3.4 Create pending upload record
-  - [ ] 3.5 Implement upload completion callback
+- [x] Task 3: Implement Upload Presigned URLs (AC: 4)
+  - [x] 3.1 Update `/backend/servers/api-server/src/routes/documents.rs:1116`
+  - [x] 3.2 Create upload request endpoint
+  - [x] 3.3 Generate presigned PUT URL
+  - [x] 3.4 Create pending upload record
+  - [x] 3.5 Implement upload completion callback
 
-- [ ] Task 4: Configure S3 CORS (AC: 4)
-  - [ ] 4.1 Add CORS configuration for direct upload
-  - [ ] 4.2 Allow PUT from frontend origins
-  - [ ] 4.3 Configure allowed headers
+- [x] Task 4: Configure S3 CORS (AC: 4)
+  - [x] 4.1 Add CORS configuration for direct upload
+  - [x] 4.2 Allow PUT from frontend origins
+  - [x] 4.3 Configure allowed headers
 
-- [ ] Task 5: Update Frontend Download Logic (AC: 1, 5)
-  - [ ] 5.1 Update document download to use presigned URLs
-  - [ ] 5.2 Handle URL expiration and retry
-  - [ ] 5.3 Show download progress
-  - [ ] 5.4 Handle download errors
+- [x] Task 5: Update Frontend Download Logic (AC: 1, 5)
+  - [x] 5.1 Update document download to use presigned URLs
+  - [x] 5.2 Handle URL expiration and retry
+  - [x] 5.3 Show download progress
+  - [x] 5.4 Handle download errors
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/84-2-esignature-email.md
+++ b/_bmad-output/implementation-artifacts/stories/84-2-esignature-email.md
@@ -44,46 +44,46 @@ So that **signers receive notifications and can access documents to sign**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Signature Email Templates (AC: 1, 2, 3, 4)
-  - [ ] 1.1 Create signature request template
-  - [ ] 1.2 Create reminder template (levels 1, 2, 3)
-  - [ ] 1.3 Create completion template
-  - [ ] 1.4 Create decline notification template
-  - [ ] 1.5 Add branding and styling
+- [x] Task 1: Create Signature Email Templates (AC: 1, 2, 3, 4)
+  - [x] 1.1 Create signature request template
+  - [x] 1.2 Create reminder template (levels 1, 2, 3)
+  - [x] 1.3 Create completion template
+  - [x] 1.4 Create decline notification template
+  - [x] 1.5 Add branding and styling
 
-- [ ] Task 2: Implement Signature Request Sending (AC: 1)
-  - [ ] 2.1 Update `/backend/servers/api-server/src/routes/signatures.rs:120`
-  - [ ] 2.2 Generate secure signing token
-  - [ ] 2.3 Create signing URL
-  - [ ] 2.4 Send email via email service
-  - [ ] 2.5 Record email sent status
+- [x] Task 2: Implement Signature Request Sending (AC: 1)
+  - [x] 2.1 Update `/backend/servers/api-server/src/routes/signatures.rs:120`
+  - [x] 2.2 Generate secure signing token
+  - [x] 2.3 Create signing URL
+  - [x] 2.4 Send email via email service
+  - [x] 2.5 Record email sent status
 
-- [ ] Task 3: Implement Reminder System (AC: 2)
-  - [ ] 3.1 Update `/backend/servers/api-server/src/routes/signatures.rs:267`
-  - [ ] 3.2 Create reminder scheduling job
-  - [ ] 3.3 Track reminder count per signer
-  - [ ] 3.4 Escalate reminder urgency
-  - [ ] 3.5 Respect business hours
+- [x] Task 3: Implement Reminder System (AC: 2)
+  - [x] 3.1 Update `/backend/servers/api-server/src/routes/signatures.rs:267`
+  - [x] 3.2 Create reminder scheduling job
+  - [x] 3.3 Track reminder count per signer
+  - [x] 3.4 Escalate reminder urgency
+  - [x] 3.5 Respect business hours
 
-- [ ] Task 4: Implement Completion Emails (AC: 3)
-  - [ ] 4.1 Update `/backend/servers/api-server/src/routes/signatures.rs:316`
-  - [ ] 4.2 Detect document completion
-  - [ ] 4.3 Generate signed document PDF
-  - [ ] 4.4 Send to all parties
-  - [ ] 4.5 Include audit trail
+- [x] Task 4: Implement Completion Emails (AC: 3)
+  - [x] 4.1 Update `/backend/servers/api-server/src/routes/signatures.rs:316`
+  - [x] 4.2 Detect document completion
+  - [x] 4.3 Generate signed document PDF
+  - [x] 4.4 Send to all parties
+  - [x] 4.5 Include audit trail
 
-- [ ] Task 5: Implement Decline Handling (AC: 4)
-  - [ ] 5.1 Add decline reason capture
-  - [ ] 5.2 Send decline notification
-  - [ ] 5.3 Mark document as declined
-  - [ ] 5.4 Allow resubmission
+- [x] Task 5: Implement Decline Handling (AC: 4)
+  - [x] 5.1 Add decline reason capture
+  - [x] 5.2 Send decline notification
+  - [x] 5.3 Mark document as declined
+  - [x] 5.4 Allow resubmission
 
-- [ ] Task 6: Add Email Tracking (AC: 5)
-  - [ ] 6.1 Configure webhook for email events
-  - [ ] 6.2 Track email opens
-  - [ ] 6.3 Track link clicks
-  - [ ] 6.4 Handle bounces
-  - [ ] 6.5 Store events for audit
+- [x] Task 6: Add Email Tracking (AC: 5)
+  - [x] 6.1 Configure webhook for email events
+  - [x] 6.2 Track email opens
+  - [x] 6.3 Track link clicks
+  - [x] 6.4 Handle bounces
+  - [x] 6.5 Store events for audit
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/84-3-price-tracking.md
+++ b/_bmad-output/implementation-artifacts/stories/84-3-price-tracking.md
@@ -45,43 +45,43 @@ So that **I can act quickly on price drops or be aware of increases**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Price History Table (AC: 1)
-  - [ ] 1.1 Create `listing_price_history` migration
-  - [ ] 1.2 Store price, timestamp, change percentage
-  - [ ] 1.3 Link to listing via foreign key
-  - [ ] 1.4 Add indexes for efficient queries
+- [x] Task 1: Create Price History Table (AC: 1)
+  - [x] 1.1 Create `listing_price_history` migration
+  - [x] 1.2 Store price, timestamp, change percentage
+  - [x] 1.3 Link to listing via foreign key
+  - [x] 1.4 Add indexes for efficient queries
 
-- [ ] Task 2: Implement Price Change Detection (AC: 1)
-  - [ ] 2.1 Update `/backend/crates/db/src/repositories/portal.rs:324-358`
-  - [ ] 2.2 Compare new price with current price on update
-  - [ ] 2.3 Calculate change percentage
-  - [ ] 2.4 Insert history record
-  - [ ] 2.5 Emit price change event
+- [x] Task 2: Implement Price Change Detection (AC: 1)
+  - [x] 2.1 Update `/backend/crates/db/src/repositories/portal.rs:324-358`
+  - [x] 2.2 Compare new price with current price on update
+  - [x] 2.3 Calculate change percentage
+  - [x] 2.4 Insert history record
+  - [x] 2.5 Emit price change event
 
-- [ ] Task 3: Implement Notification Service (AC: 2, 3)
-  - [ ] 3.1 Create price notification service
-  - [ ] 3.2 Find users who favorited listing
-  - [ ] 3.3 Filter by notification preferences
-  - [ ] 3.4 Send push and/or email notification
-  - [ ] 3.5 Throttle notifications per user
+- [x] Task 3: Implement Notification Service (AC: 2, 3)
+  - [x] 3.1 Create price notification service
+  - [x] 3.2 Find users who favorited listing
+  - [x] 3.3 Filter by notification preferences
+  - [x] 3.4 Send push and/or email notification
+  - [x] 3.5 Throttle notifications per user
 
-- [ ] Task 4: Create Price History API (AC: 4)
-  - [ ] 4.1 Create GET `/api/v1/listings/{id}/price-history`
-  - [ ] 4.2 Return price changes over time
-  - [ ] 4.3 Include change percentages
-  - [ ] 4.4 Support date range filtering
+- [x] Task 4: Create Price History API (AC: 4)
+  - [x] 4.1 Create GET `/api/v1/listings/{id}/price-history`
+  - [x] 4.2 Return price changes over time
+  - [x] 4.3 Include change percentages
+  - [x] 4.4 Support date range filtering
 
-- [ ] Task 5: Create Notification Preferences API (AC: 5)
-  - [ ] 5.1 Add price alert fields to notification preferences
-  - [ ] 5.2 Create update endpoint for preferences
-  - [ ] 5.3 Support threshold configuration
-  - [ ] 5.4 Default to enabled for price drops
+- [x] Task 5: Create Notification Preferences API (AC: 5)
+  - [x] 5.1 Add price alert fields to notification preferences
+  - [x] 5.2 Create update endpoint for preferences
+  - [x] 5.3 Support threshold configuration
+  - [x] 5.4 Default to enabled for price drops
 
-- [ ] Task 6: Frontend Price History Display (AC: 4)
-  - [ ] 6.1 Create price history chart component
-  - [ ] 6.2 Add to listing detail page
-  - [ ] 6.3 Show price change indicators
-  - [ ] 6.4 Mobile-friendly display
+- [x] Task 6: Frontend Price History Display (AC: 4)
+  - [x] 6.1 Create price history chart component
+  - [x] 6.2 Add to listing detail page
+  - [x] 6.3 Show price change indicators
+  - [x] 6.4 Mobile-friendly display
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/84-4-notification-triggers.md
+++ b/_bmad-output/implementation-artifacts/stories/84-4-notification-triggers.md
@@ -42,41 +42,41 @@ So that **I stay informed about important announcements and updates**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Create Notification Event System (AC: 1, 2, 3)
-  - [ ] 1.1 Create notification event types enum
-  - [ ] 1.2 Create event publisher trait
-  - [ ] 1.3 Implement event dispatcher
-  - [ ] 1.4 Add event handlers registry
+- [x] Task 1: Create Notification Event System (AC: 1, 2, 3)
+  - [x] 1.1 Create notification event types enum
+  - [x] 1.2 Create event publisher trait
+  - [x] 1.3 Implement event dispatcher
+  - [x] 1.4 Add event handlers registry
 
-- [ ] Task 2: Implement Announcement Triggers (AC: 1)
-  - [ ] 2.1 Update `/backend/servers/api-server/src/routes/announcements.rs:827`
-  - [ ] 2.2 Trigger on announcement publish
-  - [ ] 2.3 Resolve target audience
-  - [ ] 2.4 Send to all targeted users
+- [x] Task 2: Implement Announcement Triggers (AC: 1)
+  - [x] 2.1 Update `/backend/servers/api-server/src/routes/announcements.rs:827`
+  - [x] 2.2 Trigger on announcement publish
+  - [x] 2.3 Resolve target audience
+  - [x] 2.4 Send to all targeted users
 
-- [ ] Task 3: Implement Fault Triggers (AC: 2)
-  - [ ] 3.1 Trigger on fault status change
-  - [ ] 3.2 Notify fault reporter
-  - [ ] 3.3 Notify assigned technician
-  - [ ] 3.4 Include status in notification
+- [x] Task 3: Implement Fault Triggers (AC: 2)
+  - [x] 3.1 Trigger on fault status change
+  - [x] 3.2 Notify fault reporter
+  - [x] 3.3 Notify assigned technician
+  - [x] 3.4 Include status in notification
 
-- [ ] Task 4: Implement Vote Triggers (AC: 3)
-  - [ ] 4.1 Trigger on vote creation
-  - [ ] 4.2 Resolve eligible voters
-  - [ ] 4.3 Send voting notification
-  - [ ] 4.4 Send reminder before deadline
+- [x] Task 4: Implement Vote Triggers (AC: 3)
+  - [x] 4.1 Trigger on vote creation
+  - [x] 4.2 Resolve eligible voters
+  - [x] 4.3 Send voting notification
+  - [x] 4.4 Send reminder before deadline
 
-- [ ] Task 5: Create Notification Preferences System (AC: 4)
-  - [ ] 5.1 Create preferences table
-  - [ ] 5.2 Default preferences per user
-  - [ ] 5.3 Preferences API endpoints
-  - [ ] 5.4 Preference checking in dispatch
+- [x] Task 5: Create Notification Preferences System (AC: 4)
+  - [x] 5.1 Create preferences table
+  - [x] 5.2 Default preferences per user
+  - [x] 5.3 Preferences API endpoints
+  - [x] 5.4 Preference checking in dispatch
 
-- [ ] Task 6: Implement Multi-channel Delivery (AC: 5)
-  - [ ] 6.1 Push notification delivery
-  - [ ] 6.2 Email notification delivery
-  - [ ] 6.3 In-app notification storage
-  - [ ] 6.4 Notification history API
+- [x] Task 6: Implement Multi-channel Delivery (AC: 5)
+  - [x] 6.1 Push notification delivery
+  - [x] 6.2 Email notification delivery
+  - [x] 6.3 In-app notification storage
+  - [x] 6.4 Notification history API
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/84-5-pgvector-rag.md
+++ b/_bmad-output/implementation-artifacts/stories/84-5-pgvector-rag.md
@@ -46,42 +46,42 @@ So that **I can find relevant information even with different wording**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Set Up pgvector Extension (AC: 1)
-  - [ ] 1.1 Enable pgvector extension in PostgreSQL
-  - [ ] 1.2 Create vector column migration
-  - [ ] 1.3 Configure vector index (IVFFlat or HNSW)
-  - [ ] 1.4 Set up similarity search functions
+- [x] Task 1: Set Up pgvector Extension (AC: 1)
+  - [x] 1.1 Enable pgvector extension in PostgreSQL
+  - [x] 1.2 Create vector column migration
+  - [x] 1.3 Configure vector index (IVFFlat or HNSW)
+  - [x] 1.4 Set up similarity search functions
 
-- [ ] Task 2: Update Document Repository (AC: 1, 2)
-  - [ ] 2.1 Update `/backend/crates/db/src/repositories/llm_document.rs:434`
-  - [ ] 2.2 Add vector storage methods
-  - [ ] 2.3 Implement chunk storage with embeddings
-  - [ ] 2.4 Add batch upsert for efficiency
+- [x] Task 2: Update Document Repository (AC: 1, 2)
+  - [x] 2.1 Update `/backend/crates/db/src/repositories/llm_document.rs:434`
+  - [x] 2.2 Add vector storage methods
+  - [x] 2.3 Implement chunk storage with embeddings
+  - [x] 2.4 Add batch upsert for efficiency
 
-- [ ] Task 3: Implement Embedding Pipeline (AC: 2)
-  - [ ] 3.1 Create text extraction service
-  - [ ] 3.2 Implement chunking strategy
-  - [ ] 3.3 Integrate embedding model (OpenAI/local)
-  - [ ] 3.4 Create async processing queue
+- [x] Task 3: Implement Embedding Pipeline (AC: 2)
+  - [x] 3.1 Create text extraction service
+  - [x] 3.2 Implement chunking strategy
+  - [x] 3.3 Integrate embedding model (OpenAI/local)
+  - [x] 3.4 Create async processing queue
 
-- [ ] Task 4: Implement Semantic Search (AC: 3)
-  - [ ] 4.1 Update `/backend/crates/db/src/repositories/llm_document.rs:471`
-  - [ ] 4.2 Create semantic search query
-  - [ ] 4.3 Implement k-NN search with pgvector
-  - [ ] 4.4 Add relevance scoring
+- [x] Task 4: Implement Semantic Search (AC: 3)
+  - [x] 4.1 Update `/backend/crates/db/src/repositories/llm_document.rs:471`
+  - [x] 4.2 Create semantic search query
+  - [x] 4.3 Implement k-NN search with pgvector
+  - [x] 4.4 Add relevance scoring
 
-- [ ] Task 5: Implement Hybrid Search (AC: 4)
-  - [ ] 5.1 Create keyword search component
-  - [ ] 5.2 Combine with semantic results
-  - [ ] 5.3 Implement RRF (Reciprocal Rank Fusion)
-  - [ ] 5.4 Expose hybrid mode option
+- [x] Task 5: Implement Hybrid Search (AC: 4)
+  - [x] 5.1 Create keyword search component
+  - [x] 5.2 Combine with semantic results
+  - [x] 5.3 Implement RRF (Reciprocal Rank Fusion)
+  - [x] 5.4 Expose hybrid mode option
 
-- [ ] Task 6: Implement RAG API (AC: 5)
-  - [ ] 6.1 Create RAG query endpoint
-  - [ ] 6.2 Retrieve relevant context
-  - [ ] 6.3 Send context to LLM
-  - [ ] 6.4 Format response with citations
-  - [ ] 6.5 Handle long context windows
+- [x] Task 6: Implement RAG API (AC: 5)
+  - [x] 6.1 Create RAG query endpoint
+  - [x] 6.2 Retrieve relevant context
+  - [x] 6.3 Send context to LLM
+  - [x] 6.4 Format response with citations
+  - [x] 6.5 Handle long context windows
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/85-1-environment-variables.md
+++ b/_bmad-output/implementation-artifacts/stories/85-1-environment-variables.md
@@ -42,25 +42,25 @@ So that **mobile apps connect to the correct backend for each environment**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Configure React Native Environment (AC: 1, 3, 4, 5)
-  - [ ] 1.1 Update `/frontend/apps/mobile/src/config/api.ts:29`
-  - [ ] 1.2 Install react-native-config package
-  - [ ] 1.3 Create .env.development file
-  - [ ] 1.4 Create .env.staging file
-  - [ ] 1.5 Create .env.production file
-  - [ ] 1.6 Configure Metro bundler for env files
+- [x] Task 1: Configure React Native Environment (AC: 1, 3, 4, 5)
+  - [x] 1.1 Update `/frontend/apps/mobile/src/config/api.ts:29`
+  - [x] 1.2 Install react-native-config package
+  - [x] 1.3 Create .env.development file
+  - [x] 1.4 Create .env.staging file
+  - [x] 1.5 Create .env.production file
+  - [x] 1.6 Configure Metro bundler for env files
 
-- [ ] Task 2: Configure Android Build Variants (AC: 1, 4, 5)
-  - [ ] 2.1 Add productFlavors to build.gradle
-  - [ ] 2.2 Create development, staging, production flavors
-  - [ ] 2.3 Set applicationIdSuffix per flavor
-  - [ ] 2.4 Configure BuildConfig fields
+- [x] Task 2: Configure Android Build Variants (AC: 1, 4, 5)
+  - [x] 2.1 Add productFlavors to build.gradle
+  - [x] 2.2 Create development, staging, production flavors
+  - [x] 2.3 Set applicationIdSuffix per flavor
+  - [x] 2.4 Configure BuildConfig fields
 
-- [ ] Task 3: Configure iOS Schemes (AC: 1, 4, 5)
-  - [ ] 3.1 Create Development scheme
-  - [ ] 3.2 Create Staging scheme
-  - [ ] 3.3 Create Production scheme
-  - [ ] 3.4 Add xcconfig files per environment
+- [x] Task 3: Configure iOS Schemes (AC: 1, 4, 5)
+  - [x] 3.1 Create Development scheme
+  - [x] 3.2 Create Staging scheme
+  - [x] 3.3 Create Production scheme
+  - [x] 3.4 Add xcconfig files per environment
 
 - [x] Task 4: Configure KMP Environment (AC: 2, 3, 4, 5)
   - [x] 4.1 Update `/mobile-native/shared/src/commonMain/kotlin/.../api/ApiConfig.kt`
@@ -68,11 +68,11 @@ So that **mobile apps connect to the correct backend for each environment**.
   - [x] 4.3 Android: Read from BuildConfig
   - [x] 4.4 iOS: Read from Info.plist (keys added to Info.plist)
 
-- [ ] Task 5: Document Environment Setup (AC: 1, 2, 3, 4, 5)
-  - [ ] 5.1 Create environment setup documentation
-  - [ ] 5.2 Document local development setup
-  - [ ] 5.3 Document CI/CD configuration
-  - [ ] 5.4 Add troubleshooting guide
+- [x] Task 5: Document Environment Setup (AC: 1, 2, 3, 4, 5)
+  - [x] 5.1 Create environment setup documentation
+  - [x] 5.2 Document local development setup
+  - [x] 5.3 Document CI/CD configuration
+  - [x] 5.4 Add troubleshooting guide
 
 ## Dev Notes
 

--- a/_bmad-output/implementation-artifacts/stories/9-1-totp-2fa-setup.md
+++ b/_bmad-output/implementation-artifacts/stories/9-1-totp-2fa-setup.md
@@ -30,53 +30,53 @@ So that **my account is protected even if password is compromised**.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Database Schema & Migrations (AC: 1, 2, 3)
-  - [ ] 1.1 Create `user_2fa` table: id (UUID), user_id (FK), secret (encrypted), enabled (boolean), enabled_at, backup_codes (JSONB)
-  - [ ] 1.2 Add unique constraint on user_id
-  - [ ] 1.3 Add RLS policy - users can only access their own 2FA settings
-  - [ ] 1.4 Create index on user_id for fast lookup
+- [x] Task 1: Database Schema & Migrations (AC: 1, 2, 3)
+  - [x] 1.1 Create `user_2fa` table: id (UUID), user_id (FK), secret (encrypted), enabled (boolean), enabled_at, backup_codes (JSONB)
+  - [x] 1.2 Add unique constraint on user_id
+  - [x] 1.3 Add RLS policy - users can only access their own 2FA settings
+  - [x] 1.4 Create index on user_id for fast lookup
 
-- [ ] Task 2: Backend Domain Models & Repository (AC: 1, 2, 3)
-  - [ ] 2.1 Create TwoFactorAuth model with user_id, secret, enabled, enabled_at, backup_codes
-  - [ ] 2.2 Create DTOs: SetupTwoFactorRequest, VerifyTwoFactorRequest, BackupCode, TwoFactorStatus
-  - [ ] 2.3 Implement TwoFactorRepository: create, get_by_user_id, enable, disable, use_backup_code
+- [x] Task 2: Backend Domain Models & Repository (AC: 1, 2, 3)
+  - [x] 2.1 Create TwoFactorAuth model with user_id, secret, enabled, enabled_at, backup_codes
+  - [x] 2.2 Create DTOs: SetupTwoFactorRequest, VerifyTwoFactorRequest, BackupCode, TwoFactorStatus
+  - [x] 2.3 Implement TwoFactorRepository: create, get_by_user_id, enable, disable, use_backup_code
 
-- [ ] Task 3: TOTP Service Implementation (AC: 1, 2)
-  - [ ] 3.1 Add totp-rs crate to dependencies
-  - [ ] 3.2 Create TotpService for secret generation and code verification
-  - [ ] 3.3 Implement generate_secret() returning base32 secret
-  - [ ] 3.4 Implement verify_code(secret, code) with 30-second window
-  - [ ] 3.5 Implement generate_qr_data(email, secret) for QR code URI
+- [x] Task 3: TOTP Service Implementation (AC: 1, 2)
+  - [x] 3.1 Add totp-rs crate to dependencies
+  - [x] 3.2 Create TotpService for secret generation and code verification
+  - [x] 3.3 Implement generate_secret() returning base32 secret
+  - [x] 3.4 Implement verify_code(secret, code) with 30-second window
+  - [x] 3.5 Implement generate_qr_data(email, secret) for QR code URI
 
-- [ ] Task 4: Backup Codes Service (AC: 3)
-  - [ ] 4.1 Implement generate_backup_codes() returning 10 codes
-  - [ ] 4.2 Hash backup codes before storage (like password hashing pattern)
-  - [ ] 4.3 Implement verify_and_consume_backup_code()
+- [x] Task 4: Backup Codes Service (AC: 3)
+  - [x] 4.1 Implement generate_backup_codes() returning 10 codes
+  - [x] 4.2 Hash backup codes before storage (like password hashing pattern)
+  - [x] 4.3 Implement verify_and_consume_backup_code()
 
-- [ ] Task 5: Backend API Handlers (AC: 1, 2, 3)
-  - [ ] 5.1 POST /api/v1/auth/mfa/setup - initiate 2FA setup (returns QR code URI + backup codes)
-  - [ ] 5.2 POST /api/v1/auth/mfa/verify - verify TOTP code to complete setup
-  - [ ] 5.3 POST /api/v1/auth/mfa/disable - disable 2FA (requires current code)
-  - [ ] 5.4 GET /api/v1/auth/mfa/status - check if 2FA is enabled
-  - [ ] 5.5 Update login endpoint to check for 2FA and require code
-  - [ ] 5.6 POST /api/v1/auth/login/verify-mfa - verify MFA code during login
+- [x] Task 5: Backend API Handlers (AC: 1, 2, 3)
+  - [x] 5.1 POST /api/v1/auth/mfa/setup - initiate 2FA setup (returns QR code URI + backup codes)
+  - [x] 5.2 POST /api/v1/auth/mfa/verify - verify TOTP code to complete setup
+  - [x] 5.3 POST /api/v1/auth/mfa/disable - disable 2FA (requires current code)
+  - [x] 5.4 GET /api/v1/auth/mfa/status - check if 2FA is enabled
+  - [x] 5.5 Update login endpoint to check for 2FA and require code
+  - [x] 5.6 POST /api/v1/auth/login/verify-mfa - verify MFA code during login
 
-- [ ] Task 6: Frontend API Client (AC: 1, 2, 3)
-  - [ ] 6.1 Create security/types.ts with TwoFactorSetupResponse, VerifyMfaRequest, etc.
-  - [ ] 6.2 Create security/api.ts with fetch functions
-  - [ ] 6.3 Create security/hooks.ts with useSetupMfa, useVerifyMfa, useMfaStatus
+- [x] Task 6: Frontend API Client (AC: 1, 2, 3)
+  - [x] 6.1 Create security/types.ts with TwoFactorSetupResponse, VerifyMfaRequest, etc.
+  - [x] 6.2 Create security/api.ts with fetch functions
+  - [x] 6.3 Create security/hooks.ts with useSetupMfa, useVerifyMfa, useMfaStatus
 
-- [ ] Task 7: Frontend Components (AC: 1, 3)
-  - [ ] 7.1 Create TwoFactorSetupPage component
-  - [ ] 7.2 Create QRCodeDisplay component (using qrcode library)
-  - [ ] 7.3 Create BackupCodesDisplay component
-  - [ ] 7.4 Create TOTPCodeInput component (6-digit input)
-  - [ ] 7.5 Create TwoFactorStatusCard for settings display
+- [x] Task 7: Frontend Components (AC: 1, 3)
+  - [x] 7.1 Create TwoFactorSetupPage component
+  - [x] 7.2 Create QRCodeDisplay component (using qrcode library)
+  - [x] 7.3 Create BackupCodesDisplay component
+  - [x] 7.4 Create TOTPCodeInput component (6-digit input)
+  - [x] 7.5 Create TwoFactorStatusCard for settings display
 
-- [ ] Task 8: Frontend Login Flow Updates (AC: 2)
-  - [ ] 8.1 Update login flow to handle MFA_REQUIRED response
-  - [ ] 8.2 Create MfaVerificationStep component
-  - [ ] 8.3 Handle backup code option in MFA step
+- [x] Task 8: Frontend Login Flow Updates (AC: 2)
+  - [x] 8.1 Update login flow to handle MFA_REQUIRED response
+  - [x] 8.2 Create MfaVerificationStep component
+  - [x] 8.3 Handle backup code option in MFA step
 
 ## Dev Notes
 


### PR DESCRIPTION
## Task

Follow-up to PR #2298. The reconciliation flipped `Status:` to `done` in 15 story-md files under `_bmad-output/implementation-artifacts/stories/` but left every `Tasks / Subtasks` checkbox unchecked (`- [ ]`, zero `- [x]`), contradicting the `79-1`/`85-2` convention where a done story has a ticked task list. This ticks the checkboxes to match each file's verified-done status. Docs/tracking-only; no product code affected.

Closes #2299

## Owner

`pm-tech-lead`

## Changes

14 files (79-2/3/4, 82-1/2/3/4, 84-1..5, 85-1, 9-1): all `Tasks / Subtasks` boxes flipped `- [ ]` → `- [x]`. `85-1` correctly kept its 5 pre-existing `[x]` and gained 22 (5 → 27 checked). All warn-markers in these files were verified incidental (pre-existing "Existing TODO References" sections the stories resolved, `pending`/`replied` status enums, UI skeleton/placeholder text) — none indicated an undelivered subtask.

**82-5 (selective, truthful):** Tasks 1–4 ticked (`SendInquiryView`, `InquiriesView`, `InquiryDetailView`, `AccountView`, `LoginView` all shipped and wired in `MainTabView.swift`). Left unchecked with a one-line note rather than blanket-ticking:
- Task 5 (Profile Edit) — `EditProfileView.swift` absent; `profile` route still a stub `Text` in `MainTabView.swift`.
- Subtask 6.2 (Register) — `register` route still a stub `Text` (SSO-only login currently); Task 6 marked `[~]` partial.
- Task 7 (Push Notifications) — no `Core/Push/PushNotificationManager.swift`.

Grounded in `docs/superpowers/plans/gap-82-1-swiftui-audit.md` and verified against the actual iOS checkout.

## Tested (Band A — fast check)

Docs/tracking-only change; no build surface.
- `git diff --name-only origin/dev..HEAD` → exactly the 15 target `.md` files (exit 0).
- Malformed-checkbox scan `grep -E '^\s*- \[[^ x~-]\]'` over the stories dir → none (all boxes are valid `[ ]`/`[x]`/`[~]`/`[-]`).
- These files have no YAML frontmatter (plain `# Story` + `Status:` header), so nothing to break; markdown checkbox syntax validated above.

## Built (Band B — full build)

skipped: docs-only, no build output.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

skipped.

## Notes

- Scope-drift check is clean against the correct base: `scope-check.sh --owner pm-tech-lead --base origin/dev` → exit 0. (Running it against the worktree's stale local `dev` ref produces a false-positive listing of already-merged files — use `origin/dev`.)
- Chose the "tick to match convention" option from the issue over the "document per-task tracking as deprecated" alternative, since the sibling done stories (`79-1`, `85-2`, `80-3`) all carry ticked task lists.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQfygTRyXWxVb7r6QxDbBV)_