### PR TITLE
gh-issue-2321: fix cross-org rag/migrate RLS + assumed-provenance & CI pgvector gaps

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -315,7 +315,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -434,7 +434,7 @@ jobs:
       # library crates) provision their own `#[sqlx::test]` databases against
       # this Postgres, same as the shard job.
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -573,7 +573,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -670,7 +670,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -790,7 +790,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/backend/crates/db/migrations/00216_document_embeddings_super_admin_policy.sql
+++ b/backend/crates/db/migrations/00216_document_embeddings_super_admin_policy.sql
@@ -1,0 +1,40 @@
+-- Migration: 00216_document_embeddings_super_admin_policy.sql
+-- Follow-up to #2321 (post-merge review of PR #2312 / #2300).
+--
+-- Problem
+-- -------
+-- `document_embeddings` runs under `FORCE ROW LEVEL SECURITY` with a single
+-- org-isolation policy (`document_embeddings_org_isolation`, last redefined in
+-- 00179) whose `USING`/`WITH CHECK` clauses are purely `organization_id =
+-- get_current_org_id()`. Unlike sibling tenant tables (`unit_residents`,
+-- `delegations`, `invoices`, …) it has NO super-admin branch. Because FORCE RLS
+-- also applies to the table owner, a non-superuser app role never sees rows
+-- outside its current org on this table — even with `app.is_super_admin=true`.
+--
+-- The `POST /api/v1/ai/llm/rag/migrate` back-fill
+-- (`migrate_embeddings_to_pgvector`) is documented and gated as a global
+-- maintenance op that "converts legacy rows across every organization in one
+-- pass" via the super-admin RLS bypass. Without a super-admin policy on this
+-- table that bypass silently does not apply: the back-fill UPDATE (and its
+-- before/after `COUNT(*)`) only ever touch the caller's own org, every other
+-- organization's legacy rows stay unmigrated, and the reported `migrated`
+-- count under-reports with no error — the classic FORCE-RLS silent-0-rows
+-- pitfall.
+--
+-- Fix
+-- ---
+-- Add a permissive super-admin policy matching the established `*_super_admin`
+-- pattern (00009/00010/00040/00162). PostgreSQL OR-combines permissive
+-- policies for the same command, so a super-admin connection
+-- (`is_super_admin()` reads the `app.is_super_admin` GUC set by
+-- `set_request_context`) passes this policy for every row while ordinary org
+-- users remain constrained to `document_embeddings_org_isolation`.
+
+DROP POLICY IF EXISTS document_embeddings_super_admin ON document_embeddings;
+CREATE POLICY document_embeddings_super_admin ON document_embeddings
+    FOR ALL
+    USING (is_super_admin())
+    WITH CHECK (is_super_admin());
+
+COMMENT ON POLICY document_embeddings_super_admin ON document_embeddings IS
+    '#2321: permissive super-admin bypass so the cross-org /rag/migrate back-fill can see and convert legacy rows in every organization under FORCE RLS.';

--- a/backend/crates/db/migrations/00217_pgvector_backfill_assumed_marker.sql
+++ b/backend/crates/db/migrations/00217_pgvector_backfill_assumed_marker.sql
@@ -1,0 +1,81 @@
+-- Migration: 00217_pgvector_backfill_assumed_marker.sql
+-- Follow-up to #2321 (post-merge review of PR #2312 / #2300).
+--
+-- Problem
+-- -------
+-- 00215 made `migrate_jsonb_to_vector()` stamp the assumed embedding model
+-- (`text-embedding-3-small`) into `metadata.embedding_model` for untagged
+-- legacy rows. But 1536-dim covers BOTH `text-embedding-3-small` and the older
+-- `text-embedding-ada-002` (00081's own DDL comment sized the column for
+-- "OpenAI ada-002") — two incompatible embedding spaces. The stamp is written
+-- in a form indistinguishable from genuinely recorded provenance, so if any
+-- legacy rows were actually ada-002 the back-fill turns a *detectable unknown*
+-- (no provenance) into *confidently wrong provenance*, with no way to tell
+-- assumed rows apart after a production run.
+--
+-- Fix
+-- ---
+-- Redefine the function (forward-only; 00081/00215 are merged and never edited)
+-- so that, alongside the assumed `embedding_model`, untagged rows also get an
+-- `embedding_model_assumed: true` marker. Rows that already carry an
+-- `embedding_model` are still left untouched. A future re-embedding job (the
+-- real fix for legacy rows) can then target `metadata ? 'embedding_model_assumed'`
+-- to find exactly the rows whose provenance was inferred rather than recorded.
+--
+-- Land this BEFORE operators run `/rag/migrate` in production — once the assumed
+-- rows are stamped without the marker they are no longer identifiable.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'vector') THEN
+        EXECUTE $func$
+            CREATE OR REPLACE FUNCTION migrate_jsonb_to_vector()
+            RETURNS void AS $inner$
+            BEGIN
+                -- Single set-based UPDATE (see 00215). Only untouched legacy
+                -- rows are converted: a 1536-dim JSONB array whose vector
+                -- column is still NULL.
+                UPDATE document_embeddings
+                SET
+                    embedding_vector = (
+                        SELECT ARRAY(
+                            SELECT (e)::float8
+                            FROM jsonb_array_elements_text(embedding) AS e
+                        )
+                    )::vector,
+                    -- Preserve any pre-existing `embedding_model`. For untagged
+                    -- rows, stamp the assumed model AND an `embedding_model_assumed`
+                    -- marker so the inference stays auditable and a later
+                    -- re-embedding pass can find exactly these rows.
+                    metadata = CASE
+                        WHEN COALESCE(metadata, '{}'::jsonb) ? 'embedding_model'
+                            THEN metadata
+                        ELSE jsonb_set(
+                            jsonb_set(
+                                COALESCE(metadata, '{}'::jsonb),
+                                '{embedding_model}',
+                                to_jsonb('text-embedding-3-small'::text),
+                                true
+                            ),
+                            '{embedding_model_assumed}',
+                            'true'::jsonb,
+                            true
+                        )
+                    END,
+                    updated_at = NOW()
+                WHERE embedding IS NOT NULL
+                  AND embedding_vector IS NULL
+                  AND jsonb_typeof(embedding) = 'array'
+                  AND jsonb_array_length(embedding) = 1536;
+            END;
+            $inner$ LANGUAGE plpgsql
+        $func$;
+
+        COMMENT ON FUNCTION migrate_jsonb_to_vector IS
+            '#2321: set-based back-fill of legacy JSONB embeddings into pgvector; stamps assumed embedding_model (text-embedding-3-small) plus an embedding_model_assumed=true marker on untagged rows so inferred provenance stays auditable.';
+
+        RAISE NOTICE 'Redefined migrate_jsonb_to_vector() to add embedding_model_assumed marker';
+    ELSE
+        RAISE NOTICE 'pgvector extension not present - skipping migrate_jsonb_to_vector() redefinition';
+    END IF;
+END $$;

--- a/backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs
+++ b/backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs
@@ -76,6 +76,28 @@ async fn seed_document(pool: &PgPool, org_id: Uuid, created_by: Uuid, id: Uuid) 
     .expect("seed document");
 }
 
+/// Seed a legacy `document_embeddings` row for `org_id`: a 1536-dim JSONB
+/// array, NULL vector (column omitted so it also works without pgvector), and
+/// metadata WITHOUT an `embedding_model` key — i.e. a pre-provenance legacy row.
+/// Returns the new row id.
+async fn seed_legacy_embedding(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    let doc_id = Uuid::new_v4();
+    seed_document(pool, org_id, created_by, doc_id).await;
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO document_embeddings
+               (organization_id, document_id, chunk_index, chunk_text, embedding, metadata)
+           VALUES ($1, $2, 0, 'legacy chunk',
+                   to_jsonb(array_fill(0.1::float8, ARRAY[1536])),
+                   '{}'::jsonb)
+           RETURNING id"#,
+    )
+    .bind(org_id)
+    .bind(doc_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed legacy embedding row")
+}
+
 // POST /api/v1/ai/llm/rag/migrate as a platform admin → 200 with a numeric
 // `migrated` count. The route exists (this whole endpoint is what the gap adds)
 // and the migration is a no-op-or-more depending on pgvector availability.
@@ -206,16 +228,18 @@ async fn rag_migrate_stamps_provenance_on_legacy_row(pool: PgPool) {
         resp.json_value()
     );
 
-    let (vector_set, stamped_model): (bool, Option<String>) = sqlx::query_as(
-        r#"SELECT embedding_vector IS NOT NULL,
-                  metadata->>'embedding_model'
-           FROM document_embeddings
-           WHERE id = $1"#,
-    )
-    .bind(emb_id)
-    .fetch_one(&app.pool)
-    .await
-    .expect("re-read migrated embedding row");
+    let (vector_set, stamped_model, assumed_marker): (bool, Option<String>, Option<String>) =
+        sqlx::query_as(
+            r#"SELECT embedding_vector IS NOT NULL,
+                      metadata->>'embedding_model',
+                      metadata->>'embedding_model_assumed'
+               FROM document_embeddings
+               WHERE id = $1"#,
+        )
+        .bind(emb_id)
+        .fetch_one(&app.pool)
+        .await
+        .expect("re-read migrated embedding row");
 
     assert!(
         vector_set,
@@ -227,6 +251,97 @@ async fn rag_migrate_stamps_provenance_on_legacy_row(pool: PgPool) {
         "back-fill must stamp assumed embedding_model provenance so filtered \
          search can isolate the row's embedding space (was mixing before #2300)"
     );
+    // #2321: the assumed stamp must be distinguishable from genuinely recorded
+    // provenance (1536-dim also covers ada-002 — an incompatible space), so an
+    // `embedding_model_assumed` marker is set alongside it on untagged rows.
+    assert_eq!(
+        assumed_marker.as_deref(),
+        Some("true"),
+        "back-fill must mark inferred provenance with embedding_model_assumed=true \
+         so a later re-embedding pass can find assumed rows (#2321)"
+    );
+}
+
+// Cross-org back-fill (#2321): the endpoint is documented as converting legacy
+// rows across EVERY organization in one super-admin pass. `document_embeddings`
+// runs under FORCE RLS; migration 00216 adds the super-admin policy that makes
+// that bypass actually apply. This test seeds one legacy row in each of two
+// orgs, calls `/rag/migrate` with the platform admin's session bound to org A,
+// and asserts BOTH orgs' rows are converted and assumed-stamped.
+//
+// Caveat (called out in #2321): `#[sqlx::test]` connects as the Postgres
+// superuser, which bypasses RLS entirely — so this test passes with or without
+// the 00216 policy in this harness. It still pins the cross-org contract and,
+// once CI's Postgres carries pgvector (backend.yml → pgvector/pgvector:pg16),
+// exercises the real conversion across both orgs. Under a non-superuser app
+// role the 00216 policy is what keeps the count at 2 instead of 1.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn rag_migrate_converts_legacy_rows_across_orgs(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+
+    // Platform-admin principal, session bound to org A only.
+    let (token, _refresh) = create_authenticated_user(&app, &user).await;
+    let user_id = resolve_user_id(&app, &user).await;
+    let org_a = seed_org(&app.pool, "rag-xorg-a").await;
+    let org_b = seed_org(&app.pool, "rag-xorg-b").await;
+    seed_membership(&app.pool, org_a, user_id, "platform_admin").await;
+
+    // One legacy row (1536-dim JSONB, NULL vector, no provenance) per org.
+    let emb_a = seed_legacy_embedding(&app.pool, org_a, user_id).await;
+    let emb_b = seed_legacy_embedding(&app.pool, org_b, user_id).await;
+
+    let session = app.session(token, org_a);
+    let resp = app
+        .execute(session.post("/api/v1/ai/llm/rag/migrate").build())
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "cross-org migrate must return 200; body={}",
+        resp.text()
+    );
+
+    if !pgvector_present(&app).await {
+        assert_eq!(
+            resp.json_value()["migrated"].as_i64(),
+            Some(0),
+            "without pgvector the back-fill must report 0 migrated"
+        );
+        return;
+    }
+
+    // pgvector present: both orgs' rows must convert even though the caller's
+    // session is bound to org A — this is the cross-org super-admin pass.
+    assert!(
+        resp.json_value()["migrated"]
+            .as_i64()
+            .is_some_and(|n| n >= 2),
+        "cross-org back-fill must convert the legacy row in BOTH orgs; body={}",
+        resp.json_value()
+    );
+
+    for emb_id in [emb_a, emb_b] {
+        let (vector_set, stamped_model): (bool, Option<String>) = sqlx::query_as(
+            r#"SELECT embedding_vector IS NOT NULL,
+                      metadata->>'embedding_model'
+               FROM document_embeddings
+               WHERE id = $1"#,
+        )
+        .bind(emb_id)
+        .fetch_one(&app.pool)
+        .await
+        .expect("re-read migrated embedding row");
+        assert!(
+            vector_set,
+            "cross-org back-fill must populate embedding_vector on {emb_id}"
+        );
+        assert_eq!(
+            stamped_model.as_deref(),
+            Some("text-embedding-3-small"),
+            "cross-org back-fill must stamp assumed provenance on {emb_id}"
+        );
+    }
 }
 
 // Unauthenticated request → 401 (RlsConnection extractor guards the route).


### PR DESCRIPTION
## Task
Follow-up: rag/migrate cross-org back-fill blocked by FORCE RLS + assumed-provenance & CI pgvector gaps (PR #2312). Closes #2321.

Post-merge review of PR #2312 (#2300) found four residual gaps. This PR closes the three actionable ones (high + two medium); the low-severity async/batching item is deferred (see Notes).

## Changes
- **Finding 1 (security/correctness, high)** — `backend/crates/db/migrations/00216_document_embeddings_super_admin_policy.sql`: `document_embeddings` runs under `FORCE ROW LEVEL SECURITY` with only an org-isolation policy and **no** super-admin branch (unlike `unit_residents_super_admin`, `delegations_super_admin`, etc.). So the `/rag/migrate` back-fill's advertised "cross-org super-admin pass" silently saw only the caller's org. Adds the permissive `document_embeddings_super_admin` policy (`USING/WITH CHECK is_super_admin()`), matching the established `*_super_admin` pattern (00009/00010/00040/00162). `is_super_admin()` reads the `app.is_super_admin` GUC set by `set_request_context`.
- **Finding 3 (correctness, medium)** — `.../00217_pgvector_backfill_assumed_marker.sql`: 1536-dim covers both `text-embedding-3-small` and the incompatible `text-embedding-ada-002` (00081's own DDL comment). Redefines `migrate_jsonb_to_vector()` (forward-only) so untagged rows also get `embedding_model_assumed: true` next to the assumed model, keeping inferred provenance auditable/targetable by a future re-embedding job. Already-tagged rows are still left untouched. Must land **before** operators run `/rag/migrate` in prod.
- **Finding 2 (tests, medium)** — `.github/workflows/backend.yml`: switch all 5 Postgres service images `postgres:16` → `pgvector/pgvector:pg16` (drop-in superset; `CREATE EXTENSION vector` in 00081 is already `pg_available_extensions`-guarded). This lights up every pgvector-gated assertion (previously dead code in CI) with no test changes.
- **Tests** — `backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs`: assert `embedding_model_assumed=true` on the stamped legacy row; add `rag_migrate_converts_legacy_rows_across_orgs` (two-org back-fill in one super-admin pass).

## Owner
pm-tech-lead (task hint). Actual work is `db-migration` + a one-line CI change — see Scope drift below.

## Tested (Band A) + Built (Band B)
Verified the migrations end-to-end against a real Postgres 16 + **pgvector** instance (installed `postgresql-16-pgvector` locally):
- All 217 migrations apply cleanly in order (`ON_ERROR_STOP=1`), including 00216 + 00217. Exit 0.
- `SELECT policyname FROM pg_policies WHERE tablename='document_embeddings'` → both `document_embeddings_org_isolation` and `document_embeddings_super_admin` present.
- `migrate_jsonb_to_vector()` redefinition applied under pgvector (verified via `obj_description`).
- **Functional proof of 00217**: seeded an untagged legacy row + an already-tagged row, ran `SELECT migrate_jsonb_to_vector()`:
  - untagged → `embedding_vector` set, `embedding_model=text-embedding-3-small`, `embedding_model_assumed=true`
  - tagged (`text-embedding-3-large`) → vector set, model **preserved**, **no** assumed marker.
- Without pgvector, the 00217 DO-block correctly hits the no-op ELSE branch (function absent, no error) — matches 00081/00215.

**Environment limitation (does not affect CI):** `cargo test -p api-server --test rag_migrate_pgvector_tests --no-run` could not complete in this sandbox — the `utoipa-swagger-ui` build script downloads a Swagger UI zip from github.com, which this session's egress policy blocks (HTTP 403). This is unrelated to the change and does not occur in CI. The added test follows the exact proven pattern of the existing passing tests in the same file (same `TestApp`/`platform_admin`/`#[sqlx::test]` construction); it was reviewed line-by-line for correctness. The migration behavior it asserts is independently proven above via direct SQL.

## CI parity (Band C)
The `pgvector/pgvector:pg16` swap IS the CI-parity change: it makes CI's Postgres carry the extension so the pgvector-gated conversion + provenance + cross-org assertions actually execute in `backend.yml` instead of degrading to the contract-only branch.

## Scope drift
`scope_drift=true`. `pm-tech-lead` maps (owner-areas.json) to `docs/**`, `.research/**`, `_bmad-output/**` — a PM/architecture lens. The real deliverable is a backend/db-migration + CI change, legitimately outside that area. Touched: `backend/crates/db/migrations/00216_*.sql`, `00217_*.sql`, `backend/servers/api-server/tests/rag_migrate_pgvector_tests.rs`, `.github/workflows/backend.yml`. Reviewer to adjudicate (expected for a mislabeled owner hint on a backend task).

## Code-reuse review
`reuse-grep.sh` (db-migration): no warnings. The migration reuses the existing `is_super_admin()` helper and the `*_super_admin` permissive-policy pattern; the function redefinition follows 00215 verbatim plus the marker.

## Notes
- **Finding 4 (performance, low) deferred**: batched/async back-fill + `reindex_recommended` flag. #2321 itself says "Not urgent at current data volumes" and it would change the response contract (`MigrateEmbeddingsResponse`) — out of scope for this correctness/CI PR. Worth a separate ticket if `document_embeddings` grows.
- Goal-check IG1 (no `.research` plan) and IG2 (branch is the dispatcher-mandated `auto-impl/…`) are N/A for this GH-issue task; IG3 (TDD: separate `test:` + `fix:` commits) passes.
- Branch base `4bf8381` is an ancestor of current `dev`; `dev` only advanced by 2 pure `.research/` dispatcher commits, so the PR diff is exactly the 4 files above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1bsPNm8PMnjZFVTCHSZmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1bsPNm8PMnjZFVTCHSZmN)_