### PR TITLE
gap-84-1: wire ppt-web direct-to-S3 document upload

### DIFF
--- a/docs/screens/ppt/upload-document.md
+++ b/docs/screens/ppt/upload-document.md
@@ -117,6 +117,14 @@ UC-08 document upload — single-step form. Multi-file with per-file progress an
 
 ### Specific (recent)
 
+- **Direct-to-S3 upload wired (gap-84-1):** `DocumentUpload` now uploads via
+  `useUploadDocumentDirect` (api-client), which does `POST /api/v1/documents/upload-url`
+  → presigned `PUT` straight to S3 → `POST /api/v1/documents` to register. Bytes
+  no longer proxy through the api-server multipart `/upload` route. Per-file
+  progress is driven by the S3 PUT phase. The legacy multipart `useUploadDocument`
+  hook is still exported for callers that need the byte-proxy path. NB: a backend
+  PR (#2339) is hardening the presigned endpoint (org-scoped `file_key` +
+  signed Content-Length) — the client already sends the signed `Content-Type`.
 - The bundle uses **single-screen layout** (dropzone + metadata + submit on one page) instead of a multi-step wizard. This is intentional for the common case (1–4 files, single batch). For 10+ files or split-batch needs, document a future "advanced upload" flow.
 - File-icon block uses 3-letter colored tags matching `forms/file-upload.html`: PDF red, XLS green, DOC blue, JPG amber, PNG cyan, ZIP gray, generic gray for unknown types.
 - "HLAVNÝ" pill is auto-assigned to the first successful upload — the design states "Premenujte ho v zozname, ak chcete iný" (rename in list to swap). Production must allow per-file context menu to manually set "Make primary".
@@ -134,5 +142,6 @@ UC-08 document upload — single-step form. Multi-file with per-file progress an
 
 <!-- newest entries on top -->
 
+- 2026-07-15 — agent: wired direct-to-S3 upload (gap-84-1) — added `createUploadUrl` + `uploadDocumentDirect` bindings and `useUploadDocumentDirect` hook to @ppt/api-client; switched `DocumentUpload` to the direct hook (upload-url → presigned PUT → register). Frontend-only; backend endpoint landed in #2309.
 - 2026-05-09 — agent: design analyzed (pages/ppt-upload-document.html — 3 artboards: loaded-4-files-mixed / empty-drag-over / success-toast); flipped ppt-web redesignStatus → in-progress; attached designSource; populated functionality checklist (10 sections), 6 states, design-specific notes (HLAVNÝ auto-detect + per-file error specificity + audience-driven notification count + draft-bypass-upload-completion); declared 8 sharedComponents; added 1 relatedScreen (document-detail sibling)
 - 2026-05-08 — init: created from scan (source: sitemap)

--- a/frontend/apps/ppt-web/src/features/documents/components/DocumentUpload.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/DocumentUpload.tsx
@@ -4,7 +4,11 @@
  * Upload documents with OCR processing support.
  */
 
-import { DOCUMENT_CATEGORIES, type DocumentCategory, useUploadDocument } from '@ppt/api-client';
+import {
+  DOCUMENT_CATEGORIES,
+  type DocumentCategory,
+  useUploadDocumentDirect,
+} from '@ppt/api-client';
 import { type ChangeEvent, type DragEvent, useCallback, useState } from 'react';
 
 interface DocumentUploadProps {
@@ -49,7 +53,9 @@ export function DocumentUpload({
   const [category, setCategory] = useState<DocumentCategory>('other');
   const [isDragOver, setIsDragOver] = useState(false);
 
-  const uploadDocument = useUploadDocument();
+  // Direct-to-S3 upload (gap-84-1): bytes go straight to storage via a
+  // presigned PUT URL instead of proxying through the api-server.
+  const uploadDocument = useUploadDocumentDirect();
 
   // Note: Client-side validation improves UX, but server-side validation of file
   // signatures (magic bytes) is required for security. The backend validates file types.

--- a/frontend/packages/api-client/src/documents/api.test.ts
+++ b/frontend/packages/api-client/src/documents/api.test.ts
@@ -12,7 +12,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearTokenProvider, setTokenProvider } from '../auth/token-provider';
-import { deleteFolder, listDocuments, revokeDocumentShare } from './api';
+import {
+  createUploadUrl,
+  deleteFolder,
+  listDocuments,
+  revokeDocumentShare,
+  uploadDocumentDirect,
+} from './api';
 
 function mockOkResponse(body: unknown, status = 200): Response {
   return {
@@ -61,5 +67,92 @@ describe('documents api client', () => {
   it('resolves to undefined on a 204 revoke-share response', async () => {
     vi.mocked(fetch).mockResolvedValueOnce(mock204Response());
     await expect(revokeDocumentShare('doc-1', 'share-1')).resolves.toBeUndefined();
+  });
+
+  // --- Direct-to-S3 upload (gap-84-1) ---
+
+  it('createUploadUrl POSTs to /upload-url with the bearer token', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      mockOkResponse({
+        url: 'https://s3.example/bucket/key?sig=abc',
+        file_key: 'org/2026/07/uuid_report.pdf',
+        content_type: 'application/pdf',
+        method: 'PUT',
+        expires_at: '2026-07-15T00:05:00Z',
+      })
+    );
+
+    const res = await createUploadUrl({
+      file_name: 'report.pdf',
+      mime_type: 'application/pdf',
+      size_bytes: 1024,
+    });
+
+    const [url, init] = vi.mocked(fetch).mock.calls[0];
+    expect(url).toBe('/api/v1/documents/upload-url');
+    expect((init as RequestInit).method).toBe('POST');
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer doc-token');
+    expect(res.file_key).toBe('org/2026/07/uuid_report.pdf');
+  });
+
+  it('uploadDocumentDirect chains upload-url -> S3 PUT -> register', async () => {
+    // Mock XMLHttpRequest for the direct S3 PUT step.
+    const setRequestHeader = vi.fn();
+    const open = vi.fn();
+    const listeners: Record<string, () => void> = {};
+    const xhrMock = {
+      upload: { addEventListener: vi.fn() },
+      addEventListener: (evt: string, cb: () => void) => {
+        listeners[evt] = cb;
+      },
+      open,
+      setRequestHeader,
+      send: vi.fn(() => {
+        // Simulate a successful S3 response on next tick.
+        queueMicrotask(() => {
+          xhrMock.status = 200;
+          listeners.load?.();
+        });
+      }),
+      status: 0,
+    };
+    vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestMock() {
+      return xhrMock;
+    });
+
+    // 1) upload-url  2) register document
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockOkResponse({
+          url: 'https://s3.example/bucket/key?sig=abc',
+          file_key: 'org/2026/07/uuid_report.pdf',
+          content_type: 'application/pdf',
+          method: 'PUT',
+          expires_at: '2026-07-15T00:05:00Z',
+        })
+      )
+      .mockResolvedValueOnce(mockOkResponse({ id: 'doc-42', message: 'created' }));
+
+    const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+    const result = await uploadDocumentDirect({
+      file,
+      title: 'Report',
+      category: 'report',
+      organizationId: 'org-1',
+    });
+
+    expect(result).toEqual({ id: 'doc-42', message: 'created' });
+    // PUT went to the presigned URL with the signed Content-Type, no auth header.
+    expect(open).toHaveBeenCalledWith('PUT', 'https://s3.example/bucket/key?sig=abc');
+    expect(setRequestHeader).toHaveBeenCalledWith('Content-Type', 'application/pdf');
+    // Registration call carried the file_key from the presign response.
+    const registerBody = JSON.parse(
+      (vi.mocked(fetch).mock.calls[1][1] as RequestInit).body as string
+    );
+    expect(registerBody.file_key).toBe('org/2026/07/uuid_report.pdf');
+    expect(registerBody.mime_type).toBe('application/pdf');
+
+    vi.unstubAllGlobals();
   });
 });

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -11,6 +11,8 @@ import type {
   CreateDocumentRequest,
   CreateShareRequest,
   CreateShareResponse,
+  CreateUploadUrlRequest,
+  CreateUploadUrlResponse,
   Document,
   DocumentIntelligenceStats,
   DocumentListQuery,
@@ -298,6 +300,119 @@ export async function uploadDocument(
 
     xhr.send(formData);
   });
+}
+
+// --- Direct-to-S3 upload (gap-84-1) ---
+
+/**
+ * Request a presigned PUT URL for a direct client-to-S3 upload
+ * (`POST /api/v1/documents/upload-url`).
+ *
+ * Goes through the shared authenticated transport (the endpoint is
+ * auth-protected + tenant-scoped; the org is derived server-side from the JWT).
+ * The returned `url` is a short-lived (5 min) presigned S3 URL — the bytes are
+ * PUT straight there via {@link uploadFileToPresignedUrl}, bypassing the
+ * api-server byte proxy.
+ */
+export async function createUploadUrl(
+  data: CreateUploadUrlRequest
+): Promise<CreateUploadUrlResponse> {
+  return fetchApi(`${API_BASE}/upload-url`, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+/**
+ * PUT raw file bytes to a presigned S3 URL (gap-84-1).
+ *
+ * Uses `XMLHttpRequest` for upload-progress events. The request goes directly
+ * to the S3-compatible host, so it MUST NOT carry the api-server `Authorization`
+ * header — the presigned URL is the credential, and it is signed for exactly
+ * the `contentType` passed here, which is set as the `Content-Type` header so
+ * the request matches the signature.
+ */
+export function uploadFileToPresignedUrl(
+  url: string,
+  file: File,
+  contentType: string,
+  onProgress?: (progress: number) => void
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.upload.addEventListener('progress', (event) => {
+      if (event.lengthComputable && onProgress) {
+        onProgress(Math.round((event.loaded / event.total) * 100));
+      }
+    });
+
+    xhr.addEventListener('load', () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve();
+      } else {
+        reject(new Error(`Upload to storage failed (HTTP ${xhr.status})`));
+      }
+    });
+
+    xhr.addEventListener('error', () => {
+      reject(
+        new Error('Network connection lost. Please check your internet connection and try again.')
+      );
+    });
+
+    xhr.addEventListener('abort', () => {
+      reject(new Error('Upload was cancelled.'));
+    });
+
+    xhr.open('PUT', url);
+    // Match the Content-Type the URL was signed for — no auth header (the
+    // presigned URL is the credential).
+    xhr.setRequestHeader('Content-Type', contentType);
+    xhr.send(file);
+  });
+}
+
+/**
+ * Upload a document directly to S3, then register it (gap-84-1).
+ *
+ * Three-step flow that replaces the byte-proxying multipart {@link uploadDocument}:
+ *   1. `POST /api/v1/documents/upload-url` → presigned PUT URL + `file_key`.
+ *   2. PUT the bytes straight to S3 (progress reported here).
+ *   3. `POST /api/v1/documents` with the `file_key` to register the record.
+ *
+ * Accepts the same {@link UploadDocumentParams} shape as the legacy multipart
+ * path so callers can switch with no call-site change. The organization is
+ * derived server-side from the JWT, so `organizationId` is accepted but unused.
+ */
+export async function uploadDocumentDirect(
+  params: UploadDocumentParams
+): Promise<{ id: string; message: string }> {
+  const presigned = await createUploadUrl({
+    file_name: params.file.name,
+    mime_type: params.file.type,
+    size_bytes: params.file.size,
+  });
+
+  await uploadFileToPresignedUrl(
+    presigned.url,
+    params.file,
+    presigned.content_type,
+    params.onProgress
+  );
+
+  const registration: CreateDocumentRequest = {
+    title: params.title,
+    description: params.description,
+    category: params.category,
+    folder_id: params.folderId,
+    file_key: presigned.file_key,
+    file_name: params.file.name,
+    mime_type: presigned.content_type,
+    size_bytes: params.file.size,
+  };
+
+  return createDocument(registration);
 }
 
 // --- Document Sharing (Story 7A.5) ---

--- a/frontend/packages/api-client/src/documents/hooks.ts
+++ b/frontend/packages/api-client/src/documents/hooks.ts
@@ -187,6 +187,25 @@ export function useUploadDocument() {
   });
 }
 
+/**
+ * Direct-to-S3 upload (gap-84-1).
+ *
+ * Same call signature as {@link useUploadDocument} but uploads bytes straight
+ * to S3 via a presigned PUT URL (`POST /api/v1/documents/upload-url`) instead
+ * of proxying them through the api-server multipart `/upload` route. Invalidates
+ * the document lists on success so the new document appears.
+ */
+export function useUploadDocumentDirect() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: api.UploadDocumentParams) => api.uploadDocumentDirect(params),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: documentKeys.lists() });
+    },
+  });
+}
+
 // Create folder (gap-7a-2)
 export function useCreateFolder() {
   const queryClient = useQueryClient();

--- a/frontend/packages/api-client/src/documents/types.ts
+++ b/frontend/packages/api-client/src/documents/types.ts
@@ -225,6 +225,50 @@ export interface UpdateDocumentRequest {
   access_roles?: string[];
 }
 
+// --- Direct-to-S3 upload (gap-84-1) ---
+
+/**
+ * Request for a presigned direct-to-S3 upload URL
+ * (`POST /api/v1/documents/upload-url`). Mirrors the Rust
+ * `CreateUploadUrlRequest`. The server derives the storage key from
+ * `file_name` and validates `mime_type` / `size_bytes` up-front against the
+ * 50 MiB cap before minting a URL.
+ */
+export interface CreateUploadUrlRequest {
+  /** Original filename — used to derive the storage key and detect the content
+   * type from the extension when `mime_type` is blank. */
+  file_name: string;
+  /** MIME type the client will upload with. It MUST be sent as the
+   * `Content-Type` header on the subsequent PUT, because the presigned URL is
+   * signed for exactly this content type. */
+  mime_type: string;
+  /** Optional declared size in bytes, validated against the 50 MiB cap
+   * up-front. S3 still enforces the real byte count. */
+  size_bytes?: number;
+}
+
+/**
+ * Response carrying a presigned PUT URL for direct client-to-S3 upload
+ * (`POST /api/v1/documents/upload-url`). Mirrors the Rust
+ * `CreateUploadUrlResponse`. The client PUTs bytes straight to `url`, then
+ * registers the document via `POST /api/v1/documents` with `file_key`.
+ */
+export interface CreateUploadUrlResponse {
+  /** Presigned S3 PUT URL — the client uploads bytes directly here, bypassing
+   * the api-server byte proxy. */
+  url: string;
+  /** Storage key the object will live at. Echo back to
+   * `POST /api/v1/documents` to register the document record. */
+  file_key: string;
+  /** MIME type the client MUST set as the `Content-Type` header on the PUT so
+   * the request matches the presigned signature. */
+  content_type: string;
+  /** HTTP method to use for the upload (always `PUT`). */
+  method: string;
+  /** ISO-8601 timestamp when the presigned URL expires. */
+  expires_at: string;
+}
+
 // Document categories
 export const DOCUMENT_CATEGORIES = [
   'contract',


### PR DESCRIPTION
## Task
Wire ppt-web direct-to-S3 upload via POST /api/v1/documents/upload-url: api-client binding + UploadDocument integration + screen-map note (backend endpoint landed in #2309). Frontend-only; backend presigned-PUT hardening (org-scoped file_key + signed Content-Length) is in separate PR #2339 and is NOT touched here.

## Owner
pm-frontend (specialist: react-web)

## What changed (frontend only)
- **@ppt/api-client**
  - `types.ts`: `CreateUploadUrlRequest` / `CreateUploadUrlResponse` (mirror the Rust structs from #2309).
  - `api.ts`: `createUploadUrl()` (authenticated `POST /api/v1/documents/upload-url`), `uploadFileToPresignedUrl()` (raw XHR `PUT` straight to S3 — sets the signed `Content-Type`, **no** `Authorization` header, emits progress events), and `uploadDocumentDirect()` orchestrator (upload-url → PUT → register via `POST /api/v1/documents` with the returned `file_key`).
  - `hooks.ts`: `useUploadDocumentDirect()` — same call signature as `useUploadDocument`, invalidates the document lists on success.
- **ppt-web**: `DocumentUpload` switched from `useUploadDocument` (multipart byte-proxy) to `useUploadDocumentDirect`. The legacy multipart hook stays exported for callers that still need the proxy path.
- **screen-map**: `docs/screens/ppt/upload-document.md` — Specific-note + Agent Log entry.

No backend handler was modified — the endpoint already exists (#2309).

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` → exit 0 (tsc)
- `pnpm -F @ppt/web typecheck` → exit 0
- `biome check` on all 5 changed files → exit 0 (the per-app `lint` script is a stale broken eslint config repo-wide; Biome is the canonical linter per CLAUDE.md)
- `pnpm -F @ppt/api-client test --run src/documents/api.test.ts` → 5 passed (incl. 2 new: createUploadUrl auth + full direct-flow chaining)

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → exit 0. Triggered because this adds public API surface to @ppt/api-client.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no auth/billing/data-integrity logic; presigned-URL security hardening is owned by #2339).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Code-reuse review
`reuse-grep` emitted one advisory warning: `WARN: useU looks like an existing helper at frontend/packages/reality-api-client/src/favorites/hooks.ts`. False positive — a truncated `useU` prefix match against an unrelated reality-api-client favorites hook; `useUploadDocumentDirect` is a new, intentionally-distinct sibling of `useUploadDocument` (direct-to-S3 vs multipart proxy).

## Notes
- **goal-check**: IG3 (TDD test:/feat: commit pair) passes. IG1/IG2 report FAIL because this is a dispatcher auto-impl task, not a plan-driven `ppt-research-flow` run — there is no `.research/plans/<slug>.md` (and the task forbids touching `.research/**`), and the branch is the dispatcher-provided `auto-impl/…` rather than `impl/…`. Both are inherent to the task shape, not code defects.
- The direct PUT deliberately omits the api-server bearer token — the presigned URL is the credential and is signed for the exact `Content-Type`. The client forwards the declared size via `size_bytes` in the upload-url request, so no further client change is required for the file_key/content-type contract when #2339 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7)_