### PR TITLE
gap-84-1: add presigned PUT endpoint for direct client-to-S3 upload

### DIFF
--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -344,6 +344,44 @@ pub struct UploadDocumentResponse {
     pub message: String,
 }
 
+/// Request for a presigned direct-to-S3 upload URL (gap-84-1).
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CreateUploadUrlRequest {
+    /// Original filename — used to derive the storage key and, when
+    /// `mime_type` is blank, to detect the content type from the extension.
+    pub file_name: String,
+    /// MIME type the client will upload with. It MUST be sent as the
+    /// `Content-Type` header on the subsequent PUT, because the presigned URL
+    /// is signed for exactly this content type.
+    pub mime_type: String,
+    /// Optional declared size in bytes. When present it is validated against the
+    /// 50 MiB cap up-front so an oversize upload is rejected before the client
+    /// wastes a round-trip to S3. S3 still enforces the real byte count.
+    #[serde(default)]
+    pub size_bytes: Option<i64>,
+}
+
+/// Response carrying a presigned PUT URL for direct client-to-S3 upload
+/// (gap-84-1). The client uploads bytes straight to `url`, then registers the
+/// document via `POST /api/v1/documents` with the returned `file_key`.
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CreateUploadUrlResponse {
+    /// Presigned S3 PUT URL. The client uploads bytes directly here, bypassing
+    /// the api-server byte proxy.
+    pub url: String,
+    /// Storage key the object will live at. Echo this back to
+    /// `POST /api/v1/documents` to register the document record once the PUT
+    /// completes.
+    pub file_key: String,
+    /// MIME type the client MUST set as the `Content-Type` header on the PUT so
+    /// the request matches the presigned signature.
+    pub content_type: String,
+    /// HTTP method to use for the upload (always `PUT`).
+    pub method: String,
+    /// When the presigned URL expires.
+    pub expires_at: DateTime<Utc>,
+}
+
 /// Query for listing documents.
 #[derive(Debug, Serialize, Deserialize, ToSchema, Default, utoipa::IntoParams)]
 pub struct ListDocumentsQuery {
@@ -416,6 +454,10 @@ pub fn router() -> Router<AppState> {
         // Download/Preview (Story 7A.4)
         .route("/{id}/download", get(get_download_url))
         .route("/{id}/preview", get(get_preview_url))
+        // Presigned direct-to-S3 upload URL (gap-84-1). No body-limit override
+        // needed — only a small JSON request/response crosses the api-server;
+        // the file bytes go straight to S3.
+        .route("/upload-url", post(create_upload_url))
         // Multipart upload (Story 7A.1)
         .merge(upload_router)
 }
@@ -1449,6 +1491,167 @@ async fn get_preview_url(
     rls.release().await;
     Ok(Json(UrlResponse {
         url: presigned.url,
+        expires_at: presigned.expires_at,
+    }))
+}
+
+// ============================================================================
+// Presigned Upload-URL Handler (gap-84-1)
+// ============================================================================
+
+/// Validate a presigned-upload request before minting a URL (gap-84-1).
+///
+/// Mirrors the eager checks the multipart [`upload_document`] handler runs on
+/// received bytes, but applied up-front to the client's *declared* `mime_type`
+/// / `size_bytes` so an invalid request is rejected before a presigned URL is
+/// handed out. Kept as a pure function so it can be unit-tested without a live
+/// S3 client or DB. Returns the client error tuple on failure.
+fn validate_upload_url_request(
+    mime_type: &str,
+    size_bytes: Option<i64>,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if !ALLOWED_MIME_TYPES.contains(&mime_type) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "UNSUPPORTED_FILE_TYPE",
+                format!(
+                    "File type '{mime_type}' is not supported. \
+                    Allowed: PDF, DOC, DOCX, XLS, XLSX, PNG, JPG, GIF, WEBP, TXT, CSV"
+                ),
+            )),
+        ));
+    }
+
+    if let Some(size) = size_bytes {
+        if size < 0 {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse::new(
+                    "BAD_REQUEST",
+                    "size_bytes must be non-negative",
+                )),
+            ));
+        }
+        if size > MAX_FILE_SIZE {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                Json(ErrorResponse::new(
+                    "FILE_TOO_LARGE",
+                    format!("File exceeds maximum size of {MAX_FILE_SIZE} bytes (50 MiB)"),
+                )),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Mint a presigned PUT URL for direct client-to-S3 upload (gap-84-1).
+///
+/// Lets clients upload file bytes straight to S3-compatible storage instead of
+/// proxying them through the api-server multipart `/upload` route. Flow:
+///   1. `POST /api/v1/documents/upload-url` → this handler returns a short-lived
+///      presigned PUT URL plus the storage `file_key`.
+///   2. Client `PUT`s the bytes directly to that URL, setting
+///      `Content-Type: <content_type>` so the request matches the signature.
+///   3. Client `POST`s `/api/v1/documents` with the `file_key` to register the
+///      document record.
+///
+/// Any authenticated org member may request an upload URL — same authorization
+/// posture as the existing multipart upload handler (`AuthUser` + tenant
+/// context, no extra capability gate). The URL is scoped to a tenant-specific
+/// key and expires in 5 minutes.
+#[utoipa::path(
+    post,
+    path = "/api/v1/documents/upload-url",
+    request_body = CreateUploadUrlRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Presigned upload URL", body = CreateUploadUrlResponse),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 413, description = "File too large", body = ErrorResponse),
+        (status = 503, description = "Storage unavailable", body = ErrorResponse),
+    ),
+    tag = "Documents"
+)]
+async fn create_upload_url(
+    State(state): State<AppState>,
+    _auth: AuthUser,
+    tenant: TenantExtractor,
+    Json(req): Json<CreateUploadUrlRequest>,
+) -> Result<Json<CreateUploadUrlResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = tenant.tenant_id;
+
+    // Resolve MIME type: prefer the client's declared type, fall back to
+    // extension-based detection when it's blank (parity with upload_document).
+    let content_type = if req.mime_type.trim().is_empty() {
+        integrations::get_content_type(&req.file_name).to_string()
+    } else {
+        req.mime_type.clone()
+    };
+
+    validate_upload_url_request(&content_type, req.size_bytes)?;
+
+    // Presigning needs a real S3 client. StorageService::from_env() (sync) does
+    // not create one, so gate on has_s3_client() — same 503 contract the
+    // download handler uses.
+    let storage = state.storage_service.as_ref().ok_or_else(|| {
+        tracing::error!("Storage service not configured — presigned uploads unavailable");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "STORAGE_NOT_CONFIGURED",
+                "Document storage is not configured. Please contact support.",
+            )),
+        )
+    })?;
+    if !storage.has_s3_client() {
+        tracing::error!("Storage service present but S3 client not initialised");
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "STORAGE_NOT_CONFIGURED",
+                "Document storage is not configured. Please contact support.",
+            )),
+        ));
+    }
+
+    // Tenant-scoped storage key ({org_id}/{year}/{month}/{uuid}_{filename}).
+    let file_key = integrations::generate_storage_key(org_id, &req.file_name);
+
+    // Default TTL (5 min) is applied by generate_upload_url when None is passed.
+    let presigned = storage
+        .generate_upload_url(&file_key, &content_type, None)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                file_key = %file_key,
+                "Failed to generate presigned upload URL"
+            );
+            (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(ErrorResponse::new(
+                    "STORAGE_ERROR",
+                    "Unable to generate upload URL. Please try again later.",
+                )),
+            )
+        })?;
+
+    tracing::info!(
+        file_key = %file_key,
+        org_id = %org_id,
+        content_type = %content_type,
+        "Issued presigned direct-to-S3 upload URL"
+    );
+
+    Ok(Json(CreateUploadUrlResponse {
+        url: presigned.url,
+        file_key,
+        content_type,
+        method: "PUT".to_string(),
         expires_at: presigned.expires_at,
     }))
 }

--- a/backend/servers/api-server/src/routes/documents/document_access_test.rs
+++ b/backend/servers/api-server/src/routes/documents/document_access_test.rs
@@ -1,4 +1,5 @@
-use super::{document_access_allowed, scope_membership_allows};
+use super::{document_access_allowed, scope_membership_allows, validate_upload_url_request};
+use axum::http::StatusCode;
 use chrono::Utc;
 use db::models::Document;
 use serde_json::json;
@@ -214,4 +215,44 @@ fn membership_never_grants_non_building_unit_scopes() {
             &[Uuid::new_v4()]
         ));
     }
+}
+
+// ----------------------------------------------------------------------------
+// gap-84-1 — presigned direct-to-S3 upload URL request validation.
+//
+// `validate_upload_url_request` is the pure up-front guard `create_upload_url`
+// applies to the client's declared MIME type / size before minting a presigned
+// PUT URL. These pin the accept/reject contract without needing an S3 client.
+// ----------------------------------------------------------------------------
+
+#[test]
+fn upload_url_request_accepts_allowed_type_and_size() {
+    // Allowed MIME with a within-limit size hint.
+    assert!(validate_upload_url_request("application/pdf", Some(1024)).is_ok());
+    // Size hint omitted is fine — S3 still enforces the real byte count.
+    assert!(validate_upload_url_request("image/png", None).is_ok());
+    // Exactly at the cap is allowed.
+    assert!(validate_upload_url_request("image/jpeg", Some(db::models::MAX_FILE_SIZE)).is_ok());
+}
+
+#[test]
+fn upload_url_request_rejects_disallowed_mime_type() {
+    let err = validate_upload_url_request("application/x-msdownload", Some(10))
+        .expect_err("executable MIME must be rejected");
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn upload_url_request_rejects_oversize_hint() {
+    let too_big = db::models::MAX_FILE_SIZE + 1;
+    let err = validate_upload_url_request("application/pdf", Some(too_big))
+        .expect_err("oversize hint must be rejected before minting a URL");
+    assert_eq!(err.0, StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[test]
+fn upload_url_request_rejects_negative_size() {
+    let err = validate_upload_url_request("application/pdf", Some(-1))
+        .expect_err("negative size must be rejected");
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
 }


### PR DESCRIPTION
## Task
No presigned PUT endpoint for client-to-S3 direct upload — uploads still proxy through the server (84-1-s3-presigned-url). Add a presigned PUT endpoint so clients can upload directly to S3-compatible storage instead of proxying bytes through the api-server.

## Owner
pm-backend (specialist: rust-backend)

## What changed
Adds `POST /api/v1/documents/upload-url`. The storage layer already exposed `StorageService::generate_upload_url` (a real SigV4 PUT presigner) but nothing exposed it over HTTP — every upload still went through the multipart `POST /api/v1/documents/upload` route, which reads the whole file into memory and proxies the bytes to S3. The new endpoint mints a short-lived (5 min) presigned PUT URL so the client uploads bytes straight to S3.

Direct-upload flow:
1. `POST /api/v1/documents/upload-url` `{ file_name, mime_type, size_bytes? }` → `{ url, file_key, content_type, method: "PUT", expires_at }`.
2. Client `PUT`s the bytes directly to `url` with `Content-Type: <content_type>` (must match — the URL is signed for that content type).
3. Client `POST`s `/api/v1/documents` with the returned `file_key` to register the document record (that endpoint already accepts `file_key`).

Details:
- New DTOs `CreateUploadUrlRequest` / `CreateUploadUrlResponse` co-located in `documents/core.rs`.
- Pure `validate_upload_url_request` guard rejects disallowed MIME types (400), oversize `size_bytes` hints (413), and negative sizes (400) up-front, before a URL is handed out — mirroring the eager checks the multipart handler runs on received bytes. S3 still enforces the true byte count.
- Tenant-scoped storage key via `integrations::generate_storage_key(org_id, file_name)`.
- Returns 503 `STORAGE_NOT_CONFIGURED` when the S3 client isn't initialised (same contract as the download handler).
- Auth posture identical to the existing multipart upload: `AuthUser` + tenant context, no extra capability gate.
- Route flows through `documents::core::router()` → `route_table()` automatically; no OpenAPI `paths()` registration needed (the sibling document handlers aren't registered there either).

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0 (`Finished dev profile`).
- `SQLX_OFFLINE=true cargo test -p api-server --lib -- upload_url_request document_access` → `test result: ok. 16 passed; 0 failed`.

New unit tests (in `documents/document_access_test.rs`) — fail to compile on `dev` since `validate_upload_url_request` doesn't exist there (IG3):
- `upload_url_request_accepts_allowed_type_and_size`
- `upload_url_request_rejects_disallowed_mime_type` (400)
- `upload_url_request_rejects_oversize_hint` (413)
- `upload_url_request_rejects_negative_size` (400)

## Built (Band B — full build)
- `SQLX_OFFLINE=true cargo clippy -p api-server --lib -- -D warnings` → exit 0, 0 warnings.

## CI parity (Band C — hot-path only)
skipped: no DB/schema change; storage-adjacent but no new secret/credential surface. Band A + clippy cover the api-server CI gate.

## Notes
- No SQL changed → no `.sqlx` regeneration needed.
- Build-environment note (does not affect the PR): the `utoipa-swagger-ui` build script downloads its asset from `github.com/swagger-api/swagger-ui`, which egress policy blocks in this sandbox. I verified locally by pointing `SWAGGER_UI_DOWNLOAD_URL` at a `file://` zip repackaged from the npm `swagger-ui-dist@5.17.14` (identical dist assets). CI is unaffected.

## Scope drift
none — diff touches only `backend/servers/api-server/src/routes/documents/{core.rs,document_access_test.rs}` (inside pm-backend area).

## Code-reuse review
none — reuse-grep found no duplicated helper; reuses the existing `StorageService::generate_upload_url` and `integrations::generate_storage_key`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQfygTRyXWxVb7r6QxDbBV

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQfygTRyXWxVb7r6QxDbBV)_