### PR TITLE
gh-issue-2324: wire create-schedule UI to real endpoints

### DIFF
--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -232,6 +232,45 @@ impl ReportScheduleRepository {
         Ok(ReportSchedule::from(row))
     }
 
+    /// List report schedules for an organisation (gap-81-1 follow-up / issue #2324).
+    ///
+    /// Backs `GET /api/v1/reports/schedules`. Scoped to `caller_org_id` so a
+    /// principal only ever sees their own tenant's schedules — the org comes
+    /// from the authenticated `RlsConnection`, never the request. Optional
+    /// `report_id` / `is_active` filters narrow the result. Ordered by
+    /// `created_at DESC` (newest schedule first).
+    pub async fn list_by_org(
+        &self,
+        caller_org_id: Uuid,
+        report_id: Option<Uuid>,
+        is_active: Option<bool>,
+    ) -> Result<Vec<ReportSchedule>, AppError> {
+        let rows = sqlx::query_as::<_, ReportScheduleRow>(concat!(
+            "SELECT ",
+            report_schedule_columns!(),
+            " FROM report_schedules \
+             WHERE organization_id = $1 \
+               AND ($2::uuid IS NULL OR report_id = $2) \
+               AND ($3::boolean IS NULL OR is_active = $3) \
+             ORDER BY created_at DESC"
+        ))
+        .bind(caller_org_id)
+        .bind(report_id)
+        .bind(is_active)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                org_id = %caller_org_id,
+                "Failed to list report schedules"
+            );
+            AppError::Database(e.to_string())
+        })?;
+
+        Ok(rows.into_iter().map(ReportSchedule::from).collect())
+    }
+
     // ============================================================================
     // Execution history (Story 81.2)
     // ============================================================================

--- a/backend/servers/api-server/src/routes/reports.rs
+++ b/backend/servers/api-server/src/routes/reports.rs
@@ -211,8 +211,11 @@ pub fn router() -> Router<AppState> {
         // Story 55.5: Export Reports (Story 84.1: Background job implementation)
         .route("/export", axum::routing::post(export_report))
         .route("/export/{job_id}/status", get(get_export_job_status))
-        // gap-81-1: Create a new report schedule
-        .route("/schedules", axum::routing::post(create_schedule))
+        // gap-81-1: Create a new report schedule; issue #2324: list schedules
+        .route(
+            "/schedules",
+            axum::routing::post(create_schedule).get(list_schedules),
+        )
         // gap-81-1: Update schedule (cron expression, recipients, enabled flag)
         .route("/schedules/{id}", axum::routing::put(update_schedule))
         // Epic 81: Story 81.1 — Schedule pause/resume
@@ -2138,6 +2141,85 @@ pub(crate) fn compute_next_run_for_schedule(
             )
         }
     }
+}
+
+/// Query parameters for `GET /api/v1/reports/schedules` (issue #2324).
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct ListSchedulesQuery {
+    /// Accepted for client compatibility but **ignored for scoping** — the
+    /// organisation is always taken from the authenticated `RlsConnection`
+    /// tenant, never a client-supplied value, so a caller cannot list another
+    /// org's schedules.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub organization_id: Option<Uuid>,
+    /// Optional filter: only schedules for this (opaque) `report_id`.
+    pub report_id: Option<Uuid>,
+    /// Optional filter: `true` = active only, `false` = paused/inactive only.
+    pub is_active: Option<bool>,
+}
+
+/// Response for `GET /api/v1/reports/schedules` (issue #2324).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ListSchedulesResponse {
+    /// Schedules belonging to the caller's organisation, newest first.
+    pub schedules: Vec<ReportSchedule>,
+    /// Number of schedules returned.
+    pub total: usize,
+}
+
+/// List report schedules for the authenticated tenant (issue #2324).
+///
+/// Backs the ppt-web Schedules tab (`useReportSchedules` → `listSchedules()`),
+/// which before this endpoint existed called a route the router only registered
+/// as POST — so the list never loaded (405) and a freshly created schedule was
+/// invisible. Any authenticated org member may read their org's schedules.
+///
+/// # Security
+///
+/// Uses `RlsConnection` so the tenant is re-derived from the database session,
+/// and the repository query filters on `organization_id = rls.tenant_id()` —
+/// a principal can never see another org's schedules even by guessing IDs.
+#[utoipa::path(
+    get,
+    path = "/api/v1/reports/schedules",
+    tag = "reports",
+    params(ListSchedulesQuery),
+    responses(
+        (status = 200, description = "Schedules for the caller's organisation", body = ListSchedulesResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+    )
+)]
+pub async fn list_schedules(
+    State(state): State<AppState>,
+    mut rls: RlsConnection,
+    Query(query): Query<ListSchedulesQuery>,
+) -> Result<Json<ListSchedulesResponse>, (StatusCode, Json<ErrorResponse>)> {
+    // Tenant scoping comes from the authenticated context, not the query string.
+    let caller_org_id = rls.tenant_id();
+    rls.release().await;
+
+    let schedules = state
+        .report_schedule_repo
+        .list_by_org(caller_org_id, query.report_id, query.is_active)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                org_id = %caller_org_id,
+                "Failed to list report schedules"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "DB_ERROR",
+                    "Failed to list report schedules",
+                )),
+            )
+        })?;
+
+    let total = schedules.len();
+    Ok(Json(ListSchedulesResponse { schedules, total }))
 }
 
 /// Request body for `POST /api/v1/reports/schedules`.

--- a/docs/screens/ppt/reports.md
+++ b/docs/screens/ppt/reports.md
@@ -23,6 +23,7 @@ owner: pm-frontend
 
 ## Agent Log
 
+- 2026-07-15 — agent: react-web (gh-issue-2324, follow-up to PR #2292). Closed the "flow still broken in prod" regression PR #2292 introduced: its two list hooks called routes that did not exist. **Backend:** added `GET /api/v1/reports/schedules` → `list_schedules` (org-scoped via `RlsConnection`, reusing new `ReportScheduleRepository::list_by_org`) so `useReportSchedules` → `listSchedules()` loads instead of 405ing (the path was POST-only). **Report selector:** dropped the dead `useReports` → `/definitions` call (no report-definitions table by design, #2198). The "New Schedule" report selector is now fed by a fixed built-in report set (`features/reports/builtinReports.ts`: faults / voting / occupancy / consumption → well-known non-nil UUIDs); `useReports`/`listReports` removed from `@ppt/api-client`. **Frequency:** ScheduleForm no longer offers quarterly/yearly (backend rejects them 400 INVALID_FREQUENCY); create error toast now surfaces the backend message. **Cron:** `CreateReportSchedule` gained optional `cron_expression`, derived from the form fields on submit so new rows are cron-canonical. **i18n:** added `reports.schedule.{created,createFailed,updated,updateFailed}` to all 6 locales. **Tests:** new fetch-layer contract test (`packages/api-client/src/reports/schedules.api.test.ts`) pins GET/POST `/schedules` URL+method so a route/method drift fails CI; updated the create-schedule route test to the built-in selector.
 - 2026-07-15 — agent: pm-backend (gap-tracking-stale-status-flips). apiStatus flipped **partial → complete**. The sole remaining blocker recorded in the pinned reason — the missing Story 81.1 "Create new schedule" backend route — is now closed. `backend/servers/api-server/src/routes/reports.rs::router()` registers `POST /schedules → create_schedule` (real handler: manager-tier RBAC from the DB-backed `RlsConnection`, frequency/day-of-week/day-of-month validation, tenant-scoped insert), landed via PR #2313 (report_schedules due-work consumer + unified cadence). Frontend wired end-to-end: `@ppt/api-client` `createSchedule` (POST /schedules) + `useCreateSchedule`, consumed by `ReportsPageRoute` (`routes/groups/reports.tsx`) → `handleCreateSchedule` → `mutateAsync` with success/error toast; the "New Schedule" form's report selector is fed by `useReports`. Story 81.2 (execution history: list/filter/paginate/retry/download) was already wired both sides. All checklist items now satisfied.
 - 2026-07-01 — agent: react-web PR #2004 follow-up (round 1). CORRECTION to the pinned reason below: the earlier claim that the backend axum routes for report executions are NOT registered was FALSE. All three routes ARE registered on `dev` in `backend/servers/api-server/src/routes/reports.rs::router()` — `GET /schedules/{id}/executions` → `list_schedule_executions` (line 222), `GET /executions/{id}/download` → `get_execution_download_url` (line 224, builds the presigned-download URL), `POST /executions/{id}/retry` → `retry_execution` (lines 225-228); the router is nested at `/api/v1/reports` in `backend/servers/api-server/src/lib.rs:293`. The Story 81.2 execution-history flow is therefore backend-wired end-to-end. `apiStatus` stays **partial** for a DIFFERENT, still-genuine reason: the Story 81.1 "Create new schedule" action (`POST /api/v1/reports/schedules`) has no backend route — `router()` only registers PUT `/schedules/{id}` plus pause/resume, no create handler. See corrected pinned reason below.
 - 2026-07-01 — agent: gap-81-2 verify-to-done. Story 81.2 (Execution History) frontend is fully shipped and green: `ExecutionHistory`/`HistoryFilters` (status + date-range filter), offset/limit pagination, download and retry actions are wired end-to-end through the real api-client hooks (`useReportExecutionHistory`, `useDownloadReport`, `useRetryReportExecution`) in both `routes/groups/reports.tsx` route containers (`ReportsPageRoute`, `ScheduleDetailPageRoute`). The download hook guards empty presigned URLs and cleans up the temporary `<a>` in a `finally`; retry invalidates the executions query. The earlier download/retry test-gap follow-up (d1785e5fb) is closed: `routes/groups/reports.download-retry.route.test.tsx` now asserts the PRODUCTION route's `onError` download toast + retry-success toast (the sibling page Harness diverged there). Verified: `pnpm -F @ppt/web test --run reports` → 6 files / 70 tests pass; `pnpm -F @ppt/web typecheck` clean. (NOTE: this entry's original claim that the 81.2 backend routes do not exist was later corrected — see the 2026-07-01 react-web follow-up entry above; the routes ARE registered.) Frontend side of 81.2 is done; no frontend work remains.
@@ -57,10 +58,18 @@ owner: pm-frontend
 > presigned-download URL, and `retry_execution`), nested at `/api/v1/reports` in
 > `backend/servers/api-server/src/lib.rs`.
 >
-> Story 81.1 **"Create new schedule"** — the previously-missing gap — is now
-> closed: `router()` registers `POST /schedules → create_schedule` (real
-> handler with manager-tier RBAC derived from the DB-backed `RlsConnection`,
-> frequency + day-of-week/day-of-month validation, tenant-scoped insert), landed
-> in PR #2313. The frontend "New Schedule" form submits through `@ppt/api-client`
-> `createSchedule` (POST /schedules) + `useCreateSchedule`, wired in
-> `ReportsPageRoute` (`routes/groups/reports.tsx`). No wiring gaps remain.
+> Story 81.1 **"Create new schedule"** is closed: `router()` registers
+> `POST /schedules → create_schedule` (real handler with manager-tier RBAC
+> derived from the DB-backed `RlsConnection`, frequency + day-of-week/day-of-month
+> validation, tenant-scoped insert), landed in PR #2313. The frontend "New
+> Schedule" form submits through `@ppt/api-client` `createSchedule` (POST
+> /schedules) + `useCreateSchedule`, wired in `ReportsPageRoute`
+> (`routes/groups/reports.tsx`).
+>
+> **List/selector wiring (gh-issue-2324, follow-up to PR #2292).** The Schedules
+> tab list is now backed by `GET /api/v1/reports/schedules` → `list_schedules`
+> (org-scoped, `ReportScheduleRepository::list_by_org`); before this the router
+> registered `/schedules` POST-only, so `useReportSchedules` 405'd. The report
+> selector no longer calls a nonexistent `/definitions` list route — it uses the
+> fixed built-in report set (`features/reports/builtinReports.ts`), since
+> `report_id` is opaque with no definitions table (#2198). No wiring gaps remain.

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1050,6 +1050,12 @@
       "errorTitle": "Nepodařilo se načíst spuštění",
       "errorMessage": "Zkuste to prosím později."
     },
+    "schedule": {
+      "created": "Plán byl úspěšně vytvořen.",
+      "createFailed": "Plán se nepodařilo vytvořit.",
+      "updated": "Plán byl úspěšně aktualizován.",
+      "updateFailed": "Plán se nepodařilo aktualizovat."
+    },
     "execution": {
       "downloadFailed": "Nepodařilo se stáhnout zprávu.",
       "retryQueued": "Spuštění bylo zařazeno do fronty k opakování.",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -999,6 +999,12 @@
       "errorTitle": "Ausführungen konnten nicht geladen werden",
       "errorMessage": "Bitte versuchen Sie es später erneut."
     },
+    "schedule": {
+      "created": "Zeitplan erfolgreich erstellt.",
+      "createFailed": "Zeitplan konnte nicht erstellt werden.",
+      "updated": "Zeitplan erfolgreich aktualisiert.",
+      "updateFailed": "Zeitplan konnte nicht aktualisiert werden."
+    },
     "execution": {
       "downloadFailed": "Bericht konnte nicht heruntergeladen werden.",
       "retryQueued": "Ausführung zur Wiederholung in die Warteschlange gestellt.",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3369,6 +3369,12 @@
       "errorTitle": "Failed to load executions",
       "errorMessage": "Please try again later."
     },
+    "schedule": {
+      "created": "Schedule created successfully.",
+      "createFailed": "Failed to create schedule.",
+      "updated": "Schedule updated successfully.",
+      "updateFailed": "Failed to update schedule."
+    },
     "execution": {
       "downloadFailed": "Failed to download report.",
       "retryQueued": "Execution queued for retry.",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -999,6 +999,12 @@
       "errorTitle": "Nem sikerült betölteni a végrehajtásokat",
       "errorMessage": "Kérjük, próbálja újra később."
     },
+    "schedule": {
+      "created": "Ütemezés sikeresen létrehozva.",
+      "createFailed": "Nem sikerült létrehozni az ütemezést.",
+      "updated": "Ütemezés sikeresen frissítve.",
+      "updateFailed": "Nem sikerült frissíteni az ütemezést."
+    },
     "execution": {
       "downloadFailed": "Nem sikerült letölteni a jelentést.",
       "retryQueued": "A végrehajtás újraküldésre várakozik.",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1005,6 +1005,12 @@
       "errorTitle": "Nie udało się wczytać wykonań",
       "errorMessage": "Spróbuj ponownie później."
     },
+    "schedule": {
+      "created": "Harmonogram został utworzony.",
+      "createFailed": "Nie udało się utworzyć harmonogramu.",
+      "updated": "Harmonogram został zaktualizowany.",
+      "updateFailed": "Nie udało się zaktualizować harmonogramu."
+    },
     "execution": {
       "downloadFailed": "Nie udało się pobrać raportu.",
       "retryQueued": "Wykonanie zostało dodane do kolejki ponowień.",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1052,6 +1052,12 @@
       "errorTitle": "Nepodarilo sa načítať spustenia",
       "errorMessage": "Skúste to prosím neskôr."
     },
+    "schedule": {
+      "created": "Plán bol úspešne vytvorený.",
+      "createFailed": "Nepodarilo sa vytvoriť plán.",
+      "updated": "Plán bol úspešne aktualizovaný.",
+      "updateFailed": "Nepodarilo sa aktualizovať plán."
+    },
     "execution": {
       "downloadFailed": "Nepodarilo sa stiahnuť správu.",
       "retryQueued": "Spustenie bolo zaradené do frontu na opakovanie.",

--- a/frontend/apps/ppt-web/src/features/reports/builtinReports.ts
+++ b/frontend/apps/ppt-web/src/features/reports/builtinReports.ts
@@ -1,0 +1,31 @@
+/**
+ * Built-in report types (issue #2324).
+ *
+ * There is deliberately no report-definitions table (issue #2198): `report_id`
+ * is an opaque UUID and the reports this system generates — fault statistics,
+ * voting participation, occupancy, consumption — are computed on demand from
+ * live data, not stored as rows. The old "New Schedule" report selector was fed
+ * by `useReports` → `GET /api/v1/reports/definitions`, a route that does not
+ * exist, so the dropdown was always empty and a schedule could never be created.
+ *
+ * This fixed list replaces that dead endpoint. Each entry maps a built-in report
+ * to a stable, well-known (non-nil) UUID that the backend stores verbatim as the
+ * schedule's `report_id`. The scheduler treats `report_id` as opaque, so these
+ * IDs need only be stable and non-nil — they are NOT foreign keys.
+ */
+
+export interface BuiltinReport {
+  /** Stable, well-known, non-nil UUID persisted as the schedule's `report_id`. */
+  id: string;
+  /** i18n-independent display name shown in the report selector. */
+  name: string;
+  /** The backend report generator this schedule fires. */
+  type: 'faults' | 'voting' | 'occupancy' | 'consumption';
+}
+
+export const BUILTIN_REPORTS: readonly BuiltinReport[] = [
+  { id: 'a0000000-0000-4000-8000-000000000001', name: 'Fault statistics', type: 'faults' },
+  { id: 'a0000000-0000-4000-8000-000000000002', name: 'Voting participation', type: 'voting' },
+  { id: 'a0000000-0000-4000-8000-000000000003', name: 'Occupancy', type: 'occupancy' },
+  { id: 'a0000000-0000-4000-8000-000000000004', name: 'Consumption', type: 'consumption' },
+] as const;

--- a/frontend/apps/ppt-web/src/features/reports/components/ScheduleForm.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/ScheduleForm.tsx
@@ -4,29 +4,56 @@
  * Form for creating and editing report schedules.
  */
 
-import type {
-  CreateReportSchedule,
-  ReportDefinition,
-  ReportFormat,
-  ScheduleFrequency,
-} from '@ppt/api-client';
+import type { CreateReportSchedule, ReportFormat, ScheduleFrequency } from '@ppt/api-client';
 import { useState } from 'react';
+import { BUILTIN_REPORTS } from '../builtinReports';
 
 interface ScheduleFormProps {
-  reports: ReportDefinition[];
   initialData?: Partial<CreateReportSchedule>;
   onSubmit: (data: CreateReportSchedule) => void;
   onCancel: () => void;
   isSubmitting?: boolean;
 }
 
+// Only the cadences the backend `create_schedule` handler accepts. Quarterly and
+// yearly used to be offered here but the backend rejects them with 400
+// INVALID_FREQUENCY (issue #2324, finding 2), so they are removed to keep the
+// form in sync with the contract.
 const FREQUENCIES: { value: ScheduleFrequency; label: string }[] = [
   { value: 'daily', label: 'Daily' },
   { value: 'weekly', label: 'Weekly' },
   { value: 'monthly', label: 'Monthly' },
-  { value: 'quarterly', label: 'Quarterly' },
-  { value: 'yearly', label: 'Yearly' },
 ];
+
+/**
+ * Derive a 5-field UNIX cron expression from the legacy form fields (issue
+ * #2324, finding 3) so a freshly-created schedule is cron-canonical from birth
+ * and round-trips losslessly through the cron-first edit modal. Returns
+ * `undefined` when the time can't be parsed (the backend then falls back to the
+ * legacy frequency/time cadence).
+ */
+function deriveCron(
+  frequency: ScheduleFrequency,
+  time: string,
+  dayOfWeek: number,
+  dayOfMonth: number
+): string | undefined {
+  const match = /^(\d{1,2}):(\d{1,2})$/.exec(time);
+  if (!match) return undefined;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour > 23 || minute > 59) return undefined;
+  switch (frequency) {
+    case 'daily':
+      return `${minute} ${hour} * * *`;
+    case 'weekly':
+      return `${minute} ${hour} * * ${dayOfWeek}`;
+    case 'monthly':
+      return `${minute} ${hour} ${dayOfMonth} * *`;
+    default:
+      return undefined;
+  }
+}
 
 const FORMATS: { value: ReportFormat; label: string }[] = [
   { value: 'pdf', label: 'PDF' },
@@ -51,13 +78,7 @@ interface FormErrors {
   time?: string;
 }
 
-export function ScheduleForm({
-  reports,
-  initialData,
-  onSubmit,
-  onCancel,
-  isSubmitting,
-}: ScheduleFormProps) {
+export function ScheduleForm({ initialData, onSubmit, onCancel, isSubmitting }: ScheduleFormProps) {
   const [reportId, setReportId] = useState(initialData?.report_id || '');
   const [name, setName] = useState(initialData?.name || '');
   const [frequency, setFrequency] = useState<ScheduleFrequency>(initialData?.frequency || 'weekly');
@@ -107,16 +128,22 @@ export function ScheduleForm({
 
     if (!validate()) return;
 
+    const dow = frequency === 'weekly' ? dayOfWeek : undefined;
+    const dom = frequency === 'monthly' ? dayOfMonth : undefined;
+
     onSubmit({
       report_id: reportId,
       name,
       frequency,
-      day_of_week: frequency === 'weekly' ? dayOfWeek : undefined,
-      day_of_month: frequency === 'monthly' || frequency === 'quarterly' ? dayOfMonth : undefined,
+      day_of_week: dow,
+      day_of_month: dom,
       time,
       timezone,
       format,
       recipients: recipients.split(',').map((e) => e.trim()),
+      // Cron-canonical from birth (issue #2324, finding 3): the backend prefers
+      // this over the legacy frequency/time fields when computing next_run_at.
+      cron_expression: deriveCron(frequency, time, dayOfWeek, dayOfMonth),
     });
   };
 
@@ -139,7 +166,7 @@ export function ScheduleForm({
           }`}
         >
           <option value="">Select a report</option>
-          {reports.map((report) => (
+          {BUILTIN_REPORTS.map((report) => (
             <option key={report.id} value={report.id}>
               {report.name}
             </option>
@@ -209,7 +236,7 @@ export function ScheduleForm({
         </div>
       )}
 
-      {(frequency === 'monthly' || frequency === 'quarterly') && (
+      {frequency === 'monthly' && (
         <div>
           <label htmlFor="day-of-month" className="block text-sm font-medium text-gray-700">
             Day of Month

--- a/frontend/apps/ppt-web/src/features/reports/pages/ReportsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/pages/ReportsPage.tsx
@@ -364,7 +364,6 @@ export function ReportsPage({
               <div className="bg-white rounded-lg shadow p-6">
                 <h2 className="text-lg font-medium text-gray-900 mb-6">Create Schedule</h2>
                 <ScheduleForm
-                  reports={reports}
                   onSubmit={async (data) => {
                     await onCreateSchedule?.(data);
                     setShowScheduleForm(false);

--- a/frontend/apps/ppt-web/src/routes/groups/reports.create-schedule.route.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/reports.create-schedule.route.test.tsx
@@ -22,6 +22,7 @@ import type { ReactNode } from 'react';
 import { Suspense } from 'react';
 import { MemoryRouter, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BUILTIN_REPORTS } from '../../features/reports/builtinReports';
 import { reportRoutes } from './reports';
 
 const ORG_ID = 'org-1';
@@ -42,10 +43,6 @@ vi.mock('../../contexts', async (importOriginal) => ({
 
 vi.mock('@ppt/api-client', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@ppt/api-client')>()),
-  useReports: () => ({
-    data: { reports: [{ id: 'rep-1', name: 'Monthly Revenue' }], total: 1 },
-    isLoading: false,
-  }),
   useReportSchedules: () => ({ data: { schedules: [], total: 0 }, isLoading: false }),
   useCreateSchedule: () => ({ mutateAsync: mockCreateMutateAsync }),
   useReportExecutionHistory: () => ({
@@ -88,9 +85,11 @@ describe('ReportsPageRoute create-schedule wiring (gap-81-1)', () => {
     // Open the create form.
     await user.click(await screen.findByRole('button', { name: /new schedule/i }));
 
-    // Fill the required fields. The report selector is populated from the
-    // route's useReports data — empty before this fix.
-    await user.selectOptions(screen.getByRole('combobox', { name: /report/i }), 'rep-1');
+    // Fill the required fields. The report selector is now populated from the
+    // fixed built-in report set (issue #2324) — there is no report-definitions
+    // endpoint, so the dropdown no longer depends on a network call.
+    const builtin = BUILTIN_REPORTS[0];
+    await user.selectOptions(screen.getByRole('combobox', { name: /report/i }), builtin.id);
     await user.type(screen.getByLabelText(/schedule name/i), 'Weekly Revenue Summary');
     await user.type(screen.getByLabelText(/recipients/i), 'owner@example.com');
 
@@ -101,7 +100,7 @@ describe('ReportsPageRoute create-schedule wiring (gap-81-1)', () => {
     });
     expect(mockCreateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({
-        report_id: 'rep-1',
+        report_id: builtin.id,
         name: 'Weekly Revenue Summary',
         recipients: ['owner@example.com'],
       })

--- a/frontend/apps/ppt-web/src/routes/groups/reports.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/reports.tsx
@@ -16,7 +16,6 @@ import {
   useDownloadReport,
   useReportExecutionHistory,
   useReportSchedules,
-  useReports,
   useRetryReportExecution,
   useUpdateScheduleCron,
 } from '@ppt/api-client';
@@ -40,10 +39,10 @@ function ReportsPageRoute() {
   const { user } = useAuth();
   const organizationId = user?.organizationId ?? '';
 
-  // gap-81-1: report definitions + schedules feed the Schedules tab. Without
-  // the report list the "New Schedule" form's report selector is empty and a
-  // schedule can never be created.
-  const { data: reportsData, isLoading: reportsLoading } = useReports(organizationId);
+  // issue #2324: the "New Schedule" report selector is fed by the fixed set of
+  // built-in report types (ScheduleForm → BUILTIN_REPORTS), not a
+  // report-definitions endpoint — there is deliberately no such table (#2198).
+  // The Schedules tab list is backed by GET /api/v1/reports/schedules.
   const { data: schedulesData, isLoading: schedulesLoading } = useReportSchedules(organizationId);
   const createScheduleMutation = useCreateSchedule(organizationId);
 
@@ -56,10 +55,13 @@ function ReportsPageRoute() {
         message: t('reports.schedule.created', 'Schedule created successfully.'),
       });
     } catch (e) {
+      // Surface the backend's specific error (e.g. INVALID_FREQUENCY) instead of
+      // a fixed string so the user sees why creation failed (issue #2324).
+      const detail = e instanceof Error && e.message ? e.message : undefined;
       showToast({
         type: 'error',
         title: t('common.error'),
-        message: t('reports.schedule.createFailed', 'Failed to create schedule.'),
+        message: detail ?? t('reports.schedule.createFailed', 'Failed to create schedule.'),
       });
       throw e;
     }
@@ -150,9 +152,9 @@ function ReportsPageRoute() {
     <ReportsPage
       organizationId={organizationId}
       dataSources={[]}
-      reports={reportsData?.reports ?? []}
+      reports={[]}
       schedules={schedulesData?.schedules ?? []}
-      isLoading={reportsLoading || schedulesLoading}
+      isLoading={schedulesLoading}
       kpis={[]}
       buildings={[]}
       trendAnalysis={

--- a/frontend/packages/api-client/src/reports/api.ts
+++ b/frontend/packages/api-client/src/reports/api.ts
@@ -13,8 +13,6 @@ import type {
   CreateReportSchedule,
   CronScheduleUpdateRequest,
   DataSource,
-  ListReportsParams,
-  ListReportsResponse,
   ListSchedulesParams,
   ListSchedulesResponse,
   PeriodComparison,
@@ -61,16 +59,6 @@ export async function createReport(
     method: 'POST',
     body: JSON.stringify({ organization_id: organizationId, ...data }),
   });
-}
-
-export async function listReports(params: ListReportsParams): Promise<ListReportsResponse> {
-  const searchParams = new URLSearchParams();
-  searchParams.set('organization_id', params.organization_id);
-  if (params.type) searchParams.set('type', params.type);
-  if (params.created_by) searchParams.set('created_by', params.created_by);
-  if (params.limit) searchParams.set('limit', String(params.limit));
-  if (params.offset) searchParams.set('offset', String(params.offset));
-  return fetchApi(`${API_BASE}/definitions?${searchParams}`);
 }
 
 export async function getReport(id: string): Promise<ReportDefinition> {

--- a/frontend/packages/api-client/src/reports/hooks.ts
+++ b/frontend/packages/api-client/src/reports/hooks.ts
@@ -9,7 +9,6 @@ import {
   createSchedule,
   getReportExecutionDownloadUrl,
   getReportExecutionHistory,
-  listReports,
   listSchedules,
   pauseSchedule,
   resumeSchedule,
@@ -20,7 +19,6 @@ import {
 import type {
   CreateReportSchedule,
   CronScheduleUpdateRequest,
-  ListReportsParams,
   ListSchedulesParams,
   ReportExecutionHistoryParams,
   ReportExecutionStatus,
@@ -29,9 +27,6 @@ import type {
 // Query keys factory for cache management
 export const reportKeys = {
   all: ['reports'] as const,
-  definitions: () => [...reportKeys.all, 'definitions'] as const,
-  definitionList: (organizationId: string, filters?: Omit<ListReportsParams, 'organization_id'>) =>
-    [...reportKeys.definitions(), organizationId, filters] as const,
   schedules: () => [...reportKeys.all, 'schedules'] as const,
   scheduleList: (organizationId: string, filters?: Omit<ListSchedulesParams, 'organization_id'>) =>
     [...reportKeys.schedules(), 'list', organizationId, filters] as const,
@@ -45,23 +40,11 @@ export const reportKeys = {
   execution: (id: string) => [...reportKeys.all, 'execution', id] as const,
 };
 
-/**
- * Hook to list report definitions for an organization (Epic 53 / gap-81-1).
- *
- * Populates the report selector in the "New Schedule" form — without this the
- * ScheduleForm dropdown is empty and a schedule can never be created.
- */
-export function useReports(
-  organizationId: string,
-  filters?: Omit<ListReportsParams, 'organization_id'>,
-  options?: { enabled?: boolean }
-) {
-  return useQuery({
-    queryKey: reportKeys.definitionList(organizationId, filters),
-    queryFn: () => listReports({ organization_id: organizationId, ...filters }),
-    enabled: options?.enabled !== false && !!organizationId,
-  });
-}
+// NOTE (issue #2324): the former `useReports` hook was removed. It fetched
+// `GET /api/v1/reports/definitions`, a route that does not exist (there is no
+// report-definitions table by design — #2198), so it never populated the
+// "New Schedule" report selector. The selector now uses the fixed built-in
+// report set (`ppt-web` `features/reports/builtinReports.ts`) instead.
 
 /**
  * Hook to list report schedules for an organization (Epic 53 / gap-81-1).

--- a/frontend/packages/api-client/src/reports/schedules.api.test.ts
+++ b/frontend/packages/api-client/src/reports/schedules.api.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Request-wiring contract tests for the report-schedule transport (issue #2324).
+ *
+ * PR #2292 wired the ppt-web create-schedule flow to list hooks whose transport
+ * fns targeted routes/methods the backend never registered:
+ *   - `listSchedules()` hit `GET /api/v1/reports/schedules`, which the router
+ *     registered POST-only (→ 405), so the Schedules tab never loaded.
+ *   - the report selector was fed by a `/definitions` list route that does not
+ *     exist at all.
+ * The route-container test mocked those hooks wholesale, so the mismatch was
+ * invisible to CI. These tests spy on the real fetch layer and pin the exact
+ * URL + HTTP method each transport fn emits, so a route/method drift fails CI
+ * instead of shipping. The backend list route is added alongside this change
+ * (`backend/servers/api-server/src/routes/reports.rs` — `GET /schedules`).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSchedule, listSchedules } from './api';
+
+/** Minimal ok JSON response stub. */
+function okJson(body: unknown): Response {
+  return { ok: true, status: 200, json: async () => body } as Response;
+}
+
+/** Read the (url, method) pair the client passed to the last fetch call. */
+function lastCall(): { url: string; method: string } {
+  const calls = vi.mocked(fetch).mock.calls;
+  const call = calls[calls.length - 1];
+  if (!call) throw new Error('fetch was not called');
+  const url = String(call[0]);
+  const method = ((call[1] as RequestInit | undefined)?.method ?? 'GET').toUpperCase();
+  return { url, method };
+}
+
+describe('report-schedule api client — request wiring contract (issue #2324)', () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(okJson({ schedules: [], total: 0 }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listSchedules → GET /api/v1/reports/schedules (matches the backend GET route)', async () => {
+    await listSchedules({ organization_id: 'org-1' });
+    const { url, method } = lastCall();
+    // Must be GET — the backend registered this exact path+verb (a POST-only
+    // route here is the #2324 regression that 405'd the Schedules list).
+    expect(method).toBe('GET');
+    expect(url.startsWith('/api/v1/reports/schedules?')).toBe(true);
+    expect(url).toContain('organization_id=org-1');
+  });
+
+  it('listSchedules serializes report_id / is_active filters', async () => {
+    await listSchedules({ organization_id: 'org-1', report_id: 'rep-9', is_active: false });
+    const { url } = lastCall();
+    expect(url).toContain('report_id=rep-9');
+    expect(url).toContain('is_active=false');
+  });
+
+  it('createSchedule → POST /api/v1/reports/schedules', async () => {
+    await createSchedule('org-1', {
+      report_id: 'a0000000-0000-4000-8000-000000000001',
+      name: 'Weekly faults',
+      frequency: 'weekly',
+      day_of_week: 1,
+      time: '09:00',
+      recipients: ['owner@example.com'],
+    });
+    const { url, method } = lastCall();
+    expect(method).toBe('POST');
+    expect(url).toBe('/api/v1/reports/schedules');
+  });
+});

--- a/frontend/packages/api-client/src/reports/types.ts
+++ b/frontend/packages/api-client/src/reports/types.ts
@@ -125,6 +125,16 @@ export interface CreateReportSchedule {
   timezone?: string;
   format?: ReportFormat;
   recipients: string[];
+  /**
+   * Optional 5-field UNIX cron expression (issue #2324, finding 3).
+   *
+   * When present the backend treats it as the cadence source of truth and
+   * computes `next_run_at` from it, keeping newly-created rows cron-canonical
+   * so a later edit via the cron-first EditScheduleModal does not cross two
+   * different cadence models. The create form derives this from the legacy
+   * frequency/day/time fields on submit.
+   */
+  cron_expression?: string;
 }
 
 export interface ReportRun {


### PR DESCRIPTION
## Task
Follow-up: create-schedule UI wired to nonexistent list endpoints — flow still broken in prod (PR #2292). Closes #2324.

## Owner
pm-tech-lead (specialist: react-web — cross-stack: react-web + a small rust-backend slice)

## What was broken
PR #2292 wired the create-schedule flow to two list hooks that hit routes the backend never registered:
- `useReportSchedules` → `GET /api/v1/reports/schedules` — router had `/schedules` **POST-only** → 405, so the Schedules list never loaded.
- `useReports` → `GET /api/v1/reports/definitions` — no such route (there is deliberately no report-definitions table, #2198), so the report selector was always empty and a schedule could never be created.
The existing route test mocked those hooks wholesale, hiding the endpoint mismatch from CI.

## Fix
Backend
- Add `GET /api/v1/reports/schedules` → `list_schedules` (org-scoped via `RlsConnection.tenant_id()`, reusing new `ReportScheduleRepository::list_by_org`; optional `report_id` / `is_active` filters). `list_schedules` is chained onto the existing POST route.

Frontend
- Report selector now uses a fixed built-in report set (`features/reports/builtinReports.ts`: faults / voting / occupancy / consumption → well-known non-nil UUIDs). `report_id` is opaque and the scheduler never resolves it, so stable UUIDs are safe. Removed the dead `useReports` / `listReports` from `@ppt/api-client`.
- Frequency options restricted to `daily|weekly|monthly` (backend rejects quarterly/yearly with 400 `INVALID_FREQUENCY`); the create-failure toast now surfaces the backend error message instead of a fixed string.
- Added optional `cron_expression` to `CreateReportSchedule`, derived from the form fields on submit so new rows are cron-canonical from birth (matches the cron-first edit modal).
- Added `reports.schedule.{created,createFailed,updated,updateFailed}` to all 6 locales.

## Tested (Band A — fast check)
- `cargo check -p db` → exit 0 (repo `list_by_org` + SQL projection compile).
- `pnpm -F @ppt/api-client build` (tsc) → exit 0.
- `pnpm -F @ppt/web typecheck` (tsc --noEmit + e2e tsconfig) → exit 0.
- `biome check` on all 9 changed frontend files → exit 0 (clean). NOTE: the app-level `lint` script uses a broken ESLint v10 config repo-wide; Biome is the actual CI gate per CLAUDE.md.
- `vitest run` — api-client `src/reports` (3/3, incl. new fetch-layer contract test) and ppt-web reports (6 files / 64 tests) → all pass.

## Built (Band B — full build)
- api-client production build (tsc) ran as Band A. Backend `api-server` release build could **not** run here — see CI parity.

## CI parity (Band C)
- `cargo check -p api-server` is **blocked by an environment egress-policy denial**, not by this change: the `utoipa-swagger-ui` build script downloads its asset from `github.com/swagger-api/swagger-ui/...` and the proxy returns `HTTP 403` ("GitHub access to this repository is not enabled for this session"), yielding a corrupt 195-byte zip → build-script panic. Per the proxy policy I did not route around it. The `db` crate (where the new SQL/repo method lives) compiles clean; the new handler follows the established `RlsConnection` + `Query` + `ErrorResponse` patterns already in `reports.rs`. **Backend `api-server` compile must be confirmed by CI where the Swagger UI asset is available.**

## Scope drift
None. All 18 committed files are in the reports domain (backend reports route/repo, ppt-web reports feature + test, api-client reports, reports i18n, reports screen-map). `scope-check.sh` exited 2 only because the worktree's local `dev` ref is stale (origin/dev advanced 3 dispatcher commits after the branch was cut), pulling unrelated `news_article` / `.research` files into its base diff — none are in this commit.

## Code-reuse review
`reuse-grep.sh` (react-web) → no warnings. `list_by_org` reuses the existing `report_schedule_columns!` projection and `ReportScheduleRow`/`ReportSchedule::from` mapping.

## Screen-map
`docs/screens/ppt/reports.md` — added a 2026-07-15 Agent Log entry and refreshed the pinned apiStatus reason (list route + built-in selector now close the gap).

## Notes
- `report_id` stays opaque (#2198) — no `/definitions` endpoint was added.
- `ListReportsParams` / `ListReportsResponse` types are left in place (still barrel-exported, now unused by the transport) to avoid unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1bsPNm8PMnjZFVTCHSZmN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1bsPNm8PMnjZFVTCHSZmN)_