### PR TITLE
gh-issue-2300: pgvector back-fill stamps provenance + set-based UPDATE

### DIFF
--- a/backend/crates/db/migrations/00215_pgvector_backfill_provenance.sql
+++ b/backend/crates/db/migrations/00215_pgvector_backfill_provenance.sql
@@ -1,0 +1,89 @@
+-- Migration: 00215_pgvector_backfill_provenance.sql
+-- Epic 103 / Story 103.5: RAG pgvector back-fill correctness + performance (#2300).
+--
+-- Background
+-- ----------
+-- Migration 00081 defined `migrate_jsonb_to_vector()`, the back-fill that copies
+-- a legacy 1536-dim JSONB `embedding` into the pgvector `embedding_vector`
+-- column. PR #2291 wired it to `POST /api/v1/ai/llm/rag/migrate`. Post-merge
+-- review (#2300) found two problems with the original definition:
+--
+--   1. correctness — it copied the vector but did NOT stamp
+--      `metadata.embedding_model` provenance. Legacy rows predate provenance
+--      tagging, so after a run they still carried no `embedding_model`. The
+--      retrieval filter `filter_by_embedding_model` keeps null-provenance rows
+--      (`None => true`) for backward compatibility, so a provenance-filtered
+--      similarity search still mixed embedding spaces. Worse: before the
+--      back-fill these rows had `embedding_vector IS NULL` and were invisible to
+--      the pgvector retrieval path (`search_similar_documents` requires
+--      `embedding_vector IS NOT NULL`); populating the column pulled the exact
+--      untagged rows the task set out to isolate INTO the filtered result set.
+--
+--   2. performance — it was a row-by-row plpgsql loop with a per-row UPDATE,
+--      run synchronously across every organization in one super-admin request.
+--
+-- This migration replaces the function (forward-only: 00081 is merged and is
+-- never edited) with a single set-based UPDATE that also records provenance.
+--
+-- Provenance assumption
+-- ---------------------
+-- Legacy 1536-dim embeddings are assumed to be OpenAI `text-embedding-3-small`
+-- — the default model used everywhere else (`integrations::llm`, the embed-write
+-- path in `LlmDocumentRepository::upsert_embedding`, and `DEFAULT_EMBEDDING_DIM
+-- = 1536`). Rows that ALREADY carry an `embedding_model` key keep their own
+-- value; only untagged rows are stamped. Once stamped, a search filtered on a
+-- DIFFERENT model correctly excludes them instead of silently mixing spaces.
+--
+-- Note: after a large back-fill the IVFFlat index (`idx_document_embeddings_vector`,
+-- lists = 100) should be rebuilt (`REINDEX INDEX idx_document_embeddings_vector`)
+-- to restore recall — that is an operational step, not part of this idempotent
+-- data migration.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
+        EXECUTE $func$
+            CREATE OR REPLACE FUNCTION migrate_jsonb_to_vector()
+            RETURNS void AS $inner$
+            BEGIN
+                -- Single set-based UPDATE (replaces the 00081 row-by-row loop).
+                -- Only untouched legacy rows are converted: a 1536-dim JSONB
+                -- array whose vector column is still NULL.
+                UPDATE document_embeddings
+                SET
+                    embedding_vector = (
+                        SELECT ARRAY(
+                            SELECT (e)::float8
+                            FROM jsonb_array_elements_text(embedding) AS e
+                        )
+                    )::vector,
+                    -- Stamp assumed provenance so the retrieval filter can reason
+                    -- about the row's embedding space. Preserve any pre-existing
+                    -- `embedding_model` value; only fill it in when absent.
+                    metadata = CASE
+                        WHEN COALESCE(metadata, '{}'::jsonb) ? 'embedding_model'
+                            THEN metadata
+                        ELSE jsonb_set(
+                            COALESCE(metadata, '{}'::jsonb),
+                            '{embedding_model}',
+                            to_jsonb('text-embedding-3-small'::text),
+                            true
+                        )
+                    END,
+                    updated_at = NOW()
+                WHERE embedding IS NOT NULL
+                  AND embedding_vector IS NULL
+                  AND jsonb_typeof(embedding) = 'array'
+                  AND jsonb_array_length(embedding) = 1536;
+            END;
+            $inner$ LANGUAGE plpgsql
+        $func$;
+
+        COMMENT ON FUNCTION migrate_jsonb_to_vector IS
+            'Story 103.5 / #2300: set-based back-fill of legacy JSONB embeddings into pgvector, stamping assumed embedding_model provenance (text-embedding-3-small) on untagged rows.';
+
+        RAISE NOTICE 'Replaced migrate_jsonb_to_vector() with set-based, provenance-stamping definition';
+    ELSE
+        RAISE NOTICE 'pgvector extension not present - skipping migrate_jsonb_to_vector() redefinition';
+    END IF;
+END $$;

--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -371,13 +371,16 @@ struct MigrateEmbeddingsResponse {
 /// Wires `LlmDocumentRepository::migrate_embeddings_to_pgvector` — previously
 /// reachable only from tests — to an operator-triggerable HTTP route. Legacy
 /// `document_embeddings` rows written before the pgvector column existed store
-/// their vector as JSONB and carry no `embedding_model` provenance. The
-/// retrieval path (`search_documents_pgvector`) keeps such provenance-less rows
-/// for backward compatibility, so until they are migrated they can mix
-/// embedding spaces in a provenance-filtered similarity search. This endpoint
-/// runs the idempotent `migrate_jsonb_to_vector()` back-fill — only rows with
-/// `embedding_vector IS NULL` and a 1536-dim JSONB array are converted — and
-/// reports how many rows moved.
+/// their vector as JSONB and carry no `embedding_model` provenance. This
+/// endpoint runs the idempotent `migrate_jsonb_to_vector()` back-fill — only
+/// rows with `embedding_vector IS NULL` and a 1536-dim JSONB array are
+/// converted — and reports how many rows moved.
+///
+/// As of migration 00215 (#2300) the back-fill also stamps assumed
+/// `metadata.embedding_model` provenance (`text-embedding-3-small`) on any
+/// converted row that lacks it, so the retrieval filter
+/// (`filter_by_embedding_model`) can isolate the row's embedding space instead
+/// of silently mixing it into a provenance-filtered similarity search.
 ///
 /// Platform-admin only: the run needs the super-admin RLS bypass so it can
 /// convert legacy rows across every organization in one pass rather than only

--- a/backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs
+++ b/backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs
@@ -50,10 +50,12 @@ async fn resolve_user_id(app: &TestApp, user: &TestUser) -> Uuid {
 /// column only exist under pgvector, so the conversion assertions below are
 /// gated on this — CI's Postgres may not carry the extension.
 async fn pgvector_present(app: &TestApp) -> bool {
-    sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'vector')")
-        .fetch_one(&app.pool)
-        .await
-        .unwrap_or(false)
+    sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'vector')",
+    )
+    .fetch_one(&app.pool)
+    .await
+    .unwrap_or(false)
 }
 
 /// Seed a `documents` row so the `document_embeddings.document_id` FK

--- a/backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs
+++ b/backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs
@@ -14,9 +14,13 @@
 //! ## pgvector independence
 //! `migrate_jsonb_to_vector()` is created only when the `vector` extension is
 //! present. When it is absent the repository call is a deterministic no-op that
-//! returns 0, so these tests assert the route contract (status + JSON shape),
-//! not a specific migrated count — they pass whether or not CI's Postgres has
-//! pgvector installed.
+//! returns 0, so the route-contract tests assert status + JSON shape, not a
+//! specific migrated count — they pass whether or not CI's Postgres has pgvector
+//! installed. The data-integrity test
+//! (`rag_migrate_stamps_provenance_on_legacy_row`, #2300) seeds a legacy
+//! no-provenance JSONB row and, *only when pgvector is present*, asserts the
+//! back-fill converts it AND stamps assumed `embedding_model` provenance so a
+//! provenance-filtered search can isolate its embedding space.
 //!
 //! DB-backed via `#[sqlx::test]` (migrator = db::MIGRATOR) — bodies run in CI
 //! where Postgres is available; the local dispatcher runner only compile-gates.
@@ -39,6 +43,35 @@ async fn resolve_user_id(app: &TestApp, user: &TestUser) -> Uuid {
         .fetch_one(&app.pool)
         .await
         .expect("resolve user id")
+}
+
+/// True when the `vector` (pgvector) extension is installed on the test DB.
+/// The back-fill function `migrate_jsonb_to_vector()` and the `embedding_vector`
+/// column only exist under pgvector, so the conversion assertions below are
+/// gated on this — CI's Postgres may not carry the extension.
+async fn pgvector_present(app: &TestApp) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = 'vector')")
+        .fetch_one(&app.pool)
+        .await
+        .unwrap_or(false)
+}
+
+/// Seed a `documents` row so the `document_embeddings.document_id` FK
+/// (migration 00081) is satisfied.
+async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, id: Uuid) {
+    sqlx::query(
+        r#"INSERT INTO documents
+               (id, organization_id, title, category, file_key, file_name,
+                mime_type, size_bytes, created_by)
+           VALUES ($1, $2, 'RAG Legacy Source', 'other', $3, 'legacy.txt', 'text/plain', 1024, $4)"#,
+    )
+    .bind(id)
+    .bind(org_id)
+    .bind(format!("{org_id}/{id}.txt"))
+    .bind(created_by)
+    .execute(pool)
+    .await
+    .expect("seed document");
 }
 
 // POST /api/v1/ai/llm/rag/migrate as a platform admin → 200 with a numeric
@@ -98,6 +131,99 @@ async fn rag_migrate_non_admin_returns_403(pool: PgPool) {
         StatusCode::FORBIDDEN,
         "non-admin migrate must be 403; body={}",
         resp.text()
+    );
+}
+
+// Data-integrity test (#2300): a legacy row with a 1536-dim JSONB embedding,
+// NULL vector, and no `embedding_model` provenance must, after the back-fill,
+// have its vector populated AND be stamped with the assumed provenance
+// (`text-embedding-3-small`) so a provenance-filtered search can isolate it.
+//
+// The conversion + provenance assertions are gated on pgvector being installed
+// (the `embedding_vector` column and `migrate_jsonb_to_vector()` only exist
+// then); when absent the route is still exercised and must return 200 with a
+// numeric `migrated` count, matching this batch's pgvector-independence rule.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn rag_migrate_stamps_provenance_on_legacy_row(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+
+    // Platform-admin principal (same construction as the 200 test above).
+    let (token, _refresh) = create_authenticated_user(&app, &user).await;
+    let user_id = resolve_user_id(&app, &user).await;
+    let org_id = seed_org(&app.pool, "rag-migrate-prov").await;
+    seed_membership(&app.pool, org_id, user_id, "platform_admin").await;
+
+    // Seed a legacy embedding row: 1536-dim JSONB array, NULL vector (omitted so
+    // this INSERT also works when the pgvector column is absent), and metadata
+    // WITHOUT an `embedding_model` key — i.e. a pre-provenance legacy row.
+    let doc_id = Uuid::new_v4();
+    seed_document(&app.pool, org_id, user_id, doc_id).await;
+    let emb_id = sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO document_embeddings
+               (organization_id, document_id, chunk_index, chunk_text, embedding, metadata)
+           VALUES ($1, $2, 0, 'legacy chunk',
+                   to_jsonb(array_fill(0.1::float8, ARRAY[1536])),
+                   '{}'::jsonb)
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(doc_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("seed legacy embedding row");
+
+    let session = app.session(token, org_id);
+    let resp = app
+        .execute(session.post("/api/v1/ai/llm/rag/migrate").build())
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "migrate must return 200; body={}",
+        resp.text()
+    );
+
+    if !pgvector_present(&app).await {
+        // No pgvector on this DB: the back-fill function is absent and the run is
+        // a deterministic no-op. Nothing to convert — assert the contract only.
+        assert_eq!(
+            resp.json_value()["migrated"].as_i64(),
+            Some(0),
+            "without pgvector the back-fill must report 0 migrated"
+        );
+        return;
+    }
+
+    // pgvector present: the legacy row must now be converted AND provenance-stamped.
+    assert!(
+        resp.json_value()["migrated"]
+            .as_i64()
+            .is_some_and(|n| n >= 1),
+        "back-fill must report at least the one seeded legacy row as migrated; body={}",
+        resp.json_value()
+    );
+
+    let (vector_set, stamped_model): (bool, Option<String>) = sqlx::query_as(
+        r#"SELECT embedding_vector IS NOT NULL,
+                  metadata->>'embedding_model'
+           FROM document_embeddings
+           WHERE id = $1"#,
+    )
+    .bind(emb_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("re-read migrated embedding row");
+
+    assert!(
+        vector_set,
+        "back-fill must populate embedding_vector on the legacy row"
+    );
+    assert_eq!(
+        stamped_model.as_deref(),
+        Some("text-embedding-3-small"),
+        "back-fill must stamp assumed embedding_model provenance so filtered \
+         search can isolate the row's embedding space (was mixing before #2300)"
     );
 }
 


### PR DESCRIPTION
## Task
Follow-up: pgvector back-fill copies vectors without provenance — doesn't fix (and can worsen) embedding-space mixing (PR #2291). Closes #2300.

`migrate_jsonb_to_vector()` (migration 00081) copied legacy 1536-dim JSONB embeddings into the pgvector `embedding_vector` column but recorded **no** `metadata.embedding_model` provenance. Because `filter_by_embedding_model` keeps null-provenance rows (`None => true`), a provenance-filtered similarity search still mixed embedding spaces after a run — and worse, populating `embedding_vector` on previously-`NULL` legacy rows pulled them *into* the pgvector retrieval path (`search_similar_documents` requires `embedding_vector IS NOT NULL`), i.e. the exact mixing the task aimed to remove.

## Owner
pm-tech-lead (specialist: `db-migration`)

## Change
New forward migration **`00215_pgvector_backfill_provenance.sql`** (00081 is merged and left untouched) replaces `migrate_jsonb_to_vector()` with:

- **Correctness** — a `metadata = jsonb_set(..., '{embedding_model}', 'text-embedding-3-small')` stamp on every converted row that lacks an `embedding_model` key, so the retrieval filter can isolate the row's embedding space. Rows that already carry provenance keep their value. The assumed model (`text-embedding-3-small`) is the default used by `integrations::llm`, `upsert_embedding`, and `DEFAULT_EMBEDDING_DIM = 1536`; the assumption is documented in the migration header.
- **Performance** — a single **set-based `UPDATE ... WHERE embedding_vector IS NULL AND jsonb_typeof(embedding)='array' AND jsonb_array_length(embedding)=1536`**, replacing the row-by-row plpgsql `FOR` loop. The header also notes the operational `REINDEX` of the IVFFlat index after a large back-fill.
- Both wrapped in the same `pg_extension WHERE extname='vector'` guard as 00081, so the migration is a no-op where pgvector is absent.

Also updates the `/api/v1/ai/llm/rag/migrate` route doc comment to reflect the new provenance-stamping behaviour.

## Test-coverage
Adds `rag_migrate_stamps_provenance_on_legacy_row` to `rag_migrate_pgvector_tests.rs`: seeds a legacy row (1536-dim JSONB, NULL vector, no `embedding_model`) and, **only when pgvector is present**, asserts the back-fill populates `embedding_vector` **and** stamps `embedding_model = text-embedding-3-small`. When pgvector is absent it falls back to the batch's contract-only assertion (200 + `migrated=0`), keeping the suite pgvector-independent.

## Tested (Band A — fast check)
- `cargo check -p db` → exit 0 (db crate compiles; `api-server` was not the changed crate).
- Full migration chain **00001 → 00215 applied in order on a real pgvector-enabled Postgres 16** → exit 0. Verified the final installed `migrate_jsonb_to_vector()` is the new definition (`pg_get_functiondef` contains `text-embedding-3-small`, no `FOR rec IN` loop).
- **Function behaviour validated end-to-end on pgvector** (exact DDL extracted from the migration):
  - legacy no-provenance row → `embedding_vector` set, `embedding_model = text-embedding-3-small` ✓
  - pre-tagged row (`custom-x`) → converted, provenance **preserved** ✓
  - wrong-dimension (8-element) row → correctly **skipped** (vector stays NULL) ✓

## Built (Band B — full build)
The `api-server` integration-test binary could not be compiled in this environment: the `utoipa-swagger-ui` build script downloads Swagger UI from `github.com/swagger-api/...` at build time and that host is denied by this session's egress policy (a policy denial, not worked around). The **new test was written to mirror the existing sibling tests** in the same file and `rag_index_embedding_write_tests.rs` (same helpers, `#[sqlx::test]` harness, tuple `query_as`); CI (which has network + Postgres) will compile and run it.

## CI parity (Band C — hot-path only)
Data-integrity change, so the migration was exercised against a real pgvector DB (above) rather than only compile-gated. Route/auth behaviour is covered by the three pre-existing tests in this file.

## Scope drift
`scope-check.sh --owner pm-tech-lead` exited 2 (advisory). All three changed paths are under `backend/`, spanning the db-migration + api-server test surface required by this cross-cutting fix:
- `backend/crates/db/migrations/00215_pgvector_backfill_provenance.sql`
- `backend/servers/api-server/src/routes/ai/llm.rs` (doc comment only)
- `backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs`

## Code-reuse review
`reuse-grep.sh` clean — no duplicated helpers introduced.

## Notes
- Chose issue option (a) — stamp provenance in the back-fill — over (b) flipping `filter_by_embedding_model`'s `None => true` default, to avoid changing retrieval behaviour for not-yet-migrated rows.
- IG goal-check reports IG1/IG2/IG4–IG6 as N/A for this GitHub-issue-driven task (no `.research/plans/<slug>.md`; branch name is dispatcher-assigned `auto-impl/...`). IG3 (separate `test:`/`fix:` commits): the regression test is bundled with the fix in a single commit — the provenance assertion fails against the old 00081 function where pgvector is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UY3WN1tJmZY3qhEMDNDpJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01UY3WN1tJmZY3qhEMDNDpJo)_