### PR TITLE
gh-issue-2301: harden gap-84-4 push wiring (honest metrics, single token fetch, routing guard)

### DIFF
--- a/backend/servers/api-server/src/services/push_fanout.rs
+++ b/backend/servers/api-server/src/services/push_fanout.rs
@@ -49,7 +49,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use db::{
-    models::device_push_token::PushPlatform, repositories::DevicePushTokenRepository, DbPool,
+    models::{device_push_token::PushPlatform, DevicePushToken},
+    repositories::DevicePushTokenRepository,
+    DbPool,
 };
 use serde::Deserialize;
 use tokio::time::interval;
@@ -471,112 +473,87 @@ impl FcmHttpAdapter {
     }
 }
 
-#[async_trait]
-impl PushTransport for FcmHttpAdapter {
-    async fn send(
+impl FcmHttpAdapter {
+    /// Deliver to the FCM (Android) slice of a *pre-fetched* device-token set.
+    ///
+    /// The device tokens are fetched by the caller (once) and handed in — this
+    /// is what lets [`CombinedPushAdapter`] run FCM and APNs off a single
+    /// `get_tokens_for_user` query instead of one per provider. The returned
+    /// [`ProviderOutcome`] is richer than a bare `Result` so the combined
+    /// adapter can tell "actually delivered" from "configured but had no FCM
+    /// targets" — the distinction the honest-metrics contract needs.
+    async fn deliver(
         &self,
         user_id: Uuid,
-        _device_tokens: &[String],
+        tokens: &[DevicePushToken],
         notification: &Notification,
-    ) -> TransportResult {
+    ) -> ProviderOutcome {
         if !self.fcm_config.is_configured() {
-            // Fail closed, do NOT silently succeed. Returning `Ok(())` here
-            // made the pipeline record the push as `Sent` even though nothing
-            // was delivered — a lie that inflated delivery metrics. Surfacing
-            // `PushNotConfigured` makes the pipeline record `Skipped`, the
-            // honest outcome (in-app remains the mandatory delivery channel).
             tracing::info!(
                 user_id = %user_id,
                 title = %notification.title,
                 "[8A-3] Push skipped — FCM not configured (set FCM_PROJECT_ID or FCM_SERVER_KEY)"
             );
-            return Err(NotificationError::PushNotConfigured);
+            return ProviderOutcome::NotConfigured;
         }
 
-        // Fetch all registered device tokens for this user (service-role query,
-        // no RLS context set on the connection).
-        let tokens = match self.token_repo.get_tokens_for_user(user_id).await {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::error!(
-                    user_id = %user_id,
-                    error = %e,
-                    "[8A-3] Failed to fetch device tokens for push delivery"
-                );
-                return Err(NotificationError::PushFailed(format!(
-                    "DB error fetching tokens: {e}"
-                )));
-            }
+        // Select only the FCM devices from the shared token set. APNs tokens are
+        // routed to `ApnsHttpAdapter` by `CombinedPushAdapter`, so this adapter
+        // never touches them (no more "APNs not yet implemented — log-only").
+        let filter = PushTargetFilter {
+            platforms: Some(vec![PushPlatform::Fcm]),
+            ..Default::default()
         };
-
-        // Device-token-level target selection. The pipeline already gated the
-        // *push channel* against user preferences before this adapter is called;
-        // here we select *which of the user's registered devices* get the push.
-        // An empty filter selects every non-blank token; blank tokens are dropped.
-        let targets = select_dispatch_targets(&tokens, &PushTargetFilter::default());
+        let targets = select_dispatch_targets(tokens, &filter);
 
         if targets.is_empty() {
             tracing::debug!(
                 user_id = %user_id,
                 stored = tokens.len(),
-                "[8A-3] No dispatch targets selected for user — skipping push"
+                "[8A-3] No FCM dispatch targets selected for user — nothing to deliver"
             );
-            return Ok(());
+            return ProviderOutcome::NoTargets;
         }
 
         let project_id = self.fcm_config.project_id.clone();
         let mut any_sent = false;
-        let mut fcm_attempted = false;
         let mut stale_tokens: Vec<(Uuid, String)> = Vec::new();
 
         for target in &targets {
-            match target.platform {
-                PushPlatform::Fcm => {
-                    fcm_attempted = true;
-                    let (success, expired) = if let Some(ref pid) = project_id {
-                        self.send_fcm_v1(pid, &target.token, notification).await
-                    } else {
-                        // No project ID — use legacy API
-                        self.send_fcm_legacy(&target.token, notification).await
-                    };
+            let (success, expired) = if let Some(ref pid) = project_id {
+                self.send_fcm_v1(pid, &target.token, notification).await
+            } else {
+                // No project ID — use legacy API
+                self.send_fcm_legacy(&target.token, notification).await
+            };
 
-                    // Store delivery receipt (log + in-memory; DB table in follow-up)
-                    let receipt = PushDeliveryReceipt {
-                        token_id: target.token_id,
-                        user_id,
-                        platform: PushPlatform::Fcm,
-                        success,
-                        error: if success {
-                            None
-                        } else {
-                            Some("FCM rejected".to_string())
-                        },
-                        token_expired: expired,
-                        attempted_at: chrono::Utc::now(),
-                    };
-                    tracing::info!(
-                        token_id = %receipt.token_id,
-                        user_id = %receipt.user_id,
-                        success = receipt.success,
-                        token_expired = receipt.token_expired,
-                        "[8A-3] Push delivery receipt"
-                    );
+            // Store delivery receipt (log + in-memory; DB table in follow-up)
+            let receipt = PushDeliveryReceipt {
+                token_id: target.token_id,
+                user_id,
+                platform: PushPlatform::Fcm,
+                success,
+                error: if success {
+                    None
+                } else {
+                    Some("FCM rejected".to_string())
+                },
+                token_expired: expired,
+                attempted_at: chrono::Utc::now(),
+            };
+            tracing::info!(
+                token_id = %receipt.token_id,
+                user_id = %receipt.user_id,
+                success = receipt.success,
+                token_expired = receipt.token_expired,
+                "[8A-3] Push delivery receipt"
+            );
 
-                    if expired {
-                        stale_tokens.push((target.token_id, target.token.clone()));
-                    }
-                    if success {
-                        any_sent = true;
-                    }
-                }
-                PushPlatform::Apns => {
-                    // APNs HTTP/2 with P8 key — placeholder for follow-up
-                    tracing::info!(
-                        token_id = %target.token_id,
-                        user_id = %user_id,
-                        "[8A-3] APNs delivery not yet implemented — log-only"
-                    );
-                }
+            if expired {
+                stale_tokens.push((target.token_id, target.token.clone()));
+            }
+            if success {
+                any_sent = true;
             }
         }
 
@@ -600,16 +577,45 @@ impl PushTransport for FcmHttpAdapter {
             }
         }
 
-        // Only report failure when FCM was actually attempted and every attempt failed.
-        // APNs-only users (fcm_attempted == false) are not an error: APNs delivery is
-        // a placeholder and not expected to set any_sent.
-        if !fcm_attempted || any_sent {
-            Ok(())
+        if any_sent {
+            ProviderOutcome::Delivered
         } else {
-            Err(NotificationError::PushFailed(
+            ProviderOutcome::Failed(NotificationError::PushFailed(
                 "all FCM delivery attempts failed".to_string(),
             ))
         }
+    }
+}
+
+#[async_trait]
+impl PushTransport for FcmHttpAdapter {
+    async fn send(
+        &self,
+        user_id: Uuid,
+        _device_tokens: &[String],
+        notification: &Notification,
+    ) -> TransportResult {
+        // Standalone use (not via `CombinedPushAdapter`): fetch the user's
+        // tokens ourselves, then run the shared delivery core.
+        if !self.fcm_config.is_configured() {
+            return ProviderOutcome::NotConfigured.into_result();
+        }
+        let tokens = match self.token_repo.get_tokens_for_user(user_id).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!(
+                    user_id = %user_id,
+                    error = %e,
+                    "[8A-3] Failed to fetch device tokens for push delivery"
+                );
+                return Err(NotificationError::PushFailed(format!(
+                    "DB error fetching tokens: {e}"
+                )));
+            }
+        };
+        self.deliver(user_id, &tokens, notification)
+            .await
+            .into_result()
     }
 }
 
@@ -861,61 +867,51 @@ impl ApnsHttpAdapter {
     }
 }
 
-#[async_trait]
-impl PushTransport for ApnsHttpAdapter {
-    async fn send(
+impl ApnsHttpAdapter {
+    /// Deliver to the APNs (iOS) slice of a *pre-fetched* device-token set.
+    ///
+    /// Mirrors [`FcmHttpAdapter::deliver`]: the caller supplies the already
+    /// fetched tokens, and the richer [`ProviderOutcome`] lets the combined
+    /// adapter distinguish a real delivery from "no APNs targets".
+    async fn deliver(
         &self,
         user_id: Uuid,
-        _device_tokens: &[String],
+        tokens: &[DevicePushToken],
         notification: &Notification,
-    ) -> TransportResult {
+    ) -> ProviderOutcome {
         if !self.apns_config.is_configured() {
             tracing::info!(
                 user_id = %user_id,
                 "[8A-3] APNs push skipped — APNS_P8_KEY / APNS_KEY_ID / APNS_TEAM_ID not set"
             );
-            return Err(NotificationError::PushNotConfigured);
+            return ProviderOutcome::NotConfigured;
+        }
+
+        // Select only APNs targets before minting a JWT, so an Android-only user
+        // (no APNs tokens) short-circuits without the ES256 signing work.
+        let filter = PushTargetFilter {
+            platforms: Some(vec![PushPlatform::Apns]),
+            ..Default::default()
+        };
+        let targets = select_dispatch_targets(tokens, &filter);
+
+        if targets.is_empty() {
+            tracing::debug!(
+                user_id = %user_id,
+                "[8A-3] APNs: no APNs targets for user — nothing to deliver"
+            );
+            return ProviderOutcome::NoTargets;
         }
 
         // Mint a fresh JWT for this batch (negligible overhead vs. HTTP round-trip).
         let jwt = match mint_apns_jwt(&self.apns_config) {
             Some(t) => t,
             None => {
-                return Err(NotificationError::PushFailed(
+                return ProviderOutcome::Failed(NotificationError::PushFailed(
                     "failed to mint APNs JWT".to_string(),
                 ))
             }
         };
-
-        // Fetch all registered APNs tokens for this user (service-role, no RLS).
-        let tokens = match self.token_repo.get_tokens_for_user(user_id).await {
-            Ok(t) => t,
-            Err(e) => {
-                tracing::error!(
-                    user_id = %user_id,
-                    error = %e,
-                    "[8A-3] APNs: failed to fetch device tokens"
-                );
-                return Err(NotificationError::PushFailed(format!(
-                    "DB error fetching APNs tokens: {e}"
-                )));
-            }
-        };
-
-        // Select only APNs targets.
-        let filter = PushTargetFilter {
-            platforms: Some(vec![PushPlatform::Apns]),
-            ..Default::default()
-        };
-        let targets = select_dispatch_targets(&tokens, &filter);
-
-        if targets.is_empty() {
-            tracing::debug!(
-                user_id = %user_id,
-                "[8A-3] APNs: no APNs targets for user — skipping"
-            );
-            return Ok(());
-        }
 
         let mut any_sent = false;
         let mut stale_tokens: Vec<(Uuid, String)> = Vec::new();
@@ -971,12 +967,42 @@ impl PushTransport for ApnsHttpAdapter {
         }
 
         if any_sent {
-            Ok(())
+            ProviderOutcome::Delivered
         } else {
-            Err(NotificationError::PushFailed(
+            ProviderOutcome::Failed(NotificationError::PushFailed(
                 "all APNs delivery attempts failed".to_string(),
             ))
         }
+    }
+}
+
+#[async_trait]
+impl PushTransport for ApnsHttpAdapter {
+    async fn send(
+        &self,
+        user_id: Uuid,
+        _device_tokens: &[String],
+        notification: &Notification,
+    ) -> TransportResult {
+        if !self.apns_config.is_configured() {
+            return ProviderOutcome::NotConfigured.into_result();
+        }
+        let tokens = match self.token_repo.get_tokens_for_user(user_id).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!(
+                    user_id = %user_id,
+                    error = %e,
+                    "[8A-3] APNs: failed to fetch device tokens"
+                );
+                return Err(NotificationError::PushFailed(format!(
+                    "DB error fetching APNs tokens: {e}"
+                )));
+            }
+        };
+        self.deliver(user_id, &tokens, notification)
+            .await
+            .into_result()
     }
 }
 
@@ -984,13 +1010,49 @@ impl PushTransport for ApnsHttpAdapter {
 // CombinedPushAdapter — routes FCM and APNs by platform in one pass
 // ============================================================================
 
+/// Internal, richer-than-`Result` outcome of one provider's delivery pass.
+///
+/// The `PushTransport` trait can only return `Ok(())` / `Err(_)`, which
+/// conflates "I actually delivered a push" with "I was configured but had no
+/// tokens for my platform". [`CombinedPushAdapter`] needs that distinction to
+/// keep delivery metrics honest: if *neither* provider performed a real
+/// delivery, the pipeline must record the push as **Skipped**, not **Sent**
+/// (the inflated-`sent` lie Issue #484 removed — it re-surfaced for iOS-only
+/// users when FCM was configured but APNs was not).
+enum ProviderOutcome {
+    /// At least one device accepted the push.
+    Delivered,
+    /// Provider is configured, but the user has no tokens for this platform —
+    /// nothing was delivered and nothing failed.
+    NoTargets,
+    /// Provider credentials are not configured; it attempted nothing.
+    NotConfigured,
+    /// Provider attempted delivery and every attempt failed.
+    Failed(NotificationError),
+}
+
+impl ProviderOutcome {
+    /// Collapse to the `PushTransport` trait's `Result`, used when a single
+    /// adapter is driven directly (not through [`CombinedPushAdapter`]).
+    /// `NoTargets` maps to `Ok(())` — a configured provider with no devices for
+    /// its platform is not an error on the single-provider path.
+    fn into_result(self) -> TransportResult {
+        match self {
+            ProviderOutcome::Delivered | ProviderOutcome::NoTargets => Ok(()),
+            ProviderOutcome::NotConfigured => Err(NotificationError::PushNotConfigured),
+            ProviderOutcome::Failed(e) => Err(e),
+        }
+    }
+}
+
 /// A combined push adapter that routes delivery to the correct provider by platform.
 ///
 /// - FCM tokens (platform = `fcm`) are delivered via `FcmHttpAdapter`.
 /// - APNs tokens (platform = `apns`) are delivered via `ApnsHttpAdapter`.
 ///
-/// Both adapters fetch tokens from the DB independently so that a failure in
-/// one provider does not block the other.
+/// The user's device tokens are fetched **once** here and the shared slice is
+/// handed to each provider (which selects its own platform), so a fanout over
+/// N users costs N token queries, not 2N.
 #[derive(Clone)]
 pub struct CombinedPushAdapter {
     fcm: FcmHttpAdapter,
@@ -1013,6 +1075,78 @@ impl CombinedPushAdapter {
             apns: ApnsHttpAdapter::new(pool, apns_config),
         }
     }
+
+    /// Route a *pre-fetched* device-token set to both providers concurrently and
+    /// combine their outcomes into a single pipeline result.
+    ///
+    /// Split out from [`CombinedPushAdapter::send`] (which owns the one DB fetch)
+    /// so the routing + honest-metrics decision is unit-testable without a live
+    /// DB or gateway: an unconfigured provider and a provider with no targets for
+    /// its platform both short-circuit before any network I/O.
+    async fn deliver_with_tokens(
+        &self,
+        user_id: Uuid,
+        tokens: &[DevicePushToken],
+        notification: &Notification,
+    ) -> TransportResult {
+        // Run FCM and APNs delivery concurrently off the shared token slice.
+        let (fcm_outcome, apns_outcome) = tokio::join!(
+            self.fcm.deliver(user_id, tokens, notification),
+            self.apns.deliver(user_id, tokens, notification),
+        );
+        Self::combine(user_id, fcm_outcome, apns_outcome)
+    }
+
+    /// Combine the two providers' outcomes into the pipeline result.
+    ///
+    /// Honest-metrics contract:
+    /// - **any** provider `Delivered` → `Ok(())` (Sent); a failure on the other
+    ///   side is logged but does not suppress the successful delivery.
+    /// - no delivery but **some** provider `Failed` → `Err(PushFailed)` (Failed).
+    /// - no delivery and no failure (every provider `NoTargets` / `NotConfigured`)
+    ///   → `Err(PushNotConfigured)` so the pipeline records **Skipped**, not Sent.
+    fn combine(user_id: Uuid, fcm: ProviderOutcome, apns: ProviderOutcome) -> TransportResult {
+        let delivered =
+            matches!(fcm, ProviderOutcome::Delivered) || matches!(apns, ProviderOutcome::Delivered);
+
+        let mut failures: Vec<String> = Vec::new();
+        if let ProviderOutcome::Failed(e) = &fcm {
+            failures.push(format!("FCM: {e}"));
+        }
+        if let ProviderOutcome::Failed(e) = &apns {
+            failures.push(format!("APNs: {e}"));
+        }
+
+        if delivered {
+            if !failures.is_empty() {
+                tracing::warn!(
+                    user_id = %user_id,
+                    errors = %failures.join("; "),
+                    "[8A-3] partial push delivery — one provider delivered, another failed"
+                );
+            }
+            return Ok(());
+        }
+
+        if failures.is_empty() {
+            // Nothing delivered and nothing failed: every provider was either
+            // unconfigured or had no tokens for its platform. Record Skipped
+            // (honest) rather than Sent (the iOS-only inflated-`sent` lie).
+            tracing::info!(
+                user_id = %user_id,
+                "[8A-3] push skipped — no configured provider had a deliverable target"
+            );
+            Err(NotificationError::PushNotConfigured)
+        } else {
+            let msg = failures.join("; ");
+            tracing::warn!(
+                user_id = %user_id,
+                error = %msg,
+                "[8A-3] push delivery failed on all attempted providers"
+            );
+            Err(NotificationError::PushFailed(msg))
+        }
+    }
 }
 
 #[async_trait]
@@ -1020,64 +1154,28 @@ impl PushTransport for CombinedPushAdapter {
     async fn send(
         &self,
         user_id: Uuid,
-        device_tokens: &[String],
+        _device_tokens: &[String],
         notification: &Notification,
     ) -> TransportResult {
-        // Run FCM and APNs delivery concurrently. We collect both results so that
-        // a failure on one provider is logged but does not suppress delivery on
-        // the other.
-        let (fcm_result, apns_result) = tokio::join!(
-            self.fcm.send(user_id, device_tokens, notification),
-            self.apns.send(user_id, device_tokens, notification),
-        );
-
-        match (fcm_result, apns_result) {
-            // At least one provider succeeded or was cleanly skipped (NotConfigured).
-            (Ok(()), Ok(())) => Ok(()),
-            (Ok(()), Err(NotificationError::PushNotConfigured)) => Ok(()),
-            (Err(NotificationError::PushNotConfigured), Ok(())) => Ok(()),
-            // Both not configured — report to the pipeline so it records Skipped.
-            (
-                Err(NotificationError::PushNotConfigured),
-                Err(NotificationError::PushNotConfigured),
-            ) => Err(NotificationError::PushNotConfigured),
-            // FCM ok, APNs failed — count as partial success.
-            (Ok(()), Err(e)) => {
-                tracing::warn!(error = %e, user_id = %user_id, "[8A-3] APNs delivery failed (FCM ok)");
-                Ok(())
-            }
-            // APNs ok, FCM failed — count as partial success.
-            (Err(e), Ok(())) => {
-                tracing::warn!(error = %e, user_id = %user_id, "[8A-3] FCM delivery failed (APNs ok)");
-                Ok(())
-            }
-            // APNs ok, FCM not configured — normal when only iOS devices registered.
-            (Err(NotificationError::PushNotConfigured), Err(e)) => {
-                tracing::warn!(error = %e, user_id = %user_id, "[8A-3] APNs delivery failed, FCM not configured");
-                Err(NotificationError::PushFailed(
-                    "APNs failed and FCM not configured".to_string(),
-                ))
-            }
-            // FCM ok, APNs not configured — normal when only Android devices registered.
-            (Err(e), Err(NotificationError::PushNotConfigured)) => {
-                tracing::warn!(error = %e, user_id = %user_id, "[8A-3] FCM delivery failed, APNs not configured");
-                Err(NotificationError::PushFailed(
-                    "FCM failed and APNs not configured".to_string(),
-                ))
-            }
-            // Both failed.
-            (Err(e1), Err(e2)) => {
-                tracing::warn!(
-                    fcm_error = %e1,
-                    apns_error = %e2,
+        // Fetch the user's device tokens ONCE. Previously `FcmHttpAdapter` and
+        // `ApnsHttpAdapter` each ran `get_tokens_for_user` independently — 2N
+        // identical queries on the `dispatch_to_users` fanout hot path. Fetch
+        // here and hand both providers the shared slice.
+        let tokens = match self.fcm.token_repo.get_tokens_for_user(user_id).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!(
                     user_id = %user_id,
-                    "[8A-3] Both FCM and APNs delivery failed"
+                    error = %e,
+                    "[8A-3] Combined: failed to fetch device tokens for push delivery"
                 );
-                Err(NotificationError::PushFailed(format!(
-                    "FCM: {e1}; APNs: {e2}"
-                )))
+                return Err(NotificationError::PushFailed(format!(
+                    "DB error fetching tokens: {e}"
+                )));
             }
-        }
+        };
+        self.deliver_with_tokens(user_id, &tokens, notification)
+            .await
     }
 }
 
@@ -1839,5 +1937,185 @@ mod tests {
             platforms.contains(&PushPlatform::Fcm) && platforms.contains(&PushPlatform::Apns),
             "a mixed FCM+APNs user must produce targets for both platforms; got {platforms:?}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #2301: CombinedPushAdapter routing + honest-metrics guards
+    // ------------------------------------------------------------------
+
+    /// FCM configured (project id present), APNs left unconfigured.
+    fn fcm_only_configured() -> (FcmConfig, ApnsConfig) {
+        (
+            FcmConfig {
+                project_id: Some("test-project".to_string()),
+                server_key: None,
+                oauth_token: None,
+                fcm_base_url: None,
+            },
+            ApnsConfig {
+                p8_key_pem: None,
+                key_id: None,
+                team_id: None,
+                topic: "three.two.bit.ppt.management".to_string(),
+                apns_base_url: None,
+            },
+        )
+    }
+
+    /// APNs configured, FCM left unconfigured. (The APNs P8 is invalid so JWT
+    /// minting would fail — but the tests below never reach minting because the
+    /// user has no APNs targets, so no network I/O happens.)
+    fn apns_only_configured() -> (FcmConfig, ApnsConfig) {
+        (
+            FcmConfig {
+                project_id: None,
+                server_key: None,
+                oauth_token: None,
+                fcm_base_url: None,
+            },
+            ApnsConfig {
+                p8_key_pem: Some("--- not a real key ---".to_string()),
+                key_id: Some("ABCDE12345".to_string()),
+                team_id: Some("TEAM123456".to_string()),
+                topic: "three.two.bit.ppt.management".to_string(),
+                apns_base_url: None,
+            },
+        )
+    }
+
+    /// A lazy pool pointed at an unreachable address — never touched by the
+    /// tests below (they call `deliver_with_tokens`, which takes tokens directly
+    /// and never queries the DB).
+    fn unused_pool() -> DbPool {
+        sqlx::PgPool::connect_lazy("postgres://never-used:never@127.0.0.1:1/never")
+            .expect("connect_lazy builds without connecting")
+    }
+
+    fn test_notification() -> Notification {
+        Notification::new(
+            Uuid::new_v4(),
+            common::notifications::NotificationCategory::Announcements,
+            "Building update",
+            "The lift will be serviced tomorrow.",
+        )
+    }
+
+    /// Honest-metrics regression guard (Issue #2301, finding 2).
+    ///
+    /// FCM is configured but APNs is **not**, and the user is iOS-only (only APNs
+    /// tokens). Nothing is actually delivered — FCM has no FCM targets, APNs is
+    /// unconfigured — so `CombinedPushAdapter` must report `PushNotConfigured`
+    /// (the pipeline records **Skipped**), NOT `Ok(())` (**Sent**).
+    ///
+    /// Before this fix `(Ok(()), Err(PushNotConfigured))` mapped to `Ok(())`,
+    /// re-introducing the inflated-`sent` lie (Issue #484) for every iOS-only
+    /// user. This exercises the real `CombinedPushAdapter` routing + combine path
+    /// (no DB, no gateway: both providers short-circuit before any I/O).
+    #[tokio::test]
+    async fn ios_only_user_with_fcm_only_configured_is_skipped_not_sent() {
+        let (fcm, apns) = fcm_only_configured();
+        let adapter = CombinedPushAdapter::new(unused_pool(), fcm, apns);
+        let tokens = vec![stored_token("apns-device", "apns", None)];
+
+        let result = adapter
+            .deliver_with_tokens(Uuid::new_v4(), &tokens, &test_notification())
+            .await;
+
+        assert!(
+            matches!(result, Err(NotificationError::PushNotConfigured)),
+            "iOS-only user, only FCM configured → nothing delivered → must record \
+             Skipped (PushNotConfigured), got {result:?}"
+        );
+    }
+
+    /// Symmetric honest-metrics guard: APNs configured, FCM not, Android-only
+    /// user (only FCM tokens). Nothing delivered → Skipped, not Sent.
+    #[tokio::test]
+    async fn android_only_user_with_apns_only_configured_is_skipped_not_sent() {
+        let (fcm, apns) = apns_only_configured();
+        let adapter = CombinedPushAdapter::new(unused_pool(), fcm, apns);
+        let tokens = vec![stored_token("fcm-device", "fcm", None)];
+
+        let result = adapter
+            .deliver_with_tokens(Uuid::new_v4(), &tokens, &test_notification())
+            .await;
+
+        assert!(
+            matches!(result, Err(NotificationError::PushNotConfigured)),
+            "Android-only user, only APNs configured → nothing delivered → must \
+             record Skipped (PushNotConfigured), got {result:?}"
+        );
+    }
+
+    /// `combine` pins the honest-metrics decision table directly (no I/O).
+    #[test]
+    fn combine_records_skipped_when_nothing_delivered_and_nothing_failed() {
+        let uid = Uuid::new_v4();
+        for (fcm, apns) in [
+            // iOS-only user, FCM configured but no FCM targets, APNs not configured.
+            (ProviderOutcome::NoTargets, ProviderOutcome::NotConfigured),
+            // Android-only symmetric.
+            (ProviderOutcome::NotConfigured, ProviderOutcome::NoTargets),
+            // Neither provider configured.
+            (ProviderOutcome::NotConfigured, ProviderOutcome::NotConfigured),
+            // Both configured, user has zero registered devices.
+            (ProviderOutcome::NoTargets, ProviderOutcome::NoTargets),
+        ] {
+            assert!(
+                matches!(
+                    CombinedPushAdapter::combine(uid, fcm, apns),
+                    Err(NotificationError::PushNotConfigured)
+                ),
+                "no real delivery and no failure must record Skipped"
+            );
+        }
+    }
+
+    #[test]
+    fn combine_reports_sent_when_any_provider_delivered() {
+        let uid = Uuid::new_v4();
+        assert!(CombinedPushAdapter::combine(
+            uid,
+            ProviderOutcome::Delivered,
+            ProviderOutcome::NotConfigured,
+        )
+        .is_ok());
+        assert!(CombinedPushAdapter::combine(
+            uid,
+            ProviderOutcome::NotConfigured,
+            ProviderOutcome::Delivered,
+        )
+        .is_ok());
+        // A delivery on one side masks a failure on the other (partial success).
+        assert!(CombinedPushAdapter::combine(
+            uid,
+            ProviderOutcome::Delivered,
+            ProviderOutcome::Failed(NotificationError::PushFailed("apns down".into())),
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn combine_reports_failed_when_an_attempt_failed_and_nothing_delivered() {
+        let uid = Uuid::new_v4();
+        // APNs attempted and failed while FCM had no targets — honest Failed,
+        // NOT Sent (the old `(Ok, Err)` → `Ok` arm would have lied here too).
+        assert!(matches!(
+            CombinedPushAdapter::combine(
+                uid,
+                ProviderOutcome::NoTargets,
+                ProviderOutcome::Failed(NotificationError::PushFailed("apns down".into())),
+            ),
+            Err(NotificationError::PushFailed(_))
+        ));
+        // Both providers attempted and failed.
+        assert!(matches!(
+            CombinedPushAdapter::combine(
+                uid,
+                ProviderOutcome::Failed(NotificationError::PushFailed("fcm".into())),
+                ProviderOutcome::Failed(NotificationError::PushFailed("apns".into())),
+            ),
+            Err(NotificationError::PushFailed(_))
+        ));
     }
 }

--- a/backend/servers/api-server/src/services/push_fanout.rs
+++ b/backend/servers/api-server/src/services/push_fanout.rs
@@ -2057,7 +2057,10 @@ mod tests {
             // Android-only symmetric.
             (ProviderOutcome::NotConfigured, ProviderOutcome::NoTargets),
             // Neither provider configured.
-            (ProviderOutcome::NotConfigured, ProviderOutcome::NotConfigured),
+            (
+                ProviderOutcome::NotConfigured,
+                ProviderOutcome::NotConfigured,
+            ),
             // Both configured, user has zero registered devices.
             (ProviderOutcome::NoTargets, ProviderOutcome::NoTargets),
         ] {


### PR DESCRIPTION
## Task

Follow-up: harden gap-84-4 push wiring (Closes #2301). Post-merge review of PR #2290 raised three non-blocking findings in `backend/servers/api-server/src/services/push_fanout.rs`:

1. **test-coverage** — the IG3 regression test only exercised the platform-agnostic `select_dispatch_targets` (unchanged by #2290), so it passed on `dev` and did not guard the shipped `CombinedPushAdapter` behavior.
2. **correctness** — iOS-only users (APNs tokens) with FCM configured but APNs not configured were recorded as **Sent** when nothing was delivered: `(Ok(()), Err(PushNotConfigured))` mapped to `Ok(())`. Same inflated-`sent` lie Issue #484 removed, re-surfacing on iOS.
3. **efficiency** — `CombinedPushAdapter::send` fetched device tokens twice (FCM and APNs each queried `get_tokens_for_user`) → 2N queries on the `dispatch_to_users` fanout hot path.

## Owner

pm-tech-lead (specialist: rust-backend)

## Changes

- Introduce internal `ProviderOutcome` (`Delivered` / `NoTargets` / `NotConfigured` / `Failed`) so `CombinedPushAdapter` can distinguish a real delivery from "configured but no targets". New `combine()` records **Skipped** (`PushNotConfigured`) when no provider performed a real delivery — fixing finding 2 for the iOS path and the symmetric Android case, while preserving the existing partial-success and both-failed semantics.
- `CombinedPushAdapter::send` fetches tokens **once** and hands both providers the shared slice via a new `deliver_with_tokens` seam; each provider's `deliver(tokens)` selects its own platform — fixing finding 3 (2N → N queries).
- `FcmHttpAdapter` now filters to FCM targets only, dropping the misleading "APNs not yet implemented — log-only" branch (APNs is routed to `ApnsHttpAdapter`).
- Regression guards (finding 1) exercise the real `CombinedPushAdapter` routing + honest-metrics decision with no DB and no gateway (both providers short-circuit before any I/O): `ios_only_user_with_fcm_only_configured_is_skipped_not_sent`, the symmetric Android test, and three `combine_*` decision-table tests.

## Tested (Band A — fast check)

- `cargo check -p api-server` → exit 0 (clean)
- `cargo test -p api-server --lib push_fanout` → `39 passed; 0 failed` (includes the 5 new guards)

IG3 evidence: the new tests reference `CombinedPushAdapter::deliver_with_tokens` / `combine` / `ProviderOutcome`, which do not exist on `dev`, and pin behavior that `dev` gets wrong (records Sent instead of Skipped). Landed locally as a `test:` + `fix:` commit pair; squashed on push because `git push` is proxy-blocked in the implementer environment (pushed via GitHub API, file verified byte-identical to the locally-built/tested tree).

## Built (Band B — full build)

- `cargo clippy -p api-server --lib -- -D warnings` → exit 0 (no warnings)
- (Release build skipped: change is contained to one service module, no public-API/config/migration surface; clippy + check cover it.)

## CI parity (Band C — hot-path only)

Push delivery touches notification data-integrity, so clippy `-D warnings` (matching CI's gate) was run above. Full `just`/`act` not run — swagger-ui build asset (`utoipa-swagger-ui`) is egress-blocked in this environment; worked around locally by sourcing the dist from the allowlisted npm registry to complete the compile.

## Remote-tested

skipped (no ppt-bridge MCP in session)

## Notes

- No public API/signature changes: the `PushTransport` trait and `CombinedPushAdapter::{from_env,new,send}` are unchanged. `FcmHttpAdapter` / `ApnsHttpAdapter` still implement `PushTransport` (their `send` now delegates to the shared `deliver` core).
- `combine()`'s decision table preserves all prior arms except the two the issue flags: a both-vacuous / all-unconfigured combination now records **Skipped** instead of **Sent** (finding 2), and a "no delivery but an attempt failed" combination records **Failed** instead of **Sent**.
- scope_drift=false, code_reuse_warn=none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7MMP5Rt4JxtnAsdvwo4kr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q7MMP5Rt4JxtnAsdvwo4kr)_