### PR TITLE
gh-issue-2303: wire report_schedules due-work consumer + unify cadence model

### DIFF
--- a/backend/crates/db/src/models/report_schedule.rs
+++ b/backend/crates/db/src/models/report_schedule.rs
@@ -93,6 +93,11 @@ pub struct NewReportSchedule {
     /// First scheduled fire time (UTC), computed at creation. `None` leaves the
     /// column NULL for a later backfill tick.
     pub next_run_at: Option<DateTime<Utc>>,
+    /// Optional 5-field UNIX cron expression (issue #2303). When set it is the
+    /// schedule's canonical cadence: `next_run_at` is computed from it and it
+    /// supersedes the legacy `frequency`/`time` columns for all scheduling math.
+    /// `None` keeps the legacy cadence.
+    pub cron_expression: Option<String>,
 }
 
 /// Raw DB row for `report_schedules`.

--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -174,10 +174,10 @@ impl ReportScheduleRepository {
     /// Create (persist) a new report schedule (gap-81-1).
     ///
     /// Inserts a row into `report_schedules` and returns the persisted record.
-    /// The new schedule starts `is_active = true` / `status = 'active'` and has
-    /// no `cron_expression` (callers use the legacy `time`/`frequency` fields at
-    /// creation time and may later switch to a cron expression via
-    /// `update_schedule`).
+    /// The new schedule starts `is_active = true` / `status = 'active'`. When
+    /// `input.cron_expression` is set it becomes the canonical cadence (issue
+    /// #2303); otherwise the row uses the legacy `time`/`frequency` fields and
+    /// may switch to a cron expression later via `update_schedule`.
     ///
     /// # Cross-tenant safety
     ///
@@ -198,8 +198,9 @@ impl ReportScheduleRepository {
         let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
             "INSERT INTO report_schedules \
              (report_id, organization_id, name, frequency, day_of_week, day_of_month, \
-              time, timezone, format, recipients, is_active, status, next_run_at) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true, $11, $12) \
+              time, timezone, format, recipients, is_active, status, next_run_at, \
+              cron_expression) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, true, $11, $12, $13) \
              RETURNING ",
             report_schedule_columns!()
         ))
@@ -215,6 +216,7 @@ impl ReportScheduleRepository {
         .bind(recipients_json)
         .bind(report_schedule_status::ACTIVE)
         .bind(input.next_run_at)
+        .bind(input.cron_expression)
         .fetch_one(&self.pool)
         .await
         .map_err(|e| {
@@ -610,6 +612,107 @@ impl ReportScheduleRepository {
         })?;
 
         Ok(ReportSchedule::from(row))
+    }
+
+    // ============================================================================
+    // Scheduler due-work consumer (issue #2303, finding 1)
+    // ============================================================================
+
+    /// Get schedules that are due to fire (issue #2303).
+    ///
+    /// Returns every active schedule whose `next_run_at` has elapsed. This is
+    /// the previously-missing due-work query for `report_schedules`: before it,
+    /// `next_run_at` was write-only (set by `create`/`update_schedule`) and no
+    /// consumer ever selected schedules by it. Mirrors
+    /// `WorkflowRepository::list_due_schedules`
+    /// (`WHERE enabled AND next_run_at <= NOW()`) and
+    /// `AutomationRepository::get_due_rules`.
+    ///
+    /// A NULL `next_run_at` (parked schedule — see [`Self::advance_after_run`])
+    /// is excluded, so a schedule whose next fire could not be computed does not
+    /// re-fire. Runs unscoped on the pool because the background scheduler has no
+    /// request tenant; each returned row still carries its own `organization_id`
+    /// for downstream per-tenant handling.
+    pub async fn get_due_schedules(&self) -> Result<Vec<ReportSchedule>, AppError> {
+        let rows = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "SELECT ",
+            report_schedule_columns!(),
+            " FROM report_schedules \
+             WHERE is_active = true \
+               AND next_run_at IS NOT NULL \
+               AND next_run_at <= NOW() \
+             ORDER BY next_run_at ASC"
+        ))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to fetch due report schedules");
+            AppError::Database(e.to_string())
+        })?;
+
+        Ok(rows.into_iter().map(ReportSchedule::from).collect())
+    }
+
+    /// Advance a schedule after it has fired (issue #2303).
+    ///
+    /// Stamps `last_run_at = NOW()` and stores the recomputed `next_run_at`.
+    /// Mirrors `WorkflowRepository::update_schedule_after_run`
+    /// (`SET last_run_at = NOW(), next_run_at = $2`). Unlike
+    /// [`Self::update_schedule`] this sets `next_run_at` **unconditionally**
+    /// (no `COALESCE`): a `None` deliberately parks the schedule with a NULL
+    /// `next_run_at` so a fire whose next occurrence could not be computed stops
+    /// re-firing on every tick instead of spinning on a stale past timestamp.
+    pub async fn advance_after_run(
+        &self,
+        id: Uuid,
+        next_run_at: Option<DateTime<Utc>>,
+    ) -> Result<ReportSchedule, AppError> {
+        let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "UPDATE report_schedules \
+             SET last_run_at = NOW(), next_run_at = $2, updated_at = NOW() \
+             WHERE id = $1 \
+             RETURNING ",
+            report_schedule_columns!()
+        ))
+        .bind(id)
+        .bind(next_run_at)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, schedule_id = %id, "Failed to advance report schedule after run");
+            AppError::Database(e.to_string())
+        })?;
+
+        Ok(ReportSchedule::from(row))
+    }
+
+    /// Record a new execution row for a schedule fire (issue #2303).
+    ///
+    /// The background scheduler calls this when a schedule becomes due so the
+    /// fire is durably logged in `report_executions` and surfaced by the
+    /// Story 81.2 execution-history endpoints. The row starts in `pending`; a
+    /// downstream report generator transitions it to
+    /// `running`/`completed`/`failed`.
+    pub async fn record_execution(&self, schedule_id: Uuid) -> Result<ReportExecution, AppError> {
+        sqlx::query_as::<_, ReportExecution>(
+            r#"
+            INSERT INTO report_executions (schedule_id, status)
+            VALUES ($1, $2)
+            RETURNING id, schedule_id, status,
+                      started_at, completed_at, duration_ms,
+                      file_key, file_name, file_size,
+                      error_code, error_message, error_details,
+                      created_at
+            "#,
+        )
+        .bind(schedule_id)
+        .bind(report_execution_status::PENDING)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, schedule_id = %schedule_id, "Failed to record report execution");
+            AppError::Database(e.to_string())
+        })
     }
 }
 

--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -2104,6 +2104,42 @@ fn compute_next_run_from_cron(now: DateTime<Tz>, cron: &str) -> Option<DateTime<
     None
 }
 
+/// Resolve a schedule's next fire time from its canonical cadence (issue #2303).
+///
+/// `cron_expression` is the single source of truth when present; otherwise the
+/// legacy `frequency`/`day_of_week`/`day_of_month`/`time` columns are used. This
+/// one resolver is shared by the background scheduler's post-fire advance (see
+/// `services::scheduler::Scheduler::fire_due_report_schedules`) so the
+/// recomputed `next_run_at` can never disagree with the cadence model a schedule
+/// was created or edited with — the dual-cadence reconciliation for finding 2.
+/// Evaluated in the schedule's stored timezone; falls back to UTC if that
+/// somehow fails to parse (create/edit reject invalid zones at the edge).
+///
+/// Returns `None` when the cadence yields no future run inside the walker's
+/// horizon (or the cron expression is malformed) — the caller parks the
+/// schedule by storing a NULL `next_run_at`.
+pub(crate) fn compute_next_run_for_schedule(
+    schedule: &ReportSchedule,
+    after: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    let tz: Tz = schedule.timezone.parse().unwrap_or(chrono_tz::UTC);
+    let now = after.with_timezone(&tz);
+    match schedule.cron_expression.as_deref() {
+        Some(cron) => compute_next_run_from_cron(now, cron),
+        None => {
+            let (hour, minute) = parse_time_hhmm(&schedule.time).unwrap_or((8, 0));
+            compute_next_run_after(
+                now,
+                &schedule.frequency,
+                schedule.day_of_week,
+                schedule.day_of_month,
+                hour,
+                minute,
+            )
+        }
+    }
+}
+
 /// Request body for `POST /api/v1/reports/schedules`.
 ///
 /// `organization_id` is intentionally absent — it is derived from the
@@ -2138,6 +2174,14 @@ pub struct CreateScheduleRequest {
     /// Recipient email addresses (max 50).
     #[serde(default)]
     pub recipients: Vec<String>,
+    /// Optional 5-field UNIX cron expression (issue #2303, finding 2).
+    ///
+    /// When provided it is the schedule's cadence source of truth: `next_run_at`
+    /// is computed from it via the same cron walker `update_schedule` uses (not
+    /// from `frequency`/`time`), and it is persisted so a row is never created
+    /// with a cron/legacy split-brain. Omit it to use the legacy
+    /// `frequency`/`day_of_week`/`day_of_month`/`time` cadence.
+    pub cron_expression: Option<String>,
 }
 
 /// Create a new report schedule (gap-81-1).
@@ -2307,17 +2351,42 @@ pub async fn create_schedule(
         ));
     };
 
+    // issue #2303 (finding 2): a caller may supply a `cron_expression` at create
+    // time. When present it is the cadence source of truth — validate it and
+    // compute the first fire from the cron walker (the SAME path edits use) so a
+    // row is never created with a cron/legacy split-brain. The legacy
+    // frequency/time columns are still stored (they are NOT NULL in the schema)
+    // but `compute_next_run_for_schedule` treats cron_expression as authoritative
+    // for all later scheduling math.
+    let cron_expression = match req.cron_expression.as_deref().map(str::trim) {
+        Some(cron) if !cron.is_empty() => {
+            if !validate_cron_expression(cron) {
+                return Err(bad_request(
+                    "INVALID_CRON_EXPRESSION",
+                    "cron_expression must be a valid 5-field UNIX cron expression \
+                     (e.g. \"0 8 * * 1\")",
+                ));
+            }
+            Some(cron.to_string())
+        }
+        _ => None,
+    };
+
     // Compute the first fire time now so the row is schedulable immediately;
     // otherwise a due-work query (`WHERE next_run_at <= NOW()`) would never
-    // pick up a freshly created schedule (issue #2198).
-    let next_run_at = compute_first_next_run(
-        &frequency,
-        req.day_of_week,
-        req.day_of_month,
-        time_hour,
-        time_minute,
-        tz,
-    );
+    // pick up a freshly created schedule (issue #2198). Route through the cron
+    // walker when a cron_expression was supplied, else the legacy walker.
+    let next_run_at = match cron_expression.as_deref() {
+        Some(cron) => compute_next_run_from_cron(Utc::now().with_timezone(&tz), cron),
+        None => compute_first_next_run(
+            &frequency,
+            req.day_of_week,
+            req.day_of_month,
+            time_hour,
+            time_minute,
+            tz,
+        ),
+    };
 
     // --- Persist -----------------------------------------------------------
     let schedule = state
@@ -2334,6 +2403,7 @@ pub async fn create_schedule(
             format,
             recipients: req.recipients,
             next_run_at,
+            cron_expression,
         })
         .await
         .map_err(|e| {
@@ -2605,10 +2675,98 @@ pub async fn update_schedule(
 mod tests {
     use super::{
         compute_first_next_run, compute_next_run_after, compute_next_run_from_cron,
-        cron_field_matches, parse_time_hhmm, validate_cron_expression, validate_time_hhmm,
+        compute_next_run_for_schedule, cron_field_matches, parse_time_hhmm, validate_cron_expression,
+        validate_time_hhmm, ReportSchedule,
     };
     use chrono::{Datelike, LocalResult, TimeZone, Timelike, Utc};
     use chrono_tz::Tz;
+
+    // --- compute_next_run_for_schedule: canonical cadence resolver (issue #2303) ---
+    //
+    // This resolver is the single source of truth the background scheduler's
+    // post-fire advance uses. `cron_expression` wins when set; otherwise the
+    // legacy frequency/day/time columns are used. These no-DB tests pin that
+    // reconciliation so a schedule's re-computed next_run_at can never disagree
+    // with the cadence model it was created/edited with (finding 2).
+
+    fn schedule_fixture(
+        frequency: &str,
+        day_of_week: Option<i32>,
+        day_of_month: Option<i32>,
+        time: &str,
+        timezone: &str,
+        cron_expression: Option<&str>,
+    ) -> ReportSchedule {
+        let now = Utc::now();
+        ReportSchedule {
+            id: uuid::Uuid::new_v4(),
+            report_id: uuid::Uuid::new_v4(),
+            organization_id: uuid::Uuid::new_v4(),
+            name: "fixture".to_string(),
+            frequency: frequency.to_string(),
+            day_of_week,
+            day_of_month,
+            time: time.to_string(),
+            timezone: timezone.to_string(),
+            format: "pdf".to_string(),
+            recipients: vec![],
+            is_active: true,
+            status: "active".to_string(),
+            last_run_at: None,
+            next_run_at: None,
+            created_at: now,
+            updated_at: now,
+            cron_expression: cron_expression.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn resolver_uses_cron_expression_when_present() {
+        // cron says "every Friday 17:00" while the legacy columns say "weekly
+        // Monday 08:00" — the resolver must follow cron, never the stale legacy
+        // cadence (the exact dual-model split the issue flags).
+        let sched = schedule_fixture(
+            "weekly",
+            Some(1), // Monday, legacy
+            None,
+            "08:00", // legacy
+            "UTC",
+            Some("0 17 * * 5"), // cron: Friday 17:00
+        );
+        let after = Utc.with_ymd_and_hms(2026, 7, 13, 6, 0, 0).unwrap(); // a Monday
+        let next = compute_next_run_for_schedule(&sched, after).expect("cron cadence resolves");
+        assert!(next > after);
+        assert_eq!((next.hour(), next.minute()), (17, 0));
+        assert_eq!(
+            next.weekday().num_days_from_sunday(),
+            5,
+            "cron_expression must win over the legacy Monday/08:00 columns"
+        );
+    }
+
+    #[test]
+    fn resolver_falls_back_to_legacy_columns_without_cron() {
+        // No cron_expression → the legacy weekly/Wednesday/09:00 cadence drives it.
+        let sched = schedule_fixture("weekly", Some(3), None, "09:00", "UTC", None);
+        let after = Utc.with_ymd_and_hms(2026, 7, 13, 6, 0, 0).unwrap();
+        let next = compute_next_run_for_schedule(&sched, after).expect("legacy cadence resolves");
+        assert!(next > after);
+        assert_eq!((next.hour(), next.minute()), (9, 0));
+        assert_eq!(
+            next.weekday().num_days_from_sunday(),
+            3,
+            "legacy weekly cadence must land on Wednesday"
+        );
+    }
+
+    #[test]
+    fn resolver_returns_none_for_unsatisfiable_cadence() {
+        // A malformed cron expression yields no run → None, which the scheduler
+        // turns into a parked (NULL next_run_at) schedule instead of a re-fire loop.
+        let sched = schedule_fixture("weekly", None, None, "08:00", "UTC", Some("not a cron"));
+        let after = Utc.with_ymd_and_hms(2026, 7, 13, 6, 0, 0).unwrap();
+        assert!(compute_next_run_for_schedule(&sched, after).is_none());
+    }
 
     // --- parse_time_hhmm (issue #2198) ---
 

--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -2674,8 +2674,8 @@ pub async fn update_schedule(
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_first_next_run, compute_next_run_after, compute_next_run_from_cron,
-        compute_next_run_for_schedule, cron_field_matches, parse_time_hhmm, validate_cron_expression,
+        compute_first_next_run, compute_next_run_after, compute_next_run_for_schedule,
+        compute_next_run_from_cron, cron_field_matches, parse_time_hhmm, validate_cron_expression,
         validate_time_hhmm, ReportSchedule,
     };
     use chrono::{Datelike, LocalResult, TimeZone, Timelike, Utc};

--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -5,7 +5,8 @@
 
 use db::repositories::{
     AnnouncementRepository, ESignatureNonceRepository, FinancialRepository, MeterRepository,
-    SessionRepository, SignatureRequestRepository, UnitResidentRepository, VoteRepository,
+    ReportScheduleRepository, SessionRepository, SignatureRequestRepository, UnitResidentRepository,
+    VoteRepository,
 };
 use db::DbPool;
 use integrations::LightweightProvider;
@@ -75,6 +76,8 @@ pub struct SchedulerMetrics {
     pub signature_requests_expired: u64,
     pub sessions_cleaned: u64,
     pub login_attempts_cleaned: u64,
+    /// Report schedules fired by the due-work consumer (issue #2303).
+    pub report_schedules_fired: u64,
     pub errors: u64,
 }
 
@@ -89,6 +92,7 @@ pub struct Scheduler {
     signature_request_repo: SignatureRequestRepository,
     e_signature_nonce_repo: ESignatureNonceRepository,
     financial_repo: FinancialRepository,
+    report_schedule_repo: ReportScheduleRepository,
     notification_service: Arc<NotificationService>,
     email_service: EmailService,
     config: SchedulerConfig,
@@ -117,6 +121,7 @@ impl Scheduler {
             signature_request_repo: SignatureRequestRepository::new(pool.clone()),
             e_signature_nonce_repo: ESignatureNonceRepository::new(pool.clone()),
             financial_repo: FinancialRepository::new(pool.clone()),
+            report_schedule_repo: ReportScheduleRepository::new(pool.clone()),
             pool,
             announcement_repo,
             notification_service,
@@ -142,6 +147,7 @@ impl Scheduler {
             signature_request_repo: SignatureRequestRepository::new(pool.clone()),
             e_signature_nonce_repo: ESignatureNonceRepository::new(pool.clone()),
             financial_repo: FinancialRepository::new(pool.clone()),
+            report_schedule_repo: ReportScheduleRepository::new(pool.clone()),
             pool,
             announcement_repo,
             notification_service,
@@ -173,6 +179,7 @@ impl Scheduler {
             signature_requests_expired: guard.signature_requests_expired,
             sessions_cleaned: guard.sessions_cleaned,
             login_attempts_cleaned: guard.login_attempts_cleaned,
+            report_schedules_fired: guard.report_schedules_fired,
             errors: guard.errors,
         }
     }
@@ -274,6 +281,12 @@ impl Scheduler {
         // Story 11.6: Transition overdue invoices and fire escalation
         if let Err(e) = self.transition_overdue_invoices().await {
             tracing::error!("Failed to transition overdue invoices: {}", e);
+            self.increment_errors();
+        }
+
+        // Issue #2303: fire due report schedules and advance next_run_at.
+        if let Err(e) = self.fire_due_report_schedules().await {
+            tracing::error!("Failed to fire due report schedules: {}", e);
             self.increment_errors();
         }
     }
@@ -1339,6 +1352,97 @@ impl Scheduler {
         .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    // ========================================================================
+    // Issue #2303: Report Schedule Due-Work Consumer
+    // ========================================================================
+
+    /// Fire report schedules that are due and advance their `next_run_at`
+    /// (issue #2303, finding 1 — the previously-missing due-work consumer).
+    ///
+    /// Before this, `report_schedules.next_run_at` was write-only: `create` and
+    /// `update_schedule` set it but nothing ever selected schedules by it, so
+    /// scheduled reports never fired. This mirrors the workflow
+    /// (`list_due_schedules` + `update_schedule_after_run`) and automation
+    /// (`get_due_rules` + `update_next_run`) loops:
+    ///
+    /// 1. select active schedules whose `next_run_at` has elapsed,
+    /// 2. record a `pending` execution for each so the fire is observable in the
+    ///    Story 81.2 execution-history endpoints, then
+    /// 3. advance `last_run_at`/`next_run_at` using the schedule's canonical
+    ///    cadence (`compute_next_run_for_schedule` — cron_expression when set,
+    ///    else the legacy frequency/time columns; finding 2).
+    ///
+    /// Advancing is what stops a schedule whose `next_run_at` is in the past from
+    /// re-firing on every 60s tick. A cadence that yields no future run parks the
+    /// schedule (NULL `next_run_at`) rather than spinning.
+    ///
+    /// NOTE: actual report *generation* and email delivery are a downstream
+    /// concern — a future generator worker consumes the `pending` executions
+    /// recorded here and transitions them to completed/failed. This method owns
+    /// only the select-fire-advance loop.
+    async fn fire_due_report_schedules(&self) -> Result<(), common::errors::AppError> {
+        let due = self.report_schedule_repo.get_due_schedules().await?;
+        if due.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(count = due.len(), "Firing due report schedules");
+
+        let now = chrono::Utc::now();
+        let mut fired = 0u64;
+
+        for schedule in &due {
+            // Record the fire in execution history (Story 81.2). If this fails,
+            // skip the advance so the schedule stays due and retries next tick
+            // instead of silently losing the run.
+            if let Err(e) = self.report_schedule_repo.record_execution(schedule.id).await {
+                tracing::error!(
+                    schedule_id = %schedule.id,
+                    error = %e,
+                    "Failed to record report execution — leaving schedule due for retry"
+                );
+                continue;
+            }
+
+            // Recompute the next fire from the schedule's canonical cadence.
+            let next = crate::routes::reports::compute_next_run_for_schedule(schedule, now);
+            if next.is_none() {
+                tracing::warn!(
+                    schedule_id = %schedule.id,
+                    "Could not compute next_run_at — parking schedule (next_run_at set NULL)"
+                );
+            }
+
+            if let Err(e) = self
+                .report_schedule_repo
+                .advance_after_run(schedule.id, next)
+                .await
+            {
+                tracing::error!(
+                    schedule_id = %schedule.id,
+                    error = %e,
+                    "Failed to advance report schedule after fire"
+                );
+                continue;
+            }
+
+            fired += 1;
+            tracing::info!(
+                schedule_id = %schedule.id,
+                organization_id = %schedule.organization_id,
+                next_run_at = ?next,
+                "Fired report schedule and advanced next_run_at"
+            );
+        }
+
+        if fired > 0 {
+            let mut metrics = self.metrics.lock().unwrap();
+            metrics.report_schedules_fired += fired;
+        }
+
+        Ok(())
     }
 
     /// Helper to increment error count in metrics.

--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -5,8 +5,8 @@
 
 use db::repositories::{
     AnnouncementRepository, ESignatureNonceRepository, FinancialRepository, MeterRepository,
-    ReportScheduleRepository, SessionRepository, SignatureRequestRepository, UnitResidentRepository,
-    VoteRepository,
+    ReportScheduleRepository, SessionRepository, SignatureRequestRepository,
+    UnitResidentRepository, VoteRepository,
 };
 use db::DbPool;
 use integrations::LightweightProvider;
@@ -1397,7 +1397,11 @@ impl Scheduler {
             // Record the fire in execution history (Story 81.2). If this fails,
             // skip the advance so the schedule stays due and retries next tick
             // instead of silently losing the run.
-            if let Err(e) = self.report_schedule_repo.record_execution(schedule.id).await {
+            if let Err(e) = self
+                .report_schedule_repo
+                .record_execution(schedule.id)
+                .await
+            {
                 tracing::error!(
                     schedule_id = %schedule.id,
                     error = %e,


### PR DESCRIPTION
## Task

Implement the two findings from GitHub issue #2303 (post-merge review of PR #2295). `Closes #2303`.

**Finding 1 — scheduler-consumer-missing (HIGH):** `report_schedules.next_run_at` was write-only — set by `create`/`update_schedule` but no query ever selected schedules by it, fired them, or advanced it. Scheduled reports never fired.

**Finding 2 — dual-cadence-model (MEDIUM):** create used `frequency/day_of_week/day_of_month/time` (legacy walker, `cron_expression` NULL) while edit used `cron_expression` (cron walker); a row could end up internally inconsistent, and a report could never be created with a cron expression.

## Owner

pm-backend (specialist: rust-backend)

## What changed

**Finding 1 — due-work consumer + post-fire advance** (`crates/db/src/repositories/report_schedule.rs`, `servers/api-server/src/services/scheduler.rs`):
- `ReportScheduleRepository::get_due_schedules()` — `SELECT ... WHERE is_active AND next_run_at IS NOT NULL AND next_run_at <= NOW()`. Mirrors `workflow.rs::list_due_schedules` and `automation.rs::get_due_rules`.
- `advance_after_run(id, next_run_at)` — `SET last_run_at = NOW(), next_run_at = $2` (set **unconditionally**, not `COALESCE`, so a `None` parks the schedule with NULL `next_run_at` instead of re-firing every tick on a stale past timestamp).
- `record_execution(schedule_id)` — inserts a `pending` `report_executions` row so each fire is observable via the Story 81.2 execution-history endpoints.
- `Scheduler::fire_due_report_schedules()` wired into `run_scheduled_tasks` (60s tick): select due → record execution → advance `next_run_at`. New `report_schedules_fired` metric.

**Finding 2 — single cadence source of truth** (`servers/api-server/src/routes/reports.rs`, `crates/db/src/models/report_schedule.rs`):
- `compute_next_run_for_schedule()` — one canonical resolver: `cron_expression` is authoritative when set, else the legacy `frequency`/day/`time` columns. Used by the post-fire advance so the recompute can never disagree with the cadence the row was created/edited with.
- `CreateScheduleRequest` gains an optional `cron_expression`; when supplied it is validated and `next_run_at` is computed via the same cron walker `update_schedule` uses, and it is persisted (`NewReportSchedule.cron_expression`, added to the `create` INSERT). Both create and edit now agree.

> NOTE: actual report *generation* + email delivery remain a downstream concern — a future generator worker consumes the `pending` executions recorded here. This PR owns the select-fire-advance loop and the cadence reconciliation.

## Tested (Band A — fast check)

- `SQLX_OFFLINE=true cargo check -p db` → exit 0
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0
- `SQLX_OFFLINE=true cargo test -p db report_schedule` → exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib routes::reports::tests` → **47 passed; 0 failed**, incl. 3 new regression tests:
  - `resolver_uses_cron_expression_when_present` (cron wins over stale legacy columns)
  - `resolver_falls_back_to_legacy_columns_without_cron`
  - `resolver_returns_none_for_unsatisfiable_cadence` (→ scheduler parks the schedule)

All `sqlx` queries here use runtime-checked `query_as::<_,_>` (not the `query!` macro), so no `.sqlx` offline data regeneration is required.

## Built (Band B — full build)

- `cargo clippy -D warnings`: **could not run — the `clippy` component is not installed for the local `1.94.1` toolchain.** `cargo check` on both crates ran clean with no warnings as the substitute; CI's `backend.yml` will run clippy.
- Release build skipped (debug `cargo check` + full unit-test run cover the change).

## CI parity (Band C — hot-path only)

Skipped: not a security/auth/billing hot-path. Note: a full local api-server build is blocked in this sandbox because the `utoipa-swagger-ui` build script downloads a GitHub archive that org egress policy denies (403); compilation here used a local placeholder swagger-ui asset for verification only. CI (with network) builds it normally.

## Notes

- Scope: all changes under `backend/**` (owner pm-backend) — `scope_drift=false`.
- Code-reuse pre-flight: no duplicated helpers — `code_reuse_warn=none`.
- `compute_next_run_for_schedule` reuses the existing `compute_next_run_from_cron` / `compute_next_run_after` / `parse_time_hhmm` primitives rather than adding new cadence logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGDaqW22ELV87KCxtea2cb

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGDaqW22ELV87KCxtea2cb)_