### PR TITLE
gh-issue-2329: consolidate JWT tenant-decode + fix stale useTenantId cache on logout/login

### DIFF
--- a/frontend/apps/mobile/src/contexts/AuthContext.tsx
+++ b/frontend/apps/mobile/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useQueryClient } from '@tanstack/react-query';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 import type { ReactNode } from 'react';
@@ -56,6 +57,7 @@ interface AuthProviderProps {
 }
 
 export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
+  const queryClient = useQueryClient();
   const [state, setState] = useState<AuthState>({
     isLoading: true,
     isAuthenticated: false,
@@ -138,6 +140,12 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
         await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshToken);
         await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
 
+        // Drop the cached tenant id (issue #2329). `useTenantId` caches the
+        // JWT's `tenant_id` claim with `staleTime: Infinity`, so without this a
+        // login that follows a session which wasn't explicitly logged out would
+        // keep serving the previous org's tenant id.
+        queryClient.removeQueries({ queryKey: ['auth', 'tenant-id'] });
+
         setState((prev) => ({
           ...prev,
           isLoading: false,
@@ -150,7 +158,7 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
         throw error;
       }
     },
-    [apiBaseUrl]
+    [apiBaseUrl, queryClient]
   );
 
   const logout = useCallback(async () => {
@@ -159,6 +167,14 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
       await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY);
       await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
       await SecureStore.deleteItemAsync(USER_KEY);
+
+      // Wipe the whole query cache on logout (issue #2329). `useTenantId`
+      // caches the tenant id forever (`staleTime: Infinity`) and nothing else
+      // invalidated it, so after logout + login as a user in a *different* org
+      // its consumers kept serving the previous org's tenant id until an app
+      // restart — producing persistent cross-tenant 403s / wrong cache keys.
+      // Clearing everything also ensures no other org's data survives logout.
+      queryClient.clear();
 
       setState((prev) => ({
         ...prev,
@@ -170,7 +186,7 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
       console.error('Failed to logout:', error);
       throw error;
     }
-  }, []);
+  }, [queryClient]);
 
   const refreshToken = useCallback(async () => {
     try {

--- a/frontend/apps/mobile/src/hooks/useApi.test.ts
+++ b/frontend/apps/mobile/src/hooks/useApi.test.ts
@@ -2,45 +2,41 @@
  * Unit tests for the mobile app's core fetch/auth module.
  *
  * `useApi.ts` owns tenant-scoping for *every* api-server request: it decodes
- * the JWT client-side to pull the `tenant_id` claim and injects it as the
- * `X-Tenant-ID` header that the server's RLS extractor requires. Until now it
- * had no direct coverage — every consumer just mocked it — so these tests pin
- * the three pure-ish units the module is built on:
+ * the JWT client-side (via the shared `utils/jwt` module) to pull the
+ * `tenant_id` claim and injects it as the `X-Tenant-ID` header that the
+ * server's RLS extractor requires. These tests pin the module-specific
+ * behavior:
  *
- * - `decodeJwtPayload` (exercised through `getTenantId`, which is the only
- *   caller): base64url with and without `=` padding, the `-`/`_` → `+`/`/`
- *   conversion, and malformed tokens returning `null` without throwing.
- * - `getTenantId`: extracts the `tenant_id` claim, and yields `null` (so no
- *   header is injected) when the token/claim is missing or non-string.
- * - `apiRequest`: composes the `X-Tenant-ID` header, surfaces server error
- *   messages, and handles a 204 No-Content response.
+ * - `getTenantId`: reads the token from SecureStore and extracts the claim,
+ *   yielding `null` (so no header is injected) when the token/claim is missing.
+ *   The exhaustive base64url decode edge-cases live with the shared unit in
+ *   `utils/jwt.test.ts`; here we only cover the SecureStore integration.
+ * - `apiRequest`: composes `Authorization` / `X-Tenant-ID` headers, prefixes
+ *   relative paths with the API base URL, surfaces server error messages,
+ *   handles 204, and stays unauthenticated when the keystore read throws.
+ * - `useTenantId`: resolves the claim reactively and re-derives it after the
+ *   query cache is cleared (the logout/login cross-tenant swap of issue #2329).
  *
  * `expo-secure-store` and `expo-constants` are mocked globally in
- * `src/test/setup.ts`; `fetch` is stubbed per suite.
+ * `src/test/setup.ts`; `config/api` and `fetch` are stubbed here.
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
 import * as SecureStore from 'expo-secure-store';
-import { apiRequest, getTenantId } from './useApi';
+import { createElement, type ReactNode } from 'react';
+import { makeJwt } from '../test/jwt';
+import { apiRequest, getTenantId, useTenantId } from './useApi';
+
+// Fixed base URL so the relative-path composition is deterministic (the real
+// resolver is env/platform-dependent).
+jest.mock('../config/api', () => ({
+  getApiBaseUrl: () => 'https://api.mocked',
+}));
 
 const mockedGetItem = SecureStore.getItemAsync as jest.Mock;
 
 const ACCESS_TOKEN_KEY = 'ppt_access_token';
-
-/**
- * Build a JWT-shaped string (`header.payload.signature`) whose payload is the
- * given object, encoded exactly the way a real base64url JWT payload is.
- *
- * `keepPadding` retains the standard-base64 `=` padding instead of stripping
- * it (real JWTs strip it, but the decoder must tolerate both — see the issue).
- */
-function makeJwt(payload: Record<string, unknown>, keepPadding = false): string {
-  // `btoa` (a global in the RN runtime and Node ≥16, same one the source's
-  // decoder pairs with `atob`) keeps the test off `Buffer`, which isn't in the
-  // mobile app's TS `types`. Payloads are ASCII, so Latin1 `btoa` is safe.
-  const base64 = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_');
-  const segment = keepPadding ? base64 : base64.replace(/=+$/, '');
-  return `header.${segment}.signature`;
-}
 
 /** Prime the SecureStore mock so `getAccessToken()` returns `token`. */
 function primeToken(token: string | null): void {
@@ -53,56 +49,10 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe('getTenantId (and decodeJwtPayload via it)', () => {
-  it('extracts the tenant_id claim from a well-formed token', async () => {
+describe('getTenantId (SecureStore integration)', () => {
+  it('extracts the tenant_id claim from the stored token', async () => {
     primeToken(makeJwt({ sub: 'u-1', tenant_id: 'org-42' }));
     await expect(getTenantId()).resolves.toBe('org-42');
-  });
-
-  // Byte lengths chosen so the base64url length hits each `% 4` residue,
-  // forcing the decoder's padding math down all three branches (0, 1, 2 `=`).
-  it.each([
-    ['no padding needed (len % 4 === 0)', 'tt'],
-    ['two padding chars (len % 4 === 2)', 'ttt'],
-    ['one padding char (len % 4 === 3)', 't'],
-  ])('decodes a base64url payload with %s', async (_label, tenant) => {
-    primeToken(makeJwt({ tenant_id: tenant }));
-    await expect(getTenantId()).resolves.toBe(tenant);
-  });
-
-  it('decodes a payload whose base64url segment still carries `=` padding', async () => {
-    const withPadding = makeJwt({ tenant_id: 'ttt' }, /* keepPadding */ true);
-    // Guard the fixture: this variant must actually contain `=` so the test
-    // is exercising the padded path rather than silently matching the stripped one.
-    expect(withPadding).toContain('=');
-    primeToken(withPadding);
-    await expect(getTenantId()).resolves.toBe('ttt');
-  });
-
-  it('converts base64url `-` and `_` back to `+`/`/` before decoding', async () => {
-    // 'tn->??' encodes to a segment containing '-'; 'tn-???' contains '_'.
-    // Both must round-trip, proving the char-class replacement runs.
-    const dashToken = makeJwt({ tenant_id: 'tn->??' });
-    const underscoreToken = makeJwt({ tenant_id: 'tn-???' });
-    expect(dashToken.split('.')[1]).toContain('-');
-    expect(underscoreToken.split('.')[1]).toContain('_');
-
-    primeToken(dashToken);
-    await expect(getTenantId()).resolves.toBe('tn->??');
-
-    primeToken(underscoreToken);
-    await expect(getTenantId()).resolves.toBe('tn-???');
-  });
-
-  it.each([
-    ['a token with no dots', 'not-a-jwt'],
-    ['a single-segment token', 'onlyheader'],
-    ['an empty string', ''],
-    ['a token whose payload is not valid base64', 'header.!!!not-base64!!!.sig'],
-    ['a token whose payload is not JSON', `header.${btoa('plain text').replace(/=+$/, '')}.sig`],
-  ])('returns null (no throw) for %s', async (_label, token) => {
-    primeToken(token);
-    await expect(getTenantId()).resolves.toBeNull();
   });
 
   it('returns null when the payload has no tenant_id claim', async () => {
@@ -115,14 +65,25 @@ describe('getTenantId (and decodeJwtPayload via it)', () => {
     await expect(getTenantId()).resolves.toBeNull();
   });
 
+  it('returns null (no throw) for a malformed token', async () => {
+    primeToken('not-a-jwt');
+    await expect(getTenantId()).resolves.toBeNull();
+  });
+
   it('returns null when no token is stored', async () => {
     primeToken(null);
+    await expect(getTenantId()).resolves.toBeNull();
+  });
+
+  it('returns null (no auth) when the keystore read throws', async () => {
+    mockedGetItem.mockRejectedValue(new Error('keystore locked'));
     await expect(getTenantId()).resolves.toBeNull();
   });
 });
 
 describe('apiRequest', () => {
   let fetchMock: jest.Mock;
+  let originalFetch: typeof globalThis.fetch;
 
   /** Build a minimal `Response`-like object for the fetch mock. */
   function fakeResponse(opts: { status?: number; ok?: boolean; json?: () => Promise<unknown> }) {
@@ -135,8 +96,15 @@ describe('apiRequest', () => {
   }
 
   beforeEach(() => {
+    originalFetch = globalThis.fetch;
     fetchMock = jest.fn();
     globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    // Restore the original fetch so the stub can't leak across files (harmless
+    // under per-file jest isolation, but keeps the suite future-proof).
+    globalThis.fetch = originalFetch;
   });
 
   /** Return the headers object fetch was called with on its first call. */
@@ -167,6 +135,53 @@ describe('apiRequest', () => {
     const headers = firstCallHeaders();
     expect(headers.Authorization).toBeDefined();
     expect(headers).not.toHaveProperty('X-Tenant-ID');
+  });
+
+  it('proceeds unauthenticated (no Authorization / X-Tenant-ID) when the keystore read throws', async () => {
+    // Pins the current design: a SecureStore failure is swallowed and the
+    // request goes out anonymous rather than failing (issue #2329, finding 3).
+    mockedGetItem.mockRejectedValue(new Error('keystore locked'));
+    fetchMock.mockResolvedValueOnce(fakeResponse({ json: async () => ({}) }));
+
+    await apiRequest('https://api.test/v1/me');
+
+    const headers = firstCallHeaders();
+    expect(headers).not.toHaveProperty('Authorization');
+    expect(headers).not.toHaveProperty('X-Tenant-ID');
+  });
+
+  it('prefixes a relative path with the configured API base URL', async () => {
+    primeToken(makeJwt({ tenant_id: 'org-42' }));
+    fetchMock.mockResolvedValueOnce(fakeResponse({ json: async () => ({}) }));
+
+    await apiRequest('/api/v1/buildings');
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.mocked/api/v1/buildings');
+  });
+
+  it('leaves an absolute URL untouched', async () => {
+    primeToken(makeJwt({ tenant_id: 'org-42' }));
+    fetchMock.mockResolvedValueOnce(fakeResponse({ json: async () => ({}) }));
+
+    await apiRequest('https://api.test/v1/outages');
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.test/v1/outages');
+  });
+
+  it('still sends an expired token (no exp check) — documents the current contract', async () => {
+    // There is no `exp` check in the module and no 401→refresh→retry here
+    // (refresh is AuthContext's job), so an expired token is sent as-is.
+    const expired = makeJwt({ tenant_id: 'org-42', exp: 1 });
+    primeToken(expired);
+    fetchMock.mockResolvedValueOnce(fakeResponse({ json: async () => ({}) }));
+
+    await apiRequest('https://api.test/v1/me');
+
+    const headers = firstCallHeaders();
+    expect(headers.Authorization).toBe(`Bearer ${expired}`);
+    expect(headers['X-Tenant-ID']).toBe('org-42');
   });
 
   it('sets Content-Type and serializes the body for a mutation', async () => {
@@ -222,5 +237,35 @@ describe('apiRequest', () => {
 
     expect(result).toBeUndefined();
     expect(json).not.toHaveBeenCalled();
+  });
+});
+
+describe('useTenantId', () => {
+  function makeWrapper(client: QueryClient) {
+    return ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children);
+  }
+
+  function freshClient(): QueryClient {
+    return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  }
+
+  it('resolves the tenant id from the stored token', async () => {
+    primeToken(makeJwt({ tenant_id: 'org-A' }));
+    const { result } = renderHook(() => useTenantId(), { wrapper: makeWrapper(freshClient()) });
+
+    await waitFor(() => expect(result.current.tenantId).toBe('org-A'));
+  });
+
+  it('derives the new tenant from a fresh (post-logout) cache after a token swap', async () => {
+    // The issue #2329 fix: AuthContext.logout() clears the query cache (pinned
+    // in the auth integration suite), so a subsequent login as a user in a
+    // *different* org resolves the new tenant instead of the `staleTime:
+    // Infinity` cached value. Modeled here as a fresh client + swapped token —
+    // the empty post-logout cache no longer holds the previous org's id.
+    primeToken(makeJwt({ tenant_id: 'org-B' }));
+    const { result } = renderHook(() => useTenantId(), { wrapper: makeWrapper(freshClient()) });
+
+    await waitFor(() => expect(result.current.tenantId).toBe('org-B'));
   });
 });

--- a/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
+++ b/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
@@ -18,6 +18,7 @@
  * payload contract.
  */
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
@@ -26,8 +27,16 @@ import { AuthProvider, useAuth } from '../../contexts/AuthContext';
 
 const API_BASE = 'http://test.local';
 
+// AuthProvider calls `useQueryClient` (issue #2329 — it clears the query cache
+// on logout / after login), so it must render under a QueryClientProvider, just
+// like it does in the real app tree. A fresh client per test keeps them
+// isolated.
+let queryClient: QueryClient;
+
 const wrapper = ({ children }: { children: ReactNode }) => (
-  <AuthProvider apiBaseUrl={API_BASE}>{children}</AuthProvider>
+  <QueryClientProvider client={queryClient}>
+    <AuthProvider apiBaseUrl={API_BASE}>{children}</AuthProvider>
+  </QueryClientProvider>
 );
 
 const mockedSecureStore = SecureStore as jest.Mocked<typeof SecureStore>;
@@ -80,6 +89,7 @@ function mockFetchOnce(body: unknown, status = 200) {
 describe('AuthContext integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     globalThis.fetch = jest.fn() as jest.Mock;
     primeSecureStore();
     mockedLocalAuth.hasHardwareAsync.mockResolvedValue(true);
@@ -164,6 +174,27 @@ describe('AuthContext integration', () => {
       expect(JSON.parse(store.get('ppt_user') ?? '{}')).toEqual(sampleUser);
     });
 
+    it('evicts a stale cached tenant id on login (issue #2329)', async () => {
+      primeSecureStore();
+      // A tenant id left over from a prior session that was never explicitly
+      // logged out — must not survive into the new login.
+      queryClient.setQueryData(['auth', 'tenant-id'], 'org-stale');
+      mockFetchOnce({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        user: sampleUser,
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.login('jane@example.com', 'pw');
+      });
+
+      expect(queryClient.getQueryData(['auth', 'tenant-id'])).toBeUndefined();
+    });
+
     it('throws on bad credentials and leaves the state unauthenticated', async () => {
       primeSecureStore();
       mockFetchOnce({ message: 'Invalid credentials' }, 401);
@@ -208,6 +239,29 @@ describe('AuthContext integration', () => {
       expect(store.has('ppt_access_token')).toBe(false);
       expect(store.has('ppt_refresh_token')).toBe(false);
       expect(store.has('ppt_user')).toBe(false);
+    });
+
+    it('clears the query cache so no previous-tenant data survives (issue #2329)', async () => {
+      primeSecureStore({
+        ppt_access_token: 'access',
+        ppt_user: JSON.stringify(sampleUser),
+      });
+
+      // Seed a cached tenant id the way `useTenantId` would (staleTime:Infinity,
+      // so nothing else would ever evict it).
+      queryClient.setQueryData(['auth', 'tenant-id'], 'org-old');
+      // ...and some unrelated tenant-scoped data.
+      queryClient.setQueryData(['buildings', 'org-old'], [{ id: 'b-1' }]);
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      expect(queryClient.getQueryData(['auth', 'tenant-id'])).toBeUndefined();
+      expect(queryClient.getQueryData(['buildings', 'org-old'])).toBeUndefined();
     });
   });
 

--- a/frontend/apps/mobile/src/test/jwt.ts
+++ b/frontend/apps/mobile/src/test/jwt.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared JWT fixture builder for tests.
+ *
+ * Previously this helper was copy-pasted into `useApi.test.ts` and
+ * `DocumentUploadScreen.test.tsx` (issue #2329). It lives here now so both
+ * suites (and any future one) build tokens the same way.
+ *
+ * Produces `header.<base64url(payload)>.signature`. The header and signature
+ * segments are literal placeholders — the decoder only reads the payload
+ * segment — which keeps `Authorization: Bearer header.…`-style assertions
+ * stable.
+ */
+
+/**
+ * Build a JWT-shaped string whose payload is the given object, encoded exactly
+ * the way a real base64url JWT payload is.
+ *
+ * `keepPadding` retains the standard-base64 `=` padding instead of stripping it
+ * (real JWTs strip it, but the decoder must tolerate both — see issue #2283).
+ */
+export function makeJwt(payload: Record<string, unknown>, keepPadding = false): string {
+  // `btoa` is a global in the RN / jest-expo runtime (Node ≥ 16 too), the same
+  // one the source decoder pairs with `atob`, so the test stays off `Buffer`.
+  // Payloads are ASCII, so Latin1 `btoa` is safe.
+  const base64 = btoa(JSON.stringify(payload)).replace(/\+/g, '-').replace(/\//g, '_');
+  const segment = keepPadding ? base64 : base64.replace(/=+$/, '');
+  return `header.${segment}.signature`;
+}

--- a/frontend/apps/mobile/src/utils/jwt.test.ts
+++ b/frontend/apps/mobile/src/utils/jwt.test.ts
@@ -1,60 +1,95 @@
 /**
- * Tests for the shared client-side JWT helpers.
+ * Unit tests for the shared JWT decode util.
  *
- * This is the *single* suite for `decodeJwtPayload` / `extractTenantId` after
- * the duplicate copies in `hooks/useApi.ts` and
- * `screens/documents/DocumentUploadScreen.tsx` were consolidated here
- * (GitHub #2327). `useApi.test.ts` still exercises `decodeJwtPayload`
- * indirectly through `getTenantId`; the screen no longer owns its own copy.
- *
- * The decode relies on the `atob`/`btoa` globals shipped by the jest-expo
- * runtime.
+ * `src/utils/jwt.ts` is the single source of truth for the base64url JWT
+ * payload decode + `tenant_id` extraction that feeds the `X-Tenant-ID` header
+ * on every tenant-scoped request. It used to be triplicated (issues #2327 /
+ * #2329) with only the `useApi` copy tested; these cases pin the shared unit
+ * directly so all three callers (`useApi`, `useOfflineSupport`,
+ * `DocumentUploadScreen`) are covered by one suite.
  */
 
+import { makeJwt } from '../test/jwt';
 import { decodeJwtPayload, extractTenantId } from './jwt';
 
-/** Build an unsigned JWT (`header.base64url(payload).sig`). */
-function makeJwt(payload: Record<string, unknown>): string {
-  const b64url = (obj: unknown) =>
-    globalThis.btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url(payload)}.sig`;
-}
-
 describe('decodeJwtPayload', () => {
-  it('decodes the payload object from a base64url JWT', () => {
-    expect(decodeJwtPayload(makeJwt({ sub: 'user-1', tenant_id: 'org-7f3c' }))).toEqual({
-      sub: 'user-1',
-      tenant_id: 'org-7f3c',
+  it('decodes a well-formed payload into an object', () => {
+    expect(decodeJwtPayload(makeJwt({ sub: 'u-1', tenant_id: 'org-42' }))).toEqual({
+      sub: 'u-1',
+      tenant_id: 'org-42',
     });
   });
 
-  it('returns null for a token with fewer than two segments', () => {
-    expect(decodeJwtPayload('not-a-jwt')).toBeNull();
+  // Byte lengths chosen so the base64url length hits each `% 4` residue,
+  // forcing the padding math down all three branches (0, 1, 2 `=`).
+  it.each([
+    ['no padding needed (len % 4 === 0)', 'tt'],
+    ['two padding chars (len % 4 === 2)', 'ttt'],
+    ['one padding char (len % 4 === 3)', 't'],
+  ])('decodes a base64url payload with %s', (_label, tenant) => {
+    expect(decodeJwtPayload(makeJwt({ tenant_id: tenant }))).toEqual({ tenant_id: tenant });
   });
 
-  it('returns null when the payload segment is not valid base64/JSON', () => {
-    expect(decodeJwtPayload('header.%%%not-base64%%%.sig')).toBeNull();
+  it('decodes a payload whose base64url segment still carries `=` padding', () => {
+    const withPadding = makeJwt({ tenant_id: 'ttt' }, /* keepPadding */ true);
+    // Guard the fixture: this variant must actually contain `=` so the test
+    // exercises the padded path rather than silently matching the stripped one.
+    expect(withPadding).toContain('=');
+    expect(decodeJwtPayload(withPadding)).toEqual({ tenant_id: 'ttt' });
+  });
+
+  it('converts base64url `-` and `_` back to `+`/`/` before decoding', () => {
+    const dashToken = makeJwt({ tenant_id: 'tn->??' });
+    const underscoreToken = makeJwt({ tenant_id: 'tn-???' });
+    expect(dashToken.split('.')[1]).toContain('-');
+    expect(underscoreToken.split('.')[1]).toContain('_');
+
+    expect(decodeJwtPayload(dashToken)).toEqual({ tenant_id: 'tn->??' });
+    expect(decodeJwtPayload(underscoreToken)).toEqual({ tenant_id: 'tn-???' });
+  });
+
+  it.each([
+    ['a token with no dots', 'not-a-jwt'],
+    ['a single-segment token', 'onlyheader'],
+    ['an empty string', ''],
+    ['a token whose payload is not valid base64', 'header.!!!not-base64!!!.sig'],
+    ['a token whose payload is not JSON', `header.${btoa('plain text').replace(/=+$/, '')}.sig`],
+  ])('returns null (no throw) for %s', (_label, token) => {
+    expect(decodeJwtPayload(token)).toBeNull();
+  });
+
+  it('mojibakes multi-byte (UTF-8) claim values — Latin1 `atob` limitation, pinned', () => {
+    // A real server base64-encodes the UTF-8 *bytes* of the payload. `atob`
+    // returns a Latin1 string, so a genuinely multi-byte char (outside the
+    // Latin1 range that `btoa` can encode) comes back mojibake'd. `tenant_id`
+    // is a UUID today so this never bites; this pins the limitation the source
+    // only notes in a comment. Built by hand because `makeJwt`'s `btoa` can't
+    // encode multi-byte chars directly.
+    const json = JSON.stringify({ note: '你好' });
+    const b64url = btoa(String.fromCharCode(...new TextEncoder().encode(json)))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const decoded = decodeJwtPayload(`header.${b64url}.sig`);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.note).not.toBe('你好');
   });
 });
 
 describe('extractTenantId', () => {
-  it('decodes the tenant_id claim from a base64url JWT payload', () => {
-    expect(extractTenantId(makeJwt({ tenant_id: 'org-7f3c' }))).toBe('org-7f3c');
+  it('extracts the tenant_id claim from a well-formed token', () => {
+    expect(extractTenantId(makeJwt({ sub: 'u-1', tenant_id: 'org-42' }))).toBe('org-42');
   });
 
-  it('returns null when the tenant_id claim is absent', () => {
-    expect(extractTenantId(makeJwt({ sub: 'user-1' }))).toBeNull();
+  it('returns null when the payload has no tenant_id claim', () => {
+    expect(extractTenantId(makeJwt({ sub: 'u-1', role: 'owner' }))).toBeNull();
   });
 
-  it('returns null when tenant_id is not a string', () => {
-    expect(extractTenantId(makeJwt({ tenant_id: 42 }))).toBeNull();
+  it('returns null when tenant_id is present but not a string', () => {
+    expect(extractTenantId(makeJwt({ tenant_id: 12345 }))).toBeNull();
   });
 
-  it('returns null for a token with fewer than two segments', () => {
+  it('returns null (no throw) for a malformed token', () => {
     expect(extractTenantId('not-a-jwt')).toBeNull();
-  });
-
-  it('returns null when the payload segment is not valid base64/JSON', () => {
-    expect(extractTenantId('header.%%%not-base64%%%.sig')).toBeNull();
   });
 });


### PR DESCRIPTION
## Task
Follow-up: consolidate triplicated JWT tenant-decode + fix stale useTenantId cache on logout (PR #2305). Closes #2329.

## Owner
Specialist: `react-native` (owner area `pm-mobile`). Dispatcher hint was `pm-tech-lead` (docs/research) — overridden per the touched paths: all changes are under `frontend/apps/mobile/`.

## What changed
**Finding 1 (code-duplication, medium) — consolidated.**
- New `src/utils/jwt.ts` is the single source of truth for the base64url JWT payload decode + `tenant_id` extraction (`decodeJwtPayload`, `getTenantIdFromToken`), re-exported from `utils/index.ts`.
- `useApi.ts`, `useOfflineSupport.ts`, and `DocumentUploadScreen.tsx` now all call it (removed three character-for-character copies of the padding math). `DocumentUploadScreen.extractTenantId` is kept as a thin alias so existing callers/tests keep working.
- Decode edge-case tests moved to `src/utils/jwt.test.ts`. Shared `makeJwt` fixture extracted to `src/test/jwt.ts` (was duplicated in `useApi.test.ts` + `DocumentUploadScreen.test.tsx`).

**Finding 2 (latent-bug, medium) — fixed.**
- `AuthContext.logout()` now `queryClient.clear()`s the whole cache; `login()` evicts `['auth','tenant-id']`. Previously `useTenantId` cached the claim with `staleTime: Infinity` and nothing invalidated it, so logout+login as a user in a different org kept serving the old tenant id (persistent cross-tenant 403s) until app restart. `AuthProvider` now consumes `useQueryClient()` (it already renders under `QueryClientProvider` in the app tree).

**Finding 3 (test-gap, low) — partially addressed.**
- Added `useApi.test.ts` cases: keystore-throw → no auth headers, relative-path → base-URL prefixing, expired-token still-sent contract, and a `fetch` restore in `afterEach`.
- Added a UTF-8/multi-byte mojibake pin in `utils/jwt.test.ts` documenting the Latin1 `atob` limitation.
- Added a `useTenantId` reactive-resolution test + logout/login cache-eviction assertions in the auth integration suite.

Behavior-preserving refactor; existing tests act as the safety net.

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `pnpm -F mobile test` → exit 0 (44 suites, 559 tests pass; the "worker failed to exit gracefully" notice is pre-existing and unrelated)
- `pnpm exec biome check <11 changed paths>` → exit 0 (No fixes applied)

## Built (Band B — full build)
skipped: no Metro/expo prebuild in sandbox (per react-native specialist verify list). Change is a refactor + small logic fix, no new deps or config; typecheck + full jest + biome cover it.

## CI parity (Band C — hot-path only)
This is auth/tenant-scoping (hot-path). CI's frontend gate for mobile = biome + typecheck + jest, all run above and green. `act` not installed.

## Remote-tested
skipped

## Notes for the reviewer
- `scope_drift=false`: all 11 changed files are under `frontend/apps/mobile/**` (= `pm-mobile`). `scope-check.sh --owner pm-mobile` → exit 0 against the branch point. (Note: the repo's local `dev` ref is stale vs `origin/dev`; the scope/reuse/goal scripts must be run with `--base HEAD^` to diff only this branch.)
- `reuse-grep` emits one advisory `WARN: makeJwt @ DocumentUploadScreen.test.tsx` — a false positive: that line is the new *import* of the shared fixture (the intended consolidation), not a re-implementation.
- `goal-check.sh` reports IG1/IG2/IG3 FAIL — these are `.research` plan-flow structural checks that don't apply to a GitHub-issue follow-up: no `.research/plans/<slug>.md` (IG1), dispatcher-assigned `auto-impl/…` branch vs expected `impl/…` (IG2), and tests bundled with the fix rather than a separate `test:` commit (IG3). The IG3 *intent* is met — the logout cache-clear test fails against pre-fix `AuthContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pKMUXEAybCsheSDVx25md

---
_Generated by [Claude Code](https://claude.ai/code/session_012pKMUXEAybCsheSDVx25md)_