### PR TITLE
gh-issue-2322: harden portal-webhooks screen — role gate, pagination, i18n, screen-map

### DIFF
--- a/docs/screens/ppt/settings-portal-webhooks.md
+++ b/docs/screens/ppt/settings-portal-webhooks.md
@@ -1,0 +1,72 @@
+---
+id: ppt/settings-portal-webhooks
+name: Portal Webhooks
+product: ppt
+sitemapRefs:
+  ppt-web: ppt-settings-portal-webhooks
+implementations:
+  ppt-web:
+    route: "/settings/portal-webhooks"
+    component: PortalWebhooksPage
+    buildStatus: shipped
+    redesignStatus: not-started
+    apiStatus: partial
+endpoints: []
+relatedScreens:
+  - id: ppt/settings-integrations
+    rel: sibling
+sharedComponents: []
+diagrams: []
+useCases:
+  - UC-29
+epics:
+  - Epic-105
+designSources: []
+owner: pm-frontend
+---
+
+# Portal Webhooks
+
+Manager-facing visibility surface for inbound real-estate portal webhooks
+(Gap 83-3 / Epic 105). Inbound webhooks (`POST /api/v1/webhooks/portals/*`)
+record views and inquiries from external portals (Reality Portal, Sreality,
+Bezrealitky, Nehnutelnosti) and update per-listing syndication state; until
+Gap 83-3 there was no manager-facing surface to see any of it.
+
+`PortalWebhooksPage` renders that read-only surface from the org-scoped
+syndication read endpoint via the `@ppt/api-client` `syndication` module:
+
+- `useSyndicationDashboard({ page, limit })` — GET
+  `/api/v1/listings/syndication/dashboard` — per-listing status + org-wide
+  aggregate stats. Paginated (default `limit=20`); the page renders a prev/next
+  pager over the per-listing rows while the summary stats stay page-independent.
+
+The route is manager-gated at the route level via
+`<ProtectedRoute requiredRoles={[...MANAGER_ROLES]}>` (issue #2322) — the
+dashboard exposes org-wide stats, per-listing inquiry counts and `last_error`
+strings that residents must not read. The nav link is separately gated on
+`isManagerRole`; both now draw from the same `MANAGER_ROLES` constant in
+`routes/shared.tsx`.
+
+`apiStatus: partial` — the dashboard endpoint is consumed, but the module also
+exports `useOrganizationSyndicationStats`, `useListingSyndications` and
+`useListingSyndicationStatus` hooks that no screen consumes yet.
+
+## Notes
+
+### Specific (recent)
+
+- 2026-07-15 — `endpoints` left empty because the syndication read endpoints are
+  not (yet) in the `@ppt/sitemap` endpoint catalogue (same reason as
+  `settings-integrations`). Added the `ppt-settings-portal-webhooks` sitemap
+  entry. Follow-up (deferred to a pm-backend/typespec task): register the four
+  `routes::listings::*` syndication handlers in the api-server OpenAPI `paths()`,
+  regenerate the TS client, and swap the hand-written `syndication` module to
+  generated operations — the natural moment to prune the three unused hooks.
+
+## Agent Log
+
+- 2026-07-15 — agent: gh-issue-2322 — added the screen-map for the portal
+  webhooks status page (created in PR #2294 without one); route-level
+  manager gate, per-listing pagination, `enabled`-gated dashboard query, and
+  cs/de/hu/pl/sk translations landed alongside.

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -64,7 +64,8 @@
     "admin": "Administrace",
     "aiChat": "AI asistent",
     "iotAlerts": "Sensor Alerts",
-    "integrations": "Integrace"
+    "integrations": "Integrace",
+    "portalWebhooks": "Webhooky portálů"
   },
   "auth": {
     "signIn": "Přihlásit se",
@@ -1097,6 +1098,46 @@
     }
   },
   "settings": {
+    "portalWebhooks": {
+      "title": "Webhooky portálů",
+      "subtitle": "Stav doručení a aktivita z webhooků realitních portálů — zobrazení, poptávky a stav synchronizace podle portálu.",
+      "noOrganization": "Pro váš účet není vybrána žádná organizace, proto nelze aktivitu webhooků portálů zobrazit.",
+      "loading": "Načítání aktivity portálů…",
+      "loadError": "Nepodařilo se načíst aktivitu webhooků portálů.",
+      "summary": {
+        "title": "Přehled",
+        "active": "Aktivní",
+        "pending": "Čekající",
+        "failed": "Neúspěšné",
+        "views": "Zobrazení",
+        "inquiries": "Poptávky"
+      },
+      "byPortal": {
+        "caption": "Aktivita synchronizace podle portálu",
+        "portal": "Portál",
+        "empty": "Zatím nebyla zaznamenána žádná aktivita portálu."
+      },
+      "listings": {
+        "title": "Nabídky",
+        "empty": "Zatím žádné synchronizované nabídky.",
+        "activity": "{{views}} zobrazení · {{inquiries}} poptávek",
+        "portalActivity": "{{views}} zobrazení · {{inquiries}} poptávek",
+        "lastActivity": "Poslední aktivita: {{when}}",
+        "lastError": "Poslední chyba: {{error}}"
+      },
+      "health": {
+        "healthy": "V pořádku",
+        "degraded": "Zhoršené",
+        "unhealthy": "Nefunkční",
+        "notConfigured": "Nenakonfigurováno"
+      },
+      "pager": {
+        "label": "Stránkování nabídek",
+        "summary": "Zobrazeno {{from}}–{{to}} z {{total}} nabídek",
+        "prev": "Předchozí",
+        "next": "Další"
+      }
+    },
     "integrations": {
       "title": "Integrace",
       "subtitle": "Připojte externí rezervační kanály pro synchronizaci nabídek a rezervací.",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -64,7 +64,8 @@
     "admin": "Administration",
     "aiChat": "KI-Assistent",
     "iotAlerts": "Sensor Alerts",
-    "integrations": "Integrationen"
+    "integrations": "Integrationen",
+    "portalWebhooks": "Portal-Webhooks"
   },
   "auth": {
     "signIn": "Anmelden",
@@ -1046,6 +1047,46 @@
     }
   },
   "settings": {
+    "portalWebhooks": {
+      "title": "Portal-Webhooks",
+      "subtitle": "Zustellstatus und Aktivität von Webhooks der Immobilienportale — Aufrufe, Anfragen und Synchronisierungszustand pro Portal.",
+      "noOrganization": "Für Ihr Konto ist keine Organisation ausgewählt, daher kann die Portal-Webhook-Aktivität nicht angezeigt werden.",
+      "loading": "Portalaktivität wird geladen…",
+      "loadError": "Portal-Webhook-Aktivität konnte nicht geladen werden.",
+      "summary": {
+        "title": "Zusammenfassung",
+        "active": "Aktiv",
+        "pending": "Ausstehend",
+        "failed": "Fehlgeschlagen",
+        "views": "Aufrufe",
+        "inquiries": "Anfragen"
+      },
+      "byPortal": {
+        "caption": "Synchronisierungsaktivität nach Portal",
+        "portal": "Portal",
+        "empty": "Noch keine Portalaktivität erfasst."
+      },
+      "listings": {
+        "title": "Inserate",
+        "empty": "Noch keine synchronisierten Inserate.",
+        "activity": "{{views}} Aufrufe · {{inquiries}} Anfragen",
+        "portalActivity": "{{views}} Aufrufe · {{inquiries}} Anfragen",
+        "lastActivity": "Letzte Aktivität: {{when}}",
+        "lastError": "Letzter Fehler: {{error}}"
+      },
+      "health": {
+        "healthy": "Gesund",
+        "degraded": "Beeinträchtigt",
+        "unhealthy": "Fehlerhaft",
+        "notConfigured": "Nicht konfiguriert"
+      },
+      "pager": {
+        "label": "Inserate-Seitennavigation",
+        "summary": "{{from}}–{{to}} von {{total}} Inseraten",
+        "prev": "Zurück",
+        "next": "Weiter"
+      }
+    },
     "integrations": {
       "title": "Integrationen",
       "subtitle": "Verbinden Sie externe Buchungskanäle, um Inserate und Reservierungen zu synchronisieren.",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3421,6 +3421,12 @@
         "degraded": "Degraded",
         "unhealthy": "Unhealthy",
         "notConfigured": "Not configured"
+      },
+      "pager": {
+        "label": "Listings pagination",
+        "summary": "Showing {{from}}–{{to}} of {{total}} listings",
+        "prev": "Previous",
+        "next": "Next"
       }
     },
     "integrations": {

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -64,7 +64,8 @@
     "admin": "Adminisztráció",
     "aiChat": "AI asszisztens",
     "iotAlerts": "Sensor Alerts",
-    "integrations": "Integrációk"
+    "integrations": "Integrációk",
+    "portalWebhooks": "Portál webhookok"
   },
   "auth": {
     "signIn": "Bejelentkezés",
@@ -1019,6 +1020,46 @@
     }
   },
   "settings": {
+    "portalWebhooks": {
+      "title": "Portál webhookok",
+      "subtitle": "Az ingatlanportál-webhookok kézbesítési állapota és tevékenysége — megtekintések, érdeklődések és szinkronizálási állapot portálonként.",
+      "noOrganization": "Fiókjához nincs kiválasztva szervezet, ezért a portál webhookok tevékenysége nem jeleníthető meg.",
+      "loading": "Portáltevékenység betöltése…",
+      "loadError": "Nem sikerült betölteni a portál webhookok tevékenységét.",
+      "summary": {
+        "title": "Összegzés",
+        "active": "Aktív",
+        "pending": "Függőben",
+        "failed": "Sikertelen",
+        "views": "Megtekintések",
+        "inquiries": "Érdeklődések"
+      },
+      "byPortal": {
+        "caption": "Szinkronizálási tevékenység portálonként",
+        "portal": "Portál",
+        "empty": "Még nincs rögzített portáltevékenység."
+      },
+      "listings": {
+        "title": "Hirdetések",
+        "empty": "Még nincsenek szinkronizált hirdetések.",
+        "activity": "{{views}} megtekintés · {{inquiries}} érdeklődés",
+        "portalActivity": "{{views}} megtekintés · {{inquiries}} érdeklődés",
+        "lastActivity": "Utolsó tevékenység: {{when}}",
+        "lastError": "Utolsó hiba: {{error}}"
+      },
+      "health": {
+        "healthy": "Egészséges",
+        "degraded": "Csökkentett",
+        "unhealthy": "Hibás",
+        "notConfigured": "Nincs beállítva"
+      },
+      "pager": {
+        "label": "Hirdetések lapozása",
+        "summary": "{{total}} hirdetésből {{from}}–{{to}} megjelenítve",
+        "prev": "Előző",
+        "next": "Következő"
+      }
+    },
     "integrations": {
       "title": "Integrációk",
       "subtitle": "Kapcsoljon össze külső foglalási csatornákat a hirdetések és foglalások szinkronizálásához.",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -64,7 +64,8 @@
     "admin": "Administracja",
     "aiChat": "Asystent AI",
     "iotAlerts": "Sensor Alerts",
-    "integrations": "Integracje"
+    "integrations": "Integracje",
+    "portalWebhooks": "Webhooki portali"
   },
   "auth": {
     "signIn": "Zaloguj się",
@@ -1025,6 +1026,46 @@
     }
   },
   "settings": {
+    "portalWebhooks": {
+      "title": "Webhooki portali",
+      "subtitle": "Status dostarczania i aktywność webhooków portali nieruchomości — wyświetlenia, zapytania i stan synchronizacji dla każdego portalu.",
+      "noOrganization": "Do Twojego konta nie wybrano żadnej organizacji, więc nie można wyświetlić aktywności webhooków portali.",
+      "loading": "Ładowanie aktywności portali…",
+      "loadError": "Nie udało się załadować aktywności webhooków portali.",
+      "summary": {
+        "title": "Podsumowanie",
+        "active": "Aktywne",
+        "pending": "Oczekujące",
+        "failed": "Nieudane",
+        "views": "Wyświetlenia",
+        "inquiries": "Zapytania"
+      },
+      "byPortal": {
+        "caption": "Aktywność synchronizacji według portalu",
+        "portal": "Portal",
+        "empty": "Nie zarejestrowano jeszcze aktywności portalu."
+      },
+      "listings": {
+        "title": "Ogłoszenia",
+        "empty": "Brak zsynchronizowanych ogłoszeń.",
+        "activity": "{{views}} wyświetleń · {{inquiries}} zapytań",
+        "portalActivity": "{{views}} wyświetleń · {{inquiries}} zapytań",
+        "lastActivity": "Ostatnia aktywność: {{when}}",
+        "lastError": "Ostatni błąd: {{error}}"
+      },
+      "health": {
+        "healthy": "Sprawny",
+        "degraded": "Ograniczony",
+        "unhealthy": "Niesprawny",
+        "notConfigured": "Nie skonfigurowano"
+      },
+      "pager": {
+        "label": "Paginacja ogłoszeń",
+        "summary": "Wyświetlono {{from}}–{{to}} z {{total}} ogłoszeń",
+        "prev": "Poprzednia",
+        "next": "Następna"
+      }
+    },
     "integrations": {
       "title": "Integracje",
       "subtitle": "Połącz zewnętrzne kanały rezerwacji, aby synchronizować oferty i rezerwacje.",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -66,7 +66,8 @@
     "admin": "Administrácia",
     "aiChat": "AI asistent",
     "iotAlerts": "Sensor Alerts",
-    "integrations": "Integrácie"
+    "integrations": "Integrácie",
+    "portalWebhooks": "Webhooky portálov"
   },
   "auth": {
     "signIn": "Prihlásiť sa",
@@ -1099,6 +1100,46 @@
     }
   },
   "settings": {
+    "portalWebhooks": {
+      "title": "Webhooky portálov",
+      "subtitle": "Stav doručenia a aktivita z webhookov realitných portálov — zobrazenia, dopyty a stav synchronizácie podľa portálu.",
+      "noOrganization": "Pre váš účet nie je vybraná žiadna organizácia, preto nie je možné zobraziť aktivitu webhookov portálov.",
+      "loading": "Načítava sa aktivita portálov…",
+      "loadError": "Nepodarilo sa načítať aktivitu webhookov portálov.",
+      "summary": {
+        "title": "Prehľad",
+        "active": "Aktívne",
+        "pending": "Čakajúce",
+        "failed": "Neúspešné",
+        "views": "Zobrazenia",
+        "inquiries": "Dopyty"
+      },
+      "byPortal": {
+        "caption": "Aktivita synchronizácie podľa portálu",
+        "portal": "Portál",
+        "empty": "Zatiaľ nebola zaznamenaná žiadna aktivita portálu."
+      },
+      "listings": {
+        "title": "Inzeráty",
+        "empty": "Zatiaľ žiadne synchronizované inzeráty.",
+        "activity": "{{views}} zobrazení · {{inquiries}} dopytov",
+        "portalActivity": "{{views}} zobrazení · {{inquiries}} dopytov",
+        "lastActivity": "Posledná aktivita: {{when}}",
+        "lastError": "Posledná chyba: {{error}}"
+      },
+      "health": {
+        "healthy": "V poriadku",
+        "degraded": "Zhoršené",
+        "unhealthy": "Nefunkčné",
+        "notConfigured": "Nenakonfigurované"
+      },
+      "pager": {
+        "label": "Stránkovanie inzerátov",
+        "summary": "Zobrazené {{from}}–{{to}} z {{total}} inzerátov",
+        "prev": "Predchádzajúce",
+        "next": "Ďalšie"
+      }
+    },
     "integrations": {
       "title": "Integrácie",
       "subtitle": "Pripojte externé rezervačné kanály na synchronizáciu ponúk a rezervácií.",

--- a/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.test.tsx
@@ -170,4 +170,22 @@ describe('PortalWebhooksPage (Gap 83-3)', () => {
     // The failed portal's last error is shown to the manager.
     expect(screen.getByText(/signature mismatch/i)).toBeInTheDocument();
   });
+
+  it('does not render a pager when all listings fit on one page', () => {
+    // total (1) <= limit (20) — single page, no pager (issue #2322).
+    dashboard = loadedDashboard();
+    render(<PortalWebhooksPage />);
+    expect(screen.queryByRole('button', { name: /next/i })).not.toBeInTheDocument();
+  });
+
+  it('renders a prev/next pager with a range summary when listings span pages', () => {
+    const base = loadedDashboard();
+    // 45 listings at 20/page → 3 pages; page 1 shows "1–20 of 45".
+    dashboard = { ...base, data: { ...base.data, total: 45, page: 1, limit: 20 } };
+    render(<PortalWebhooksPage />);
+    expect(screen.getByText(/showing 1–20 of 45 listings/i)).toBeInTheDocument();
+    // On the first page, "Previous" is disabled and "Next" is enabled.
+    expect(screen.getByRole('button', { name: /previous/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /next/i })).toBeEnabled();
+  });
 });

--- a/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.tsx
+++ b/frontend/apps/ppt-web/src/features/settings/webhooks/PortalWebhooksPage.tsx
@@ -20,8 +20,12 @@
 
 import { useSyndicationDashboard } from '@ppt/api-client';
 import type React from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../../contexts';
+
+/** Per-page size for the per-listing dashboard rows (matches the API default). */
+const PAGE_SIZE = 20;
 
 /** Human-readable portal labels for the known real-estate portals. */
 const PORTAL_LABELS: Record<string, string> = {
@@ -84,9 +88,27 @@ export const PortalWebhooksPage: React.FC = () => {
   const { user } = useAuth();
   const organizationId = user?.organizationId ?? '';
 
-  const dashboard = useSyndicationDashboard();
+  const [page, setPage] = useState(1);
+  // Gate the query on a resolved organization: without it the request is doomed
+  // and would surface a spurious loadError alert beneath the noOrganization
+  // banner (issue #2322).
+  const dashboard = useSyndicationDashboard(
+    { page, limit: PAGE_SIZE },
+    { enabled: !!organizationId }
+  );
   const stats = dashboard.data?.organization_stats;
   const listings = dashboard.data?.listings ?? [];
+
+  // Pagination is over the per-listing rows only; the org-wide summary stats
+  // are aggregate and page-independent.
+  const total = dashboard.data?.total ?? 0;
+  const limit = dashboard.data?.limit ?? PAGE_SIZE;
+  const currentPage = dashboard.data?.page ?? page;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const rangeFrom = total === 0 ? 0 : (currentPage - 1) * limit + 1;
+  const rangeTo = Math.min(currentPage * limit, total);
+  const canPrev = currentPage > 1;
+  const canNext = currentPage < totalPages;
 
   return (
     <div className="max-w-4xl mx-auto p-6 space-y-6">
@@ -293,6 +315,45 @@ export const PortalWebhooksPage: React.FC = () => {
                 );
               })}
             </ul>
+          )}
+
+          {/* Pager — the per-listing rows are paginated (default 20/page); the
+              summary stats above stay page-independent. Only shown when the
+              org has more listings than a single page can hold. */}
+          {totalPages > 1 && (
+            <nav
+              className="flex items-center justify-between gap-4 pt-2"
+              aria-label={t('settings.portalWebhooks.pager.label', {
+                defaultValue: 'Listings pagination',
+              })}
+            >
+              <p className="text-xs text-gray-500">
+                {t('settings.portalWebhooks.pager.summary', {
+                  defaultValue: 'Showing {{from}}–{{to}} of {{total}} listings',
+                  from: rangeFrom,
+                  to: rangeTo,
+                  total,
+                })}
+              </p>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={!canPrev}
+                >
+                  {t('settings.portalWebhooks.pager.prev', { defaultValue: 'Previous' })}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={() => setPage((p) => (canNext ? p + 1 : p))}
+                  disabled={!canNext}
+                >
+                  {t('settings.portalWebhooks.pager.next', { defaultValue: 'Next' })}
+                </button>
+              </div>
+            </nav>
           )}
         </section>
       )}

--- a/frontend/apps/ppt-web/src/routes/groups/core.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/core.tsx
@@ -38,6 +38,7 @@ import {
   TemplateLibraryPage,
   TwoFactorAuthPage,
 } from '../lazyRoutes';
+import { MANAGER_ROLES } from '../shared';
 
 // Sessions management page (#966) — lazy-loaded.
 const SessionsPage = lazy(() =>
@@ -206,11 +207,14 @@ export function settingsRoutes() {
           </ProtectedRoute>
         }
       />
-      {/* Portal webhook delivery status — Real Estate Portal Webhooks (Gap 83-3) */}
+      {/* Portal webhook delivery status — Real Estate Portal Webhooks (Gap 83-3).
+          Manager-gated at the route level (not just the nav link): the dashboard
+          exposes org-wide syndication stats, per-listing inquiry counts and
+          last_error strings that residents must not read (issue #2322). */}
       <Route
         path="/settings/portal-webhooks"
         element={
-          <ProtectedRoute>
+          <ProtectedRoute requiredRoles={[...MANAGER_ROLES]}>
             <PortalWebhooksPage />
           </ProtectedRoute>
         }

--- a/frontend/apps/ppt-web/src/routes/shared.tsx
+++ b/frontend/apps/ppt-web/src/routes/shared.tsx
@@ -27,15 +27,24 @@ export function transformBuildingForUI(building: ApiBuilding): {
 }
 
 /**
+ * Roles permitted to perform manager-level (operator) actions.
+ *
+ * Single source of truth shared by {@link isManagerRole} (nav/inline gating)
+ * and `<ProtectedRoute requiredRoles={...}>` (route-level gating) so the two
+ * cannot drift apart.
+ */
+export const MANAGER_ROLES = [
+  'manager',
+  'org_admin',
+  'super_admin',
+  'technical_manager',
+  'property_manager',
+] as const;
+
+/**
  * Manager-equivalent role check shared by detail/workspace route wrappers.
  * Returns true for any role permitted to perform manager-level actions.
  */
 export function isManagerRole(role: string | undefined): boolean {
-  return (
-    role === 'manager' ||
-    role === 'org_admin' ||
-    role === 'super_admin' ||
-    role === 'technical_manager' ||
-    role === 'property_manager'
-  );
+  return role != null && (MANAGER_ROLES as readonly string[]).includes(role);
 }

--- a/frontend/apps/ppt-web/src/test/sitemap-routes.test.ts
+++ b/frontend/apps/ppt-web/src/test/sitemap-routes.test.ts
@@ -45,7 +45,7 @@ describe('PPT-Web Route Definitions', () => {
     });
 
     it('should have correct route count', () => {
-      expect(sitemap.routes[app].length).toBe(19);
+      expect(sitemap.routes[app].length).toBe(20);
     });
   });
 

--- a/frontend/packages/api-client/src/syndication/hooks.ts
+++ b/frontend/packages/api-client/src/syndication/hooks.ts
@@ -2,7 +2,7 @@
  * Portal Syndication React Query hooks (Epic 105 — Real Estate Portal Webhooks).
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import * as api from './api';
 import type { SyndicationDashboardQuery } from './types';
 
@@ -17,10 +17,15 @@ export const syndicationKeys = {
 };
 
 /** Organization syndication dashboard (per-listing rows + aggregate stats). */
-export function useSyndicationDashboard(query: SyndicationDashboardQuery = {}) {
+export function useSyndicationDashboard(
+  query: SyndicationDashboardQuery = {},
+  options?: { enabled?: boolean }
+) {
   return useQuery({
     queryKey: syndicationKeys.dashboard(query),
     queryFn: () => api.getSyndicationDashboard(query),
+    enabled: options?.enabled ?? true,
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/frontend/packages/sitemap/src/data/ppt-web/index.ts
+++ b/frontend/packages/sitemap/src/data/ppt-web/index.ts
@@ -185,6 +185,18 @@ export const pptWebRoutes: FrontendRoute[] = [
     tags: ['settings', 'integrations', 'airbnb', 'protected'],
   },
   {
+    id: 'ppt-settings-portal-webhooks',
+    app: 'ppt-web',
+    path: '/settings/portal-webhooks',
+    name: 'Portal Webhooks',
+    description:
+      'Real-estate portal webhook delivery status — per-listing syndication health & org stats',
+    auth: { required: true, tenantContext: { required: true } },
+    component: 'PortalWebhooksPage',
+    feature: 'Epic-105',
+    tags: ['settings', 'syndication', 'webhooks', 'protected'],
+  },
+  {
     id: 'ppt-settings-notifications',
     app: 'ppt-web',
     path: '/settings/notifications',

--- a/frontend/packages/sitemap/src/json/sitemap.json
+++ b/frontend/packages/sitemap/src/json/sitemap.json
@@ -208,6 +208,22 @@
         "tags": ["settings", "integrations", "airbnb", "protected"]
       },
       {
+        "id": "ppt-settings-portal-webhooks",
+        "app": "ppt-web",
+        "path": "/settings/portal-webhooks",
+        "name": "Portal Webhooks",
+        "description": "Real-estate portal webhook delivery status — per-listing syndication health & org stats",
+        "auth": {
+          "required": true,
+          "tenantContext": {
+            "required": true
+          }
+        },
+        "component": "PortalWebhooksPage",
+        "feature": "Epic-105",
+        "tags": ["settings", "syndication", "webhooks", "protected"]
+      },
+      {
         "id": "ppt-settings-notifications",
         "app": "ppt-web",
         "path": "/settings/notifications",
@@ -3693,10 +3709,10 @@
     }
   ],
   "metadata": {
-    "generated_at": "2026-07-08T22:20:18.727Z",
+    "generated_at": "2026-07-15T08:17:56.663Z",
     "version": "1.0.0",
     "stats": {
-      "ppt_web_routes": 19,
+      "ppt_web_routes": 20,
       "reality_web_routes": 9,
       "mobile_screens": 6,
       "api_server_endpoints": 77,


### PR DESCRIPTION
## Task
Follow-up: portal-webhooks screen — role gate, pagination, screen-map, i18n, OpenAPI swap (PR #2294). Closes #2322.

Post-merge review of PR #2294 flagged shape refinements on the `/settings/portal-webhooks` surface. This PR lands the **frontend** findings; the OpenAPI-swap finding is deferred (see Notes).

| # | Finding (issue #2322) | Sev | Done |
|---|---|---|---|
| 1 | security — route only nav-gated, not route/handler-gated | med | ✅ route gate |
| 2 | performance — page-1-only, no pager | med | ✅ |
| 3 | regressions — no screen-map | med | ✅ |
| 4 | correctness — dashboard query fires without org → spurious loadError | low | ✅ |
| 5 | i18n — en-only strings | low | ✅ |
| 6 | better-approach — OpenAPI paths() + generated-client swap | low | ⏸ deferred |

### What changed
- **Route role-gate**: `core.tsx` now wraps the route in `<ProtectedRoute requiredRoles={[...MANAGER_ROLES]}>`. Added a `MANAGER_ROLES` const in `routes/shared.tsx` as the single source of truth shared with `isManagerRole` (the nav-link gate) so the two can't drift. Residents can no longer open the page.
- **Pagination**: `PortalWebhooksPage` gets `page` state, passes `{ page, limit: 20 }`, and renders a prev/next pager + "showing N of M" range over the per-listing rows (summary stats stay page-independent). Hook now sets `placeholderData: keepPreviousData`.
- **Correctness**: `useSyndicationDashboard` gains an `options.enabled` param; the page passes `enabled: !!organizationId` so the noOrganization banner no longer coexists with a doomed request's error alert.
- **i18n**: `nav.portalWebhooks` + `settings.portalWebhooks.*` (incl. new `pager.*`) added to `cs/de/hu/pl/sk` (+ `pager.*` to `en`).
- **Screen-map**: new `docs/screens/ppt/settings-portal-webhooks.md` (`buildStatus: shipped`, `apiStatus: partial`) + `ppt-settings-portal-webhooks` sitemap entry; `sitemap.json` regenerated (Biome-normalised to keep the diff to the new entry only).

## Owner
pm-tech-lead (hint) — actual specialist: **react-web**.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` (tsc) → exit 0
- `pnpm -F @ppt/web typecheck` (tsc --noEmit + e2e) → exit 0
- `biome check` on all 6 changed TS/TSX + sitemap files → exit 0 (import order auto-fixed in core.tsx)
- `pnpm -F @ppt/web test --run PortalWebhooksPage.test.tsx` → **7 passed** (incl. 2 new pager cases; new cases fail on `origin/dev` — IG3)
- `pnpm -F @ppt/screen-map cli validate` → 167 screen-maps, 0 errors, 0 warnings

> Note: `pnpm -F @ppt/web lint` (eslint) is broken repo-wide (missing `eslint.config.js`; ESLint v9 flat-config migration) and is a **pre-existing** failure unrelated to this change. Per CLAUDE.md the frontend lint gate is Biome, which passes.

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production) → exit 0, built in 19.1s

## CI parity (Band C — hot-path only)
skipped — not a hot-path change (read-only manager UI; the security fix is a defense-in-depth **frontend** route gate, no auth/billing/data-integrity server logic touched).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
`scope_drift=true`. `scope-check --owner pm-tech-lead` maps that role to `docs/**` only, so every `frontend/**` file registers as drift. This is expected: the task is inherently a **react-web** frontend task and `pm-tech-lead` is only the dispatcher's owner hint. `docs/screens/ppt/settings-portal-webhooks.md` is in-scope for the hint; all frontend files are the legitimate substance of the task. No off-task files touched.

## Code-reuse review
`reuse-grep` emitted one warning: `WARN: useS looks like an existing helper at .../reality-api-client/src/favorites/hooks.ts`. **False positive** — a truncated-prefix match. No new helper was added; `useSyndicationDashboard` already existed and was only extended (added `options.enabled`). `MANAGER_ROLES` is a new const but deliberately deduplicates the role list previously inlined in `isManagerRole`.

## Notes
- **Finding 6 (OpenAPI swap) deferred**, matching the issue author's framing ("tracking it here so it doesn't evaporate" → "pm-backend/typespec task"). It requires registering the four `routes::listings::*` syndication handlers in the api-server OpenAPI `paths()` (`backend/servers/api-server/src/main.rs`), `pnpm generate-api`, then replacing the hand-written `@ppt/api-client` `syndication` module with generated operations — cross-stack backend work outside a react-web PR. That swap is also the right moment to prune the module's 3 currently-unused hooks. Recorded in the new screen-map's Notes so it doesn't evaporate.
- The backend defense-in-depth handler role-check (issue finding 1, "backend follow-up, pm-backend") is likewise a separate api-server task — not in this frontend PR.
- Goal-check IG1/IG2 fail structurally (no `.research/plans/` file; dispatcher-assigned `auto-impl/*` branch), which is inherent to this GitHub-issue task type, not a quality gap. IG3 passes (separate `test:` then `feat:` commits).


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1bsPNm8PMnjZFVTCHSZmN)_