### PR TITLE
gap-84-2-build-document-sign-page: build signer-facing document-sign page in ppt-web

### DIFF
--- a/docs/screens/ppt/document-sign.md
+++ b/docs/screens/ppt/document-sign.md
@@ -6,7 +6,7 @@ implementations:
   ppt-web:
     route: /sign
     component: DocumentSignPage
-    buildStatus: planned
+    buildStatus: shipped
     redesignStatus: not-started
     apiStatus: complete
   mobile:
@@ -35,20 +35,21 @@ owner: pm-integration
 Signer-facing public page opened from the emailed `{BASE_URL}/sign?token=<v1…>`
 link (E-Signature Email Integration, Epic 84.2). No auth — the `v1.` HMAC token
 is the only credential. This screen is the frontend consumer for the
-already-shipped backend `/api/v1/signatures/sign` endpoints; the ppt-web page
-itself is not built yet (`buildStatus: planned`).
+already-shipped backend `/api/v1/signatures/sign` endpoints. The ppt-web page
+is built and wired as a public (unauthenticated) `/sign` route
+(`buildStatus: shipped`).
 
 ### Load / render context (`GET /api/v1/signatures/sign?token=…`)
-- [ ] [w] Lift `token` from the query string and call `getSignContext`
-- [ ] [w] Show document subject/title (`subject`) and the requester's optional `message`
-- [ ] [w] Show signer identity — `signer_name` + `signer_email` (echoed from the verified token)
-- [ ] [w] Render the document to sign (PDF preview surface)
-- [ ] [w] Reflect `signer_status` (`pending` / `viewed`) so a returning signer sees their state
+- [x] [w] Lift `token` from the query string and call `getSignContext`
+- [x] [w] Show document subject/title (`subject`) and the requester's optional `message`
+- [x] [w] Show signer identity — `signer_name` + `signer_email` (echoed from the verified token)
+- [ ] [w] Render the document to sign (PDF preview surface) — deferred: the public render context returns no document URL (document fetch is auth-gated), so no PDF is shown yet; only document metadata is surfaced
+- [x] [w] Reflect `signer_status` (`pending` / `viewed`) so a returning signer sees their state
 
 ### Sign / decline (`POST /api/v1/signatures/sign?token=…`)
-- [ ] [w] "Adopt & sign" flow — capture `typed_name` as lightweight signing evidence
-- [ ] [w] On success, show confirmation from `SubmitSignatureResponse.message`; branch on `status` (`in_progress` while other signers remain vs `completed` once everyone has signed)
-- [ ] [w] Guard against re-sign — once the signer is `signed`/`declined` the endpoint refuses; surface a friendly "already signed" state instead of an error toast
+- [x] [w] "Adopt & sign" flow — capture `typed_name` as lightweight signing evidence
+- [x] [w] On success, show confirmation from `SubmitSignatureResponse.message`; branch on `status` (`in_progress` while other signers remain vs `completed` once everyone has signed)
+- [x] [w] Guard against re-sign — once the signer is `signed`/`declined` the endpoint refuses; surface a friendly "already signed" state instead of an error toast
 
 ## States
 
@@ -83,9 +84,17 @@ No `sitemapRefs` for the same reason — `/sign` is not in the sitemap route tab
 
 ### Specific (recent)
 
-- ppt-web page is not implemented yet; `route: /sign` records the intended
-  public path. When the page is built, wire it as an unauthenticated route and
-  flip `ppt-web.buildStatus` → `shipped`.
+- ppt-web page is now built: `DocumentSignPage`
+  (`features/documents/pages/DocumentSignPage.tsx`) wired as a PUBLIC `/sign`
+  route in `routes/groups/documents.tsx` (no `ProtectedRoute`). It consumes the
+  new `@ppt/api-client` signer hooks `useSignContext` / `useSubmitSignature`
+  (auth-less `fetch`, typed `SignError` carrying the backend error `code`).
+  Strings live under the `documentSign.*` i18n namespace in all six locale
+  bundles (parity locked by `documentSignI18n.test.ts`).
+- PDF preview is intentionally deferred — the public render context carries no
+  document URL (the document blob is behind an authenticated endpoint), so the
+  page shows the document subject/message metadata rather than the file itself.
+  Revisit if a token-scoped public document-fetch endpoint is added.
 - Mobile is `n/a` — the signing link is a public web page opened from email, not
   a screen in the RN app.
 
@@ -93,4 +102,5 @@ No `sitemapRefs` for the same reason — `/sign` is not in the sitemap route tab
 
 <!-- newest entries on top -->
 
+- 2026-07-15 — agent: gap-84-2-build-document-sign-page — built the signer-facing `/sign` page (`DocumentSignPage`) against the shipped `/api/v1/signatures/sign` API; added public signer client (`getSignContext`/`submitSignature`/`SignError` + `useSignContext`/`useSubmitSignature`) to `@ppt/api-client` esignature module; added `documentSign.*` strings to all 6 locales + a key-parity regression test; flipped `ppt-web.buildStatus` planned→shipped. PDF preview deferred (no public document URL in render context).
 - 2026-07-14 — agent: gap-84-2-no-screen-map-entry-for-a — created this screen-map for the signer-facing `/sign` page (Epic 84.2 E-Signature Email Integration). Backend `/api/v1/signatures/sign` consumer endpoints are shipped + tested; frontend page is `planned`. Endpoints/sitemapRefs left empty by design (signature routes are not in `@ppt/sitemap`); documented in prose. Manager-side request creation stays on `ppt/document-detail`.

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1605,5 +1605,34 @@
     "saveFailed": "Spouštěč se nepodařilo aktualizovat",
     "resetDone": "Spouštěče obnoveny na výchozí",
     "resetFailed": "Spouštěče se nepodařilo obnovit"
+  },
+  "documentSign": {
+    "title": "Podepsat dokument",
+    "subtitle": "Zkontrolujte níže uvedené údaje a podepište přijetím svého podpisu.",
+    "loading": "Načítá se váš požadavek na podpis…",
+    "documentLabel": "Dokument",
+    "untitledDocument": "Dokument bez názvu",
+    "messageLabel": "Zpráva od odesílatele",
+    "signerLabel": "Podepisujete jako",
+    "confirmationTitle": "Podpis zaznamenán",
+    "allSigned": "Všichni podepisující nyní podepsali. Dokončený dokument bude odeslán žadateli.",
+    "othersRemain": "Váš podpis je zaznamenán. Stále čekáme na ostatní podepisující.",
+    "alreadySignedTitle": "Již podepsáno",
+    "form": {
+      "nameLabel": "Pro podpis zadejte své celé jméno",
+      "nameRequired": "Pro podpis zadejte své celé jméno.",
+      "consent": "Zadáním svého jména a výběrem možnosti Podepsat souhlasíte, že se jedná o váš elektronický podpis na tomto dokumentu.",
+      "submit": "Přijmout a podepsat",
+      "submitting": "Podepisuje se…"
+    },
+    "errors": {
+      "invalidTitle": "Neplatný odkaz k podpisu",
+      "invalid": "Tento odkaz k podpisu je neplatný. Zkontrolujte odkaz ve svém e-mailu nebo požádejte odesílatele o nový.",
+      "expired": "Platnost tohoto odkazu k podpisu vypršela. Požádejte odesílatele o nový.",
+      "alreadySigned": "Na tento požadavek na podpis jste již odpověděli. Není potřeba žádná další akce.",
+      "linkUsed": "Tento odkaz k podpisu již byl použit. Pokud stále potřebujete podepsat, požádejte odesílatele o nový odkaz.",
+      "notOpen": "Tento požadavek na podpis již není otevřen k podpisu.",
+      "generic": "Při načítání tohoto požadavku na podpis došlo k chybě. Zkuste to prosím znovu."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1498,5 +1498,34 @@
     "saveFailed": "Auslöser konnte nicht aktualisiert werden",
     "resetDone": "Auslöser auf Standard zurückgesetzt",
     "resetFailed": "Auslöser konnten nicht zurückgesetzt werden"
+  },
+  "documentSign": {
+    "title": "Dokument unterschreiben",
+    "subtitle": "Bitte überprüfen Sie die folgenden Angaben und unterschreiben Sie, indem Sie Ihre Unterschrift übernehmen.",
+    "loading": "Ihre Signaturanfrage wird geladen…",
+    "documentLabel": "Dokument",
+    "untitledDocument": "Unbenanntes Dokument",
+    "messageLabel": "Nachricht des Absenders",
+    "signerLabel": "Unterschreiben als",
+    "confirmationTitle": "Unterschrift erfasst",
+    "allSigned": "Alle Unterzeichner haben nun unterschrieben. Das fertiggestellte Dokument wird an den Anforderer gesendet.",
+    "othersRemain": "Ihre Unterschrift wurde erfasst. Wir warten noch auf die übrigen Unterzeichner.",
+    "alreadySignedTitle": "Bereits unterschrieben",
+    "form": {
+      "nameLabel": "Geben Sie zum Unterschreiben Ihren vollständigen Namen ein",
+      "nameRequired": "Bitte geben Sie zum Unterschreiben Ihren vollständigen Namen ein.",
+      "consent": "Durch Eingabe Ihres Namens und Auswahl von „Unterschreiben“ stimmen Sie zu, dass dies Ihre elektronische Unterschrift auf diesem Dokument ist.",
+      "submit": "Übernehmen und unterschreiben",
+      "submitting": "Wird unterschrieben…"
+    },
+    "errors": {
+      "invalidTitle": "Signaturlink ungültig",
+      "invalid": "Dieser Signaturlink ist ungültig. Bitte überprüfen Sie den Link in Ihrer E-Mail oder bitten Sie den Absender um einen neuen.",
+      "expired": "Dieser Signaturlink ist abgelaufen. Bitten Sie den Absender um einen neuen.",
+      "alreadySigned": "Sie haben auf diese Signaturanfrage bereits reagiert. Es sind keine weiteren Schritte erforderlich.",
+      "linkUsed": "Dieser Signaturlink wurde bereits verwendet. Wenn Sie noch unterschreiben müssen, bitten Sie den Absender um einen neuen Link.",
+      "notOpen": "Diese Signaturanfrage ist nicht mehr zur Unterschrift geöffnet.",
+      "generic": "Beim Laden dieser Signaturanfrage ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3891,5 +3891,34 @@
     "saveFailed": "Could not update trigger",
     "resetDone": "Triggers reset to defaults",
     "resetFailed": "Could not reset triggers"
+  },
+  "documentSign": {
+    "title": "Sign document",
+    "subtitle": "Please review the details below and adopt your signature to sign.",
+    "loading": "Loading your signing request…",
+    "documentLabel": "Document",
+    "untitledDocument": "Untitled document",
+    "messageLabel": "Message from sender",
+    "signerLabel": "Signing as",
+    "confirmationTitle": "Signature recorded",
+    "allSigned": "All signers have now signed. The completed document will be sent to the requester.",
+    "othersRemain": "Your signature is recorded. We're still waiting on the other signers.",
+    "alreadySignedTitle": "Already signed",
+    "form": {
+      "nameLabel": "Type your full name to sign",
+      "nameRequired": "Please type your full name to sign.",
+      "consent": "By typing your name and selecting Sign, you agree that this is your electronic signature on this document.",
+      "submit": "Adopt & sign",
+      "submitting": "Signing…"
+    },
+    "errors": {
+      "invalidTitle": "Signing link not valid",
+      "invalid": "This signing link is invalid. Please check the link in your email or ask the sender for a new one.",
+      "expired": "This signing link has expired. Ask the sender for a new one.",
+      "alreadySigned": "You have already responded to this signature request. No further action is needed.",
+      "linkUsed": "This signing link has already been used. If you still need to sign, ask the sender for a new link.",
+      "notOpen": "This signature request is no longer open for signing.",
+      "generic": "Something went wrong while loading this signing request. Please try again."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1471,5 +1471,34 @@
     "saveFailed": "A trigger frissítése sikertelen",
     "resetDone": "Triggerek visszaállítva alapértékre",
     "resetFailed": "A triggerek visszaállítása sikertelen"
+  },
+  "documentSign": {
+    "title": "Dokumentum aláírása",
+    "subtitle": "Kérjük, ellenőrizze az alábbi adatokat, és írja alá az aláírása elfogadásával.",
+    "loading": "Az aláírási kérelme betöltése folyamatban…",
+    "documentLabel": "Dokumentum",
+    "untitledDocument": "Névtelen dokumentum",
+    "messageLabel": "Üzenet a küldőtől",
+    "signerLabel": "Aláírás mint",
+    "confirmationTitle": "Aláírás rögzítve",
+    "allSigned": "Minden aláíró aláírta. Az elkészült dokumentumot elküldjük a kérelmezőnek.",
+    "othersRemain": "Aláírását rögzítettük. Még várunk a többi aláíróra.",
+    "alreadySignedTitle": "Már aláírva",
+    "form": {
+      "nameLabel": "Az aláíráshoz írja be a teljes nevét",
+      "nameRequired": "Az aláíráshoz kérjük, írja be a teljes nevét.",
+      "consent": "Neve beírásával és az Aláírás lehetőség kiválasztásával elfogadja, hogy ez az Ön elektronikus aláírása ezen a dokumentumon.",
+      "submit": "Elfogadás és aláírás",
+      "submitting": "Aláírás folyamatban…"
+    },
+    "errors": {
+      "invalidTitle": "Érvénytelen aláírási hivatkozás",
+      "invalid": "Ez az aláírási hivatkozás érvénytelen. Ellenőrizze a hivatkozást az e-mailjében, vagy kérjen újat a küldőtől.",
+      "expired": "Ez az aláírási hivatkozás lejárt. Kérjen újat a küldőtől.",
+      "alreadySigned": "Erre az aláírási kérelemre már válaszolt. Nincs szükség további teendőre.",
+      "linkUsed": "Ezt az aláírási hivatkozást már felhasználták. Ha még alá kell írnia, kérjen új hivatkozást a küldőtől.",
+      "notOpen": "Ez az aláírási kérelem már nem nyitott aláírásra.",
+      "generic": "Hiba történt az aláírási kérelem betöltése közben. Kérjük, próbálja újra."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1477,5 +1477,34 @@
     "saveFailed": "Nie udało się zaktualizować wyzwalacza",
     "resetDone": "Przywrócono domyślne wyzwalacze",
     "resetFailed": "Nie udało się zresetować wyzwalaczy"
+  },
+  "documentSign": {
+    "title": "Podpisz dokument",
+    "subtitle": "Sprawdź poniższe dane i podpisz, przyjmując swój podpis.",
+    "loading": "Trwa wczytywanie Twojej prośby o podpis…",
+    "documentLabel": "Dokument",
+    "untitledDocument": "Dokument bez tytułu",
+    "messageLabel": "Wiadomość od nadawcy",
+    "signerLabel": "Podpisujesz jako",
+    "confirmationTitle": "Podpis zapisany",
+    "allSigned": "Wszyscy podpisujący już podpisali. Ukończony dokument zostanie wysłany do zamawiającego.",
+    "othersRemain": "Twój podpis został zapisany. Nadal czekamy na pozostałych podpisujących.",
+    "alreadySignedTitle": "Już podpisano",
+    "form": {
+      "nameLabel": "Wpisz swoje imię i nazwisko, aby podpisać",
+      "nameRequired": "Wpisz swoje imię i nazwisko, aby podpisać.",
+      "consent": "Wpisując swoje imię i nazwisko oraz wybierając Podpisz, zgadzasz się, że jest to Twój podpis elektroniczny na tym dokumencie.",
+      "submit": "Przyjmij i podpisz",
+      "submitting": "Podpisywanie…"
+    },
+    "errors": {
+      "invalidTitle": "Nieprawidłowy link do podpisu",
+      "invalid": "Ten link do podpisu jest nieprawidłowy. Sprawdź link w wiadomości e-mail lub poproś nadawcę o nowy.",
+      "expired": "Ten link do podpisu wygasł. Poproś nadawcę o nowy.",
+      "alreadySigned": "Już odpowiedziałeś na tę prośbę o podpis. Nie są potrzebne żadne dalsze działania.",
+      "linkUsed": "Ten link do podpisu został już użyty. Jeśli nadal musisz podpisać, poproś nadawcę o nowy link.",
+      "notOpen": "Ta prośba o podpis nie jest już otwarta do podpisania.",
+      "generic": "Podczas wczytywania tej prośby o podpis wystąpił błąd. Spróbuj ponownie."
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1607,5 +1607,34 @@
     "saveFailed": "Spúšťač sa nepodarilo aktualizovať",
     "resetDone": "Spúšťače obnovené na predvolené",
     "resetFailed": "Spúšťače sa nepodarilo obnoviť"
+  },
+  "documentSign": {
+    "title": "Podpísať dokument",
+    "subtitle": "Skontrolujte nižšie uvedené údaje a podpíšte prijatím svojho podpisu.",
+    "loading": "Načítava sa vaša žiadosť o podpis…",
+    "documentLabel": "Dokument",
+    "untitledDocument": "Dokument bez názvu",
+    "messageLabel": "Správa od odosielateľa",
+    "signerLabel": "Podpisujete ako",
+    "confirmationTitle": "Podpis zaznamenaný",
+    "allSigned": "Všetci podpisujúci teraz podpísali. Dokončený dokument bude odoslaný žiadateľovi.",
+    "othersRemain": "Váš podpis je zaznamenaný. Stále čakáme na ostatných podpisujúcich.",
+    "alreadySignedTitle": "Už podpísané",
+    "form": {
+      "nameLabel": "Na podpísanie zadajte svoje celé meno",
+      "nameRequired": "Na podpísanie zadajte svoje celé meno.",
+      "consent": "Zadaním svojho mena a výberom možnosti Podpísať súhlasíte, že ide o váš elektronický podpis na tomto dokumente.",
+      "submit": "Prijať a podpísať",
+      "submitting": "Podpisuje sa…"
+    },
+    "errors": {
+      "invalidTitle": "Neplatný odkaz na podpis",
+      "invalid": "Tento odkaz na podpis je neplatný. Skontrolujte odkaz vo svojom e-maile alebo požiadajte odosielateľa o nový.",
+      "expired": "Platnosť tohto odkazu na podpis vypršala. Požiadajte odosielateľa o nový.",
+      "alreadySigned": "Na túto žiadosť o podpis ste už odpovedali. Nie je potrebná žiadna ďalšia akcia.",
+      "linkUsed": "Tento odkaz na podpis už bol použitý. Ak stále potrebujete podpísať, požiadajte odosielateľa o nový odkaz.",
+      "notOpen": "Táto žiadosť o podpis už nie je otvorená na podpisovanie.",
+      "generic": "Pri načítavaní tejto žiadosti o podpis sa vyskytla chyba. Skúste to znova."
+    }
   }
 }

--- a/frontend/apps/ppt-web/src/features/documents/documentSignI18n.test.ts
+++ b/frontend/apps/ppt-web/src/features/documents/documentSignI18n.test.ts
@@ -1,0 +1,78 @@
+/// <reference types="vitest/globals" />
+/**
+ * Document-signing (signer page) i18n key-presence regression (gap-84-2).
+ *
+ * The signer-facing `/sign` page (`DocumentSignPage`, Epic 84.2) reads every
+ * string from the `documentSign.*` namespace. When the page was added, those
+ * keys had to land in ALL six locale bundles (en/sk/cs/de/pl/hu) — not just
+ * `en.json` — or the whole public signing surface would silently fall back to
+ * English for sk/cs/de/pl/hu signers (invisible to typecheck + lint because
+ * `t(...)` degrades via `fallbackLng`).
+ *
+ * This test locks that in: every leaf key present under `documentSign` in
+ * `en.json` must exist — and be a non-empty string — in all six bundles.
+ *
+ * Fails on `main` (no `documentSign` block exists in any locale); passes once
+ * the page ships its strings in every bundle.
+ */
+
+import cs from '../../../messages/cs.json';
+import de from '../../../messages/de.json';
+import en from '../../../messages/en.json';
+import hu from '../../../messages/hu.json';
+import pl from '../../../messages/pl.json';
+import sk from '../../../messages/sk.json';
+
+type Json = Record<string, unknown>;
+
+const BUNDLES: Record<string, Json> = { en, sk, cs, de, pl, hu };
+
+/** Dotted leaf-key paths reachable from a nested object. */
+function leafPaths(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object') return [prefix];
+  return Object.entries(obj as Json).flatMap(([k, v]) =>
+    leafPaths(v, prefix ? `${prefix}.${k}` : k)
+  );
+}
+
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, part) => {
+    if (acc === null || typeof acc !== 'object') return undefined;
+    return (acc as Json)[part];
+  }, obj);
+}
+
+/** The full set of documentSign leaf-key paths, taken from en.json as reference. */
+const SIGN_PATHS: string[] = leafPaths((en as Json).documentSign, 'documentSign');
+
+describe('document-sign i18n keys', () => {
+  it('covers exactly the six shipped locale bundles', () => {
+    expect(Object.keys(BUNDLES).sort()).toEqual(['cs', 'de', 'en', 'hu', 'pl', 'sk']);
+  });
+
+  it('reference key set is non-trivial', () => {
+    // title/subtitle/loading/... + 5 form.* + 7 errors.* = 23 leaves.
+    expect(SIGN_PATHS.length).toBeGreaterThanOrEqual(23);
+  });
+
+  for (const [locale, bundle] of Object.entries(BUNDLES)) {
+    describe(`locale: ${locale}`, () => {
+      for (const path of SIGN_PATHS) {
+        it(`defines a non-empty ${path}`, () => {
+          const value = getPath(bundle, path);
+          expect(value, `${path} missing in ${locale}.json`).toBeTypeOf('string');
+          expect((value as string).trim().length).toBeGreaterThan(0);
+        });
+      }
+    });
+  }
+
+  it('keeps every locale in lockstep — no locale has missing documentSign keys', () => {
+    for (const [locale, bundle] of Object.entries(BUNDLES)) {
+      const present = SIGN_PATHS.filter((p) => typeof getPath(bundle, p) === 'string');
+      expect(present, `${locale}.json documentSign-key set drifted from the reference`).toEqual(
+        SIGN_PATHS
+      );
+    }
+  });
+});

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx
@@ -1,0 +1,264 @@
+/**
+ * DocumentSignPage — signer-facing public signing page (Epic 84.2).
+ *
+ * Opened from the emailed `{BASE_URL}/sign?token=<v1…>` link. There is NO auth:
+ * the HMAC `token` in the query string is the only credential. This page is the
+ * frontend consumer for the already-shipped backend `/api/v1/signatures/sign`
+ * endpoints:
+ *
+ *   GET  /api/v1/signatures/sign?token=…  → render context (does not consume nonce)
+ *   POST /api/v1/signatures/sign?token=…  → record the signature (single-use)
+ *
+ * The manager-side half (create request / list signer status / remind / cancel)
+ * lives on `DocumentSignaturePanel` (document detail) and is unrelated here.
+ *
+ * Because this route is public we consume the `@ppt/api-client` signer hooks
+ * (`useSignContext` / `useSubmitSignature`) which use an auth-less `fetch` and
+ * surface a typed `SignError` carrying the backend error `code`, so we can
+ * branch the UI on EXPIRED / INVALID / ALREADY_SIGNED rather than a generic
+ * error toast.
+ */
+
+import { SignError, useSignContext, useSubmitSignature } from '@ppt/api-client';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
+
+/** Error codes the backend returns from the `/sign` endpoints. */
+type SignErrorCode =
+  | 'SIGNING_LINK_EXPIRED'
+  | 'INVALID_SIGNING_LINK'
+  | 'REQUEST_NOT_OPEN'
+  | 'ALREADY_SIGNED'
+  | 'LINK_ALREADY_USED';
+
+/** Map a caught error to the i18n key for its friendly copy. */
+function errorMessageKey(error: unknown): string {
+  if (error instanceof SignError) {
+    const code = error.code as SignErrorCode;
+    switch (code) {
+      case 'SIGNING_LINK_EXPIRED':
+        return 'documentSign.errors.expired';
+      case 'ALREADY_SIGNED':
+        return 'documentSign.errors.alreadySigned';
+      case 'LINK_ALREADY_USED':
+        return 'documentSign.errors.linkUsed';
+      case 'REQUEST_NOT_OPEN':
+        return 'documentSign.errors.notOpen';
+      default:
+        return 'documentSign.errors.invalid';
+    }
+  }
+  return 'documentSign.errors.generic';
+}
+
+/** A signer who has already completed should see a friendly state, not a form. */
+function isTerminalSignerStatus(status: string): boolean {
+  return status === 'signed' || status === 'declined';
+}
+
+/** Card shell so every state (loading / error / form / done) shares one frame. */
+function SignCard({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="max-w-xl mx-auto px-4 py-10">
+      <div
+        className="rounded-xl p-6 md:p-8"
+        style={{
+          backgroundColor: 'var(--color-surface)',
+          border: '1px solid var(--color-border)',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function DocumentSignPage() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token') ?? undefined;
+
+  const { data: context, isLoading, isError, error: contextError } = useSignContext(token);
+
+  const submit = useSubmitSignature(token ?? '');
+
+  const [typedName, setTypedName] = useState('');
+  const [nameError, setNameError] = useState<string>();
+
+  // Prefill the adopt-signature name with the signer's roster name once loaded.
+  useEffect(() => {
+    if (context?.signer_name) {
+      setTypedName((current) => current || context.signer_name);
+    }
+  }, [context?.signer_name]);
+
+  // --- No token in the URL --------------------------------------------------
+  if (!token) {
+    return (
+      <SignCard>
+        <h1 className="text-xl font-semibold mb-2">{t('documentSign.errors.invalidTitle')}</h1>
+        <p style={{ color: 'var(--color-text-secondary)' }}>{t('documentSign.errors.invalid')}</p>
+      </SignCard>
+    );
+  }
+
+  // --- Loading render context ----------------------------------------------
+  if (isLoading) {
+    return (
+      <SignCard>
+        <p style={{ color: 'var(--color-text-secondary)' }}>{t('documentSign.loading')}</p>
+      </SignCard>
+    );
+  }
+
+  // --- Render-context error (expired / invalid / already-signed) -----------
+  if (isError || !context) {
+    // ALREADY_SIGNED comes back as an error from GET, but it is a friendly
+    // "you're done" state rather than a failure.
+    const alreadySigned =
+      contextError instanceof SignError && contextError.code === 'ALREADY_SIGNED';
+    return (
+      <SignCard>
+        <h1 className="text-xl font-semibold mb-2">
+          {t(
+            alreadySigned ? 'documentSign.alreadySignedTitle' : 'documentSign.errors.invalidTitle'
+          )}
+        </h1>
+        <p style={{ color: 'var(--color-text-secondary)' }}>{t(errorMessageKey(contextError))}</p>
+      </SignCard>
+    );
+  }
+
+  // --- Signer already completed (status echoed in the context) -------------
+  if (isTerminalSignerStatus(context.signer_status)) {
+    return (
+      <SignCard>
+        <h1 className="text-xl font-semibold mb-2">{t('documentSign.alreadySignedTitle')}</h1>
+        <p style={{ color: 'var(--color-text-secondary)' }}>
+          {t('documentSign.errors.alreadySigned')}
+        </p>
+      </SignCard>
+    );
+  }
+
+  // --- Successful submit confirmation --------------------------------------
+  if (submit.isSuccess) {
+    const completed = submit.data.status === 'completed';
+    return (
+      <SignCard>
+        <h1 className="text-xl font-semibold mb-2">{t('documentSign.confirmationTitle')}</h1>
+        <p style={{ color: 'var(--color-text-secondary)' }}>{submit.data.message}</p>
+        <p className="mt-3 text-sm" style={{ color: 'var(--color-text-secondary)' }}>
+          {t(completed ? 'documentSign.allSigned' : 'documentSign.othersRemain')}
+        </p>
+      </SignCard>
+    );
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setNameError(undefined);
+    const trimmed = typedName.trim();
+    if (!trimmed) {
+      setNameError(t('documentSign.form.nameRequired'));
+      return;
+    }
+    submit.mutate({ typed_name: trimmed });
+  };
+
+  const submitError = submit.isError ? submit.error : undefined;
+
+  return (
+    <SignCard>
+      <h1 className="text-2xl font-bold mb-1">{t('documentSign.title')}</h1>
+      <p className="mb-6" style={{ color: 'var(--color-text-secondary)' }}>
+        {t('documentSign.subtitle')}
+      </p>
+
+      {/* Document + requester context */}
+      <dl className="space-y-3 mb-6">
+        <div>
+          <dt
+            className="text-xs uppercase tracking-wide"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            {t('documentSign.documentLabel')}
+          </dt>
+          <dd className="font-medium">{context.subject || t('documentSign.untitledDocument')}</dd>
+        </div>
+        {context.message && (
+          <div>
+            <dt
+              className="text-xs uppercase tracking-wide"
+              style={{ color: 'var(--color-text-secondary)' }}
+            >
+              {t('documentSign.messageLabel')}
+            </dt>
+            <dd style={{ whiteSpace: 'pre-wrap' }}>{context.message}</dd>
+          </div>
+        )}
+        <div>
+          <dt
+            className="text-xs uppercase tracking-wide"
+            style={{ color: 'var(--color-text-secondary)' }}
+          >
+            {t('documentSign.signerLabel')}
+          </dt>
+          <dd className="font-medium">
+            {context.signer_name}{' '}
+            <span style={{ color: 'var(--color-text-secondary)' }}>({context.signer_email})</span>
+          </dd>
+        </div>
+      </dl>
+
+      {/* Adopt & sign */}
+      <form onSubmit={handleSubmit} noValidate>
+        <label htmlFor="typed-name" className="block text-sm font-medium mb-1">
+          {t('documentSign.form.nameLabel')}
+        </label>
+        <input
+          id="typed-name"
+          type="text"
+          value={typedName}
+          onChange={(event) => setTypedName(event.target.value)}
+          disabled={submit.isPending}
+          className="w-full rounded-lg px-3 py-2 mb-1"
+          style={{
+            backgroundColor: 'var(--color-background)',
+            border: `1px solid ${nameError ? 'var(--color-danger, #dc2626)' : 'var(--color-border)'}`,
+            color: 'var(--color-text)',
+          }}
+          aria-invalid={!!nameError}
+          aria-describedby={nameError ? 'typed-name-error' : undefined}
+        />
+        {nameError && (
+          <p
+            id="typed-name-error"
+            className="text-sm mb-2"
+            style={{ color: 'var(--color-danger, #dc2626)' }}
+          >
+            {nameError}
+          </p>
+        )}
+        <p className="text-xs mb-4" style={{ color: 'var(--color-text-secondary)' }}>
+          {t('documentSign.form.consent')}
+        </p>
+
+        {submitError && (
+          <p className="text-sm mb-4" style={{ color: 'var(--color-danger, #dc2626)' }}>
+            {t(errorMessageKey(submitError))}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submit.isPending}
+          className="btn-primary-token px-5 py-2.5 rounded-lg font-medium disabled:opacity-60"
+        >
+          {submit.isPending ? t('documentSign.form.submitting') : t('documentSign.form.submit')}
+        </button>
+      </form>
+    </SignCard>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/documents/pages/index.ts
+++ b/frontend/apps/ppt-web/src/features/documents/pages/index.ts
@@ -4,6 +4,7 @@
 
 export { DocumentDetail } from './DocumentDetail';
 export { DocumentDetailPage } from './DocumentDetailPage';
+export { DocumentSignPage } from './DocumentSignPage';
 export { DocumentsPage } from './DocumentsPage';
 export { DocumentUploadPage } from './DocumentUploadPage';
 export { FolderTreePage } from './FolderTreePage';

--- a/frontend/apps/ppt-web/src/routes/groups/documents.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/documents.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../../contexts';
 import {
   ArticleDetailPage,
   DocumentDetailPage,
+  DocumentSignPage,
   DocumentsPage,
   DocumentTemplatesPage,
   DocumentUploadPage,
@@ -100,6 +101,10 @@ export function documentRoutes() {
           </ProtectedRoute>
         }
       />
+      {/* Signer-facing public signing page (Epic 84.2). PUBLIC — no
+          ProtectedRoute: authority is the HMAC `?token=` from the emailed
+          `{BASE_URL}/sign?token=…` link, not a platform session. */}
+      <Route path="/sign" element={<DocumentSignPage />} />
     </>
   );
 }

--- a/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
+++ b/frontend/apps/ppt-web/src/routes/lazyRoutes.tsx
@@ -18,6 +18,10 @@ export const DocumentUploadPage = lazy(() =>
 export const DocumentDetailPage = lazy(() =>
   import('../features/documents').then((m) => ({ default: m.DocumentDetailPage }))
 );
+// Signer-facing public signing page (Epic 84.2) — no auth; opened from email.
+export const DocumentSignPage = lazy(() =>
+  import('../features/documents').then((m) => ({ default: m.DocumentSignPage }))
+);
 export const FolderTreePage = lazy(() =>
   import('../features/documents').then((m) => ({ default: m.FolderTreePage }))
 );

--- a/frontend/packages/api-client/src/esignature/api.test.ts
+++ b/frontend/packages/api-client/src/esignature/api.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Contract tests for the signer-facing `/sign` transport (Epic 84, Story 84.2).
+ *
+ * The backend `ErrorResponse` (see `backend/crates/common/src/errors.rs`)
+ * serializes its discriminant in the JSON `code` field:
+ *   { "code": "SIGNING_LINK_EXPIRED", "message": "...", "timestamp": "..." }
+ *
+ * `signRequest` must read that `code` field so the signer page can branch its
+ * UI on `SIGNING_LINK_EXPIRED` / `INVALID_SIGNING_LINK` / `ALREADY_SIGNED` /
+ * `LINK_ALREADY_USED` / `REQUEST_NOT_OPEN`. A previous revision read `body.error`
+ * (a field the backend never sends), so `SignError.code` always fell back to
+ * `HTTP_<status>` and every error-state branch was dead. These tests pin the
+ * real wire contract so that regression can't return silently.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getSignContext, SignError, submitSignature } from './api';
+
+const TOKEN = 'test-token';
+
+/** Build an error Response whose JSON body mimics the backend `ErrorResponse`. */
+function errorJson(status: number, body: unknown): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('signRequest error mapping — reads backend `code` field', () => {
+  it('410 SIGNING_LINK_EXPIRED body → SignError.code === "SIGNING_LINK_EXPIRED"', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      errorJson(410, {
+        code: 'SIGNING_LINK_EXPIRED',
+        message: 'This signing link has expired',
+        timestamp: '2026-07-15T00:00:00Z',
+      })
+    );
+
+    await expect(getSignContext(TOKEN)).rejects.toMatchObject({
+      name: 'SignError',
+      code: 'SIGNING_LINK_EXPIRED',
+      status: 410,
+      message: 'This signing link has expired',
+    });
+  });
+
+  it('propagates each signer error discriminant from the `code` field', async () => {
+    const cases: Array<{ status: number; code: string }> = [
+      { status: 401, code: 'INVALID_SIGNING_LINK' },
+      { status: 409, code: 'ALREADY_SIGNED' },
+      { status: 409, code: 'LINK_ALREADY_USED' },
+      { status: 409, code: 'REQUEST_NOT_OPEN' },
+    ];
+
+    for (const { status, code } of cases) {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        errorJson(status, { code, message: `err ${code}`, timestamp: 'x' })
+      );
+      const err = await submitSignature(TOKEN).catch((e) => e);
+      expect(err).toBeInstanceOf(SignError);
+      expect(err.code).toBe(code);
+      expect(err.status).toBe(status);
+    }
+  });
+
+  it('falls back to HTTP_<status> only when the body carries no code', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(errorJson(500, {}));
+    const err = await getSignContext(TOKEN).catch((e) => e);
+    expect(err).toBeInstanceOf(SignError);
+    expect(err.code).toBe('HTTP_500');
+  });
+});

--- a/frontend/packages/api-client/src/esignature/api.ts
+++ b/frontend/packages/api-client/src/esignature/api.ts
@@ -154,11 +154,11 @@ async function signRequest<T>(url: string, options: RequestInit = {}): Promise<T
 
   if (!response.ok) {
     const body = (await response.json().catch(() => ({}))) as {
-      error?: string;
+      code?: string;
       message?: string;
     };
     throw new SignError(
-      body.error ?? `HTTP_${response.status}`,
+      body.code ?? `HTTP_${response.status}`,
       response.status,
       body.message ?? `HTTP ${response.status}`
     );

--- a/frontend/packages/api-client/src/esignature/api.ts
+++ b/frontend/packages/api-client/src/esignature/api.ts
@@ -15,10 +15,14 @@ import type {
   SendReminderBody,
   SendReminderResponse,
   SignatureRequestResponse,
+  SignRenderContext,
+  SubmitSignatureBody,
+  SubmitSignatureResponse,
 } from './types';
 
 const DOCUMENTS_BASE = '/api/v1/documents';
 const SIGNATURE_REQUESTS_BASE = '/api/v1/signature-requests';
+const SIGN_BASE = '/api/v1/signatures/sign';
 
 function getAuthHeaders(): HeadersInit {
   const token = getToken();
@@ -103,6 +107,85 @@ export async function cancelSignatureRequest(
   body: CancelSignatureRequestBody = {}
 ): Promise<CancelSignatureRequestResponse> {
   return apiRequest<CancelSignatureRequestResponse>(`${SIGNATURE_REQUESTS_BASE}/${id}/cancel`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Signer-facing /sign consumer endpoints (Epic 84.2).
+// ---------------------------------------------------------------------------
+
+/**
+ * Error thrown by the signer-facing `/sign` endpoints. Carries the backend
+ * error `code` and HTTP `status` so the signing page can branch its UI on
+ * `SIGNING_LINK_EXPIRED` / `INVALID_SIGNING_LINK` / `ALREADY_SIGNED` /
+ * `LINK_ALREADY_USED` / `REQUEST_NOT_OPEN` instead of showing one generic
+ * message. `apiRequest` above throws a bare `Error`; the signer page needs the
+ * discriminant, hence this dedicated type + fetch wrapper.
+ */
+export class SignError extends Error {
+  readonly code: string;
+  readonly status: number;
+
+  constructor(code: string, status: number, message: string) {
+    super(message);
+    this.name = 'SignError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+/**
+ * Fetch wrapper for the PUBLIC `/sign` endpoints. Unlike `apiRequest` it sends
+ * NO `Authorization` header — the signer is typically not a platform user and
+ * all authority comes from the HMAC token in the query string. It also does
+ * NOT go through the shared axios client, so a `401 INVALID_SIGNING_LINK` never
+ * triggers the app's 401→login redirect (the signer must see that state).
+ */
+async function signRequest<T>(url: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+      message?: string;
+    };
+    throw new SignError(
+      body.error ?? `HTTP_${response.status}`,
+      response.status,
+      body.message ?? `HTTP ${response.status}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Fetch the render context for a signing link (read-only; does not consume the
+ * single-use nonce).
+ * GET /api/v1/signatures/sign?token=…
+ */
+export async function getSignContext(token: string): Promise<SignRenderContext> {
+  return signRequest<SignRenderContext>(`${SIGN_BASE}?token=${encodeURIComponent(token)}`);
+}
+
+/**
+ * Record the signature for a signing link. Single-use: the backend consumes
+ * the nonce atomically, so a replay/double-submit is rejected with 409.
+ * POST /api/v1/signatures/sign?token=…
+ */
+export async function submitSignature(
+  token: string,
+  body: SubmitSignatureBody = {}
+): Promise<SubmitSignatureResponse> {
+  return signRequest<SubmitSignatureResponse>(`${SIGN_BASE}?token=${encodeURIComponent(token)}`, {
     method: 'POST',
     body: JSON.stringify(body),
   });

--- a/frontend/packages/api-client/src/esignature/hooks.ts
+++ b/frontend/packages/api-client/src/esignature/hooks.ts
@@ -8,6 +8,7 @@ import type {
   CancelSignatureRequestBody,
   CreateSignatureRequestBody,
   SendReminderBody,
+  SubmitSignatureBody,
 } from './types';
 
 // Query keys
@@ -16,6 +17,7 @@ export const esignatureKeys = {
   requestsForDocument: (documentId: string) =>
     [...esignatureKeys.all, 'document', documentId] as const,
   request: (id: string) => [...esignatureKeys.all, 'request', id] as const,
+  signContext: (token: string) => [...esignatureKeys.all, 'sign-context', token] as const,
 };
 
 /**
@@ -98,5 +100,32 @@ export function useCancelSignatureRequest(documentId?: string) {
         });
       }
     },
+  });
+}
+
+/**
+ * Signer-facing render context for a signing link (Epic 84.2).
+ * Read-only — does NOT consume the single-use nonce. Token errors (expired /
+ * invalid / already-signed) are surfaced as `SignError`; we disable retries so
+ * the signer sees the terminal state immediately rather than after backoff.
+ */
+export function useSignContext(token: string | undefined) {
+  return useQuery({
+    queryKey: esignatureKeys.signContext(token ?? ''),
+    queryFn: () => api.getSignContext(token!),
+    enabled: !!token,
+    retry: false,
+    staleTime: 0,
+    gcTime: 0,
+  });
+}
+
+/**
+ * Record the signature for a signing link (Epic 84.2).
+ * The single-use nonce is consumed server-side, so this is not retried.
+ */
+export function useSubmitSignature(token: string) {
+  return useMutation({
+    mutationFn: (body: SubmitSignatureBody = {}) => api.submitSignature(token, body),
   });
 }

--- a/frontend/packages/api-client/src/esignature/types.ts
+++ b/frontend/packages/api-client/src/esignature/types.ts
@@ -99,3 +99,43 @@ export interface CancelSignatureRequestResponse {
   signature_request: SignatureRequest;
   message: string;
 }
+
+// ---------------------------------------------------------------------------
+// Signer-facing /sign consumer endpoint (Epic 84.2).
+// Public: authority is the HMAC token in the `?token=` query string, so these
+// carry NO auth header. Mirrors backend `SignRenderContext` /
+// `SubmitSignatureRequest` / `SubmitSignatureResponse` in
+// `routes/signatures.rs` (snake_case JSON, matching the types above).
+// ---------------------------------------------------------------------------
+
+/** Render context returned by `GET /api/v1/signatures/sign?token=…`. */
+export interface SignRenderContext {
+  /** The signature request (envelope) id. */
+  request_id: string;
+  /** The document being signed. */
+  document_id: string;
+  /** Human-facing subject/title of the request. */
+  subject?: string;
+  /** Optional message the requester attached for signers. */
+  message?: string;
+  /** The signer's display name (from the request roster). */
+  signer_name: string;
+  /** The signer's email (echoed from the verified token). */
+  signer_email: string;
+  /** The signer's current status (e.g. `pending`, `viewed`). */
+  signer_status: string;
+}
+
+/** Body for `POST /api/v1/signatures/sign?token=…`. A bare `{}` is accepted. */
+export interface SubmitSignatureBody {
+  /** The full name the signer typed to adopt their signature (evidence). */
+  typed_name?: string;
+}
+
+/** Response from `POST /api/v1/signatures/sign?token=…`. */
+export interface SubmitSignatureResponse {
+  /** Request status AFTER recording this signature (`in_progress` / `completed`). */
+  status: string;
+  /** Human-facing confirmation message. */
+  message: string;
+}


### PR DESCRIPTION
## Task
Build the signer-facing document-sign page in ppt-web against the shipped signing API; flip screen-map ppt/document-sign buildStatus planned->shipped; verify signature-request email delivery.

## Owner
pm-frontend (specialist: react-web)

## What shipped
- **New public signer page** `DocumentSignPage` (`frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx`), wired as a **public** `/sign` route (no `ProtectedRoute`) in `routes/groups/documents.tsx`. Opened from the emailed `{BASE_URL}/sign?token=<v1…>` link; the HMAC `?token=` is the only credential.
- **`@ppt/api-client` esignature module** — added the previously-missing signer surface: `getSignContext(token)` / `submitSignature(token, body)` + a typed `SignError` (carries the backend error `code`), and hooks `useSignContext` / `useSubmitSignature`. These use an **auth-less `fetch`** (no `Authorization` header) that does NOT go through the shared axios 401→login interceptor, so a `401 INVALID_SIGNING_LINK` renders as a signer-facing state instead of redirecting to login.
- Page covers every state from the screen-map: token-missing, loading, `SIGNING_LINK_EXPIRED` (410), `INVALID_SIGNING_LINK` (401), `ALREADY_SIGNED` / `LINK_ALREADY_USED` / `REQUEST_NOT_OPEN` (409), the adopt-&-sign (`typed_name`) flow, and the `in_progress` vs `completed` confirmation branch.
- **i18n**: `documentSign.*` strings added to all six locale bundles (en/sk/cs/de/pl/hu).
- **Screen-map** `docs/screens/ppt/document-sign.md`: `ppt-web.buildStatus` planned → shipped, checklist boxes ticked, Agent Log entry added.

### Scope notes / deferrals
- **PDF preview deferred.** The public render context (`SignRenderContext`) returns `document_id` but no document URL — the document blob is behind an authenticated endpoint — so the page surfaces the document subject/message metadata rather than the file. Flagged in the screen-map for a future token-scoped public document-fetch endpoint.
- **Email delivery verification (task item 3):** confirmed by inspection only, no code change needed. The signature-request invitation email is already shipped + tested: `send_signature_request_email` (`backend/servers/api-server/src/services/email.rs`), fired from `create_signature_request_for_document` in `routes/signatures.rs`; the signing URL is built by `LightweightProvider::build_signing_url` (`backend/crates/integrations/src/esignature.rs`) with a fail-closed nonce persisted before send; covered by `esignature_email_status_tracking_tests.rs`.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` (tsc) → exit 0
- `pnpm -F @ppt/web typecheck` → exit 0
- `biome check` (changed set, 42 files) → exit 0  *(note: the per-app `lint` script points at a broken/absent eslint config repo-wide; the real CI lint gate is `biome check .`)*
- `pnpm -F @ppt/web exec vitest run documentSignI18n.test.ts` → 141 passed

**IG3 (failing-on-main test):** `documentSignI18n.test.ts` fails at the `test:` commit (8 failed — no `documentSign` namespace exists) and passes at the `feat:` commit (141 passed). Verified by running the test against the test-only commit in a scratch worktree.

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → exit 0 (built in ~7–8s)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (public signer page consumes an already-shipped, already-tested backend; no security/auth/billing/data-integrity change in this PR — token verification lives entirely server-side).

## Code-reuse review
`reuse-grep.sh` emitted one advisory: `WARN: useS looks like an existing helper at frontend/packages/screen-map/src/review-server/client/app.tsx`. **Spurious** — a truncated `useS` prefix match against an unrelated screen-map file. The new hooks `useSignContext` / `useSubmitSignature` do not exist elsewhere and are added alongside the existing esignature hooks.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- Scope-drift check: clean (all changes under `frontend/**` + `docs/screens/**`, within pm-frontend areas).
- Goal-check IG1/IG2/IG5/IG6/IG8 are structurally N/A for this dispatcher gap task (no `.research/plans/<slug>.md`, dispatcher-mandated `auto-impl/*` branch — neither of which I create/rename; `.research/**` untouched by design). IG3 (the meaningful TDD gate) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7)_