### PR TITLE
gh-issue-2302: capture letter-suffixed epics in screen-map drift extractor

### DIFF
--- a/frontend/packages/screen-map/src/extract-known.ts
+++ b/frontend/packages/screen-map/src/extract-known.ts
@@ -11,7 +11,11 @@ export interface KnownContexts {
  * Extract the "known IDs" sets that drive the drift-context optional checks
  * in `scanDrift`. Sources:
  * - `docs/use-cases.md` — regex `\bUC-(\d+(?:\.\d+)?)\b`.
- * - `docs/epics/EPIC-NNN-*.md` — regex `^EPIC-(\d+)` on filenames.
+ * - `docs/epics/EPIC-NNN-*.md` — regex `^EPIC-0*(\d+[A-Z]*)` on filenames. The
+ *   optional letter suffix preserves the established `10A`/`10B`/`7B` epic
+ *   convention (see `docs/EPIC_STORY_STATUS.md`); leading zeros are stripped and
+ *   the suffix is upper-cased so the extracted id matches the unpadded frontmatter
+ *   refs (`Epic-10A`, not `Epic-010A`).
  * - `frontend/packages/ui-kit/src/index.ts` — `export { Foo, Bar }` and `export const Baz`
  *   (excludes `export type` lines so type-only exports aren't treated as components).
  *
@@ -44,8 +48,8 @@ async function extractEpics(repoRoot: string): Promise<Set<string>> {
     const entries = await readdir(path.join(repoRoot, 'docs/epics'));
     const out = new Set<string>();
     for (const entry of entries) {
-      const m = entry.match(/^EPIC-(\d+)/i);
-      if (m) out.add(`Epic-${m[1]}`);
+      const m = entry.match(/^EPIC-0*(\d+[A-Z]*)/i);
+      if (m) out.add(`Epic-${m[1].toUpperCase()}`);
     }
     return out;
   } catch (err) {

--- a/frontend/packages/screen-map/src/scan.ts
+++ b/frontend/packages/screen-map/src/scan.ts
@@ -132,8 +132,11 @@ async function scanEpics(dir: string, product: Product): Promise<CandidateScreen
   } catch {
     return [];
   }
+  // Capture an optional upper-cased letter suffix (10A/10B/7B convention, see
+  // docs/EPIC_STORY_STATUS.md) and strip leading zeros so the synthesized
+  // candidate matches the unpadded `Epic-10A` frontmatter refs.
   const epics = entries
-    .map((entry) => entry.match(/^EPIC-(\d+)/i)?.[1])
+    .map((entry) => entry.match(/^EPIC-0*(\d+[A-Z]*)/i)?.[1]?.toUpperCase())
     .filter((id): id is string => Boolean(id));
   return [...new Set(epics)].map((num) => ({
     id: `${product}/epic-${num}`,

--- a/frontend/packages/screen-map/tests/context.test.ts
+++ b/frontend/packages/screen-map/tests/context.test.ts
@@ -54,7 +54,7 @@ describe('buildValidationContext', () => {
       );
       const ctx = await buildValidationContext({ repoRoot: root });
       expect(ctx.knownUseCases?.has('UC-12')).toBe(true);
-      expect(ctx.knownEpics?.has('Epic-001')).toBe(true);
+      expect(ctx.knownEpics?.has('Epic-1')).toBe(true);
       expect(ctx.knownComponents?.has('BuildingHeader')).toBe(true);
     });
   });

--- a/frontend/packages/screen-map/tests/extract-known.test.ts
+++ b/frontend/packages/screen-map/tests/extract-known.test.ts
@@ -25,13 +25,31 @@ describe('extractKnownContexts', () => {
     expect(ctx.knownUseCases.has('UC-13')).toBe(true);
   });
 
-  it('extracts Epic IDs from docs/epics/*.md filenames', async () => {
+  it('extracts Epic IDs from docs/epics/*.md filenames (leading zeros stripped)', async () => {
     await mkdir(path.join(tmpRoot, 'docs/epics'), { recursive: true });
     await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-001-foo.md'), '');
     await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-002-bar.md'), '');
     const ctx = await extractKnownContexts(tmpRoot);
-    expect(ctx.knownEpics.has('Epic-001')).toBe(true);
-    expect(ctx.knownEpics.has('Epic-002')).toBe(true);
+    // Numeric prefixes normalize to the unpadded frontmatter form (`Epic-1`),
+    // matching how `epics:` refs are written in screen-map frontmatter.
+    expect(ctx.knownEpics.has('Epic-1')).toBe(true);
+    expect(ctx.knownEpics.has('Epic-2')).toBe(true);
+  });
+
+  it('preserves and upper-cases letter-suffixed epics (10A/10B/7B convention)', async () => {
+    await mkdir(path.join(tmpRoot, 'docs/epics'), { recursive: true });
+    // Letter-suffixed epic — must round-trip to the canonical `Epic-10A`.
+    await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-010A-oauth.md'), '');
+    // Plain numeric epic — must still collapse to `Epic-10`, not `Epic-010`.
+    await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-010-platform.md'), '');
+    // Lowercase suffix normalizes so `Epic-7b` and `Epic-7B` don't diverge.
+    await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-007b-docs.md'), '');
+    const ctx = await extractKnownContexts(tmpRoot);
+    expect(ctx.knownEpics.has('Epic-10A')).toBe(true);
+    expect(ctx.knownEpics.has('Epic-10')).toBe(true);
+    expect(ctx.knownEpics.has('Epic-7B')).toBe(true);
+    // The letter-suffixed epic must NOT collapse to the bare numeric prefix.
+    expect(ctx.knownEpics.has('Epic-010A')).toBe(false);
   });
 
   it('extracts component names from frontend/packages/ui-kit exports', async () => {

--- a/frontend/packages/screen-map/tests/fixtures/epic-sample/EPIC-010B-platform-admin.md
+++ b/frontend/packages/screen-map/tests/fixtures/epic-sample/EPIC-010B-platform-admin.md
@@ -1,0 +1,1 @@
+# Epic 10B — Platform Administration

--- a/frontend/packages/screen-map/tests/scan.test.ts
+++ b/frontend/packages/screen-map/tests/scan.test.ts
@@ -57,7 +57,10 @@ describe('scanCandidates', () => {
       },
     });
     const epics = candidates.flatMap((c) => c.epics ?? []);
-    expect(epics).toContain('Epic-001');
+    // Leading zeros are stripped to match the unpadded frontmatter refs.
+    expect(epics).toContain('Epic-1');
+    // Letter-suffixed epics (10A/10B/7B convention) round-trip, upper-cased.
+    expect(epics).toContain('Epic-10B');
   });
 
   it('includes user-add entries with source: "user"', async () => {


### PR DESCRIPTION
## Task

Follow-up to PR #2297: the screen-map drift scanner's epic extractor regex `^EPIC-(\d+)` only captures the numeric prefix, so letter-suffixed epics (Epic-10A/10B/7B — an established convention per `docs/EPIC_STORY_STATUS.md`) can never match `knownEpics`, and `10A`/`10B` collapse to a single `Epic-10`. Widen the regex to capture an optional letter suffix and uppercase-normalize it, in both `extract-known.ts` and `scan.ts`. Add unit tests: `EPIC-010A-oauth.md` → `Epic-10A`, and confirm `EPIC-010-*.md` still → `Epic-10`.

Closes #2302

## Owner

`pm-tech-lead` (frontend/TypeScript specialist — `frontend/packages/screen-map/`).

## Change

Both epic extractors widened from `/^EPIC-(\d+)/i` to `/^EPIC-0*(\d+[A-Z]*)/i`:
- `src/extract-known.ts:47` — `out.add(\`Epic-${m[1].toUpperCase()}\`)`
- `src/scan.ts:136` — `entry.match(...)?.[1]?.toUpperCase()`, carried through the existing `Epic-${num}` / `epic-${num}` templates.

Two normalizations, both needed for the extracted id to match real refs:
1. **Optional `[A-Z]*` suffix + `.toUpperCase()`** — preserves the `10A`/`10B`/`7B` convention and stops `Epic-10b`/`Epic-10B` from diverging. This is the core fix for the reported bug (letter epics collapsing to the numeric prefix).
2. **`0*` leading-zero strip** — `scanDrift` matches by exact string membership (`knownEpics.has(epic)`), and every real `epics:` frontmatter ref in `docs/screens/**` is unpadded (`Epic-9`, `Epic-10A`, `Epic-8A`). An `EPIC-010A-*.md` file must therefore extract as `Epic-10A`, not `Epic-010A`, or the ref would still be flagged `unknown-epic`. The test spec (`EPIC-010A` → `Epic-10A`, `EPIC-010` → `Epic-10`) encodes exactly this.

Two pre-existing tests asserted the padded form (`EPIC-001-foo.md` → `Epic-001`); that expectation locked in a latent mismatch (a padded id never matches an unpadded ref). Updated to the canonical unpadded form (`Epic-1`).

## Tested (Band A — fast check)

```
pnpm -F @ppt/screen-map test        # vitest: 18 files, 77 passed | 1 skipped — exit 0
pnpm -F @ppt/screen-map typecheck   # tsc --noEmit — exit 0
biome check <5 changed files>       # No fixes applied — exit 0
```

TDD evidence: with the `test:` commit's src at `dev` state, the 3 affected test files show 4 failures (`expected [ 'Epic-001', 'Epic-010' ] to include 'Epic-1'`, letter-suffix + context assertions) — confirming the fix addresses a real gap. Green after the `fix:` commit.

## Built (Band B — full build)

skipped: change <50 LOC, no public API/config touch (two regex widenings + tests in an internal tooling package).

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

skipped.

## Scope drift

`scope-check.sh --owner pm-tech-lead` reports exit 2 because `pm-tech-lead` maps to `docs/**` / `.research/**` / `_bmad-output/**` in `owner-areas.json`, while this change lives under `frontend/packages/screen-map/` (pm-frontend's area). This is an owner-hint/area-map artifact, not real drift: the dispatcher labeled the task `pm-tech-lead` but described it as the frontend/TypeScript screen-map specialist, and all 6 changed files belong to the one cohesive, on-task package. Drifting paths:

```
frontend/packages/screen-map/src/extract-known.ts
frontend/packages/screen-map/src/scan.ts
frontend/packages/screen-map/tests/context.test.ts
frontend/packages/screen-map/tests/extract-known.test.ts
frontend/packages/screen-map/tests/scan.test.ts
frontend/packages/screen-map/tests/fixtures/epic-sample/EPIC-010B-platform-admin.md
```

## Code-reuse review

`reuse-grep.sh` — no warnings (no new security/auth/crypto/http helpers; the change reuses the existing extractor functions).

## Notes

- The linked framing note in #2302 (that `validateScreenMap` never inspects `epics`) is unchanged and out of scope — the real consumer is `cli update` / `scanDrift`, which this fix corrects.
- Latent-only today (`docs/epics/` doesn't exist yet, so `scanDrift` skips the epic check), but the fix makes the extractor correct the moment an `EPIC-NNN-*.md` tree lands.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UY3WN1tJmZY3qhEMDNDpJo)_