### PR TITLE
gh-issue-2341: harden reality-web listing detail — type-guard features/photos, 404 status

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
@@ -106,6 +106,22 @@ describe('buildListingJsonLd', () => {
     expect('image' in jsonLd).toBe(false);
   });
 
+  // #2341: a partial 200 can carry wrong-typed (not just missing) collection
+  // fields. buildListingJsonLd must tolerate a non-array `photos` (skip image)
+  // and a non-object `features` (ignored — never emitted) without throwing.
+  it('tolerates wrong-typed photos/features (non-array photos, string features)', () => {
+    const malformed = {
+      ...validListing,
+      photos: {} as unknown as ListingDetail['photos'],
+      features: 'x' as unknown as ListingDetail['features'],
+    };
+    expect(() => buildListingJsonLd(malformed)).not.toThrow();
+    const jsonLd = buildListingJsonLd(malformed) as Record<string, unknown>;
+    expect(jsonLd).not.toBeNull();
+    expect(jsonLd.name).toBe('Beautiful Apartment');
+    expect('image' in jsonLd).toBe(false);
+  });
+
   it('omits optional price/rooms/area blocks when missing', () => {
     const minimal = {
       title: 'Minimal',

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
@@ -11,7 +11,8 @@
 import type { ListingDetail } from '@ppt/reality-api-client';
 import type { Metadata } from 'next';
 import { headers } from 'next/headers';
-import { ListingDetailContent, ListingNotFound } from '@/components/listings';
+import { notFound } from 'next/navigation';
+import { ListingDetailContent } from '@/components/listings';
 import { buildListingJsonLd, isRenderableListing } from './jsonLd';
 import { buildListingMetadata } from './metadata';
 
@@ -100,8 +101,13 @@ export default async function ListingDetailPage({ params }: PageProps) {
   const host = await resolveHost();
   const listing = await getListing(slug, host);
 
+  // A missing / malformed listing must emit a real HTTP 404, not a 200 with
+  // "not found" markup: this is a public, SEO-indexed portal, and a soft-404
+  // (200 body) lets crawlers index dead listings. `notFound()` renders the
+  // locale-aware `app/[locale]/not-found.tsx` with a 404 status. `notFound()`
+  // returns `never`, so `listing` is non-null below (#2341).
   if (!listing) {
-    return <ListingNotFound />;
+    notFound();
   }
 
   // JSON-LD structured data, built defensively: a partial/malformed 200 body

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
@@ -122,4 +122,30 @@ describe('ListingDetailContent', () => {
     expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
     expect(screen.getByText('Bare Listing')).toBeInTheDocument();
   });
+
+  // #2341 (medium): a partial 200 can carry *wrong-typed* collection fields,
+  // not just null/undefined. `features: "x"` fed to `Object.entries` yields
+  // per-character garbage entries; nullish-coalescing (`?? {}`) does not catch
+  // it. The type-guard must reject a non-object `features`.
+  it('does not throw and renders no features when features is a string', () => {
+    const partial = {
+      ...validListing,
+      features: 'x' as unknown as ListingDetail['features'],
+    };
+    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
+    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
+    // No per-character feature ("x", "0", …) leaked into the features section.
+    expect(screen.queryByText('features')).not.toBeInTheDocument();
+  });
+
+  // #2341 (medium): a non-array `photos` (e.g. `{}`) makes PhotoGallery throw
+  // on `.length` / `.map`. `?? []` does not catch a truthy non-array.
+  it('does not throw when photos is a non-array object', () => {
+    const partial = {
+      ...validListing,
+      photos: {} as unknown as ListingDetail['photos'],
+    };
+    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
+    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
+  });
 });

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
@@ -97,14 +97,22 @@ export function ListingDetailContent({ listing, jsonLd }: ListingDetailContentPr
     return tFeatures(key);
   };
 
-  // `listing.features` / `listing.photos` are validated as present for bodies
-  // that reach here via `getListing`, but this component is exported and may
-  // receive a partial body from other callers. Guard the unguarded derefs so a
-  // missing `features` (Object.entries) or `photos` (PhotoGallery) can never
-  // crash SSR with a 500.
-  const activeFeatures = Object.entries(listing.features ?? {})
+  // `listing.features` / `listing.photos` are typed as present, but this
+  // component is exported and a partial/malformed 200 body (from getListing's
+  // upstream, or another caller) can carry *wrong-typed* values, not just
+  // null/undefined. `features: "x"` makes `Object.entries` emit per-character
+  // garbage entries, and a non-array `photos` (e.g. `{}`) makes `PhotoGallery`
+  // throw on `.length` / `.map` — the same SSR-500 this guard exists to
+  // prevent (#2276 / #2341). Type-guard both, not just nullish-coalesce.
+  const featuresObj =
+    listing.features && typeof listing.features === 'object' && !Array.isArray(listing.features)
+      ? listing.features
+      : {};
+  const activeFeatures = Object.entries(featuresObj)
     .filter(([, value]) => value === true)
     .map(([key]) => key as keyof ListingFeatures);
+
+  const photos = Array.isArray(listing.photos) ? listing.photos : [];
 
   return (
     <div className="page-container">
@@ -132,7 +140,7 @@ export function ListingDetailContent({ listing, jsonLd }: ListingDetailContentPr
             {/* Main Content */}
             <div className="main-content">
               {/* Photo Gallery */}
-              <PhotoGallery photos={listing.photos ?? []} title={listing.title} />
+              <PhotoGallery photos={photos} title={listing.title} />
 
               {/* Header */}
               <div className="listing-header">


### PR DESCRIPTION
## Task
Follow-up: harden reality-web listing detail body validation — type-guard features/photos, 404 status (PR #2281) (Closes #2341)

## Owner
pm-tech-lead (hint) — actual specialist: **nextjs-web** (reality-web / Next.js SSR)

## What changed (addresses #2341 findings)
- **robustness (medium) — type-guard `features` / `photos`.** `ListingDetailContent`
  now type-guards both collection fields instead of only nullish-coalescing:
  `features` is used only when it is a real non-array object, else `{}`; `photos`
  only when it is an array, else `[]`. A malformed 200 with `features: "x"` no
  longer feeds per-character garbage into `Object.entries`, and a non-array
  `photos` (e.g. `{}`) no longer throws in `PhotoGallery` — the same SSR-500
  class #2276/#2281 set out to eliminate, for a wrong-typed shape.
- **http-semantics (low) — real 404.** `page.tsx` now calls Next's `notFound()`
  for a missing/malformed listing instead of returning `<ListingNotFound/>`
  with a 200. This renders the existing locale-aware `app/[locale]/not-found.tsx`
  with a genuine HTTP 404, so crawlers stop indexing soft-404s on the public
  portal. `notFound()` returns `never`, so `listing` narrows to non-null after.
- **Tests.** Added wrong-typed regressions: `features: "x"` and `photos: {}` in
  `ListingDetailContent.test.tsx` (the `photos: {}` case genuinely throws on the
  pre-fix code — a real fail-on-main guard), plus a `buildListingJsonLd`
  tolerance case in `jsonLd.test.ts`.

`buildListingJsonLd` / `isRenderableListing` already tolerate wrong-typed
`photos`/`features` (via `Array.isArray` + required-field-only checks), so no
change was needed there; the crash site was the client component's derefs.

### schema-validation (low) — deferred
The issue also proposed a shared `parseListingDetail()` / zod normalizer to
replace the hand-rolled predicates. Not done here: it is a larger refactor
(new dep or new normalizer contract) and the concrete crash is fully closed by
the type-guards above. Flagging for a separate decision; `isRenderableListing`
remains the single required-field source of truth.

## Tested (Band A — fast check)
- `pnpm -F reality-web typecheck` → exit 0
- `npx biome check` on the 4 changed files → exit 0 (`next lint` script is
  mis-wired in this workspace; Biome is the repo linter per CLAUDE.md)
- `npx vitest run ListingDetailContent.test.tsx jsonLd.test.ts` → 25 passed

## Built (Band B — full build)
- `pnpm -F reality-web build` → exit 0 (Next.js production build; SSR/i18n OK;
  `/[locale]/listings/[slug]` remains dynamic `ƒ`, compatible with `notFound()`)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2, but this is an **owner-hint
artifact**, not real drift: the `owner_role` hint was `pm-tech-lead`, which does
not own reality-web frontend paths, whereas the real specialist is `nextjs-web`.
All 4 changed files are squarely inside the issue's target module
(`frontend/apps/reality-web/src/{app/[locale]/listings/[slug],components/listings}`).

## Notes
- IG goal-check (`goal-check.sh`) is tailored to the `.research/plans/` research
  flow: IG1 (plan file) and IG2 (`impl/<slug>` branch name) are N/A for this
  GitHub-issue-driven `auto-impl` task; regression tests are present (IG3 intent),
  bundled in the single `fix:` commit rather than a split `test:`/`fix:` pair.
- Branch is based on an ancestor of `dev`; the 6 intervening commits
  (notifications/favorites) don't touch these files — PR diff is the 4 files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pKMUXEAybCsheSDVx25md

---
_Generated by [Claude Code](https://claude.ai/code/session_012pKMUXEAybCsheSDVx25md)_