### PR TITLE
fix(ai-chat): gate escalated list + user-scope feedback + remove unscoped dead methods (#2317)

### DIFF
--- a/backend/crates/db/src/repositories/ai_chat.rs
+++ b/backend/crates/db/src/repositories/ai_chat.rs
@@ -261,68 +261,26 @@ impl AiChatRepository {
         Ok(result.rows_affected() > 0)
     }
 
-    /// Update session title.
-    pub async fn update_session_title<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-        title: &str,
-    ) -> Result<AiChatSession, sqlx::Error>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as(
-            "UPDATE ai_chat_sessions SET title = $2, updated_at = NOW() WHERE id = $1 RETURNING *",
-        )
-        .bind(id)
-        .bind(title)
-        .fetch_one(executor)
-        .await
-    }
+    // SECURITY (#2317): the unscoped `update_session_title` (WHERE id = $1,
+    // no org/user predicate) and the legacy org-unscoped `add_feedback` were
+    // deleted here — both had zero non-test callers and were latent
+    // within-tenant IDOR footguns if a future handler wired them up. Use
+    // owner-scoped variants (`(id, org_id, user_id)` in the WHERE clause) if
+    // either operation is ever needed again.
 
-    /// Add training feedback for a message.
-    /// Record AI training feedback for a message.
-    ///
-    /// `user_id` is passed explicitly by the caller and must originate from the
-    /// verified request principal, never from client input in `data`.
-    pub async fn add_feedback<'e, E>(
-        &self,
-        executor: E,
-        user_id: Uuid,
-        data: ProvideFeedback,
-    ) -> Result<AiTrainingFeedback, sqlx::Error>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as(
-            r#"
-            INSERT INTO ai_training_feedback (message_id, user_id, rating, helpful, feedback_text)
-            VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (message_id, user_id) DO UPDATE SET
-                rating = EXCLUDED.rating,
-                helpful = EXCLUDED.helpful,
-                feedback_text = EXCLUDED.feedback_text
-            RETURNING *
-            "#,
-        )
-        .bind(data.message_id)
-        .bind(user_id)
-        .bind(data.rating)
-        .bind(data.helpful)
-        .bind(data.feedback_text)
-        .fetch_one(executor)
-        .await
-    }
-
-    /// Record AI training feedback for a message — tenant-scoped (issue
-    /// #766 / #816).
+    /// Record AI training feedback for a message — tenant- AND owner-scoped
+    /// (issues #766 / #816 / #2317).
     ///
     /// `user_id` and `org_id` both originate from the verified request
     /// principal. The `INSERT ... SELECT ... WHERE EXISTS` only writes when
-    /// the target message's parent session belongs to the caller's org, so a
-    /// caller in org B cannot attach feedback to a message in org A's chat
-    /// session (an IDOR write + training-data-poisoning vector). Returns
-    /// `Ok(None)` when the message does not exist or belongs to another org.
+    /// the target message's parent session belongs to the caller's org AND is
+    /// owned by the caller. Sessions are per-user private within an org
+    /// (#2279), so the org-only guard let a colleague in the same org
+    /// attach/overwrite feedback on another member's private message and use
+    /// the write's success/failure as a message-UUID existence oracle (#2317).
+    /// Returns `Ok(None)` when the message does not exist, belongs to another
+    /// org, or belongs to another user's session — indistinguishably, to avoid
+    /// an existence oracle.
     pub async fn add_feedback_for_org<'e, E>(
         &self,
         executor: E,
@@ -340,7 +298,7 @@ impl AiChatRepository {
             WHERE EXISTS (
                 SELECT 1 FROM ai_chat_messages m
                 JOIN ai_chat_sessions s ON s.id = m.session_id
-                WHERE m.id = $1 AND s.organization_id = $6
+                WHERE m.id = $1 AND s.organization_id = $6 AND s.user_id = $2
             )
             ON CONFLICT (message_id, user_id) DO UPDATE SET
                 rating = EXCLUDED.rating,
@@ -359,7 +317,12 @@ impl AiChatRepository {
         .await
     }
 
-    /// Get escalated messages for review.
+    /// Get escalated messages for review — org-scoped, deliberately CROSS-USER.
+    ///
+    /// This is the one AI-chat read that spans every user's sessions in the
+    /// org (escalation review). It must only be reachable from a role-gated
+    /// handler: `list_escalated` in api-server enforces
+    /// `rls.role().is_manager()` before calling this (#2317).
     pub async fn list_escalated_messages<'e, E>(
         &self,
         executor: E,

--- a/backend/servers/api-server/src/routes/ai/sessions.rs
+++ b/backend/servers/api-server/src/routes/ai/sessions.rs
@@ -852,11 +852,13 @@ async fn provide_feedback(
     let mut feedback = req;
     feedback.message_id = message_id;
 
-    // SECURITY (issue #766 / #816): feedback author AND the owning tenant are
-    // both derived from the RLS-validated request context, never from the body or
-    // the path. The repo only writes when the target message's session belongs
-    // to the caller's org — otherwise a caller in org B could attach feedback
-    // to (and poison the training signal for) org A's chat messages.
+    // SECURITY (issue #766 / #816 / #2317): feedback author AND the owning
+    // tenant are both derived from the RLS-validated request context, never
+    // from the body or the path. The repo only writes when the target message's
+    // session belongs to the caller's org AND is owned by the caller — sessions
+    // are per-user private (#2279), so an org-only guard let a colleague
+    // attach/overwrite feedback on another member's private message and use the
+    // 201-vs-404 response as a message-UUID existence oracle.
     let org_id = rls.tenant_id();
     let user_id = rls.user_id();
     let result = state
@@ -888,6 +890,23 @@ async fn list_escalated(
     mut rls: RlsConnection,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    // SECURITY (#2317): escalated messages are a cross-user, org-wide view of
+    // other members' private AI-chat content (sessions are per-user private,
+    // see #2279). Escalation review is a manager/admin function — without this
+    // gate any authenticated org member (e.g. a plain resident) could read the
+    // full content of every escalated message in the org. The RBAC check uses
+    // the DB-derived role from the RLS-validated request context, same pattern
+    // as the report-schedule handlers (`rls.role().is_manager()`).
+    if !rls.role().is_manager() {
+        rls.release().await;
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "Manager role or above required to review escalated messages",
+            )),
+        ));
+    }
     let tenant_id = rls.tenant_id();
 
     let result = state

--- a/backend/servers/api-server/tests/ai_chat_escalated_rbac_tests.rs
+++ b/backend/servers/api-server/tests/ai_chat_escalated_rbac_tests.rs
@@ -1,0 +1,231 @@
+//! Regression tests for the RBAC gate on `GET /api/v1/ai/chat/escalated`
+//! (issue #2317, follow-up to #2279/#2289).
+//!
+//! `list_escalated` returns the full content of ALL escalated AI-chat messages
+//! org-wide via `list_escalated_messages(org_id)` — a deliberately cross-user
+//! read (escalation review). AI chat sessions are per-user private within an
+//! org (#2279), so before #2317 any authenticated org member — including a
+//! plain resident — could read other members' escalated messages, partially
+//! reopening the confidentiality exposure #2289 closed.
+//!
+//! The fix adds an `rls.role().is_manager()` check inside the handler (the
+//! same pattern as the report-schedule handlers, see
+//! `report_schedule_rbac_tests.rs`).
+//!
+//! # What these tests verify
+//!
+//! 1. **RBAC denial** — `list_escalated_as_resident_is_rejected`: a user
+//!    authenticated with a *real* JWT whose DB-backed membership role is
+//!    `resident` gets past `AuthUser` and `ValidatedTenantExtractor`, reaches
+//!    the handler, and is rejected by the `rls.role().is_manager()` branch
+//!    with a strict `403 FORBIDDEN` — proving the RBAC predicate fires, not
+//!    the outer JWT gate.
+//! 2. **Manager allow** — `list_escalated_as_manager_succeeds`: the same
+//!    request from a `manager`-role member returns `200 OK` with the seeded
+//!    escalated message, proving the gate does not lock out the legitimate
+//!    escalation-review path.
+//! 3. **JWT gate** — `list_escalated_without_auth_is_rejected`: no
+//!    Authorization header at all is rejected with 401/403 before any handler
+//!    logic runs.
+
+#![allow(dead_code)]
+
+mod common;
+
+use axum::http::StatusCode;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user, seed_membership, seed_org, TestApp, TestUser};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Look up a user id by email (the user is created by
+/// `create_authenticated_user` via `POST /api/v1/auth/register`).
+async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("fetch user id")
+}
+
+/// Seed a session owned by `user_id` with one escalated message; returns the
+/// message id.
+async fn seed_escalated_message(pool: &PgPool, org_id: Uuid, user_id: Uuid) -> Uuid {
+    let session = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO ai_chat_sessions (organization_id, user_id, title)
+        VALUES ($1, $2, 'escalation rbac session') RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed session");
+
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO ai_chat_messages (session_id, role, content, escalated, escalation_reason)
+        VALUES ($1, 'assistant', 'sensitive escalated answer', TRUE, 'needs human')
+        RETURNING id
+        "#,
+    )
+    .bind(session)
+    .fetch_one(pool)
+    .await
+    .expect("seed escalated message")
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — #2317: an authenticated Resident gets 403 from the RBAC check
+// ---------------------------------------------------------------------------
+
+/// A user with a real Bearer JWT whose DB-backed membership role is
+/// `resident` requests the org-wide escalated-message list. The request
+/// passes `AuthUser` and `ValidatedTenantExtractor` and reaches the handler;
+/// the handler's `if !rls.role().is_manager()` branch fires and returns a
+/// strict `403 FORBIDDEN` with the `FORBIDDEN` error code — the escalated
+/// content of other members' private sessions is never returned.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_escalated_as_resident_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "esc-rbac").await;
+
+    // Another member's escalated message exists in the org — this is exactly
+    // the content the resident must NOT be able to read.
+    let victim = seed_user_raw(&pool, "esc-victim@ai-esc-rbac.test").await;
+    let _message = seed_escalated_message(&pool, org, victim).await;
+
+    // Register + login a real user, then attach them to `org` as a resident.
+    let resident = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &resident).await;
+    let resident_id = user_id_for(&pool, &resident.email).await;
+    seed_membership(&pool, org, resident_id, "resident").await;
+
+    let response = app
+        .execute(
+            app.get("/api/v1/ai/chat/escalated")
+                .bearer(&access_token)
+                .tenant(org)
+                .build(),
+        )
+        .await;
+
+    // The RBAC check inside the handler must fire — not the outer JWT gate.
+    assert_eq!(
+        response.status,
+        StatusCode::FORBIDDEN,
+        "#2317: authenticated resident must be rejected by the RBAC check \
+         (`rls.role().is_manager()`) with 403, got {} body={}",
+        response.status,
+        response.text(),
+    );
+
+    let body: serde_json::Value = response.json_value();
+    let code = body
+        .get("code")
+        .and_then(|c| c.as_str())
+        .unwrap_or_default();
+    assert_eq!(
+        code, "FORBIDDEN",
+        "#2317: 403 response must carry the FORBIDDEN code, body={}",
+        body
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — #2317: a Manager gets 200 with the escalated messages
+// ---------------------------------------------------------------------------
+
+/// The legitimate escalation-review path: a `manager`-role member requests
+/// the escalated list and receives `200 OK` including the seeded escalated
+/// message from another member's session (escalation review is deliberately
+/// cross-user — that is why the endpoint is role-gated rather than
+/// owner-scoped).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_escalated_as_manager_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "esc-mgr").await;
+
+    let member = seed_user_raw(&pool, "esc-member@ai-esc-rbac.test").await;
+    let message = seed_escalated_message(&pool, org, member).await;
+
+    let manager = TestUser::new();
+    let (access_token, _) = create_authenticated_user(&app, &manager).await;
+    let manager_id = user_id_for(&pool, &manager.email).await;
+    seed_membership(&pool, org, manager_id, "manager").await;
+
+    let response = app
+        .execute(
+            app.get("/api/v1/ai/chat/escalated")
+                .bearer(&access_token)
+                .tenant(org)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "#2317: a manager must be able to review escalated messages, got {} body={}",
+        response.status,
+        response.text(),
+    );
+
+    let body: serde_json::Value = response.json_value();
+    let messages = body
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .expect("response has a messages array");
+    assert!(
+        messages
+            .iter()
+            .any(|m| m.get("id").and_then(|id| id.as_str()) == Some(message.to_string().as_str())),
+        "#2317: the manager's escalated list must include the seeded escalated \
+         message, body={}",
+        body
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — no auth header at all → 401/403 from the auth gate
+// ---------------------------------------------------------------------------
+
+/// Unauthenticated request must be rejected by the auth layer before any
+/// handler logic runs (same contract as `ai_auth_tests.rs`).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_escalated_without_auth_is_rejected(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let response = app
+        .execute(app.get("/api/v1/ai/chat/escalated").build())
+        .await;
+
+    assert!(
+        response.status == StatusCode::UNAUTHORIZED || response.status == StatusCode::FORBIDDEN,
+        "unauthenticated request must be rejected with 401/403, got {}",
+        response.status,
+    );
+}
+
+/// Seed a bare user row (no auth flow needed — the row only exists so the
+/// escalated message has a real owner distinct from the caller).
+async fn seed_user_raw(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Esc RBAC User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}

--- a/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/ai_llm_cross_tenant_idor_tests.rs
@@ -31,6 +31,11 @@
 //! — otherwise any colleague in the same org can read/delete/post into another
 //! member's private session. Tests (1b)–(1d) pin that owner predicate.
 //!
+//! Issue #2317 extends the same per-user model to the feedback write path:
+//! `add_feedback_for_org` now also requires `s.user_id = <caller>` in its
+//! EXISTS guard (test 2b), and the unscoped legacy repo methods
+//! (`update_session_title`, `add_feedback`) were deleted outright.
+//!
 //! Why repo-layer and not HTTP-layer: `TestApp` mounts the router WITHOUT
 //! `host_tenant_middleware`, so `RequestPrincipal` can never resolve an
 //! `effective_org` in tests (see `equipment_cross_tenant_idor_tests.rs`'s
@@ -399,6 +404,115 @@ async fn add_feedback_for_org_blocks_cross_tenant_write(pool: PgPool) {
     assert_eq!(
         count_after_same, 1,
         "exactly one feedback row exists after the same-org write"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (2b) Feedback write is OWNER-scoped WITHIN a tenant (issue #2317) — a
+//      colleague in the same org cannot attach/overwrite feedback on another
+//      member's private message, nor use the write's success/failure as a
+//      message-UUID existence oracle. Sessions are per-user private (#2279);
+//      this pins the `s.user_id = $2` predicate added to the EXISTS guard in
+//      `add_feedback_for_org`.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_feedback_for_org_blocks_within_tenant_cross_user_write(pool: PgPool) {
+    let repo = AiChatRepository::new(pool.clone());
+
+    let org = seed_org(&pool, "wt-fb").await;
+    let owner = seed_user(&pool, "wt-fb-owner@ai-idor.test").await;
+    // `attacker` is a DIFFERENT user in the SAME org.
+    let attacker = seed_user(&pool, "wt-fb-attacker@ai-idor.test").await;
+    let session = seed_session(&pool, org, owner).await;
+    let message = seed_message(&pool, session).await;
+
+    // Same-org, different-user feedback write is refused: the repo returns
+    // None (indistinguishable from "message does not exist" — no oracle) and
+    // writes nothing.
+    let cross_user = repo
+        .add_feedback_for_org(
+            &pool,
+            attacker,
+            org,
+            ProvideFeedback {
+                message_id: message,
+                rating: Some(1),
+                helpful: Some(false),
+                feedback_text: Some("colleague poison".to_string()),
+            },
+        )
+        .await
+        .expect("query ok");
+    assert!(
+        cross_user.is_none(),
+        "issue #2317: a colleague in the same org must NOT attach feedback to \
+         another member's private message"
+    );
+
+    let count_after_cross: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ai_training_feedback WHERE message_id = $1")
+            .bind(message)
+            .fetch_one(&pool)
+            .await
+            .expect("query ok");
+    assert_eq!(
+        count_after_cross, 0,
+        "no feedback row may be written by a within-tenant cross-user caller"
+    );
+
+    // Demonstrate the leak the owner predicate closes: the org-only EXISTS
+    // (the vulnerable pre-fix guard) matches the message for ANY member of
+    // the same org.
+    let org_only_exists: bool = sqlx::query_scalar(
+        r#"
+        SELECT EXISTS (
+            SELECT 1 FROM ai_chat_messages m
+            JOIN ai_chat_sessions s ON s.id = m.session_id
+            WHERE m.id = $1 AND s.organization_id = $2
+        )
+        "#,
+    )
+    .bind(message)
+    .bind(org)
+    .fetch_one(&pool)
+    .await
+    .expect("query ok");
+    assert!(
+        org_only_exists,
+        "sanity: the org-only EXISTS (the vulnerable pre-fix guard) does match \
+         the message for any member of the same org"
+    );
+
+    // The session owner can attach feedback to their own message.
+    let as_owner = repo
+        .add_feedback_for_org(
+            &pool,
+            owner,
+            org,
+            ProvideFeedback {
+                message_id: message,
+                rating: Some(5),
+                helpful: Some(true),
+                feedback_text: Some("great".to_string()),
+            },
+        )
+        .await
+        .expect("query ok");
+    assert!(
+        as_owner.is_some(),
+        "the session owner must be able to attach feedback to their own message"
+    );
+
+    let count_after_owner: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM ai_training_feedback WHERE message_id = $1")
+            .bind(message)
+            .fetch_one(&pool)
+            .await
+            .expect("query ok");
+    assert_eq!(
+        count_after_owner, 1,
+        "exactly one feedback row exists after the owner's write"
     );
 }
 


### PR DESCRIPTION
## Task
AI chat: adjacent within-tenant exposures left open by the per-user privacy model pinned in PR #2289 (findings 1–3 of #2317).

## Fix

**1. Role-gate `GET /api/v1/ai/chat/escalated` (MEDIUM).**
`list_escalated` returned the full content of ALL escalated messages org-wide to any authenticated org member — a plain resident could read other members' private escalated AI-chat content. The handler now enforces `rls.role().is_manager()` (same DB-derived-role RBAC pattern as the report-schedule handlers) and returns a strict `403 FORBIDDEN` for non-manager roles. Escalation review stays deliberately cross-user for manager/admin tiers; the repo method's doc comment now records that it must only be reachable from the role-gated handler.

**2. Owner-scope `add_feedback_for_org` (MEDIUM).**
The `INSERT … SELECT … WHERE EXISTS` guard checked only `s.organization_id = $6`. Under the per-user privacy model (#2279), a colleague could attach/overwrite training feedback on another member's private message and use 201-vs-404 as a message-UUID existence oracle. The EXISTS now also requires `s.user_id = $2` (the verified principal — already threaded by the handler, so no signature change). `Ok(None)` is returned indistinguishably for not-found / other-org / other-user. SECURITY comments updated at both layers. Column names verified by eye against `backend/crates/db/migrations/00042_create_ai_chat.sql` (no sqlx offline metadata).

**3. Delete dead unscoped repo methods (LOW).**
`update_session_title` (`WHERE id = $1`, no org/user predicate) and the legacy pre-#766 `add_feedback` (no org/owner guard) had **zero non-test callers** (verified by grep across the workspace — the only hits were the definitions and a historical doc-comment mention). Both deleted; a SECURITY tombstone comment in the repo file explains why and what shape a future replacement must have.

**Not in scope:** finding 4 (per-user RLS predicate on `ai_chat_sessions`/`ai_chat_messages`) is a design task for the db-migration specialist and remains tracked in #2317.

## Regression tests (IG3)
- `ai_chat_escalated_rbac_tests.rs` (new): `list_escalated_as_resident_is_rejected` (real JWT + `resident` membership → strict 403 `FORBIDDEN` from the RBAC branch, not the JWT gate), `list_escalated_as_manager_succeeds` (manager → 200 including another member's escalated message), `list_escalated_without_auth_is_rejected` (401/403 outer gate). Style follows `report_schedule_rbac_tests.rs`.
- `ai_llm_cross_tenant_idor_tests.rs` (2b): `add_feedback_for_org_blocks_within_tenant_cross_user_write` — same-org non-owner write refused (`None`, zero rows), sanity assertion that the org-only EXISTS (pre-fix guard) does match, owner write succeeds. Style follows the (1b)–(1d) tests from #2289.

The resident-403 and cross-user-feedback tests fail on the pre-fix code by construction (no role gate existed; the org-only EXISTS matched).

## Verification
- `cargo fmt -p db -p api-server` → exit 0.
- Local `SQLX_OFFLINE=true cargo check -p api-server -p db` was started but the shared dev host is saturated (load avg ~43, 20 concurrent rustc from sibling worktrees) — the check had not completed after >80 min of wall time and is still running. Opening as **draft**; CI (`backend.yml` check + test with a Postgres service) is the authoritative gate per repo convention. Will post local check/test results as a follow-up comment if they land before CI.
- Local Postgres on :5433 is reachable; the new `#[sqlx::test]` cases will be run there as soon as the compile lock frees.

**Do not merge until CI is green.**

Closes findings 1–3 of #2317 (finding 4 remains open there).

---
_Generated by Claude Code (rust-backend fixer, issue #2317)_