### PR TITLE
gh-issue-2328: lower-case synthesized epic candidate ids + tighten suffix regex

### DIFF
--- a/frontend/packages/screen-map/src/extract-known.ts
+++ b/frontend/packages/screen-map/src/extract-known.ts
@@ -11,11 +11,13 @@ export interface KnownContexts {
  * Extract the "known IDs" sets that drive the drift-context optional checks
  * in `scanDrift`. Sources:
  * - `docs/use-cases.md` — regex `\bUC-(\d+(?:\.\d+)?)\b`.
- * - `docs/epics/EPIC-NNN-*.md` — regex `^EPIC-0*(\d+[A-Z]*)` on filenames. The
- *   optional letter suffix preserves the established `10A`/`10B`/`7B` epic
- *   convention (see `docs/EPIC_STORY_STATUS.md`); leading zeros are stripped and
- *   the suffix is upper-cased so the extracted id matches the unpadded frontmatter
- *   refs (`Epic-10A`, not `Epic-010A`).
+ * - `docs/epics/EPIC-NNN-*.md` — regex `^EPIC-0*(\d+[A-Z]?)(?=[-.]|$)` on
+ *   filenames. The optional single letter suffix preserves the established
+ *   `10A`/`10B`/`7B` epic convention (see `docs/EPIC_STORY_STATUS.md`); leading
+ *   zeros are stripped and the suffix is upper-cased so the extracted id matches
+ *   the unpadded frontmatter refs (`Epic-10A`, not `Epic-010A`). The `(?=[-.]|$)`
+ *   boundary rejects malformed ids (`EPIC-10beta`, `EPIC-7A2-*`) rather than
+ *   silently mis-binning them onto a real-looking epic.
  * - `frontend/packages/ui-kit/src/index.ts` — `export { Foo, Bar }` and `export const Baz`
  *   (excludes `export type` lines so type-only exports aren't treated as components).
  *
@@ -48,7 +50,7 @@ async function extractEpics(repoRoot: string): Promise<Set<string>> {
     const entries = await readdir(path.join(repoRoot, 'docs/epics'));
     const out = new Set<string>();
     for (const entry of entries) {
-      const m = entry.match(/^EPIC-0*(\d+[A-Z]*)/i);
+      const m = entry.match(/^EPIC-0*(\d+[A-Z]?)(?=[-.]|$)/i);
       if (m) out.add(`Epic-${m[1].toUpperCase()}`);
     }
     return out;

--- a/frontend/packages/screen-map/src/scan.ts
+++ b/frontend/packages/screen-map/src/scan.ts
@@ -132,14 +132,19 @@ async function scanEpics(dir: string, product: Product): Promise<CandidateScreen
   } catch {
     return [];
   }
-  // Capture an optional upper-cased letter suffix (10A/10B/7B convention, see
-  // docs/EPIC_STORY_STATUS.md) and strip leading zeros so the synthesized
-  // candidate matches the unpadded `Epic-10A` frontmatter refs.
+  // Capture an optional single upper-cased letter suffix (10A/10B/7B
+  // convention, see docs/EPIC_STORY_STATUS.md) bounded by the segment end, and
+  // strip leading zeros so the synthesized candidate matches the unpadded
+  // `Epic-10A` frontmatter refs. The `(?=[-.]|$)` boundary rejects malformed
+  // ids (`EPIC-10beta`, `EPIC-7A2-*`) instead of silently mis-binning them.
   const epics = entries
-    .map((entry) => entry.match(/^EPIC-0*(\d+[A-Z]*)/i)?.[1]?.toUpperCase())
+    .map((entry) => entry.match(/^EPIC-0*(\d+[A-Z]?)(?=[-.]|$)/i)?.[1]?.toUpperCase())
     .filter((id): id is string => Boolean(id));
   return [...new Set(epics)].map((num) => ({
-    id: `${product}/epic-${num}`,
+    // Human-facing fields keep the upper-cased suffix (`Epic-10B`) so they
+    // match frontmatter refs; the id slug is lower-cased to satisfy the
+    // schema id regex (`/^[a-z...]/`) — see schema.ts IdSchema.
+    id: `${product}/epic-${num.toLowerCase()}`,
     name: `Epic-${num}`,
     product,
     source: 'epics' as const,

--- a/frontend/packages/screen-map/src/schema.ts
+++ b/frontend/packages/screen-map/src/schema.ts
@@ -47,7 +47,7 @@ export const DesignSourceRefSchema = z
   })
   .passthrough();
 
-const IdSchema = z.string().regex(/^(ppt|reality|reality-mobile)\/[a-z0-9-]+$/, {
+export const IdSchema = z.string().regex(/^(ppt|reality|reality-mobile)\/[a-z0-9-]+$/, {
   message: 'id must match <product>/<slug> using kebab-case',
 });
 

--- a/frontend/packages/screen-map/tests/extract-known.test.ts
+++ b/frontend/packages/screen-map/tests/extract-known.test.ts
@@ -52,6 +52,22 @@ describe('extractKnownContexts', () => {
     expect(ctx.knownEpics.has('Epic-010A')).toBe(false);
   });
 
+  it('rejects malformed epic filenames instead of mis-binning them', async () => {
+    await mkdir(path.join(tmpRoot, 'docs/epics'), { recursive: true });
+    // Missing hyphen typo — must NOT become a garbage `Epic-10BETA`.
+    await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-10beta.md'), '');
+    // Multi-char malformed suffix — must NOT silently truncate onto `Epic-7A`.
+    await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-7A2-x.md'), '');
+    // A well-formed epic alongside them still extracts normally.
+    await writeFile(path.join(tmpRoot, 'docs/epics/EPIC-011-billing.md'), '');
+    const ctx = await extractKnownContexts(tmpRoot);
+    expect(ctx.knownEpics.has('Epic-11')).toBe(true);
+    expect(ctx.knownEpics.has('Epic-10BETA')).toBe(false);
+    expect(ctx.knownEpics.has('Epic-7A')).toBe(false);
+    // The two malformed names contribute nothing; only the valid epic remains.
+    expect(ctx.knownEpics.size).toBe(1);
+  });
+
   it('extracts component names from frontend/packages/ui-kit exports', async () => {
     await mkdir(path.join(tmpRoot, 'frontend/packages/ui-kit/src'), { recursive: true });
     await writeFile(

--- a/frontend/packages/screen-map/tests/scan.test.ts
+++ b/frontend/packages/screen-map/tests/scan.test.ts
@@ -1,7 +1,10 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { scanCandidates } from '../src/scan.js';
+import { IdSchema } from '../src/schema.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const fixturesDir = path.join(here, 'fixtures');
@@ -61,6 +64,67 @@ describe('scanCandidates', () => {
     expect(epics).toContain('Epic-1');
     // Letter-suffixed epics (10A/10B/7B convention) round-trip, upper-cased.
     expect(epics).toContain('Epic-10B');
+  });
+
+  it('synthesizes a schema-valid lower-case id for a letter-suffixed epic', async () => {
+    const epicsDir = await mkdtemp(path.join(os.tmpdir(), 'scan-epic-id-'));
+    try {
+      await writeFile(path.join(epicsDir, 'EPIC-010B-platform-admin.md'), '');
+      const candidates = await scanCandidates({
+        product: 'ppt',
+        repoRoot: '/',
+        epicsDir,
+        sources: {
+          sitemap: false,
+          useCases: false,
+          epics: true,
+          designSource: undefined,
+          userAdd: [],
+        },
+      });
+      const epic = candidates.find((c) => c.source === 'epics');
+      expect(epic).toBeDefined();
+      // Human-facing fields keep the upper-cased suffix...
+      expect(epic?.name).toBe('Epic-10B');
+      expect(epic?.epics).toEqual(['Epic-10B']);
+      // ...but the id slug is lower-cased so it satisfies the frontmatter schema.
+      expect(epic?.id).toBe('ppt/epic-10b');
+      // Guard against drift between the synthesized id and the schema it must
+      // pass through in `screens init` (IdSchema is the id regex in schema.ts).
+      expect(IdSchema.safeParse(epic?.id).success).toBe(true);
+    } finally {
+      await rm(epicsDir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects malformed epic filenames instead of mis-binning them', async () => {
+    const epicsDir = await mkdtemp(path.join(os.tmpdir(), 'scan-epic-neg-'));
+    try {
+      await mkdir(epicsDir, { recursive: true });
+      // Missing hyphen typo — must NOT become a garbage `Epic-10BETA`.
+      await writeFile(path.join(epicsDir, 'EPIC-10beta.md'), '');
+      // Multi-char malformed suffix — must NOT silently truncate to `Epic-7A`.
+      await writeFile(path.join(epicsDir, 'EPIC-7A2-x.md'), '');
+      const candidates = await scanCandidates({
+        product: 'ppt',
+        repoRoot: '/',
+        epicsDir,
+        sources: {
+          sitemap: false,
+          useCases: false,
+          epics: true,
+          designSource: undefined,
+          userAdd: [],
+        },
+      });
+      const epics = candidates.flatMap((c) => c.epics ?? []);
+      expect(epics).not.toContain('Epic-10BETA');
+      expect(epics).not.toContain('Epic-7A');
+      // Neither malformed name yields any candidate at all.
+      expect(candidates.filter((c) => c.source === 'epics')).toHaveLength(0);
+    } finally {
+      await rm(epicsDir, { recursive: true, force: true });
+    }
   });
 
   it('includes user-add entries with source: "user"', async () => {


### PR DESCRIPTION
## Task
Follow-up: scanEpics synthesizes schema-invalid mixed-case candidate ids (ppt/epic-10B) (PR #2311). Closes #2328.

Two consistency gaps from PR #2311's regex widening:

1. **schema-consistency (medium)** — `scanEpics` (`frontend/packages/screen-map/src/scan.ts`) interpolated the now-uppercased suffix capture directly into the candidate screen **id** (`ppt/epic-10B`), which violates the frontmatter id schema (`/^[a-z][a-z0-9-]*\/[a-z0-9-]+$/`). `screens init` writes the id verbatim (and derives the filename slug from it), so the first `init` against a letter-suffixed epic emitted a screen-map that immediately failed `screens validate`. Fixed by lower-casing the id slug (`ppt/epic-10b`) while keeping the upper-cased form for the human-facing `name`/`epics` fields.

2. **regex-shape (low)** — tightened the epic-filename regex from `^EPIC-0*(\d+[A-Z]*)` (greedy, unbounded) to `^EPIC-0*(\d+[A-Z]?)(?=[-.]|$)` in both `scan.ts` and `extract-known.ts`. `10A`/`10B`/`7B` still pass; malformed names (`EPIC-10beta` → was `Epic-10BETA`; `EPIC-7A2-*` → was silently truncated to `Epic-7A`) now fail to match and surface as unrecognized instead of being mis-binned onto a real-looking epic.

Also exported `IdSchema` from `schema.ts` so the new test asserts the synthesized id against the actual schema regex — preventing the id/schema from drifting apart again.

## Owner
pm-tech-lead (hint only; actual specialist: generic tooling — `frontend/packages/screen-map`)

## Tested (Band A — fast check)
- `pnpm -F @ppt/screen-map test` → 80 passed | 1 skipped, exit 0
- `pnpm -F @ppt/screen-map typecheck` (tsc --noEmit) → exit 0
- `pnpm biome check` on the 5 changed files → exit 0

**Failing-on-main evidence (IG3):** the 3 new assertions were committed first (`test:` commit) and run against the unmodified source — all 3 fail (`ppt/epic-10B` id, `Epic-10BETA`/`Epic-7A` mis-binning). The `fix:` commit turns them green.

## Built (Band B — full build)
- `pnpm -F @ppt/screen-map build` (tsc) → exit 0 (IdSchema is now a public export via `export * from schema.js`)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; tooling package only)

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2: all changed paths are under `frontend/packages/screen-map/`, outside `pm-tech-lead`'s mapped areas (`docs/**`, `.research/**`, `_bmad-output/**`). Expected — `owner_role` was a hint only; the real specialist is generic tooling and the issue itself targets `frontend/packages/screen-map`. No unrelated files touched (5 files, all in the screen-map package). `reuse-grep.sh` clean.

## Notes
- IG1/IG2 goal-checks fail structurally (no `.research/plans/` file; dispatcher-assigned `auto-impl/*` branch) — both inapplicable to a GitHub-issue-driven dispatcher task. IG3 (TDD) passes.
- The id fix keeps `name`/`epics` upper-cased so they continue to match `Epic-10B` frontmatter refs; only the id slug is lower-cased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7)_