### PR TITLE
gh-issue-2343: agency /me endpoint + 404-vs-error distinction across agency dashboards

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal/agencies.rs
+++ b/backend/crates/db/src/repositories/reality_portal/agencies.rs
@@ -75,6 +75,31 @@ impl RealityPortalRepository {
             .await
     }
 
+    /// Get the agency the given portal user belongs to.
+    ///
+    /// Resolves the agency via the caller's `reality_agency_members` row,
+    /// picking the earliest-joined membership when a user belongs to more
+    /// than one. Returns `None` when the user is not a member of any agency
+    /// so the caller can answer `404` (used by `GET /api/v1/agencies/me`).
+    pub async fn get_agency_for_user(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Option<RealityAgency>, SqlxError> {
+        sqlx::query_as::<_, RealityAgency>(
+            r#"
+            SELECT a.*
+            FROM reality_agencies a
+            JOIN reality_agency_members m ON m.agency_id = a.id
+            WHERE m.user_id = $1
+            ORDER BY m.joined_at ASC
+            LIMIT 1
+            "#,
+        )
+        .bind(user_id)
+        .fetch_optional(&self.pool)
+        .await
+    }
+
     /// List public agencies (verified status only). Used by the public
     /// directory surface in `reality-web` and the KMP mobile clients.
     pub async fn list_public_agencies(

--- a/backend/servers/reality-server/src/main.rs
+++ b/backend/servers/reality-server/src/main.rs
@@ -174,6 +174,7 @@ fn parse_default_origins() -> Vec<HeaderValue> {
         // Epic 32: Agencies
         routes::agencies::create_agency,
         routes::agencies::get_agency,
+        routes::agencies::get_my_agency,
         routes::agencies::get_agency_by_slug,
         routes::agencies::update_agency,
         routes::agencies::update_branding,

--- a/backend/servers/reality-server/src/routes/agencies.rs
+++ b/backend/servers/reality-server/src/routes/agencies.rs
@@ -25,6 +25,10 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", post(create_agency))
         .route("/", get(list_agencies))
+        // `/me` must be registered before `/{id}` so the literal segment
+        // isn't shadowed by the UUID path param (a `GET /agencies/me` used
+        // to fall through to `get_agency` and fail UUID parsing).
+        .route("/me", get(get_my_agency))
         .route("/{id}", get(get_agency))
         .route("/{id}", put(update_agency))
         // /{id}/branding handled by routes::agency_branding (mounted at
@@ -157,6 +161,43 @@ pub async fn get_agency(
         })?;
 
     Ok(Json(AgencyResponse { agency }))
+}
+
+/// Get the agency the authenticated portal user belongs to.
+///
+/// Returns the caller's agency as a bare `RealityAgency` (the reality-web
+/// `useMyAgency()` hook reads the entity directly, not wrapped in
+/// `AgencyResponse`). Answers `404` when the caller has no agency so the
+/// frontend can show the "Create Agency" onboarding CTA rather than the
+/// generic load-error/retry screen (Issue #2343).
+#[utoipa::path(
+    get,
+    path = "/api/v1/agencies/me",
+    tag = "Agencies",
+    responses(
+        (status = 200, description = "The caller's agency", body = RealityAgency),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Caller is not a member of any agency")
+    ),
+    security(("session_token" = []))
+)]
+pub async fn get_my_agency(
+    State(state): State<AppState>,
+    principal: RequestPrincipal,
+) -> Result<Json<RealityAgency>, (axum::http::StatusCode, String)> {
+    let agency = state
+        .reality_portal_repo
+        .get_agency_for_user(principal.user_id)
+        .await
+        .map_err(|e| crate::util::errors::db_error("get my agency", e))?
+        .ok_or_else(|| {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "You are not a member of any agency".to_string(),
+            )
+        })?;
+
+    Ok(Json(agency))
 }
 
 /// Get agency by slug.

--- a/frontend/apps/reality-web/src/app/[locale]/agency/error.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/agency/error.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+/**
+ * Route-segment error boundary for the agency dashboards (Issue #2343,
+ * finding 3). The parent `[locale]/error.tsx` already catches render-time
+ * throws for the whole locale segment; this scoped boundary is a backstop
+ * for the agency client components (dashboard, listings, realtors,
+ * branding) so a render-time throw in any one of them degrades gracefully
+ * to an in-place error/retry surface instead of white-screening, without
+ * unmounting the surrounding locale chrome.
+ *
+ * Lives inside the locale layout, so NextIntlClientProvider is in scope and
+ * useTranslations() resolves in the user's locale.
+ */
+
+import { useTranslations } from 'next-intl';
+import { useEffect } from 'react';
+import { StateView } from '@/components/states';
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function AgencyErrorBoundary({ error, reset }: ErrorPageProps) {
+  const t = useTranslations('error');
+  useEffect(() => {
+    console.error('reality-web agency error boundary:', error);
+  }, [error]);
+
+  return (
+    <StateView icon="🛠️" code="500" title={t('title')} description={t('description')}>
+      <button type="button" className="state-action" onClick={reset}>
+        {t('retry')}
+      </button>
+      <style jsx global>{`
+        .state-action {
+          padding: 10px 20px; border-radius: 8px; border: none; cursor: pointer;
+          background: var(--ppt-color-primary); color: var(--ppt-fg-on-accent); font-weight: 500;
+          text-align: center; font-size: 15px;
+        }
+        .state-action:hover { background: var(--ppt-color-primary-hover); }
+      `}</style>
+    </StateView>
+  );
+}

--- a/frontend/apps/reality-web/src/components/agency/AgencyBranding.tsx
+++ b/frontend/apps/reality-web/src/components/agency/AgencyBranding.tsx
@@ -8,9 +8,16 @@
 import { useAgencyBranding, useMyAgency, useUpdateBranding } from '@ppt/reality-api-client';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
+import { AgencyLoadError, isNotFoundError, NoAgencyMessage } from './AgencyErrorStates';
 
 export function AgencyBranding() {
-  const { data: agency } = useMyAgency();
+  const {
+    data: agency,
+    isLoading: agencyLoading,
+    isError: agencyError,
+    error: agencyErrorObj,
+    refetch: refetchAgency,
+  } = useMyAgency();
   const { data: branding, isLoading } = useAgencyBranding(agency?.id || '');
   const updateBranding = useUpdateBranding();
 
@@ -85,7 +92,17 @@ export function AgencyBranding() {
     setCoverFile(null);
   };
 
-  if (isLoading) {
+  // Distinguish an agency-load failure from a genuine "no agency" state so a
+  // transport/server error no longer renders the empty branding form against a
+  // missing agency (Issue #2343, sibling of Issue #2277).
+  if (agencyError && !isNotFoundError(agencyErrorObj)) {
+    return <AgencyLoadError onRetry={() => refetchAgency()} />;
+  }
+  if (!agencyLoading && !agency) {
+    return <NoAgencyMessage />;
+  }
+
+  if (agencyLoading || isLoading) {
     return <BrandingSkeleton />;
   }
 

--- a/frontend/apps/reality-web/src/components/agency/AgencyDashboard.test.tsx
+++ b/frontend/apps/reality-web/src/components/agency/AgencyDashboard.test.tsx
@@ -61,6 +61,39 @@ describe('AgencyDashboard — agency load error handling (Issue #2277)', () => {
     expect(refetch).toHaveBeenCalledOnce();
   });
 
+  it('shows "No Agency Found" (not the error/retry state) when the query fails with a 404', () => {
+    // Issue #2343: GET /api/v1/agencies/me answers 404 when the caller has no
+    // agency. A 404 is the genuine "no agency" case, so it must reach the
+    // onboarding CTA — NOT the transport-error/retry screen.
+    mockUseMyAgency.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { status: 404 },
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMyAgency>);
+
+    render(<AgencyDashboard />);
+
+    expect(screen.getByText(/No Agency Found/i)).toBeInTheDocument();
+    expect(screen.queryByText('loadErrorTitle')).not.toBeInTheDocument();
+  });
+
+  it('shows the error/retry state (not "No Agency Found") when the query fails with a 500', () => {
+    mockUseMyAgency.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { status: 500 },
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useMyAgency>);
+
+    render(<AgencyDashboard />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('loadErrorTitle');
+    expect(screen.queryByText(/No Agency Found/i)).not.toBeInTheDocument();
+  });
+
   it('still shows the "No Agency Found" empty state when the query succeeds with no agency', () => {
     mockUseMyAgency.mockReturnValue({
       data: undefined,

--- a/frontend/apps/reality-web/src/components/agency/AgencyDashboard.tsx
+++ b/frontend/apps/reality-web/src/components/agency/AgencyDashboard.tsx
@@ -16,6 +16,12 @@ import {
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import {
+  AgencyLoadError,
+  isNotFoundError,
+  NoAgencyMessage,
+  SectionError,
+} from './AgencyErrorStates';
 
 type PeriodType = '7d' | '30d' | '90d' | '12m';
 
@@ -26,6 +32,7 @@ export function AgencyDashboard() {
     data: agency,
     isLoading: agencyLoading,
     isError: agencyError,
+    error: agencyErrorObj,
     refetch: refetchAgency,
   } = useMyAgency();
   const {
@@ -45,11 +52,14 @@ export function AgencyDashboard() {
     return <DashboardSkeleton />;
   }
 
-  // Distinguish a failed fetch from a genuine "no agency" state. Without this
-  // branch, a 500/network error settles as `agency === undefined` and falls
-  // through to <NoAgencyMessage />, showing an actual agency owner the
-  // misleading "No Agency Found / Create Agency" screen (Issue #2277).
-  if (agencyError) {
+  // Distinguish a failed fetch from a genuine "no agency" state. A 500/network
+  // error settles as `agency === undefined` and would fall through to
+  // <NoAgencyMessage />, showing an actual agency owner the misleading
+  // "No Agency Found / Create Agency" screen (Issue #2277). Conversely a 404
+  // *is* the genuine "no agency" case (Issue #2343) — GET /agencies/me returns
+  // 404 when the caller has no agency — so it must reach <NoAgencyMessage />,
+  // not the error/retry screen.
+  if (agencyError && !isNotFoundError(agencyErrorObj)) {
     return <AgencyLoadError onRetry={() => refetchAgency()} />;
   }
 
@@ -864,135 +874,6 @@ function StatsCardsSkeleton() {
           height: 100px;
           background: var(--ppt-border-default);
           border-radius: 12px;
-        }
-      `}</style>
-    </div>
-  );
-}
-
-function NoAgencyMessage() {
-  return (
-    <div className="no-agency">
-      <svg
-        width="64"
-        height="64"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="var(--ppt-fg-subtle)"
-        strokeWidth="1.5"
-        aria-hidden="true"
-      >
-        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-        <polyline points="9 22 9 12 15 12 15 22" />
-      </svg>
-      <h2>No Agency Found</h2>
-      <p>You are not associated with any agency.</p>
-      <Link href="/agency/create" className="create-button">
-        Create Agency
-      </Link>
-      <style jsx>{`
-        .no-agency {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          padding: 64px 24px;
-          text-align: center;
-          min-height: 50vh;
-        }
-        h2 {
-          font-size: 1.5rem;
-          color: var(--ppt-fg-primary);
-          margin: 24px 0 8px;
-        }
-        p {
-          color: var(--ppt-fg-muted);
-          margin: 0 0 24px;
-        }
-        .create-button {
-          padding: 12px 24px;
-          background: var(--ppt-color-primary);
-          color: var(--ppt-fg-on-accent);
-          border-radius: 8px;
-          text-decoration: none;
-          font-weight: 500;
-        }
-        .create-button:hover {
-          background: var(--ppt-color-primary-hover);
-        }
-      `}</style>
-    </div>
-  );
-}
-
-function AgencyLoadError({ onRetry }: { onRetry: () => void }) {
-  const t = useTranslations('agency');
-  return (
-    <div className="agency-error" role="alert">
-      <svg
-        width="64"
-        height="64"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="var(--ppt-color-danger, #ef4444)"
-        strokeWidth="1.5"
-        aria-hidden="true"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <line x1="12" y1="8" x2="12" y2="12" />
-        <line x1="12" y1="16" x2="12.01" y2="16" />
-      </svg>
-      <h2>{t('loadErrorTitle')}</h2>
-      <p>{t('loadErrorMessage')}</p>
-      <button type="button" className="retry-button" onClick={onRetry}>
-        {t('retry')}
-      </button>
-      <style jsx>{`
-        .agency-error {
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          padding: 64px 24px;
-          text-align: center;
-          min-height: 50vh;
-        }
-        h2 {
-          font-size: 1.5rem;
-          color: var(--ppt-fg-primary);
-          margin: 24px 0 8px;
-        }
-        p {
-          color: var(--ppt-fg-muted);
-          margin: 0 0 24px;
-        }
-        .retry-button {
-          padding: 12px 24px;
-          background: var(--ppt-color-primary);
-          color: var(--ppt-fg-on-accent);
-          border: none;
-          border-radius: 8px;
-          font-weight: 500;
-          cursor: pointer;
-        }
-        .retry-button:hover {
-          background: var(--ppt-color-primary-hover);
-        }
-      `}</style>
-    </div>
-  );
-}
-
-function SectionError({ message }: { message: string }) {
-  return (
-    <div className="section-error" role="alert">
-      <span>{message}</span>
-      <style jsx>{`
-        .section-error {
-          padding: 24px;
-          text-align: center;
-          color: var(--ppt-fg-muted);
-          font-size: 14px;
         }
       `}</style>
     </div>

--- a/frontend/apps/reality-web/src/components/agency/AgencyErrorStates.tsx
+++ b/frontend/apps/reality-web/src/components/agency/AgencyErrorStates.tsx
@@ -1,0 +1,164 @@
+/**
+ * Shared agency dashboard error / empty states.
+ *
+ * Extracted from AgencyDashboard (PR #2280) so every agency route —
+ * dashboard, listings, realtors, branding — renders the same
+ * error/retry and "no agency" surfaces instead of each re-implementing
+ * (or omitting) them (Issue #2343, findings 1–2).
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+/**
+ * Read the HTTP status off a thrown fetch error without importing the
+ * client's `ApiError` class here (the agency components mock
+ * `@ppt/reality-api-client` wholesale in their unit tests, so importing a
+ * runtime symbol from it would be `undefined` under test). The client
+ * attaches `status` to every non-2xx error, so a plain structural read is
+ * enough to tell a genuine 404 ("no agency") from a 5xx/network failure.
+ */
+export function isNotFoundError(error: unknown): boolean {
+  return (error as { status?: number } | null | undefined)?.status === 404;
+}
+
+/**
+ * Full-page load-error state with a Retry affordance. Shown when the
+ * agency query fails with a transport/server error (i.e. NOT a 404).
+ */
+export function AgencyLoadError({ onRetry }: { onRetry: () => void }) {
+  const t = useTranslations('agency');
+  return (
+    <div className="agency-error" role="alert">
+      <svg
+        width="64"
+        height="64"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="var(--ppt-color-danger, #ef4444)"
+        strokeWidth="1.5"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="8" x2="12" y2="12" />
+        <line x1="12" y1="16" x2="12.01" y2="16" />
+      </svg>
+      <h2>{t('loadErrorTitle')}</h2>
+      <p>{t('loadErrorMessage')}</p>
+      <button type="button" className="retry-button" onClick={onRetry}>
+        {t('retry')}
+      </button>
+      <style jsx>{`
+        .agency-error {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          padding: 64px 24px;
+          text-align: center;
+          min-height: 50vh;
+        }
+        h2 {
+          font-size: 1.5rem;
+          color: var(--ppt-fg-primary);
+          margin: 24px 0 8px;
+        }
+        p {
+          color: var(--ppt-fg-muted);
+          margin: 0 0 24px;
+        }
+        .retry-button {
+          padding: 12px 24px;
+          background: var(--ppt-color-primary);
+          color: var(--ppt-fg-on-accent);
+          border: none;
+          border-radius: 8px;
+          font-weight: 500;
+          cursor: pointer;
+        }
+        .retry-button:hover {
+          background: var(--ppt-color-primary-hover);
+        }
+      `}</style>
+    </div>
+  );
+}
+
+/** Inline per-section error used inside an otherwise-loaded dashboard. */
+export function SectionError({ message }: { message: string }) {
+  return (
+    <div className="section-error" role="alert">
+      <span>{message}</span>
+      <style jsx>{`
+        .section-error {
+          padding: 24px;
+          text-align: center;
+          color: var(--ppt-fg-muted);
+          font-size: 14px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+/**
+ * "No agency" onboarding state. Reached when the agency query genuinely
+ * resolves to no agency (a 404 or a null body) — the point being that this
+ * must NOT be shown on a transport/server error.
+ */
+export function NoAgencyMessage() {
+  return (
+    <div className="no-agency">
+      <svg
+        width="64"
+        height="64"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="var(--ppt-fg-subtle)"
+        strokeWidth="1.5"
+        aria-hidden="true"
+      >
+        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+        <polyline points="9 22 9 12 15 12 15 22" />
+      </svg>
+      <h2>No Agency Found</h2>
+      <p>You are not associated with any agency.</p>
+      <Link href="/agency/create" className="create-button">
+        Create Agency
+      </Link>
+      <style jsx>{`
+        .no-agency {
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          padding: 64px 24px;
+          text-align: center;
+          min-height: 50vh;
+        }
+        h2 {
+          font-size: 1.5rem;
+          color: var(--ppt-fg-primary);
+          margin: 24px 0 8px;
+        }
+        p {
+          color: var(--ppt-fg-muted);
+          margin: 0 0 24px;
+        }
+        .create-button {
+          padding: 12px 24px;
+          background: var(--ppt-color-primary);
+          color: var(--ppt-fg-on-accent);
+          border-radius: 8px;
+          text-decoration: none;
+          font-weight: 500;
+        }
+        .create-button:hover {
+          background: var(--ppt-color-primary-hover);
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/apps/reality-web/src/components/agency/AgencyListings.tsx
+++ b/frontend/apps/reality-web/src/components/agency/AgencyListings.tsx
@@ -10,6 +10,12 @@ import type { AgencyListing, AgencyListingStatus } from '@ppt/reality-api-client
 import { useAgencyListings, useMyAgency, useRealtors } from '@ppt/reality-api-client';
 import Link from 'next/link';
 import { useState } from 'react';
+import {
+  AgencyLoadError,
+  isNotFoundError,
+  NoAgencyMessage,
+  SectionError,
+} from './AgencyErrorStates';
 
 type StatusFilter = 'all' | AgencyListingStatus;
 
@@ -18,14 +24,34 @@ export function AgencyListings() {
   const [realtorFilter, setRealtorFilter] = useState<string>('all');
   const [page, setPage] = useState(1);
 
-  const { data: agency } = useMyAgency();
+  const {
+    data: agency,
+    isLoading: agencyLoading,
+    isError: agencyError,
+    error: agencyErrorObj,
+    refetch: refetchAgency,
+  } = useMyAgency();
   const { data: realtors } = useRealtors(agency?.id || '');
-  const { data: listingsData, isLoading } = useAgencyListings(agency?.id || '', {
+  const {
+    data: listingsData,
+    isLoading,
+    isError: listingsError,
+  } = useAgencyListings(agency?.id || '', {
     status: statusFilter === 'all' ? undefined : statusFilter,
     realtorId: realtorFilter === 'all' ? undefined : realtorFilter,
     page,
     limit: 20,
   });
+
+  // Distinguish an agency-load failure from a genuine "no agency" state so a
+  // transport/server error no longer renders the misleading empty state
+  // ("No listings yet") one route over from Issue #2277 (Issue #2343).
+  if (agencyError && !isNotFoundError(agencyErrorObj)) {
+    return <AgencyLoadError onRetry={() => refetchAgency()} />;
+  }
+  if (!agencyLoading && !agency) {
+    return <NoAgencyMessage />;
+  }
 
   const statusOptions: { value: StatusFilter; label: string }[] = [
     { value: 'all', label: 'All' },
@@ -117,6 +143,8 @@ export function AgencyListings() {
       <div className="table-container">
         {isLoading ? (
           <ListingsTableSkeleton />
+        ) : listingsError ? (
+          <SectionError message="Couldn't load listings. Please try again." />
         ) : listingsData?.listings.length === 0 ? (
           <EmptyState />
         ) : (

--- a/frontend/apps/reality-web/src/components/agency/RealtorManagement.tsx
+++ b/frontend/apps/reality-web/src/components/agency/RealtorManagement.tsx
@@ -18,6 +18,12 @@ import {
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useState } from 'react';
+import {
+  AgencyLoadError,
+  isNotFoundError,
+  NoAgencyMessage,
+  SectionError,
+} from './AgencyErrorStates';
 
 type TabType = 'all' | 'active' | 'invited' | 'inactive';
 
@@ -26,8 +32,14 @@ export function RealtorManagement() {
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [selectedRealtor, setSelectedRealtor] = useState<Realtor | null>(null);
 
-  const { data: agency } = useMyAgency();
-  const { data: realtors, isLoading } = useRealtors(agency?.id || '');
+  const {
+    data: agency,
+    isLoading: agencyLoading,
+    isError: agencyError,
+    error: agencyErrorObj,
+    refetch: refetchAgency,
+  } = useMyAgency();
+  const { data: realtors, isLoading, isError: realtorsError } = useRealtors(agency?.id || '');
 
   const filteredRealtors = realtors?.filter((r) => {
     if (activeTab === 'all') return true;
@@ -56,6 +68,16 @@ export function RealtorManagement() {
         realtors?.filter((r) => r.status === 'inactive' || r.status === 'suspended').length || 0,
     },
   ];
+
+  // Distinguish an agency-load failure from a genuine "no agency" state so a
+  // transport/server error no longer renders the misleading "No realtors yet"
+  // empty state (Issue #2343, sibling of Issue #2277).
+  if (agencyError && !isNotFoundError(agencyErrorObj)) {
+    return <AgencyLoadError onRetry={() => refetchAgency()} />;
+  }
+  if (!agencyLoading && !agency) {
+    return <NoAgencyMessage />;
+  }
 
   return (
     <div className="realtor-management">
@@ -106,6 +128,8 @@ export function RealtorManagement() {
       <div className="realtor-list">
         {isLoading ? (
           <RealtorListSkeleton />
+        ) : realtorsError ? (
+          <SectionError message="Couldn't load realtors. Please try again." />
         ) : filteredRealtors?.length === 0 ? (
           <EmptyState tab={activeTab} onInvite={() => setShowInviteModal(true)} />
         ) : (

--- a/frontend/packages/reality-api-client/src/agency/hooks.ts
+++ b/frontend/packages/reality-api-client/src/agency/hooks.ts
@@ -22,6 +22,30 @@ import type {
   UpdateRealtorRequest,
 } from './types';
 
+/**
+ * Error thrown by the agency fetchers on a non-2xx response.
+ *
+ * Carries the HTTP `status` so callers can distinguish a genuine `404`
+ * ("you have no agency" — an expected onboarding state) from a transport
+ * or server error (5xx/network) that warrants an error/retry screen.
+ * Before this existed every failure was an opaque `Error`, so a 404 and a
+ * 500 were indistinguishable and both surfaced the retry UI (Issue #2343).
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(status: number) {
+    super(`API error: ${status}`);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
+/** Type guard for {@link ApiError} with an optional status match. */
+export function isApiError(error: unknown, status?: number): error is ApiError {
+  return error instanceof ApiError && (status === undefined || error.status === status);
+}
+
 async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> {
   const response = await fetch(`${getApiBase()}${endpoint}`, {
     headers: {
@@ -33,7 +57,7 @@ async function fetchApi<T>(endpoint: string, options?: RequestInit): Promise<T> 
   });
 
   if (!response.ok) {
-    throw new Error(`API error: ${response.status}`);
+    throw new ApiError(response.status);
   }
 
   return response.json();
@@ -85,6 +109,10 @@ export function useMyAgency() {
   return useQuery({
     queryKey: ['my-agency'],
     queryFn: () => fetchApi<Agency>('/api/v1/agencies/me'),
+    // A 404 means "this user has no agency" — an expected state, not a
+    // transient failure — so don't burn retries spinning on it. Transport
+    // and server errors (5xx/network) still get the default retry behaviour.
+    retry: (failureCount, error) => !isApiError(error, 404) && failureCount < 3,
   });
 }
 
@@ -247,7 +275,7 @@ export function useUpdateBranding() {
       });
 
       if (!response.ok) {
-        throw new Error(`API error: ${response.status}`);
+        throw new ApiError(response.status);
       }
 
       return response.json();


### PR DESCRIPTION
## Task
Follow-up: agency 404 conflation + unfixed sibling dashboards + missing `/agencies/me` endpoint (PR #2280). Closes #2343.

Addresses all four findings from the post-merge review of PR #2280.

## Owner
pm-tech-lead (cross-stack: nextjs-web + reality-server backend slice)

## What changed

### Finding 1 (high) — 404 conflation + missing `GET /api/v1/agencies/me`
**Backend (reality-server):**
- New `RealityPortalRepository::get_agency_for_user(user_id)` — resolves the caller's agency via their `reality_agency_members` row (earliest-joined when multiple), `None` when they belong to no agency. Runtime `query_as` (no sqlx offline data needed).
- New `GET /api/v1/agencies/me` handler (`routes/agencies.rs`): `RequestPrincipal`-authenticated, returns the **bare** `RealityAgency` (matching the `useMyAgency()` contract, which reads the entity directly), `404` when the caller has no agency, and is registered **before** `/{id}` so the literal `me` segment isn't shadowed by the UUID path param. Added to the OpenAPI `paths(...)` list in `main.rs`.

**Frontend (reality-api-client + reality-web):**
- `fetchApi` now throws a typed `ApiError` carrying `status` (+ exported `isApiError` guard); the branding mutation fetch uses it too.
- `useMyAgency` sets `retry: (n, e) => !isApiError(e, 404) && n < 3` so a genuine "no agency" 404 doesn't spin the retry.
- `AgencyDashboard` now branches `if (agencyError && !isNotFoundError(agencyErrorObj))` → `AgencyLoadError`; a 404 (or null body) falls through to the `NoAgencyMessage` onboarding CTA.

### Finding 2 (medium) — sibling dashboards left unfixed
- `AgencyListings`, `RealtorManagement`, `AgencyBranding` now read `isError`/`error`/`refetch` from `useMyAgency` and apply the #2280 pattern (AgencyLoadError on non-404 failure, NoAgencyMessage on 404/none). Child-hook fetch failures (listings/realtors) now surface a `SectionError` instead of the misleading empty state.

### Finding 3 (low) — no shared error boundary
- Added `app/[locale]/agency/error.tsx` route-segment boundary (mirrors the existing `[locale]/error.tsx`) as a render-throw backstop scoped to the agency segment.
- De-duplicated the per-file error UI by lifting `AgencyLoadError` / `SectionError` / `NoAgencyMessage` into a shared `components/agency/AgencyErrorStates.tsx`.

### Finding 4 (low) — test gap
- Extended `AgencyDashboard.test.tsx` with a 404 case (asserts `NoAgencyMessage`, not the retry screen) and a 500 case (asserts `AgencyLoadError`). The 404 case fails on `dev` and passes with this change (regression coverage / IG3).

## Tested (Band A — fast check)
- `pnpm -F @ppt/reality-api-client build` (tsc) — exit 0
- `pnpm -F reality-web typecheck` (tsc --noEmit) — exit 0
- `biome check` on all changed frontend files — exit 0 (after safe autofix)
- `pnpm -F reality-web exec vitest run src/components/agency/AgencyDashboard.test.tsx` — **6/6 pass** (incl. new 404/500 cases)
- `cargo check -p db` — exit 0 (compiles the new `get_agency_for_user` repo method)

## Built (Band B — full build)
- Frontend public-API surface (client package) built via tsc above — exit 0.
- `cargo check -p reality-server` — **could not complete locally**: the `utoipa-swagger-ui` build script fetches Swagger UI from `github.com`, which is a hard `403` org-egress denial in this sandbox (`InvalidArchive("Could not find EOCD")` on the truncated cached zip). This is the documented environment constraint, **not a code issue** — my reality-server changes are isolated (one repo method in the already-compiled `db` crate, one handler, one route registration, one OpenAPI path entry) and type-check against the compiled `db` types. **Deferred to CI** (`backend.yml` has github egress and will compile the full crate).

## CI parity (Band C — hot-path only)
Not run locally (backend full build blocked by the swagger-ui egress constraint above). `backend.yml` + `frontend.yml` will run on this PR.

## Remote-tested
skipped (no ppt-bridge MCP in this session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports drift (exit 2) because `pm-tech-lead` maps to architecture areas rather than these specific files. All touched paths are the legitimate targets for issue #2343 (agency backend route + reality-web agency components + client hooks). No unrelated files touched.

## Code-reuse review
`reuse-grep.sh --specialist nextjs-web` — no warnings.

## Notes
- The `/me` endpoint returns the **bare** `RealityAgency` (not the `AgencyResponse { agency }` wrapper) deliberately, to match the existing `useMyAgency()` frontend contract which reads `agency.id`/`agency.name` directly.
- Pre-existing, unrelated: `RealtorManagement.test.tsx` (the `InviteRealtorModal` suite) has 4 failing tests on `dev` — they query `getByLabelText(/email \*/i)` but the modal renders i18n keys that the test's next-intl mock echoes. Verified identical failures on the baseline with my changes stashed; **not touched here** (out of scope for #2343 finding 4, which concerns `AgencyDashboard` tests).
- `NoAgencyMessage` keeps its existing hardcoded English copy (no `noAgency*` i18n keys exist); only the error/retry/section keys — which already exist in all 6 locales — are used via `useTranslations`.
- Follow-up not done here: a `screen-edit reality/agency-dashboard` Agent Log entry (issue notes it as non-blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EA4CSfg13eedzxF95Bk9gH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EA4CSfg13eedzxF95Bk9gH)_