### PR TITLE
gh-issue-2320: org-scoped file_key + signed Content-Length on presigned document PUT

### DIFF
--- a/backend/crates/common/src/lib.rs
+++ b/backend/crates/common/src/lib.rs
@@ -12,7 +12,7 @@ pub mod types;
 pub use errors::*;
 pub use i18n::{I18nResolver, Locale, MessageKey};
 pub use log_hash::{email_log_hash, EMAIL_LOG_HASH_LEN};
-pub use media::supports_inline_preview;
+pub use media::{supports_inline_preview, ALLOWED_UPLOAD_MIME_TYPES};
 pub use notifications::*;
 pub use sitemap::Sitemap;
 pub use tenant::*;

--- a/backend/crates/common/src/media.rs
+++ b/backend/crates/common/src/media.rs
@@ -1,5 +1,29 @@
 //! Shared media-type helpers.
 
+/// Allowed MIME types for end-user file uploads.
+///
+/// Single source of truth (GH #2320) shared by the document model
+/// (`db::models::ALLOWED_MIME_TYPES`) and the storage layer
+/// (`integrations::ALLOWED_MIME_TYPES`), both of which re-export this const.
+/// Previously the two crates kept independent, identical lists; drift between
+/// them surfaced as a confusing 503 `STORAGE_ERROR` (handler accepted, storage
+/// rejected) instead of a 400.
+pub const ALLOWED_UPLOAD_MIME_TYPES: &[&str] = &[
+    // Documents
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "text/plain",
+    "text/csv",
+    // Images
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+];
+
 /// Returns `true` for MIME types the platform renders **inline** (preview)
 /// rather than forcing a download.
 ///

--- a/backend/crates/db/src/models/document.rs
+++ b/backend/crates/db/src/models/document.rs
@@ -14,21 +14,11 @@ use uuid::Uuid;
 pub const MAX_FILE_SIZE: i64 = 50 * 1024 * 1024;
 
 /// Allowed MIME types for document upload.
-pub const ALLOWED_MIME_TYPES: &[&str] = &[
-    // Documents
-    "application/pdf",
-    "application/msword",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/vnd.ms-excel",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "text/plain",
-    "text/csv",
-    // Images
-    "image/png",
-    "image/jpeg",
-    "image/gif",
-    "image/webp",
-];
+///
+/// Re-export of the single source of truth in `common` (GH #2320) — the same
+/// list the storage layer (`integrations::ALLOWED_MIME_TYPES`) enforces, so
+/// handler-side and storage-side validation can never drift.
+pub use common::ALLOWED_UPLOAD_MIME_TYPES as ALLOWED_MIME_TYPES;
 
 /// Document category enum values.
 pub mod document_category {

--- a/backend/crates/integrations/src/storage.rs
+++ b/backend/crates/integrations/src/storage.rs
@@ -414,6 +414,10 @@ impl StorageService {
     ///
     /// * `key` - The S3 object key where the file will be stored
     /// * `content_type` - Expected MIME type of the upload
+    /// * `content_length` - Exact byte count of the upload. Signed into the
+    ///   URL (GH #2320), so S3 rejects a PUT whose `Content-Length` differs —
+    ///   this is what actually enforces the 50 MiB cap on the direct PUT path
+    ///   (presigned PUT has no `content-length-range` policy like POST does).
     /// * `expires_in_secs` - URL validity duration in seconds (default: 5 minutes)
     ///
     /// # Returns
@@ -423,6 +427,7 @@ impl StorageService {
         &self,
         key: &str,
         content_type: &str,
+        content_length: i64,
         expires_in_secs: Option<i64>,
     ) -> Result<PresignedUrl, StorageError> {
         // Validate content type
@@ -430,11 +435,25 @@ impl StorageService {
             return Err(StorageError::InvalidContentType(content_type.to_string()));
         }
 
+        // Validate size before touching the S3 client so callers get a typed
+        // error (and unit tests can pin this without a live client).
+        if content_length < 0 {
+            return Err(StorageError::UploadError(format!(
+                "content_length must be non-negative, got {content_length}"
+            )));
+        }
+        if content_length > MAX_UPLOAD_SIZE_BYTES {
+            return Err(StorageError::FileTooLarge(
+                content_length,
+                MAX_UPLOAD_SIZE_BYTES,
+            ));
+        }
+
         let expires_in = expires_in_secs.unwrap_or(DEFAULT_UPLOAD_EXPIRATION_SECS);
         let expires_at = Utc::now() + Duration::seconds(expires_in);
 
         let url = self
-            .build_presigned_put_url(key, content_type, expires_in)
+            .build_presigned_put_url(key, content_type, content_length, expires_in)
             .await?;
 
         Ok(PresignedUrl { url, expires_at })
@@ -518,10 +537,17 @@ impl StorageService {
     ///
     /// P0-05 (see build_presigned_get_url comment): real SigV4 via
     /// aws_sdk_s3 instead of the previous unsigned-URL placeholder.
+    ///
+    /// GH #2320: `Content-Length` is included as a signed header alongside
+    /// `Content-Type`, so a PUT whose body length differs from
+    /// `content_length` fails S3 signature validation. Without this the 50 MiB
+    /// cap was purely advisory — a presigned PUT accepts any body size when
+    /// only Content-Type is signed.
     async fn build_presigned_put_url(
         &self,
         key: &str,
         content_type: &str,
+        content_length: i64,
         expires_in: i64,
     ) -> Result<String, StorageError> {
         let client = self.get_s3_client()?;
@@ -534,6 +560,7 @@ impl StorageService {
             .bucket(&self.config.bucket)
             .key(key)
             .content_type(content_type)
+            .content_length(content_length)
             .presigned(presign_cfg)
             .await
             .map_err(|e| StorageError::PresignError(e.to_string()))?;
@@ -541,6 +568,7 @@ impl StorageService {
         tracing::debug!(
             key = %key,
             content_type = %content_type,
+            content_length = %content_length,
             expires_in = %expires_in,
             "Generated presigned upload URL"
         );
@@ -904,21 +932,12 @@ impl StorageService {
 // ============================================================================
 
 /// Allowed MIME types for upload.
-pub const ALLOWED_MIME_TYPES: &[&str] = &[
-    // Documents
-    "application/pdf",
-    "application/msword",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/vnd.ms-excel",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "text/plain",
-    "text/csv",
-    // Images
-    "image/png",
-    "image/jpeg",
-    "image/gif",
-    "image/webp",
-];
+///
+/// Re-export of the single source of truth in `common` (GH #2320) — the same
+/// list the document handlers (`db::models::ALLOWED_MIME_TYPES`) enforce, so
+/// handler-side and storage-side validation can never drift. Same pattern as
+/// [`supports_inline_preview`] (GH #1413).
+pub use common::ALLOWED_UPLOAD_MIME_TYPES as ALLOWED_MIME_TYPES;
 
 /// Check if a content type is allowed for upload.
 pub fn is_allowed_content_type(content_type: &str) -> bool {
@@ -1286,6 +1305,102 @@ mod tests {
             amz_expires_secs(&presigned.url),
             Some(120),
             "explicit preview TTL must be honoured in the signed URL"
+        );
+    }
+
+    // ========================================================================
+    // GH #2320 — presigned PUT must sign Content-Length.
+    //
+    // A presigned PUT that signs only Content-Type accepts a body of any size
+    // (up to S3's 5 GB single-PUT limit) — the 50 MiB cap was advisory. These
+    // pin that `generate_upload_url` (a) signs the exact byte count so S3
+    // rejects a mismatched PUT, and (b) rejects oversize/negative sizes before
+    // ever building a URL.
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_generate_upload_url_signs_content_length() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let presigned = service
+            .generate_upload_url("org/2026/07/file.pdf", "application/pdf", 1024, None)
+            .await
+            .expect("upload URL should mint");
+
+        assert!(
+            presigned.url.contains("X-Amz-Signature="),
+            "minted upload URL must be SigV4-signed, got {}",
+            presigned.url
+        );
+        // Content-Length (and Content-Type) must be *signed* headers — that is
+        // what makes S3 reject a PUT whose body length differs from the
+        // declared size. The `;` separator is percent-encoded in the URL.
+        let signed_headers = presigned
+            .url
+            .split(['?', '&'])
+            .find_map(|kv| kv.strip_prefix("X-Amz-SignedHeaders="))
+            .expect("presigned URL must carry X-Amz-SignedHeaders")
+            .to_lowercase()
+            .replace("%3b", ";");
+        assert!(
+            signed_headers.contains("content-length"),
+            "content-length must be a signed header, got {signed_headers}"
+        );
+        assert!(
+            signed_headers.contains("content-type"),
+            "content-type must be a signed header, got {signed_headers}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_upload_url_allows_exactly_max_size() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        assert!(service
+            .generate_upload_url("org/k.pdf", "application/pdf", MAX_UPLOAD_SIZE_BYTES, None)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_generate_upload_url_rejects_oversize_content_length() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let err = service
+            .generate_upload_url(
+                "org/k.pdf",
+                "application/pdf",
+                MAX_UPLOAD_SIZE_BYTES + 1,
+                None,
+            )
+            .await
+            .expect_err("oversize content_length must be rejected");
+        assert!(
+            matches!(err, StorageError::FileTooLarge(..)),
+            "expected FileTooLarge, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_upload_url_rejects_negative_content_length() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let err = service
+            .generate_upload_url("org/k.pdf", "application/pdf", -1, None)
+            .await
+            .expect_err("negative content_length must be rejected");
+        assert!(
+            matches!(err, StorageError::UploadError(_)),
+            "expected UploadError, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_upload_url_rejects_disallowed_content_type() {
+        let service = presigning_service(DEFAULT_DOWNLOAD_EXPIRATION_SECS).await;
+        let err = service
+            .generate_upload_url("org/k.html", "text/html", 10, None)
+            .await
+            .expect_err("disallowed content type must be rejected");
+        assert!(
+            matches!(err, StorageError::InvalidContentType(_)),
+            "expected InvalidContentType, got {err:?}"
         );
     }
 

--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -354,9 +354,11 @@ pub struct CreateUploadUrlRequest {
     /// `Content-Type` header on the subsequent PUT, because the presigned URL
     /// is signed for exactly this content type.
     pub mime_type: String,
-    /// Optional declared size in bytes. When present it is validated against the
-    /// 50 MiB cap up-front so an oversize upload is rejected before the client
-    /// wastes a round-trip to S3. S3 still enforces the real byte count.
+    /// Exact size of the upload in bytes. REQUIRED (GH #2320): it is validated
+    /// against the 50 MiB cap up-front and signed into the presigned URL as
+    /// `Content-Length`, so S3 rejects a PUT whose body length differs. The
+    /// client MUST send exactly this many bytes. Kept `Option` at the serde
+    /// layer only so a missing field yields a clear 400 instead of a 422.
     #[serde(default)]
     pub size_bytes: Option<i64>,
 }
@@ -546,6 +548,16 @@ async fn create_document(
             )),
         ));
     }
+
+    // SECURITY (#2320): file_key must lie inside the caller's org namespace.
+    // Both key producers (the presigned upload-url mint and the multipart
+    // upload path) emit `{org_id}/{year}/{month}/{uuid}_{name}` via
+    // `integrations::generate_storage_key`. Without this guard, any org member
+    // could register a "document" pointing at an arbitrary bucket object
+    // (another org's files, or a `messages/{thread_id}/…` attachment) and then
+    // exfiltrate it through the presigned download/preview handlers — the same
+    // bucket-wide IDOR fixed for messaging in #1791/#1770.
+    validate_file_key_org_scope(&req.file_key, org_id)?;
 
     // Validate category
     if !document_category::ALL.contains(&req.category.as_str()) {
@@ -1499,17 +1511,47 @@ async fn get_preview_url(
 // Presigned Upload-URL Handler (gap-84-1)
 // ============================================================================
 
+/// Validate that a client-supplied `file_key` lies inside the caller's org
+/// namespace (GH #2320).
+///
+/// Mirrors the messaging guard from #1791/#1770 (`link_message_attachment`):
+/// the key must start with the tenant's own `{org_id}/` prefix (the shape both
+/// key producers emit via `integrations::generate_storage_key`) and must not
+/// contain a `..` component. Kept as a pure function so the accept/reject
+/// contract can be unit-tested without a DB.
+fn validate_file_key_org_scope(
+    file_key: &str,
+    org_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let expected_prefix = format!("{org_id}/");
+    if !file_key.starts_with(&expected_prefix) || file_key.contains("..") {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "INVALID_FILE_KEY",
+                "file_key must reference an object uploaded for this organization",
+            )),
+        ));
+    }
+    Ok(())
+}
+
 /// Validate a presigned-upload request before minting a URL (gap-84-1).
 ///
 /// Mirrors the eager checks the multipart [`upload_document`] handler runs on
 /// received bytes, but applied up-front to the client's *declared* `mime_type`
 /// / `size_bytes` so an invalid request is rejected before a presigned URL is
 /// handed out. Kept as a pure function so it can be unit-tested without a live
-/// S3 client or DB. Returns the client error tuple on failure.
+/// S3 client or DB.
+///
+/// GH #2320: `size_bytes` is now REQUIRED — it is signed into the presigned
+/// PUT URL as `Content-Length`, which is what actually enforces the 50 MiB
+/// cap on the direct-to-S3 path. Returns the validated size on success, or
+/// the client error tuple on failure.
 fn validate_upload_url_request(
     mime_type: &str,
     size_bytes: Option<i64>,
-) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<i64, (StatusCode, Json<ErrorResponse>)> {
     if !ALLOWED_MIME_TYPES.contains(&mime_type) {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -1523,28 +1565,35 @@ fn validate_upload_url_request(
         ));
     }
 
-    if let Some(size) = size_bytes {
-        if size < 0 {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                Json(ErrorResponse::new(
-                    "BAD_REQUEST",
-                    "size_bytes must be non-negative",
-                )),
-            ));
-        }
-        if size > MAX_FILE_SIZE {
-            return Err((
-                StatusCode::PAYLOAD_TOO_LARGE,
-                Json(ErrorResponse::new(
-                    "FILE_TOO_LARGE",
-                    format!("File exceeds maximum size of {MAX_FILE_SIZE} bytes (50 MiB)"),
-                )),
-            ));
-        }
+    let Some(size) = size_bytes else {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "BAD_REQUEST",
+                "size_bytes is required — it is signed into the upload URL as Content-Length",
+            )),
+        ));
+    };
+    if size < 0 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "BAD_REQUEST",
+                "size_bytes must be non-negative",
+            )),
+        ));
+    }
+    if size > MAX_FILE_SIZE {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            Json(ErrorResponse::new(
+                "FILE_TOO_LARGE",
+                format!("File exceeds maximum size of {MAX_FILE_SIZE} bytes (50 MiB)"),
+            )),
+        ));
     }
 
-    Ok(())
+    Ok(size)
 }
 
 /// Mint a presigned PUT URL for direct client-to-S3 upload (gap-84-1).
@@ -1554,7 +1603,9 @@ fn validate_upload_url_request(
 ///   1. `POST /api/v1/documents/upload-url` → this handler returns a short-lived
 ///      presigned PUT URL plus the storage `file_key`.
 ///   2. Client `PUT`s the bytes directly to that URL, setting
-///      `Content-Type: <content_type>` so the request matches the signature.
+///      `Content-Type: <content_type>` and a `Content-Length` equal to the
+///      declared `size_bytes` — both are signed headers (GH #2320), so a
+///      mismatched request fails S3 signature validation.
 ///   3. Client `POST`s `/api/v1/documents` with the `file_key` to register the
 ///      document record.
 ///
@@ -1592,7 +1643,7 @@ async fn create_upload_url(
         req.mime_type.clone()
     };
 
-    validate_upload_url_request(&content_type, req.size_bytes)?;
+    let size_bytes = validate_upload_url_request(&content_type, req.size_bytes)?;
 
     // Presigning needs a real S3 client. StorageService::from_env() (sync) does
     // not create one, so gate on has_s3_client() — same 503 contract the
@@ -1622,8 +1673,10 @@ async fn create_upload_url(
     let file_key = integrations::generate_storage_key(org_id, &req.file_name);
 
     // Default TTL (5 min) is applied by generate_upload_url when None is passed.
+    // size_bytes is signed into the URL as Content-Length (GH #2320) so S3
+    // rejects a PUT whose body length differs from the declared size.
     let presigned = storage
-        .generate_upload_url(&file_key, &content_type, None)
+        .generate_upload_url(&file_key, &content_type, size_bytes, None)
         .await
         .map_err(|e| {
             tracing::error!(

--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -1519,7 +1519,7 @@ async fn get_preview_url(
 /// key producers emit via `integrations::generate_storage_key`) and must not
 /// contain a `..` component. Kept as a pure function so the accept/reject
 /// contract can be unit-tested without a DB.
-fn validate_file_key_org_scope(
+pub(crate) fn validate_file_key_org_scope(
     file_key: &str,
     org_id: Uuid,
 ) -> Result<(), (StatusCode, Json<ErrorResponse>)> {

--- a/backend/servers/api-server/src/routes/documents/document_access_test.rs
+++ b/backend/servers/api-server/src/routes/documents/document_access_test.rs
@@ -1,4 +1,7 @@
-use super::{document_access_allowed, scope_membership_allows, validate_upload_url_request};
+use super::{
+    document_access_allowed, scope_membership_allows, validate_file_key_org_scope,
+    validate_upload_url_request,
+};
 use axum::http::StatusCode;
 use chrono::Utc;
 use db::models::Document;
@@ -227,12 +230,23 @@ fn membership_never_grants_non_building_unit_scopes() {
 
 #[test]
 fn upload_url_request_accepts_allowed_type_and_size() {
-    // Allowed MIME with a within-limit size hint.
-    assert!(validate_upload_url_request("application/pdf", Some(1024)).is_ok());
-    // Size hint omitted is fine — S3 still enforces the real byte count.
-    assert!(validate_upload_url_request("image/png", None).is_ok());
+    // Allowed MIME with a within-limit size; the validated size is echoed back.
+    assert_eq!(
+        validate_upload_url_request("application/pdf", Some(1024)).expect("valid request"),
+        1024
+    );
     // Exactly at the cap is allowed.
     assert!(validate_upload_url_request("image/jpeg", Some(db::models::MAX_FILE_SIZE)).is_ok());
+}
+
+#[test]
+fn upload_url_request_rejects_missing_size() {
+    // GH #2320: size_bytes is required — it is signed into the presigned PUT
+    // URL as Content-Length, which is what actually enforces the 50 MiB cap
+    // on the direct-to-S3 path.
+    let err = validate_upload_url_request("image/png", None)
+        .expect_err("missing size_bytes must be rejected");
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
 }
 
 #[test]
@@ -255,4 +269,63 @@ fn upload_url_request_rejects_negative_size() {
     let err = validate_upload_url_request("application/pdf", Some(-1))
         .expect_err("negative size must be rejected");
     assert_eq!(err.0, StatusCode::BAD_REQUEST);
+}
+
+// ----------------------------------------------------------------------------
+// GH #2320 — org-scoped file_key guard at document registration.
+//
+// `validate_file_key_org_scope` is the pure guard `create_document` applies to
+// the client-supplied `file_key` before persisting it. Without it, any org
+// member could register a "document" pointing at an arbitrary bucket object
+// (another org's files, `messages/{thread_id}/…` attachments) and exfiltrate
+// it via the presigned download/preview handlers — a bucket-wide IDOR
+// (mirrors the messaging guard from #1791/#1770).
+// ----------------------------------------------------------------------------
+
+#[test]
+fn file_key_own_org_prefix_accepted() {
+    let org_id = Uuid::new_v4();
+    // Shape emitted by integrations::generate_storage_key.
+    let key = format!("{org_id}/2026/07/{}_report.pdf", Uuid::new_v4());
+    assert!(validate_file_key_org_scope(&key, org_id).is_ok());
+}
+
+#[test]
+fn file_key_foreign_org_prefix_rejected() {
+    let org_id = Uuid::new_v4();
+    let other_org = Uuid::new_v4();
+    let key = format!("{other_org}/2026/07/{}_secret.pdf", Uuid::new_v4());
+    let err = validate_file_key_org_scope(&key, org_id)
+        .expect_err("foreign-org file_key must be rejected");
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn file_key_messages_prefix_rejected() {
+    let org_id = Uuid::new_v4();
+    let key = format!("messages/{}/{}", Uuid::new_v4(), Uuid::new_v4());
+    let err = validate_file_key_org_scope(&key, org_id)
+        .expect_err("message-attachment file_key must be rejected");
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn file_key_with_dot_dot_rejected_even_under_own_prefix() {
+    let org_id = Uuid::new_v4();
+    let key = format!("{org_id}/../{}/2026/07/escape.pdf", Uuid::new_v4());
+    let err =
+        validate_file_key_org_scope(&key, org_id).expect_err("path traversal must be rejected");
+    assert_eq!(err.0, StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn file_key_empty_and_bare_prefix_variants_rejected() {
+    let org_id = Uuid::new_v4();
+    // Empty key.
+    assert!(validate_file_key_org_scope("", org_id).is_err());
+    // Org id without the trailing slash separator.
+    assert!(validate_file_key_org_scope(&org_id.to_string(), org_id).is_err());
+    // Prefix-substring trick: `{org_id}abc/...` must not match `{org_id}/`.
+    let tricky = format!("{org_id}abc/2026/07/file.pdf");
+    assert!(validate_file_key_org_scope(&tricky, org_id).is_err());
 }

--- a/backend/servers/api-server/src/routes/documents/versions.rs
+++ b/backend/servers/api-server/src/routes/documents/versions.rs
@@ -161,6 +161,12 @@ async fn create_version(
         ));
     }
 
+    // SECURITY (#2320): the version's file_key must lie inside the caller's org
+    // namespace, same as document registration — otherwise a member could point
+    // a new version at another org's bucket object and exfiltrate it through the
+    // version download/preview presign.
+    validate_file_key_org_scope(&req.file_key, tenant.tenant_id)?;
+
     let data = CreateDocumentVersion {
         file_key: req.file_key,
         file_name: req.file_name,

--- a/backend/servers/api-server/src/routes/messaging.rs
+++ b/backend/servers/api-server/src/routes/messaging.rs
@@ -1446,8 +1446,11 @@ async fn request_attachment_upload_url(
         }
     };
 
+    // file_size is signed into the URL as Content-Length (GH #2320) so S3
+    // rejects a PUT whose body length differs from the declared size — this
+    // is what actually enforces the size cap on the direct PUT path.
     let presigned = storage
-        .generate_upload_url(&file_key, &body.file_type, None)
+        .generate_upload_url(&file_key, &body.file_type, body.file_size, None)
         .await
         .map_err(|e| {
             // Content-type rejections are a client error; everything else is a

--- a/backend/servers/api-server/tests/documents_core_crud_tests.rs
+++ b/backend/servers/api-server/tests/documents_core_crud_tests.rs
@@ -110,7 +110,7 @@ async fn create_document_succeeds(pool: PgPool) {
                 .json(json!({
                     "title": "Contract 2026",
                     "category": "contracts",
-                    "file_key": "org/contracts/2026.pdf",
+                    "file_key": format!("{org_id}/contracts/2026.pdf"),
                     "file_name": "2026.pdf",
                     "mime_type": "application/pdf",
                     "size_bytes": 4096
@@ -277,7 +277,7 @@ async fn create_version_succeeds(pool: PgPool) {
             app.session(token, org_id)
                 .post(&format!("/api/v1/documents/{doc_id}/versions"))
                 .json(json!({
-                    "file_key": "org/docs/v2.pdf",
+                    "file_key": format!("{org_id}/docs/v2.pdf"),
                     "file_name": "v2.pdf",
                     "mime_type": "application/pdf",
                     "size_bytes": 8192


### PR DESCRIPTION
## Context
Follow-up from post-merge review of PR #2309 (presigned direct-to-S3 upload). Closes the two HIGH-severity findings.

## Changes
- **file_key IDOR at registration (HIGH)** — `create_document` inserted client-supplied `req.file_key` verbatim; download/preview handlers then presign GET on it, so any org member could register a document pointing at another org's object (or a `messages/{thread}/…` attachment) and exfiltrate it. Added `validate_file_key_org_scope()` (pure, unit-tested): requires the key to start with the caller's `{org_id}/` prefix and rejects any `..` component — mirroring the messaging guard from #1791/#1770.
- **50 MiB cap not enforced on presigned PUT (HIGH)** — `build_presigned_put_url` signed only Content-Type, leaving Content-Length unsigned (any body size accepted). `size_bytes` is now required on the mint endpoint and signed via `.content_length(...)` so S3 rejects size mismatches; the upload-url handler rejects missing/negative/oversize sizes up front.
- MIME allowlist consolidation into `common` (finding 5) where it was a clean hoist.

## Scope
Findings 1, 2, 5 of #2320. Finding 3 (completion tracking / orphaned-object reconcile job) remains tracked in #2320.

## Verification
- `cargo check -p api-server -p integrations -p common -p db` — clean
- `cargo test -p integrations storage` — 23 passed (incl. new `signs_content_length`, `rejects_oversize_content_length`, `rejects_negative_content_length`, `allows_exactly_max_size`)
- new accept/reject unit tests for `validate_file_key_org_scope` in `document_access_test.rs`
- `cargo fmt` applied

Refs #2320