### PR TITLE
gap-83-2-booking-com-connect-happy-path-fetch: exercise Booking.com fetch_property outbound happy path

### DIFF
--- a/backend/crates/integrations/src/booking/mod.rs
+++ b/backend/crates/integrations/src/booking/mod.rs
@@ -3046,4 +3046,140 @@ mod tests {
         assert!(!err.success);
         assert_eq!(err.error.as_deref(), Some("rate rejected"));
     }
+
+    // ==================== fetch_property outbound happy path ====================
+
+    /// A well-formed `OTA_HotelDescriptiveInfoRS` success body carrying the
+    /// property fields `parse_property_response` extracts. Deliberately free of
+    /// any `<Errors>` / `<Error` marker so the parser takes the success branch.
+    const HOTEL_DESCRIPTIVE_INFO_RS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<OTA_HotelDescriptiveInfoRS xmlns="http://www.opentravel.org/OTA/2003/05" Version="1.0">
+  <Success/>
+  <HotelDescriptiveContents>
+    <HotelDescriptiveContent HotelCode="H42" HotelName="Grand Test Hotel">
+      <HotelInfo Rating="4">
+        <Descriptions>
+          <DescriptiveText>A lovely seaside hotel.</DescriptiveText>
+        </Descriptions>
+        <Position Latitude="48.1486" Longitude="17.1077"/>
+      </HotelInfo>
+      <ContactInfos>
+        <ContactInfo>
+          <Address CountryCode="SK">
+            <AddressLine>123 Ocean Drive</AddressLine>
+            <CityName>Bratislava</CityName>
+            <StateProv>BL</StateProv>
+            <PostalCode>81101</PostalCode>
+          </Address>
+          <Email>info@grandtest.example</Email>
+          <Phone PhoneNumber="+421900000000"/>
+          <URL>https://grandtest.example</URL>
+        </ContactInfo>
+      </ContactInfos>
+      <Policies>
+        <Policy>
+          <PolicyInfo CheckInTime="14:00" CheckOutTime="11:00"/>
+        </Policy>
+      </Policies>
+    </HotelDescriptiveContent>
+  </HotelDescriptiveContents>
+</OTA_HotelDescriptiveInfoRS>"#;
+
+    /// The connect / sync "happy path" hinges on `fetch_property` issuing a real
+    /// `OTA_HotelDescriptiveInfoRQ` POST and parsing the descriptive-info
+    /// response — a path that was previously only reachable against the live
+    /// Booking.com endpoint (documented limitation). The base-URL seam
+    /// (`BookingCredentials::with_url`, mirroring Airbnb's `with_base_url`
+    /// from #2240) lets us point the client at [`MockOtaServer`] and exercise
+    /// the outbound call + response parsing deterministically.
+    #[tokio::test]
+    async fn test_fetch_property_happy_path_issues_request_and_parses_response() {
+        let server =
+            MockOtaServer::spawn(vec![MockResponse::status(200, HOTEL_DESCRIPTIVE_INFO_RS)]).await;
+
+        let creds = BookingCredentials::with_url(
+            "H42".to_string(),
+            "user".to_string(),
+            "pass".to_string(),
+            server.url(),
+        );
+        let client = BookingClient::new(creds);
+
+        let property = client
+            .fetch_property("H42")
+            .await
+            .expect("fetch_property should succeed on a well-formed OTA response");
+
+        // Exactly one outbound call was made.
+        assert_eq!(server.hits(), 1, "fetch_property should POST once");
+
+        // The outbound request is a namespaced OTA_HotelDescriptiveInfoRQ that
+        // carries the requested hotel code.
+        let sent = server.bodies();
+        assert_eq!(sent.len(), 1);
+        assert!(
+            sent[0].contains("OTA_HotelDescriptiveInfoRQ"),
+            "outbound body should be an OTA_HotelDescriptiveInfoRQ, got: {}",
+            sent[0]
+        );
+        assert!(
+            sent[0].contains("HotelCode=\"H42\""),
+            "outbound body should target the requested hotel code, got: {}",
+            sent[0]
+        );
+
+        // The response was parsed into the typed property.
+        assert_eq!(property.hotel_id, "H42");
+        assert_eq!(property.name, "Grand Test Hotel");
+        assert_eq!(
+            property.description.as_deref(),
+            Some("A lovely seaside hotel.")
+        );
+        assert_eq!(property.star_rating, Some(4));
+        assert_eq!(property.address.street, "123 Ocean Drive");
+        assert_eq!(property.address.city, "Bratislava");
+        assert_eq!(property.address.state.as_deref(), Some("BL"));
+        assert_eq!(property.address.postal_code, "81101");
+        assert_eq!(property.address.country_code, "SK");
+        assert_eq!(
+            property.contact.email.as_deref(),
+            Some("info@grandtest.example")
+        );
+        assert_eq!(property.contact.phone.as_deref(), Some("+421900000000"));
+        assert_eq!(
+            property.contact.website.as_deref(),
+            Some("https://grandtest.example")
+        );
+        assert_eq!(property.check_in_time.as_deref(), Some("14:00"));
+        assert_eq!(property.check_out_time.as_deref(), Some("11:00"));
+        assert!(property.synced_at.is_some());
+    }
+
+    /// `fetch_properties` fans out to `fetch_property` for the configured hotel
+    /// id; on the happy path it returns the single parsed property (rather than
+    /// the placeholder fallback used when the descriptive-info call fails).
+    #[tokio::test]
+    async fn test_fetch_properties_happy_path_returns_parsed_property() {
+        let server =
+            MockOtaServer::spawn(vec![MockResponse::status(200, HOTEL_DESCRIPTIVE_INFO_RS)]).await;
+
+        let creds = BookingCredentials::with_url(
+            "H42".to_string(),
+            "user".to_string(),
+            "pass".to_string(),
+            server.url(),
+        );
+        let client = BookingClient::new(creds);
+
+        let properties = client
+            .fetch_properties()
+            .await
+            .expect("fetch_properties should succeed");
+
+        assert_eq!(properties.len(), 1);
+        assert_eq!(properties[0].hotel_id, "H42");
+        // The real parsed name proves we took the success path, not the
+        // "Property {hotel_id}" placeholder built on fetch failure.
+        assert_eq!(properties[0].name, "Grand Test Hotel");
+    }
 }


### PR DESCRIPTION
## Task
Booking.com connect happy path (fetch_property outbound call) NOT exercised in tests — documented limitation, needs base-URL seam like Airbnb's (#2240 pattern) (83-2-booking-integration Booking.com OAuth and Sync)

## Owner
pm-integration

## What changed
The Booking.com connect/sync "happy path" hinges on `BookingClient::fetch_property` issuing a real `OTA_HotelDescriptiveInfoRQ` POST and parsing the descriptive-info response — a path that was previously only reachable against the live Booking.com endpoint (documented limitation), so its success branch was never exercised in tests.

The required base-URL seam already exists on the Booking side: `BookingCredentials::with_url(...)` (the analogue of Airbnb's `AirbnbClient::with_base_url` from #2240) lets a caller point the client at a stub server. The in-crate `MockOtaServer` (a raw-tokio one-connection HTTP/1.1 mock, already used by the push/retry tests) provides the stub. This PR wires the two together to close the coverage gap — **test-only, no product-code change**:

- `test_fetch_property_happy_path_issues_request_and_parses_response` — drives `fetch_property` against `MockOtaServer`, asserts exactly one outbound POST, that the request body is a namespaced `OTA_HotelDescriptiveInfoRQ` carrying the requested `HotelCode`, and that every field of the returned `BookingProperty` (name, description, rating, address, contact, check-in/out times) is parsed from the OTA response.
- `test_fetch_properties_happy_path_returns_parsed_property` — covers the `fetch_properties` wrapper's success path, proving it returns the real parsed property rather than the `Property {hotel_id}` placeholder built on fetch failure.

## Tested (Band A — fast check)
- `cargo check -p integrations` → exit 0
- `cargo test -p integrations --lib fetch_propert` → `2 passed; 0 failed` (256 filtered out)
- `cargo fmt -p integrations -- --check` → exit 0 (clean after formatting)
- `cargo clippy -p integrations --tests` → exit 0, no warnings

## Built (Band B — full build)
skipped: test-only change, no product code / public API / config / migration touched (the crate + test binary compile clean under Band A).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only; no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- No production code changed — the seam (`BookingCredentials::with_url`) and mock harness (`MockOtaServer`) both pre-existed; this only adds the missing happy-path coverage that the gap describes.
- goal-check IG1/IG2 report FAIL because this is a dispatcher `auto-impl/*` gap task rather than a `.research/plans/*` flow (no plan file authored — per dispatcher instruction not to write `.research/**`; branch uses the dispatcher-assigned `auto-impl/...` name). IG3 is a WARN: this is a documented-limitation coverage gap where the added test is itself the deliverable, so there is no accompanying `fix:` commit. Verify gate (Band A) is fully green.
- scope-check (pm-integration) and reuse-grep both clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M1YU7ce96BfEb3idgpDtHG)_