### PR TITLE
gh-issue-2323: extract QueryErrorBanner + sweep raw error-message leaks on mobile

### DIFF
--- a/docs/screens/ppt/dashboard.md
+++ b/docs/screens/ppt/dashboard.md
@@ -86,6 +86,8 @@ UC-15 + UC-02 + UC-03 + UC-04 hub for residents on mobile (RN). The home screen 
 
 ### Specific (recent)
 
+- Load errors surface via a retryable inline banner above the stats grid (`hasError` across all four dashboard queries; #2282/#2304). The banner is now the shared `components/QueryErrorBanner.tsx` (extracted #2323) so sibling screens can reuse the same contract — it renders a caller-provided, already-localized message and never a raw `error.message`. The whole mobile screens tree was swept in #2323 to drop raw `error.message`/`combinedError.message` renders (backend-internals leak).
+- Dashboard dates now localize to `i18n.language` (was hardcoded `en-US`); the announcement category badge is translated via `dashboard.category.*` (was rendering the raw enum).
 - Mobile tokens defined as a JS object (`MOB_TOKENS`) inline in screens.jsx — production must replace with imports from a shared RN theme file consumed from `@ppt/ui-kit` or equivalent. Don't ship inline-token objects.
 - 📌 emoji in pinned-announcement card violates SKILL.md non-negotiable — replace with Lucide `pin` SVG. Same for any other emoji glyph elsewhere.
 - Greeting "Good morning," is time-of-day dependent; use locale-aware ranges (sk: "Dobré ráno" until 10:00, "Dobrý deň" 10–18, "Dobrý večer" 18–22, "Dobrú noc" 22+).
@@ -101,5 +103,6 @@ UC-15 + UC-02 + UC-03 + UC-04 hub for residents on mobile (RN). The home screen 
 
 <!-- newest entries on top -->
 
+- 2026-07-15 — agent: extracted reusable `QueryErrorBanner` from DashboardScreen and swept sibling mobile screens to drop raw `error.message` leaks (#2282/#2304 follow-up, #2323); localized dashboard dates (`i18n.language`) + announcement category badge (`dashboard.category.*`); fixed cs/de `dashboard.loadError` retry-label copy; added QueryErrorBanner regression suite
 - 2026-05-09 — agent: design analyzed (ui_kits/mobile/screens.jsx — MobHomeScreen); flipped mobile redesignStatus → in-progress; attached designSource; populated functionality checklist (6 sections), states, design-specific notes; declared 4 sharedComponents; added 3 relatedScreens (faults-list / announcements / report-fault as children of dashboard)
 - 2026-05-08 — init: created from scan (source: sitemap)

--- a/frontend/apps/mobile/src/components/QueryErrorBanner.test.tsx
+++ b/frontend/apps/mobile/src/components/QueryErrorBanner.test.tsx
@@ -1,0 +1,32 @@
+/**
+ * QueryErrorBanner — unit tests (#2323).
+ *
+ * The banner is the extracted, reusable form of the inline error strip
+ * DashboardScreen shipped for #2282/#2304. These tests lock its contract:
+ * it renders the caller-provided (already-localized) message, exposes a
+ * retry button wired to `onRetry`, and never renders a raw error string.
+ *
+ * The global test setup (src/test/setup.ts) mocks react-i18next so `t`
+ * returns the key — hence the assertion on the `common.retry` key.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { QueryErrorBanner } from './QueryErrorBanner';
+
+describe('QueryErrorBanner', () => {
+  it('renders the provided localized message and a retry button', () => {
+    render(<QueryErrorBanner message="dashboard.loadError" onRetry={jest.fn()} />);
+
+    expect(screen.getByText('dashboard.loadError')).toBeTruthy();
+    expect(screen.getByText('common.retry')).toBeTruthy();
+  });
+
+  it('calls onRetry when the retry button is pressed', () => {
+    const onRetry = jest.fn();
+    render(<QueryErrorBanner message="dashboard.loadError" onRetry={onRetry} />);
+
+    fireEvent.press(screen.getByText('common.retry'));
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/apps/mobile/src/components/QueryErrorBanner.tsx
+++ b/frontend/apps/mobile/src/components/QueryErrorBanner.tsx
@@ -1,0 +1,62 @@
+/**
+ * QueryErrorBanner — inline, retryable error banner.
+ *
+ * Extracted from `DashboardScreen` (#2282/#2304) so the "surface a distinct,
+ * retryable banner above whatever partial data loaded" contract can be reused
+ * across screens instead of copy-pasting the JSX + styles (#2323).
+ *
+ * Unlike the full-screen `ErrorState`, this renders as a compact strip meant
+ * to sit ABOVE partial content: on a screen that fans out several independent
+ * queries, the ones that succeeded still render beneath the banner. The banner
+ * shows a caller-provided, already-localized `message` (never a raw
+ * backend/error string — that would leak internals) and a retry button wired
+ * to `onRetry` (typically the screen's existing pull-to-refresh `onRefresh`).
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors } from '../screens/shared/screenStyles';
+
+export interface QueryErrorBannerProps {
+  /** Localized, user-facing message. Do NOT pass a raw `error.message`. */
+  message: string;
+  /** Called when the user taps retry — usually the screen's `onRefresh`. */
+  onRetry: () => void;
+}
+
+export function QueryErrorBanner({ message, onRetry }: QueryErrorBannerProps) {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.banner} accessibilityRole="alert">
+      <Text style={styles.icon}>⚠️</Text>
+      <Text style={styles.text}>{message}</Text>
+      <Pressable style={styles.button} onPress={onRetry} accessibilityRole="button">
+        <Text style={styles.buttonText}>{t('common.retry')}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    marginHorizontal: 16,
+    marginTop: 16,
+    padding: 12,
+    borderRadius: 12,
+    backgroundColor: colors.dangerBg,
+    borderWidth: 1,
+    borderColor: colors.danger,
+  },
+  icon: { fontSize: 20 },
+  text: { flex: 1, fontSize: 13, color: colors.dangerDark },
+  button: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: colors.danger,
+  },
+  buttonText: { color: colors.white, fontSize: 13, fontWeight: '600' },
+});

--- a/frontend/apps/mobile/src/components/index.ts
+++ b/frontend/apps/mobile/src/components/index.ts
@@ -1,3 +1,5 @@
 export { LanguageSwitcher } from './LanguageSwitcher';
+export type { QueryErrorBannerProps } from './QueryErrorBanner';
+export { QueryErrorBanner } from './QueryErrorBanner';
 export type { EmptyStateProps, ErrorStateProps, LoadingSkeletonProps } from './states';
 export { EmptyState, ErrorState, LoadingSkeleton } from './states';

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -57,7 +57,13 @@
   },
   "dashboard": {
     "title": "Prehled",
-    "loadError": "Nepodarilo se nacist prehled. Pretazenim obnovte nebo klepnete na Opakovat.",
+    "loadError": "Nepodarilo se nacist prehled. Potazenim dolu obnovte nebo klepnete na Zkusit znovu.",
+    "category": {
+      "general": "Obecne",
+      "urgent": "Nalehave",
+      "maintenance": "Udrzba",
+      "event": "Udalost"
+    },
     "welcome": "Vitejte",
     "welcomeBack": "Vitejte zpet,",
     "recentActivity": "Posledni aktivita",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -57,7 +57,13 @@
   },
   "dashboard": {
     "title": "Dashboard",
-    "loadError": "Dashboard konnte nicht geladen werden. Zum Aktualisieren nach unten ziehen oder auf Wiederholen tippen.",
+    "loadError": "Dashboard konnte nicht geladen werden. Zum Aktualisieren nach unten ziehen oder auf Erneut versuchen tippen.",
+    "category": {
+      "general": "Allgemein",
+      "urgent": "Dringend",
+      "maintenance": "Wartung",
+      "event": "Ereignis"
+    },
     "welcome": "Willkommen",
     "welcomeBack": "Willkommen zuruck,",
     "recentActivity": "Letzte Aktivitat",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -58,6 +58,12 @@
   "dashboard": {
     "title": "Dashboard",
     "loadError": "Couldn't load your dashboard. Pull down to refresh or tap retry.",
+    "category": {
+      "general": "General",
+      "urgent": "Urgent",
+      "maintenance": "Maintenance",
+      "event": "Event"
+    },
     "welcome": "Welcome",
     "welcomeBack": "Welcome back,",
     "recentActivity": "Recent Activity",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -58,6 +58,12 @@
   "dashboard": {
     "title": "Iranyitopult",
     "loadError": "Nem sikerult betolteni az iranyitopultot. Huzza le a frissiteshez, vagy koppintson az Ujra gombra.",
+    "category": {
+      "general": "Altalanos",
+      "urgent": "Surgos",
+      "maintenance": "Karbantartas",
+      "event": "Esemeny"
+    },
     "welcome": "Udvozoljuk",
     "welcomeBack": "Udvozoljuk ujra,",
     "recentActivity": "Legutobbi tevekenyseg",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -58,6 +58,12 @@
   "dashboard": {
     "title": "Panel",
     "loadError": "Nie udalo sie zaladowac panelu. Pociagnij, aby odswiezyc, lub dotknij Ponow.",
+    "category": {
+      "general": "Ogolne",
+      "urgent": "Pilne",
+      "maintenance": "Konserwacja",
+      "event": "Wydarzenie"
+    },
     "welcome": "Witaj",
     "welcomeBack": "Witaj ponownie,",
     "recentActivity": "Ostatnia aktywnosc",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -58,6 +58,12 @@
   "dashboard": {
     "title": "Prehlad",
     "loadError": "Nepodarilo sa nacitat prehlad. Potiahnutim obnovte alebo klepnite na Skusit znova.",
+    "category": {
+      "general": "Vseobecne",
+      "urgent": "Naliehave",
+      "maintenance": "Udrzba",
+      "event": "Udalost"
+    },
     "welcome": "Vitajte",
     "welcomeBack": "Vitajte spat,",
     "recentActivity": "Posledna aktivita",

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -259,7 +259,6 @@ export function AnnouncementsScreen({ onNavigate }: AnnouncementsScreenProps) {
           <View style={styles.emptyState}>
             <Text style={styles.emptyIcon}>⚠️</Text>
             <Text style={styles.emptyTitle}>Couldn't load announcements</Text>
-            <Text style={styles.emptyText}>{error.message}</Text>
           </View>
         ) : filteredAnnouncements.length === 0 ? (
           <View style={styles.emptyState}>

--- a/frontend/apps/mobile/src/screens/buildings/BuildingsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/buildings/BuildingsScreen.tsx
@@ -129,7 +129,6 @@ export function BuildingsScreen({ onNavigate }: BuildingsScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load buildings</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
           </View>
         ) : buildings.length === 0 ? (
           <View style={s.emptyState}>

--- a/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { QueryErrorBanner } from '../../components';
 import { useAuth } from '../../contexts/AuthContext';
 import { useApiQuery } from '../../hooks/useApi';
 import { colors } from '../shared/screenStyles';
@@ -63,7 +64,7 @@ interface DashboardScreenProps {
 }
 
 export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user, logout } = useAuth();
 
   // Each card pulls its own count so a single slow/down endpoint doesn't
@@ -155,9 +156,11 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
     ]);
   }, [announcementsQuery, faultsStatsQuery, votesQuery, unreadMessagesQuery]);
 
+  // Localize dates to the active UI language (mirrors VotingScreen). Previously
+  // hardcoded `'en-US'`, so dates never localized for sk/cs/de/hu/pl users (#2282).
   const formatDate = (dateString: string): string => {
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' });
   };
 
   const getCategoryColor = (category: Announcement['category']): string => {
@@ -210,20 +213,9 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
         }
       >
         {/* Error banner — shown when any card's query failed so the zeroed
-            stats below aren't mistaken for a genuinely empty building (#2282). */}
-        {hasError && (
-          <View style={styles.errorBanner} accessibilityRole="alert">
-            <Text style={styles.errorBannerIcon}>⚠️</Text>
-            <Text style={styles.errorBannerText}>{t('dashboard.loadError')}</Text>
-            <Pressable
-              style={styles.errorBannerButton}
-              onPress={onRefresh}
-              accessibilityRole="button"
-            >
-              <Text style={styles.errorBannerButtonText}>{t('common.retry')}</Text>
-            </Pressable>
-          </View>
-        )}
+            stats below aren't mistaken for a genuinely empty building (#2282).
+            Extracted to the shared QueryErrorBanner component (#2323). */}
+        {hasError && <QueryErrorBanner message={t('dashboard.loadError')} onRetry={onRefresh} />}
 
         {/* Stats Grid */}
         <View style={styles.statsGrid}>
@@ -286,7 +278,9 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
                       { backgroundColor: getCategoryColor(announcement.category) },
                     ]}
                   >
-                    <Text style={styles.categoryText}>{announcement.category}</Text>
+                    <Text style={styles.categoryText}>
+                      {t(`dashboard.category.${announcement.category}`)}
+                    </Text>
                   </View>
                   <Text style={styles.announcementDate}>{formatDate(announcement.createdAt)}</Text>
                 </View>
@@ -341,27 +335,6 @@ const styles = StyleSheet.create({
   logoutButton: { padding: 8 },
   logoutText: { color: 'rgba(255, 255, 255, 0.9)', fontSize: 14 },
   scrollView: { flex: 1 },
-  errorBanner: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    marginHorizontal: 16,
-    marginTop: 16,
-    padding: 12,
-    borderRadius: 12,
-    backgroundColor: colors.dangerBg,
-    borderWidth: 1,
-    borderColor: colors.danger,
-  },
-  errorBannerIcon: { fontSize: 20 },
-  errorBannerText: { flex: 1, fontSize: 13, color: colors.dangerDark },
-  errorBannerButton: {
-    paddingHorizontal: 14,
-    paddingVertical: 8,
-    borderRadius: 8,
-    backgroundColor: colors.danger,
-  },
-  errorBannerButtonText: { color: colors.white, fontSize: 13, fontWeight: '600' },
   statsGrid: { flexDirection: 'row', flexWrap: 'wrap', padding: 16, gap: 12 },
   statCard: {
     flex: 1,

--- a/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
@@ -144,7 +144,6 @@ export function DocumentDetailScreen({ documentId, onBack }: DocumentDetailScree
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn’t load document</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
             <Pressable style={[s.primaryButton, styles.retryButton]} onPress={handleRetry}>
               <Text style={s.primaryButtonText}>Retry</Text>
             </Pressable>

--- a/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
@@ -179,7 +179,6 @@ export function DocumentPermissionsScreen({ documentId, onBack }: DocumentPermis
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>{t('documents.permissions.loadError')}</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
             <Pressable style={[s.primaryButton, styles.retryButton]} onPress={handleRetry}>
               <Text style={s.primaryButtonText}>{t('common.retry')}</Text>
             </Pressable>

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -339,7 +339,6 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
           <View style={styles.emptyState}>
             <Text style={styles.emptyIcon}>⚠️</Text>
             <Text style={styles.emptyTitle}>{t('documents.loadError') ?? "Couldn't load"}</Text>
-            <Text style={styles.emptyText}>{combinedError.message}</Text>
           </View>
         ) : filteredDocuments.length === 0 ? (
           <View style={styles.emptyState}>

--- a/frontend/apps/mobile/src/screens/faults/FaultsListScreen.tsx
+++ b/frontend/apps/mobile/src/screens/faults/FaultsListScreen.tsx
@@ -188,7 +188,6 @@ export function FaultsListScreen({ onNavigate }: FaultsListScreenProps) {
           <View style={styles.emptyState}>
             <Text style={styles.emptyIcon}>⚠️</Text>
             <Text style={styles.emptyTitle}>Couldn't load faults</Text>
-            <Text style={styles.emptyText}>{error.message}</Text>
           </View>
         ) : filteredFaults.length === 0 ? (
           <View style={styles.emptyState}>

--- a/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
@@ -132,7 +132,6 @@ export function FormsScreen({ onNavigate }: FormsScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load forms</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
           </View>
         ) : forms.length === 0 ? (
           <View style={s.emptyState}>

--- a/frontend/apps/mobile/src/screens/leases/LeaseSignatureScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseSignatureScreen.tsx
@@ -193,7 +193,6 @@ export function LeaseSignatureScreen({ esignatureId, onBack }: LeaseSignatureScr
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>{t('esignature.loadError')}</Text>
-            <Text style={s.emptyText}>{loadError.message}</Text>
             <Pressable
               style={[s.primaryButton, { marginTop: 24 }]}
               onPress={() => requestQuery.refetch()}

--- a/frontend/apps/mobile/src/screens/leases/LeasesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeasesScreen.tsx
@@ -171,7 +171,6 @@ export function LeasesScreen({ onNavigate }: LeasesScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load leases</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
           </View>
         ) : leases.length === 0 ? (
           <View style={s.emptyState}>

--- a/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
@@ -137,7 +137,6 @@ export function MessagesScreen({ onNavigate }: MessagesScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load messages</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
             <Pressable style={s.primaryButton} onPress={() => refetch()}>
               <Text style={s.primaryButtonText}>Try again</Text>
             </Pressable>

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -186,7 +186,6 @@ export function ThreadDetailScreen({
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load conversation</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
             <Pressable style={s.primaryButton} onPress={onRefresh}>
               <Text style={s.primaryButtonText}>Try again</Text>
             </Pressable>

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
@@ -158,7 +158,6 @@ export function MeterDetailScreen({
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load meter</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
           </View>
         ) : (
           <>

--- a/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
@@ -164,7 +164,6 @@ export function MetersScreen({ onNavigate }: MetersScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load meters</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
           </View>
         ) : meters.length === 0 ? (
           <View style={s.emptyState}>

--- a/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/neighbors/NeighborsScreen.tsx
@@ -169,7 +169,6 @@ export function NeighborsScreen(_props: NeighborsScreenProps) {
       <View style={[s.container, styles.center]}>
         <Text style={s.emptyIcon}>⚠️</Text>
         <Text style={s.emptyTitle}>Could not load neighbours</Text>
-        <Text style={s.emptyText}>{error instanceof Error ? error.message : 'Unknown error'}</Text>
         <Pressable style={[s.primaryButton, { marginTop: 16 }]} onPress={onRefresh}>
           <Text style={s.primaryButtonText}>Retry</Text>
         </Pressable>

--- a/frontend/apps/mobile/src/screens/news/NewsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/news/NewsScreen.tsx
@@ -119,7 +119,6 @@ export function NewsScreen({ onNavigate }: NewsScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load news</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
           </View>
         ) : filtered.length === 0 ? (
           <View style={s.emptyState}>

--- a/frontend/apps/mobile/src/screens/outages/OutagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/outages/OutagesScreen.tsx
@@ -181,7 +181,6 @@ export function OutagesScreen({ onNavigate }: OutagesScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>Couldn't load outages</Text>
-            <Text style={s.emptyText}>{error.message}</Text>
           </View>
         ) : filtered.length === 0 ? (
           <View style={s.emptyState}>

--- a/frontend/apps/mobile/src/screens/voting/VoteDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/voting/VoteDetailScreen.tsx
@@ -288,7 +288,6 @@ export function VoteDetailScreen({ voteId, onBack }: VoteDetailScreenProps) {
           <View style={s.emptyState}>
             <Text style={s.emptyIcon}>⚠️</Text>
             <Text style={s.emptyTitle}>{t('voting.loadError') ?? "Couldn't load vote"}</Text>
-            <Text style={s.emptyText}>{loadError.message}</Text>
           </View>
         ) : (
           <>

--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
@@ -254,7 +254,6 @@ export function VotingScreen({ onNavigate }: VotingScreenProps) {
           <View style={styles.emptyState}>
             <Text style={styles.emptyIcon}>⚠️</Text>
             <Text style={styles.emptyTitle}>{t('voting.loadError') ?? "Couldn't load votes"}</Text>
-            <Text style={styles.emptyText}>{error.message}</Text>
           </View>
         ) : filteredVotes.length === 0 ? (
           <View style={styles.emptyState}>


### PR DESCRIPTION
## Task
Follow-up: extract reusable query-error banner + sweep sibling mobile screens with silent-zero pattern (PR #2304). Closes #2323.

## Owner
`pm-mobile` (task hint was `pm-tech-lead`, but the work lives in `frontend/apps/mobile/**` → the specialist is `react-native` / owner `pm-mobile`).

## What changed & why

**Investigation note (scope-correction):** the issue's grep looked for `isError` and concluded the sibling screens had *zero* error handling. In fact nearly every sibling `useApiQuery` screen already has an `error ?` branch — but they all render **raw `error.message` / `combinedError.message`** to the user, i.e. the exact *opposite* problem the issue flags in `DocumentsScreen` (backend-internals leak). So the sweep here is the correct generalization: remove the raw-error leak everywhere while keeping the descriptive title + retry / pull-to-refresh. (The banner-over-partial-data pattern from #2304 is specific to the dashboard's 4-independent-query fan-out; single-query list screens have no partial data to show, so their existing full error-state is the right shape — only the leak needed fixing.)

- **better-approach:** extracted the inline banner into reusable `frontend/apps/mobile/src/components/QueryErrorBanner.tsx` (localized `message` + retry button, `accessibilityRole="alert"`; refuses to render raw error strings by contract). `DashboardScreen` now uses it; its 5 `errorBanner*` styles moved into the component. Existing `DashboardScreen.test.tsx` passes unchanged (asserts on i18n keys).
- **regressions:** swept raw `error.message`/`combinedError.message`/`loadError.message` renders out of 18 screens — faults, meters (+detail), news, announcements, leases (+signature), outages, forms, buildings, neighbors, messages (+thread), voting (+detail), documents (+detail, +permissions). `DocumentsScreen` now shows `documents.loadError` only, per the issue.
- **correctness (from #2282, previously untracked):** `DashboardScreen` dates localize via `i18n.language` (was hardcoded `en-US`, mirrors `VotingScreen`); announcement category badge translated via `dashboard.category.*` (was rendering the raw `general` enum).
- **i18n:** fixed `cs`/`de` `dashboard.loadError` so the retry-label wording matches each locale's actual `common.retry`; added `dashboard.category.{general,urgent,maintenance,event}` to all six locales.
- **conventions:** updated `docs/screens/ppt/dashboard.md` (Agent Log + Notes) per CLAUDE.md screen-map protocol A.

Out of scope (left untouched, as the issue notes): the file-wide missing-diacritics in the locale files.

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `pnpm -F mobile test` → 43 suites, **543 tests passed** (incl. new `QueryErrorBanner.test.tsx` and unchanged `DashboardScreen.test.tsx` / `LeaseSignatureScreen.test.tsx`)
- `pnpm exec biome check <changed paths>` → clean after autofix (import-order + indentation only)

## Built (Band B — full build)
Skipped a device build (`expo run:*` needs an emulator unavailable to the routine). Full `tsc --noEmit` + full jest suite cover the change (UI-only, no native/config surface).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Note: this change *reduces* an information-disclosure surface (raw backend error strings no longer shown to end users).

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-mobile` exits 2 on a single path: `docs/screens/ppt/dashboard.md`. This is the CLAUDE.md-protocol-A screen-map update the issue explicitly requested (conventions finding) and falls under `pm-frontend`'s `docs/screens/**` area rather than `pm-mobile`'s. All code changes are in-area for `pm-mobile` (`frontend/apps/mobile/**`). No unexpected drift.

## Notes
- The regression coverage for the leak-removal is implicit: the swept branches previously rendered `error.message`; existing screen tests (buildings/forms/leases/meters/neighbors/voting/messages/threads/documents) still pass, and `LeaseSignatureScreen.test.tsx` asserts on the localized title (not the removed raw line).
- `QueryErrorBanner` is exported from `components/index.ts` so the remaining fan-out screens can adopt it as they gain multi-query partial-data layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1bsPNm8PMnjZFVTCHSZmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1bsPNm8PMnjZFVTCHSZmN)_