### PR TITLE
gh-issue-2319: quiet benign push skips + drop dead PushTransport param (follow-up to #2310)

### DIFF
--- a/backend/crates/common/src/notifications/pipeline.rs
+++ b/backend/crates/common/src/notifications/pipeline.rs
@@ -177,12 +177,12 @@ pub trait EmailTransport: Send + Sync {
 #[async_trait::async_trait]
 pub trait PushTransport: Send + Sync {
     /// Send a push notification to every registered device token for the user.
-    async fn send(
-        &self,
-        user_id: Uuid,
-        device_tokens: &[String],
-        notification: &Notification,
-    ) -> TransportResult;
+    ///
+    /// Implementations look up the user's device tokens themselves (once, via the
+    /// service-role pool) and route each to its provider. There is intentionally no
+    /// `device_tokens` parameter: the pipeline does not pre-fetch tokens, and a
+    /// vestigial slice only invites callers to populate it and expect it to matter.
+    async fn send(&self, user_id: Uuid, notification: &Notification) -> TransportResult;
 }
 
 /// Transport adapter for in-app (stored) notifications.

--- a/backend/servers/api-server/src/services/notification_pipeline.rs
+++ b/backend/servers/api-server/src/services/notification_pipeline.rs
@@ -762,9 +762,8 @@ impl NotificationPipeline {
                 // Epic 8A-3 / gap-84-4: `CombinedPushAdapter` fetches device
                 // tokens internally from `device_push_tokens` via the
                 // service-role pool and routes each token to its provider
-                // (FCM for Android, APNs for iOS). The `device_tokens` slice is
-                // left empty here; adapters that pre-fetch tokens can still use it.
-                self.push_adapter.send(user_id, &[], notification).await
+                // (FCM for Android, APNs for iOS).
+                self.push_adapter.send(user_id, notification).await
             }
             NotificationChannel::InApp => {
                 self.in_app_adapter
@@ -778,10 +777,15 @@ impl NotificationPipeline {
             // Issue #484: transport-not-configured is a `skipped`
             // outcome, not a failure. Keeps `sent` counters honest.
             Err(NotificationError::PushNotConfigured) => {
+                // `PushNotConfigured` is returned both when no provider is
+                // configured AND when providers are configured but the user has
+                // no deliverable device tokens (`combine()` NoTargets + NoTargets).
+                // Both are Skipped, not Failed — keep the wording accurate for
+                // operators diagnosing why a push was skipped.
                 tracing::debug!(
                     user_id = %user_id,
                     channel = %channel,
-                    "[Epic 2B] Push channel skipped — FCM not configured"
+                    "[Epic 2B] Push channel skipped — provider not configured or no deliverable device targets"
                 );
                 record.into_skipped()
             }

--- a/backend/servers/api-server/src/services/push_fanout.rs
+++ b/backend/servers/api-server/src/services/push_fanout.rs
@@ -589,12 +589,7 @@ impl FcmHttpAdapter {
 
 #[async_trait]
 impl PushTransport for FcmHttpAdapter {
-    async fn send(
-        &self,
-        user_id: Uuid,
-        _device_tokens: &[String],
-        notification: &Notification,
-    ) -> TransportResult {
+    async fn send(&self, user_id: Uuid, notification: &Notification) -> TransportResult {
         // Standalone use (not via `CombinedPushAdapter`): fetch the user's
         // tokens ourselves, then run the shared delivery core.
         if !self.fcm_config.is_configured() {
@@ -978,12 +973,7 @@ impl ApnsHttpAdapter {
 
 #[async_trait]
 impl PushTransport for ApnsHttpAdapter {
-    async fn send(
-        &self,
-        user_id: Uuid,
-        _device_tokens: &[String],
-        notification: &Notification,
-    ) -> TransportResult {
+    async fn send(&self, user_id: Uuid, notification: &Notification) -> TransportResult {
         if !self.apns_config.is_configured() {
             return ProviderOutcome::NotConfigured.into_result();
         }
@@ -1057,6 +1047,11 @@ impl ProviderOutcome {
 pub struct CombinedPushAdapter {
     fcm: FcmHttpAdapter,
     apns: ApnsHttpAdapter,
+    /// The combined adapter owns the single token fetch (see [`CombinedPushAdapter::send`]).
+    /// Kept as its own field rather than reaching into `self.fcm.token_repo`, so the
+    /// "fetch once" responsibility is expressed on the adapter that owns it and does not
+    /// break if `FcmHttpAdapter` is later extracted to another module.
+    token_repo: DevicePushTokenRepository,
 }
 
 impl CombinedPushAdapter {
@@ -1064,7 +1059,8 @@ impl CombinedPushAdapter {
     pub fn from_env(pool: DbPool) -> Self {
         Self {
             fcm: FcmHttpAdapter::from_env(pool.clone()),
-            apns: ApnsHttpAdapter::from_env(pool),
+            apns: ApnsHttpAdapter::from_env(pool.clone()),
+            token_repo: DevicePushTokenRepository::new(pool),
         }
     }
 
@@ -1072,7 +1068,8 @@ impl CombinedPushAdapter {
     pub fn new(pool: DbPool, fcm_config: FcmConfig, apns_config: ApnsConfig) -> Self {
         Self {
             fcm: FcmHttpAdapter::new(pool.clone(), fcm_config),
-            apns: ApnsHttpAdapter::new(pool, apns_config),
+            apns: ApnsHttpAdapter::new(pool.clone(), apns_config),
+            token_repo: DevicePushTokenRepository::new(pool),
         }
     }
 
@@ -1151,17 +1148,12 @@ impl CombinedPushAdapter {
 
 #[async_trait]
 impl PushTransport for CombinedPushAdapter {
-    async fn send(
-        &self,
-        user_id: Uuid,
-        _device_tokens: &[String],
-        notification: &Notification,
-    ) -> TransportResult {
+    async fn send(&self, user_id: Uuid, notification: &Notification) -> TransportResult {
         // Fetch the user's device tokens ONCE. Previously `FcmHttpAdapter` and
         // `ApnsHttpAdapter` each ran `get_tokens_for_user` independently — 2N
         // identical queries on the `dispatch_to_users` fanout hot path. Fetch
         // here and hand both providers the shared slice.
-        let tokens = match self.fcm.token_repo.get_tokens_for_user(user_id).await {
+        let tokens = match self.token_repo.get_tokens_for_user(user_id).await {
             Ok(t) => t,
             Err(e) => {
                 tracing::error!(
@@ -1221,7 +1213,7 @@ impl PushFanoutConfig {
 /// Redis list key the notification pipeline enqueues push jobs onto.
 ///
 /// Producers `RPUSH` a JSON-serialized [`Notification`] onto this list; the
-/// worker `BLPOP`s from the head and delivers each one via [`FcmHttpAdapter`].
+/// worker `BLPOP`s from the head and delivers each one via [`CombinedPushAdapter`].
 pub const PUSH_FANOUT_QUEUE_KEY: &str = "push_fanout_queue";
 
 /// BLPOP block timeout (seconds) used when draining the queue.
@@ -1255,8 +1247,8 @@ const MAX_JOBS_PER_TICK: usize = 256;
 /// ```
 ///
 /// On each tick the worker `BLPOP`s from the head of the list (short timeout)
-/// and delivers each job via [`FcmHttpAdapter::send`], up to
-/// [`MAX_JOBS_PER_TICK`] jobs per tick.
+/// and delivers each job via [`CombinedPushAdapter::send`] (one token fetch,
+/// platform-routed FCM + APNs), up to [`MAX_JOBS_PER_TICK`] jobs per tick.
 ///
 /// When Redis is not available (or the worker is disabled) the worker falls
 /// through to a no-op heartbeat loop so the server always starts cleanly — the
@@ -1335,8 +1327,9 @@ impl PushFanoutWorker {
     /// Process pending push jobs from the queue.
     ///
     /// When Redis is available we `BLPOP` jobs off [`PUSH_FANOUT_QUEUE_KEY`] and
-    /// deliver each one via [`FcmHttpAdapter::send`], up to
-    /// [`MAX_JOBS_PER_TICK`] jobs per tick. When Redis is not available we just
+    /// deliver each one via [`CombinedPushAdapter::send`] (one token fetch,
+    /// platform-routed FCM + APNs), up to [`MAX_JOBS_PER_TICK`] jobs per tick.
+    /// When Redis is not available we just
     /// log a heartbeat (the in-process pipeline delivers push synchronously).
     async fn process_pending_jobs(&self) {
         let Some(ref pubsub) = self.pubsub else {
@@ -1399,13 +1392,7 @@ impl PushFanoutWorker {
             }
         };
 
-        // `device_tokens` is unused by the adapters (they re-fetch from the DB),
-        // so an empty slice is fine here.
-        match self
-            .adapter
-            .send(notification.user_id, &[], &notification)
-            .await
-        {
+        match self.adapter.send(notification.user_id, &notification).await {
             Ok(()) => {
                 tracing::debug!(
                     notification_id = %notification.id,
@@ -1413,11 +1400,24 @@ impl PushFanoutWorker {
                     "[8A-3] PushFanoutWorker delivered queued push job"
                 );
             }
+            Err(NotificationError::PushNotConfigured) => {
+                // Not a failure: either no provider is configured, or the user
+                // has no deliverable device tokens (`combine()` maps both to
+                // `PushNotConfigured`, which the synchronous pipeline records as
+                // Skipped). Mirror that here — a benign no-device user must not
+                // emit warn-level "delivery failed" noise or trip warn-based
+                // alerting.
+                tracing::debug!(
+                    notification_id = %notification.id,
+                    user_id = %notification.user_id,
+                    "[8A-3] PushFanoutWorker: push skipped — no configured provider had a deliverable target"
+                );
+            }
             Err(e) => {
-                // Delivery failed (FCM not configured, DB error, or all sends
-                // failed). The in-app channel remains the mandatory record, so
-                // we log and move on rather than re-queue (avoids hot-looping on
-                // a permanently failing job).
+                // Genuine failure (DB error or all provider sends failed). The
+                // in-app channel remains the mandatory record, so we log and move
+                // on rather than re-queue (avoids hot-looping on a permanently
+                // failing job).
                 tracing::warn!(
                     notification_id = %notification.id,
                     user_id = %notification.user_id,

--- a/backend/servers/api-server/tests/push_delivery_receipt_tests.rs
+++ b/backend/servers/api-server/tests/push_delivery_receipt_tests.rs
@@ -178,7 +178,7 @@ async fn successful_fcm_delivery_receipt_returns_ok(pool: PgPool) {
     );
     let notification = make_notification(user_id);
 
-    let result = adapter.send(user_id, &[], &notification).await;
+    let result = adapter.send(user_id, &notification).await;
 
     assert!(
         result.is_ok(),
@@ -223,7 +223,7 @@ async fn apns_only_path_no_fcm_attempted_returns_ok(pool: PgPool) {
     );
     let notification = make_notification(user_id);
 
-    let result = adapter.send(user_id, &[], &notification).await;
+    let result = adapter.send(user_id, &notification).await;
 
     // APNs-only → fcm_attempted == false → must return Ok(()) regardless.
     assert!(
@@ -288,7 +288,7 @@ async fn fcm_not_registered_deletes_stale_token(pool: PgPool) {
 
     // The adapter may return Err (all FCM attempts failed) — that is fine.
     // What matters is that the stale token was deleted.
-    let _ = adapter.send(user_id, &[], &notification).await;
+    let _ = adapter.send(user_id, &notification).await;
 
     assert!(
         !token_exists(&pool, &stale_token).await,
@@ -343,7 +343,7 @@ async fn fcm_failure_with_apns_token_returns_err_not_silent_ok(pool: PgPool) {
     );
     let notification = make_notification(user_id);
 
-    let result = adapter.send(user_id, &[], &notification).await;
+    let result = adapter.send(user_id, &notification).await;
 
     // FCM was attempted and failed; fcm_attempted=true and any_sent=false
     // → must return Err, NOT silently Ok(()) as if only APNs tokens existed.
@@ -397,7 +397,7 @@ async fn legacy_fcm_successful_delivery_returns_ok(pool: PgPool) {
     let adapter = make_legacy_adapter(pool.clone(), server.uri(), "AAAA-legacy-server-key");
     let notification = make_notification(user_id);
 
-    let result = adapter.send(user_id, &[], &notification).await;
+    let result = adapter.send(user_id, &notification).await;
 
     assert!(
         result.is_ok(),
@@ -444,7 +444,7 @@ async fn legacy_fcm_not_registered_deletes_stale_token(pool: PgPool) {
     let adapter = make_legacy_adapter(pool.clone(), server.uri(), "AAAA-legacy-server-key");
     let notification = make_notification(user_id);
 
-    let _ = adapter.send(user_id, &[], &notification).await;
+    let _ = adapter.send(user_id, &notification).await;
 
     assert!(
         !token_exists(&pool, &stale_token).await,


### PR DESCRIPTION
## Task
Follow-up hardening from post-merge review of PR #2310 (closes #2319). Non-blocking cleanup findings on the gap-84-4 push-fanout wiring:

1. **regression (medium)** — `PushFanoutWorker` logged `warn!("push delivery failed for queued job")` for benign no-device users. With both providers configured and a user who has zero registered device tokens, `combine()` returns `Err(PushNotConfigured)` and the worker treated every `Err` as a failure — warn noise + miscategorized outcome for warn-based alerting.
2. **conventions (low)** — `PushNotConfigured` is overloaded ("configured but no deliverable targets" as well as "not configured"); the pipeline's Skipped log still said "FCM not configured".
3. **stale docs (low)** — three rustdoc references still pointed at `FcmHttpAdapter::send`; the worker has routed through `CombinedPushAdapter` since #2290.
4. **better-approach (low)** — `PushTransport::send`'s `device_tokens: &[String]` param was dead weight (all impls bound `_device_tokens`, all call sites passed `&[]`).
5. **better-approach (low)** — `CombinedPushAdapter::send` fetched tokens by reaching into `self.fcm.token_repo` (a child's private field).

## Changes
- `push_fanout.rs` `deliver_job`: explicit `Err(NotificationError::PushNotConfigured)` arm → `debug!` "push skipped — no configured provider had a deliverable target"; `warn!` retained only for genuine `PushFailed` / DB errors.
- `notification_pipeline.rs`: reworded the Skipped debug log to "provider not configured or no deliverable device targets" (chose the minimal-reword option over a new `PushNoTargets` variant to keep the change contained).
- `push_fanout.rs`: fixed 3 stale rustdoc refs `FcmHttpAdapter` → `CombinedPushAdapter`.
- `pipeline.rs` + 3 impls + 2 call sites + receipt integration test: removed the `device_tokens` param from `PushTransport::send`.
- `CombinedPushAdapter`: added its own `token_repo` field (constructed from the pool in `new`/`from_env`); `send` now fetches through `self.token_repo`.

## Owner
Specialist: `rust-backend`. owner_role hint was `pm-tech-lead` (docs/.research/_bmad only) — see Scope drift.

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p common` → exit 0 (trait-definition crate)
- `SQLX_OFFLINE=true cargo check -p api-server` → exit 0
- `SQLX_OFFLINE=true cargo test -p api-server --lib push_fanout` → exit 0 (39 passed, incl. the iOS-/Android-only "skipped not sent" combine tests)
- `cargo test -p api-server --test push_delivery_receipt_tests --no-run` → exit 0 (edited integration test compiles)

Note: the api-server compile requires the `utoipa-swagger-ui` build script, whose GitHub zip download is blocked by org proxy policy in this environment. Verified locally by pointing `SWAGGER_UI_DOWNLOAD_URL` at a minimal local zip (verify-only; the `utoipa-swagger-ui` feature list in `backend/Cargo.toml` was NOT changed in this PR). CI has real network access and will build normally.

## Built (Band B — full build)
Skipped: change is a small, localized refactor + log-level/doc edit; no new public API surface (the trait change removes a param), no migration, no build-output config.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no auth/billing/data-integrity change — logging + a dead-param removal on an internal transport trait).

## Scope drift
`scope-check` flags all 4 backend files as outside `pm-tech-lead`'s mapped areas (`docs/**`, `.research/**`, `_bmad-output/**`). This is an owner_role/area-map artifact, not real drift: the task's `owner_role` was an explicit hint only and the real specialist is `rust-backend`. Every changed path is under `backend/**`, which is `pm-backend`'s owned area. No files outside backend were touched.

## Notes
- Chose the minimal fixes the finding text called out (reworded log rather than a new `NotificationError::PushNoTargets` variant; removed the dead param rather than repurposing it to `Option<&[DevicePushToken]>`) to keep the follow-up tightly scoped.
- goal-check IG1/IG2/IG8 are N/A here: this is a GitHub-issue follow-up (no `.research/plan`, dispatcher-assigned `auto-impl/*` branch, no archive move), not the plan-driven flow those checks target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7

---
_Generated by [Claude Code](https://claude.ai/code/session_01StvkM4KrcxhH2S3se7DQz7)_