### PR TITLE
gh-issue-2318: give report-schedule scheduler worker RLS context so due schedules actually fire

### DIFF
--- a/backend/crates/db/migrations/00218_report_schedules_worker_rls.sql
+++ b/backend/crates/db/migrations/00218_report_schedules_worker_rls.sql
@@ -1,0 +1,68 @@
+-- Issue #2318 (findings 1 + 4, follow-up to PR #2313): give the report-schedule
+-- due-work consumer a working RLS context + a due-work index.
+--
+-- Background
+-- ----------
+-- `report_schedules` / `report_executions` (00162) carry FORCE ROW LEVEL
+-- SECURITY with a `is_super_admin() OR organization_id = get_current_org_id()`
+-- policy, and the production api-server connects as the table OWNER — bound by
+-- FORCE, no BYPASSRLS (00179). The background scheduler
+-- (`api-server::services::scheduler::fire_due_report_schedules`, PR #2313) ran
+-- its due-work SELECT on the bare pool with no GUC set, so
+-- `get_current_org_id()` returned NULL, the policy evaluated false, and the
+-- query **silently returned 0 rows**: scheduled reports never fired in prod.
+--
+-- Fix (mirrors 00136_listings_global_read_policy.sql)
+-- ---------------------------------------------------
+-- Add an `is_global_read_context()` SELECT-only leg so the context-less
+-- worker can opt into the 4th RLS context (`set_global_read_context(TRUE)`)
+-- for the cross-org due-work read. Policies for the same command are OR'd,
+-- so a separate FOR SELECT policy extends the existing FOR ALL policy without
+-- touching it.
+--
+-- Writes stay org-scoped: FOR SELECT policies have no WITH CHECK, so the
+-- existing tenant-isolation policy remains the only INSERT/UPDATE/DELETE
+-- gate. The scheduler performs its per-schedule writes (`record_execution`,
+-- `advance_after_run`) under `set_tenant_context(schedule.organization_id)`.
+
+-- ============================================================================
+-- report_schedules: global-read SELECT leg for the scheduler worker.
+-- ============================================================================
+DROP POLICY IF EXISTS report_schedules_global_read ON report_schedules;
+
+CREATE POLICY report_schedules_global_read ON report_schedules
+    FOR SELECT
+    USING (is_global_read_context());
+
+COMMENT ON POLICY report_schedules_global_read ON report_schedules IS
+    'Issue #2318: cross-org SELECT for context-less background workers '
+    '(app.global_read = on). Read-only — writes remain gated by the '
+    'org-scoped report_schedules_tenant_isolation policy.';
+
+-- ============================================================================
+-- report_executions: same leg, so the worker (and any future generator
+-- worker consuming pending executions) can read execution rows cross-org.
+-- ============================================================================
+DROP POLICY IF EXISTS report_executions_global_read ON report_executions;
+
+CREATE POLICY report_executions_global_read ON report_executions
+    FOR SELECT
+    USING (is_global_read_context());
+
+COMMENT ON POLICY report_executions_global_read ON report_executions IS
+    'Issue #2318: cross-org SELECT for context-less background workers '
+    '(app.global_read = on). Read-only — writes remain gated by the '
+    'org-scoped report_executions_tenant_isolation policy.';
+
+-- ============================================================================
+-- Due-work partial index (issue #2318, finding 4).
+--
+-- `get_due_schedules` filters
+--   `WHERE is_active AND next_run_at IS NOT NULL AND next_run_at <= NOW()`
+-- every 60s, but 00162 only indexed organization_id and status — a full-table
+-- scan per tick. Mirrors `idx_workflow_schedules_next` (00047) and
+-- `idx_automation_rules_next_run` (00064).
+-- ============================================================================
+CREATE INDEX IF NOT EXISTS idx_report_schedules_next
+    ON report_schedules(next_run_at)
+    WHERE is_active = TRUE AND next_run_at IS NOT NULL;

--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -13,6 +13,7 @@ use crate::models::report_schedule::{
 use crate::DbPool;
 use chrono::{DateTime, Duration, Utc};
 use common::errors::AppError;
+use sqlx::{Executor, Postgres};
 use uuid::Uuid;
 
 /// Canonical projection for `report_schedules` rows.
@@ -630,10 +631,24 @@ impl ReportScheduleRepository {
     ///
     /// A NULL `next_run_at` (parked schedule — see [`Self::advance_after_run`])
     /// is excluded, so a schedule whose next fire could not be computed does not
-    /// re-fire. Runs unscoped on the pool because the background scheduler has no
-    /// request tenant; each returned row still carries its own `organization_id`
-    /// for downstream per-tenant handling.
-    pub async fn get_due_schedules(&self) -> Result<Vec<ReportSchedule>, AppError> {
+    /// re-fire. Each returned row carries its own `organization_id` for
+    /// downstream per-tenant handling.
+    ///
+    /// RLS (issue #2318): `report_schedules` has FORCE RLS, so this must NOT
+    /// run on the bare pool — with no GUC set, `get_current_org_id()` returns
+    /// NULL, the tenant-isolation policy evaluates false, and the query
+    /// silently returns 0 rows. The caller must supply an executor (a
+    /// checked-out connection) with `set_global_read_context(TRUE)` applied so
+    /// the cross-org `report_schedules_global_read` SELECT policy (migration
+    /// 00216) grants visibility. Follows the executor-passing shape of
+    /// `WorkflowRepository::list_due_schedules`.
+    pub async fn get_due_schedules<'e, E>(
+        &self,
+        executor: E,
+    ) -> Result<Vec<ReportSchedule>, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let rows = sqlx::query_as::<_, ReportScheduleRow>(concat!(
             "SELECT ",
             report_schedule_columns!(),
@@ -643,7 +658,7 @@ impl ReportScheduleRepository {
                AND next_run_at <= NOW() \
              ORDER BY next_run_at ASC"
         ))
-        .fetch_all(&self.pool)
+        .fetch_all(executor)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to fetch due report schedules");
@@ -662,11 +677,19 @@ impl ReportScheduleRepository {
     /// (no `COALESCE`): a `None` deliberately parks the schedule with a NULL
     /// `next_run_at` so a fire whose next occurrence could not be computed stops
     /// re-firing on every tick instead of spinning on a stale past timestamp.
-    pub async fn advance_after_run(
+    ///
+    /// RLS (issue #2318): under FORCE RLS an unscoped UPDATE matches 0 rows →
+    /// `fetch_one` → RowNotFound. The caller must supply an executor with
+    /// `set_tenant_context(schedule.organization_id)` applied.
+    pub async fn advance_after_run<'e, E>(
         &self,
+        executor: E,
         id: Uuid,
         next_run_at: Option<DateTime<Utc>>,
-    ) -> Result<ReportSchedule, AppError> {
+    ) -> Result<ReportSchedule, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         let row = sqlx::query_as::<_, ReportScheduleRow>(concat!(
             "UPDATE report_schedules \
              SET last_run_at = NOW(), next_run_at = $2, updated_at = NOW() \
@@ -676,7 +699,7 @@ impl ReportScheduleRepository {
         ))
         .bind(id)
         .bind(next_run_at)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, schedule_id = %id, "Failed to advance report schedule after run");
@@ -693,7 +716,19 @@ impl ReportScheduleRepository {
     /// Story 81.2 execution-history endpoints. The row starts in `pending`; a
     /// downstream report generator transitions it to
     /// `running`/`completed`/`failed`.
-    pub async fn record_execution(&self, schedule_id: Uuid) -> Result<ReportExecution, AppError> {
+    ///
+    /// RLS (issue #2318): `report_executions` has FORCE RLS with an org-scoped
+    /// `WITH CHECK` (via the parent schedule), so an unscoped INSERT is
+    /// rejected. The caller must supply an executor with
+    /// `set_tenant_context(schedule.organization_id)` applied.
+    pub async fn record_execution<'e, E>(
+        &self,
+        executor: E,
+        schedule_id: Uuid,
+    ) -> Result<ReportExecution, AppError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
         sqlx::query_as::<_, ReportExecution>(
             r#"
             INSERT INTO report_executions (schedule_id, status)
@@ -707,7 +742,7 @@ impl ReportScheduleRepository {
         )
         .bind(schedule_id)
         .bind(report_execution_status::PENDING)
-        .fetch_one(&self.pool)
+        .fetch_one(executor)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, schedule_id = %schedule_id, "Failed to record report execution");

--- a/backend/crates/db/tests/report_schedule_scheduler_rls_tests.rs
+++ b/backend/crates/db/tests/report_schedule_scheduler_rls_tests.rs
@@ -1,0 +1,225 @@
+//! RLS regression test for the report-schedule due-work consumer (issue #2318,
+//! follow-up to PR #2313).
+//!
+//! Background
+//! ----------
+//! `report_schedules` / `report_executions` (migration 00162) carry FORCE ROW
+//! LEVEL SECURITY with an org-scoped policy, and the production api-server
+//! connects as the table OWNER — bound by FORCE, no BYPASSRLS (00179). The
+//! scheduler's `fire_due_report_schedules` loop originally ran on the bare
+//! pool with no GUC set, so:
+//!
+//!   * `get_due_schedules()` silently returned 0 rows (policy false),
+//!   * `record_execution()`'s INSERT failed its WITH CHECK,
+//!   * `advance_after_run()`'s UPDATE matched 0 rows → RowNotFound.
+//!
+//! Migration 00216 adds an `is_global_read_context()` SELECT-only leg to both
+//! tables, and the scheduler now reads due work under the global-read context
+//! and writes under each schedule's own tenant context.
+//!
+//! This test exercises the full select → record → advance loop through the
+//! repository methods on a `NOSUPERUSER NOBYPASSRLS` role (FORCE does not bind
+//! the `#[sqlx::test]` superuser, so a behavioral assertion would otherwise
+//! pass vacuously — same role-switch discipline as `budget_rls_repo_tests.rs`):
+//!
+//!   1. **Deny-all reproduction** — role bound, NO context set (the exact
+//!      pre-fix scheduler behavior): `get_due_schedules` returns nothing even
+//!      though a due schedule exists.
+//!   2. **Global-read fix** — with `set_global_read_context(TRUE)` the due
+//!      schedule is visible cross-org, and the global-read context cannot
+//!      WRITE (INSERT into `report_executions` is rejected).
+//!   3. **Tenant-context writes** — under
+//!      `set_tenant_context(schedule.organization_id)`, `record_execution`
+//!      creates a `pending` row and `advance_after_run(id, None)` parks the
+//!      schedule (NULL `next_run_at`), after which it stops appearing as due.
+
+use db::repositories::ReportScheduleRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org_id)
+        .bind(user_id)
+        .bind(is_super_admin)
+        .execute(pool)
+        .await
+        .expect("set_request_context");
+}
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Reports {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@reports.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+/// Seed a due schedule directly (as superuser, RLS-exempt): active, with a
+/// `next_run_at` one hour in the past so `get_due_schedules` should return it.
+async fn seed_due_schedule(pool: &PgPool, org_id: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO report_schedules
+            (report_id, organization_id, name, frequency, is_active, status, next_run_at)
+        VALUES ($1, $2, $3, 'daily', TRUE, 'active', NOW() - INTERVAL '1 hour')
+        RETURNING id
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(org_id)
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("seed due schedule")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn scheduler_due_work_loop_under_force_rls(pool: PgPool) {
+    let repo = ReportScheduleRepository::new(pool.clone());
+
+    // --- Seed as superuser / super-admin context. ---
+    set_ctx(&pool, None, None, true).await;
+    let org_a = seed_org(
+        &pool,
+        format!("rls-reports-a-{}", Uuid::new_v4().simple()).as_str(),
+    )
+    .await;
+    let org_b = seed_org(
+        &pool,
+        format!("rls-reports-b-{}", Uuid::new_v4().simple()).as_str(),
+    )
+    .await;
+    let schedule_a = seed_due_schedule(&pool, org_a, "Due schedule A").await;
+    let schedule_b = seed_due_schedule(&pool, org_b, "Due schedule B").await;
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE actually binds (the production
+    //     owner role experiences the policies the same way). ---
+    let role = format!("ppt_rls_reports_{}", Uuid::new_v4().simple());
+    for stmt in [
+        format!("CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"),
+        format!(
+            "GRANT SELECT, INSERT, UPDATE, DELETE ON report_schedules, report_executions TO \"{role}\""
+        ),
+        format!(
+            "GRANT EXECUTE ON FUNCTION get_current_org_id(), is_super_admin(), \
+             is_global_read_context(), set_global_read_context(BOOLEAN), \
+             set_tenant_context(UUID), clear_request_context() TO \"{role}\""
+        ),
+        format!("GRANT SELECT ON organizations TO \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .expect("grant setup");
+    }
+
+    let mut conn = pool.acquire().await.expect("acquire");
+    sqlx::query("SELECT clear_request_context()")
+        .execute(&mut *conn)
+        .await
+        .expect("clear ctx");
+    sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+        .execute(&mut *conn)
+        .await
+        .expect("set role");
+
+    // ====================================================================
+    // (1) DENY-ALL reproduction: no context set — the pre-fix scheduler
+    //     behavior. Both due schedules exist but the read returns nothing.
+    // ====================================================================
+    let due = repo
+        .get_due_schedules(&mut *conn)
+        .await
+        .expect("due query without context should not error");
+    assert!(
+        due.is_empty(),
+        "FORCE RLS with no context must silently hide due schedules (pre-#2318 no-op repro)"
+    );
+
+    // ====================================================================
+    // (2) Global-read context: the cross-org due-work read now works.
+    // ====================================================================
+    db::tenant_context::set_global_read_context(&mut *conn, true)
+        .await
+        .expect("set global-read context");
+
+    let due = repo
+        .get_due_schedules(&mut *conn)
+        .await
+        .expect("due query under global-read context");
+    let due_ids: Vec<Uuid> = due.iter().map(|s| s.id).collect();
+    assert!(
+        due_ids.contains(&schedule_a) && due_ids.contains(&schedule_b),
+        "global-read context must see due schedules across orgs, got {due_ids:?}"
+    );
+    let sched_a = due
+        .iter()
+        .find(|s| s.id == schedule_a)
+        .expect("schedule A present");
+    assert_eq!(sched_a.organization_id, org_a, "row carries its own org id");
+
+    // Global-read is SELECT-only: recording an execution from this context
+    // must be rejected by the org-scoped WITH CHECK.
+    let write_from_global = repo.record_execution(&mut *conn, schedule_a).await;
+    assert!(
+        write_from_global.is_err(),
+        "global-read context must not be able to INSERT report_executions"
+    );
+
+    // ====================================================================
+    // (3) Tenant-context writes: record + advance under the schedule's org.
+    // ====================================================================
+    db::tenant_context::set_global_read_context(&mut *conn, false)
+        .await
+        .expect("drop global-read context");
+    db::tenant_context::set_tenant_context(&mut *conn, org_a)
+        .await
+        .expect("set tenant context for org A");
+
+    let execution = repo
+        .record_execution(&mut *conn, schedule_a)
+        .await
+        .expect("record_execution under tenant context");
+    assert_eq!(execution.schedule_id, schedule_a);
+    assert_eq!(execution.status, "pending");
+
+    // advance_after_run(id, None) parks the schedule (NULL next_run_at).
+    let advanced = repo
+        .advance_after_run(&mut *conn, schedule_a, None)
+        .await
+        .expect("advance_after_run under tenant context");
+    assert_eq!(advanced.id, schedule_a);
+    assert!(
+        advanced.next_run_at.is_none(),
+        "None next_run_at must park the schedule"
+    );
+    assert!(advanced.last_run_at.is_some(), "advance stamps last_run_at");
+
+    // The parked schedule stops appearing as due; org B's untouched schedule
+    // is still due.
+    db::tenant_context::set_global_read_context(&mut *conn, true)
+        .await
+        .expect("re-enter global-read context");
+    let due_after = repo
+        .get_due_schedules(&mut *conn)
+        .await
+        .expect("due query after advance");
+    let due_after_ids: Vec<Uuid> = due_after.iter().map(|s| s.id).collect();
+    assert!(
+        !due_after_ids.contains(&schedule_a),
+        "parked schedule must not re-fire"
+    );
+    assert!(
+        due_after_ids.contains(&schedule_b),
+        "unrelated due schedule must remain due"
+    );
+}

--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -1382,9 +1382,46 @@ impl Scheduler {
     /// concern — a future generator worker consumes the `pending` executions
     /// recorded here and transitions them to completed/failed. This method owns
     /// only the select-fire-advance loop.
+    ///
+    /// RLS (issue #2318): both tables carry FORCE RLS, and the production
+    /// api-server connects as the table owner (bound by FORCE, no BYPASSRLS —
+    /// see migration 00179). Running on the bare pool therefore made this loop
+    /// a silent no-op: no GUC set → `get_current_org_id()` NULL → the due-work
+    /// SELECT returned 0 rows. The loop now checks out a dedicated connection,
+    /// reads due work under the global-read context (SELECT-only policy leg,
+    /// migration 00218), and performs each schedule's writes under that
+    /// schedule's own tenant context. The context is cleared before the
+    /// connection returns to the pool.
     async fn fire_due_report_schedules(&self) -> Result<(), common::errors::AppError> {
-        let due = self.report_schedule_repo.get_due_schedules().await?;
+        // Dedicated connection: RLS context GUCs are session-local, so the
+        // whole select-fire-advance loop must run on one connection.
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .map_err(|e| common::errors::AppError::Database(e.to_string()))?;
+
+        // Global-read context for the cross-org due-work SELECT.
+        db::tenant_context::set_global_read_context(&mut *conn, true)
+            .await
+            .map_err(|e| common::errors::AppError::Database(e.to_string()))?;
+
+        let due = self
+            .report_schedule_repo
+            .get_due_schedules(&mut *conn)
+            .await;
+
+        // Drop the global-read flag before any writes; the per-schedule writes
+        // below run under each schedule's own tenant context.
+        db::tenant_context::set_global_read_context(&mut *conn, false)
+            .await
+            .map_err(|e| common::errors::AppError::Database(e.to_string()))?;
+
+        let due = due?;
         if due.is_empty() {
+            db::tenant_context::clear_request_context(&mut *conn)
+                .await
+                .map_err(|e| common::errors::AppError::Database(e.to_string()))?;
             return Ok(());
         }
 
@@ -1394,12 +1431,26 @@ impl Scheduler {
         let mut fired = 0u64;
 
         for schedule in &due {
+            // Each due row carries its organization_id: scope the connection to
+            // that tenant so the org-scoped write policies pass.
+            if let Err(e) =
+                db::tenant_context::set_tenant_context(&mut *conn, schedule.organization_id).await
+            {
+                tracing::error!(
+                    schedule_id = %schedule.id,
+                    organization_id = %schedule.organization_id,
+                    error = %e,
+                    "Failed to set tenant context — leaving schedule due for retry"
+                );
+                continue;
+            }
+
             // Record the fire in execution history (Story 81.2). If this fails,
             // skip the advance so the schedule stays due and retries next tick
             // instead of silently losing the run.
             if let Err(e) = self
                 .report_schedule_repo
-                .record_execution(schedule.id)
+                .record_execution(&mut *conn, schedule.id)
                 .await
             {
                 tracing::error!(
@@ -1421,7 +1472,7 @@ impl Scheduler {
 
             if let Err(e) = self
                 .report_schedule_repo
-                .advance_after_run(schedule.id, next)
+                .advance_after_run(&mut *conn, schedule.id, next)
                 .await
             {
                 tracing::error!(
@@ -1440,6 +1491,12 @@ impl Scheduler {
                 "Fired report schedule and advanced next_run_at"
             );
         }
+
+        // Defensive: reset every RLS-relevant GUC before the connection goes
+        // back to the pool so tenant context cannot bleed onto the next user.
+        db::tenant_context::clear_request_context(&mut *conn)
+            .await
+            .map_err(|e| common::errors::AppError::Database(e.to_string()))?;
 
         if fired > 0 {
             let mut metrics = self.metrics.lock().unwrap();


### PR DESCRIPTION
## Context
Follow-up from post-merge review of PR #2313. The report-schedule due-work consumer was a **silent no-op in production**: `report_schedules`/`report_executions` carry FORCE RLS and the api-server connects as the table owner (bound by FORCE, no BYPASSRLS — 00179). The scheduler ran its due-work SELECT on the bare pool with no GUC, so `get_current_org_id()` was NULL, the policy evaluated false, and the query returned 0 rows — scheduled reports never fired.

## Changes
- **Migration `00218_report_schedules_worker_rls.sql`** — adds a SELECT-only `is_global_read_context()` policy leg to both tables (mirrors `00136_listings_global_read_policy.sql`); writes stay gated by the existing org-scoped tenant-isolation policy. Also adds the due-work partial index `idx_report_schedules_next` (finding 4), mirroring `idx_workflow_schedules_next`/`idx_automation_rules_next_run`.
- **Scheduler** (`fire_due_report_schedules`) — checks out a dedicated connection (RLS GUCs are session-local), reads due work under global-read context, clears it, then performs each schedule's `record_execution`/`advance_after_run` under that schedule's own tenant context, and defensively clears all context before the connection returns to the pool.
- **Repo methods** `get_due_schedules`/`record_execution`/`advance_after_run` now take an `Executor` so the caller controls the RLS-scoped connection.

> Migration renumbered 00216→00218 to avoid collision with in-flight PR #2335 (00216/00217).

## Scope
Findings 1, 2 (partial), 4 of #2318. Finding 3 (frontend `cron_expression` client field) and finding 5 (atomic claim / `SELECT … FOR UPDATE SKIP LOCKED` across replicas) remain tracked in #2318.

## Verification
- `cargo check -p api-server -p db` — clean
- `cargo fmt` applied
- Added `#[sqlx::test]` covering the full select→record→advance loop under global-read + tenant context.

Refs #2318