### PR TITLE
gh-issue-2342: retry (5xx) inquiry webhook on unmatched syndication instead of silent 200 drop

### DIFF
--- a/backend/servers/api-server/src/routes/portal_webhooks.rs
+++ b/backend/servers/api-server/src/routes/portal_webhooks.rs
@@ -820,6 +820,24 @@ fn classify_inquiry_persist(result: Result<(), &sqlx::Error>) -> InquiryPersistO
     }
 }
 
+/// Response for an inbound INQUIRY whose syndication mapping cannot be found.
+///
+/// The inquiry path is lead-bearing (#2342 finding 2): an unmatched syndication
+/// must escalate to a retriable `500` rather than a silent `success:false` / 200
+/// ack, so the portal re-delivers the lead instead of dropping it. Extracted as
+/// a pure fn so the contract is unit-testable without a DB/pool (mirroring
+/// `classify_inquiry_persist`).
+fn inquiry_unmatched_syndication_response(
+) -> Result<Json<WebhookAckResponse>, (StatusCode, Json<ErrorResponse>)> {
+    Err((
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            "LEAD_SYNDICATION_UNMATCHED",
+            "No syndication mapping found for inquiry; please retry",
+        )),
+    ))
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -986,5 +1004,31 @@ mod tests {
         // idempotent duplicate; any other error must fall through to `Retry`.
         assert!(!is_unique_violation(&sqlx::Error::PoolClosed));
         assert!(!is_unique_violation(&sqlx::Error::RowNotFound));
+    }
+
+    // ------------------------------------------------------------------
+    // Regression for #2342 finding 2: the residual silent-drop. On dev the
+    // inquiry path returned `success:false` / HTTP 200 when the syndication
+    // mapping was not found — dropping a lead the same way #2275's DB-error
+    // branch did. An unmatched syndication on the lead-bearing inquiry path
+    // must now return a retriable 5xx so the portal re-delivers.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn inquiry_unmatched_syndication_returns_retriable_5xx_not_silent_ack() {
+        let res = inquiry_unmatched_syndication_response();
+        let (status, body) = res.expect_err(
+            "unmatched syndication on the lead-bearing inquiry path must return a \
+             retriable 5xx, not a silent success:false / 200 ack (#2342 finding 2)",
+        );
+        assert!(
+            status.is_server_error(),
+            "must be a 5xx so the portal retries; got {status}"
+        );
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            body.0.code, "LEAD_SYNDICATION_UNMATCHED",
+            "stable error code lets the portal / operators distinguish the unmatched-lead case"
+        );
     }
 }

--- a/backend/servers/api-server/src/routes/portal_webhooks.rs
+++ b/backend/servers/api-server/src/routes/portal_webhooks.rs
@@ -680,16 +680,29 @@ async fn process_inquiry_webhook(
     let syndication = match syndication {
         Some(s) => s,
         None => {
-            tracing::warn!(
+            // #2342 finding 2: unlike the analytics (view / generic) paths, the
+            // inquiry path carries a *lead*. #2275 fixed the silent-drop only for
+            // the DB-error branch; an inquiry whose syndication mapping is briefly
+            // absent (e.g. racing the syndication upsert) still took a
+            // `success:false` / 200 ack and was dropped with only a `warn!`, and
+            // the portal never retried. Escalate to a retriable 500 so the portal
+            // re-delivers the lead instead of dropping it — mirroring #2275's
+            // "prefer retry over silent drop" contract for lead-bearing events.
+            //
+            // `event = "inquiry_syndication_unmatched"` is the stable token to
+            // alert on (a log-based metric surrogate until a counter facade
+            // lands — see PR notes). Trade-off: a genuinely-unknown external_id
+            // will be retried by the portal; acceptable here because the sender
+            // is signature-verified (#833) and only delivers inquiries for
+            // listings we syndicated to it, so unmatched ⇒ transient race. A
+            // bounded dead-letter table is the durable follow-up (finding 3).
+            tracing::error!(
                 portal = %portal,
                 external_id = %webhook.external_id,
-                "Syndication not found for external ID"
+                event = "inquiry_syndication_unmatched",
+                "No syndication mapping for inbound inquiry lead — returning 500 so the portal retries (#2342 finding 2)"
             );
-            return Ok(Json(WebhookAckResponse {
-                success: false,
-                message: Some("Syndication not found".to_string()),
-                acknowledged_at: Utc::now(),
-            }));
+            return inquiry_unmatched_syndication_response();
         }
     };
 


### PR DESCRIPTION
## Task
Follow-up: portal inquiry retry path creates duplicate leads + residual silent-drops (PR #2278) (Closes #2342)

Scoped to the **rust-backend slice** of the issue — **finding 2** (residual silent-drop on the inquiry path). Findings 1 (dup-lead dedup index), 3 (durable outbox) and 4 (missing CREATE TABLE migration / `query_as!` + RLS) are DB/schema work and are deferred to a separate `db-migration` PR (see Notes). The issue itself splits specialists this way (`rust-backend` for finding 2; `db-migration` for the index/table).

## Owner
pm-backend (specialist: rust-backend). Single-file `backend/servers/api-server/` route change.

## What changed (finding 2)
`process_inquiry_webhook` returned `success:false` / **HTTP 200** when `find_syndication_by_external_id` returned `None` — the same silent-drop class as #2275, which scoped its fix to the DB-error branch only. An inquiry whose syndication mapping is briefly absent (racing the syndication upsert) was acked 200 with only a `warn!`, so the portal never retried and the lead was dropped.

- The lead-bearing inquiry path now escalates an unmatched syndication to a **retriable 500 `LEAD_SYNDICATION_UNMATCHED`** via a pure `inquiry_unmatched_syndication_response()` helper, so the portal re-delivers — mirroring #2275's "prefer retry over silent drop" contract.
- Added a stable `event = "inquiry_syndication_unmatched"` **error-level structured log** as the observable signal the issue asked for (log-based metric surrogate until a counter facade lands).
- The **view / generic analytics paths** (no lead) keep their best-effort `success:false` / 200 — unchanged.
- Trade-off (documented inline): a genuinely-unknown `external_id` will be retried by the portal. Acceptable because the sender is signature-verified (#833, fail-closed) and only delivers inquiries for listings we syndicated to it, so unmatched ⇒ transient race. A bounded dead-letter table is the durable follow-up (finding 3).

## Tested (Band A — fast check)
- `SQLX_OFFLINE=true cargo check -p api-server` — **exit 0**
- `SQLX_OFFLINE=true cargo test -p api-server --lib portal_webhooks` — **exit 0**, 9 passed (1 new regression):
  - `inquiry_unmatched_syndication_returns_retriable_5xx_not_silent_ack` — pins that the unmatched-syndication inquiry path returns a retriable 5xx (`LEAD_SYNDICATION_UNMATCHED`), not a silent 200. DB-free (mirrors the existing `classify_inquiry_persist` unit tests).

## Built (Band B — full build)
- `cargo clippy -p api-server --lib -- -D warnings` — **exit 0** (clean)
- `cargo fmt -p api-server -- --check` — **exit 0**

## CI parity (Band C — hot-path only)
Hot-path (lead capture / data integrity). CI equivalents run locally: `cargo check` + `cargo test` + `cargo clippy -D warnings` + `cargo fmt --check` all green (above). `just` not installed in this env — ran the workflow commands directly.

Environment note: the `api-server` build downloads the Swagger UI asset from github.com, which this sandbox's egress blocks (same as PR #2278). Verified by pointing `SWAGGER_UI_DOWNLOAD_URL` at a `file://` zip repackaged from `swagger-ui-dist@5.17.14` (npm mirror). Env-only workaround — **no source/dependency change**.

## Scope drift
None — `scope-check.sh --owner pm-backend --base origin/dev` exit 0 (single file `backend/servers/api-server/src/routes/portal_webhooks.rs`; merge-base = the branch point).

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` exit 0 (no new auth/crypto/http helpers; the added helper is a 6-line pure response builder).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- **Deferred to a `db-migration` follow-up** (need a live DB to verify; the table has no in-repo schema, so authoring/guessing it here is unsafe/unverifiable):
  - **Finding 1 (dup leads, medium):** `portal_webhook_events` has no unique constraint, so the existing `InquiryPersistOutcome::Duplicate` (23505→200) branch from #2278 is dead code and portal re-deliveries INSERT duplicate lead rows. Needs the partial unique index `(portal, event_type, external_id) WHERE external_id IS NOT NULL` + `ON CONFLICT`.
  - **Finding 4 (schema-drift/RLS, low):** confirmed — **no CREATE TABLE migration for `portal_webhook_events` exists anywhere in `backend/**/*.sql`**; the insert uses runtime `query_as::<_,T>` with no `.sqlx` metadata. Commit the table migration, then convert to `query_as!` and add an RLS-policy note.
  - **Finding 3 (durable outbox, low):** append-only `inbound_webhook_raw` capture before ack.
- goal-check: IG3 (TDD test:/fix: evidence) passes. IG1 (`.research/plans/*.md`) and IG2 (`impl/<slug>` branch) are inapplicable to a GH-issue dispatcher task — no research plan exists and the `auto-impl/…` branch was dispatcher-chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pKMUXEAybCsheSDVx25md

---
_Generated by [Claude Code](https://claude.ai/code/session_012pKMUXEAybCsheSDVx25md)_