### PR TITLE
code-review-mobile-native-kmp-mylistings-analytics-stub-retry1: wire KMP MyListings + ListingAnalytics to portal API

### DIFF
--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
@@ -128,6 +128,13 @@ fun RealityPortalApp(
                 sessionToken = sessionToken,
             )
         }
+    val portalListingsRepository =
+        remember(sessionToken) {
+            three.two.bit.ppt.reality.realtor.PortalListingsRepository(
+                baseUrl = baseUrl,
+                sessionToken = sessionToken,
+            )
+        }
 
     // Handle pending deep link navigation (Epic 122)
     LaunchedEffect(pendingDeepLink) {
@@ -143,6 +150,7 @@ fun RealityPortalApp(
         listingRepository = listingRepository,
         favoritesRepository = favoritesRepository,
         inquiryRepository = inquiryRepository,
+        portalListingsRepository = portalListingsRepository,
     )
 }
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
@@ -40,8 +40,6 @@ import three.two.bit.ppt.reality.listing.ListingType
 import three.two.bit.ppt.reality.listing.PropertyCategory
 import three.two.bit.ppt.reality.realtor.PortalListing
 import three.two.bit.ppt.reality.realtor.PortalListingsRepository
-import three.two.bit.ppt.reality.ui.realtor.AnalyticsMetric
-import three.two.bit.ppt.reality.ui.realtor.RealtorListing
 import three.two.bit.ppt.reality.ui.account.AccountScreen
 import three.two.bit.ppt.reality.ui.agency.AgencyHubScreen
 import three.two.bit.ppt.reality.ui.agency.AgencyInquiriesScreen
@@ -55,9 +53,11 @@ import three.two.bit.ppt.reality.ui.home.HomeScreen
 import three.two.bit.ppt.reality.ui.inquiries.InquiriesScreen
 import three.two.bit.ppt.reality.ui.listing.ListingDetailScreen
 import three.two.bit.ppt.reality.ui.profile.ProfileEditScreen
+import three.two.bit.ppt.reality.ui.realtor.AnalyticsMetric
 import three.two.bit.ppt.reality.ui.realtor.CreateListingScreen
 import three.two.bit.ppt.reality.ui.realtor.ListingAnalyticsScreen
 import three.two.bit.ppt.reality.ui.realtor.MyListingsScreen
+import three.two.bit.ppt.reality.ui.realtor.RealtorListing
 import three.two.bit.ppt.reality.ui.savedsearches.SavedSearchesScreen
 import three.two.bit.ppt.reality.ui.search.SearchScreen
 import three.two.bit.ppt.reality.util.FormatUtils
@@ -453,7 +453,9 @@ fun RealityNavHost(
                     isLoading = true
                     portalListingsRepository
                         .listMyListings(limit = 100)
-                        .onSuccess { resp -> listings = resp.listings.map { it.toRealtorListing() } }
+                        .onSuccess { resp ->
+                            listings = resp.listings.map { it.toRealtorListing() }
+                        }
                         .onFailure { listings = emptyList() }
                     isLoading = false
                 }
@@ -536,10 +538,10 @@ fun RealityNavHost(
 /**
  * Map a wire [PortalListing] into the [RealtorListing] the MyListings screen renders.
  *
- * The list endpoint (`GET /api/v1/my/listings`) is deliberately lightweight — it carries no
- * per-row view/inquiry counters (those live behind the per-listing analytics endpoint) and no
- * media, so [RealtorListing.views]/[RealtorListing.inquiries] stay 0 and [RealtorListing.imageUrl]
- * stays null here rather than triggering an N+1 analytics fan-out just to fill two badges.
+ * The list endpoint (`GET /api/v1/my/listings`) is deliberately lightweight — it carries no per-row
+ * view/inquiry counters (those live behind the per-listing analytics endpoint) and no media, so
+ * [RealtorListing.views]/[RealtorListing.inquiries] stay 0 and [RealtorListing.imageUrl] stays null
+ * here rather than triggering an N+1 analytics fan-out just to fill two badges.
  */
 private fun PortalListing.toRealtorListing(): RealtorListing =
     RealtorListing(

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
@@ -38,6 +38,10 @@ import three.two.bit.ppt.reality.inquiry.InquiryRepository
 import three.two.bit.ppt.reality.listing.ListingRepository
 import three.two.bit.ppt.reality.listing.ListingType
 import three.two.bit.ppt.reality.listing.PropertyCategory
+import three.two.bit.ppt.reality.realtor.PortalListing
+import three.two.bit.ppt.reality.realtor.PortalListingsRepository
+import three.two.bit.ppt.reality.ui.realtor.AnalyticsMetric
+import three.two.bit.ppt.reality.ui.realtor.RealtorListing
 import three.two.bit.ppt.reality.ui.account.AccountScreen
 import three.two.bit.ppt.reality.ui.agency.AgencyHubScreen
 import three.two.bit.ppt.reality.ui.agency.AgencyInquiriesScreen
@@ -56,6 +60,7 @@ import three.two.bit.ppt.reality.ui.realtor.ListingAnalyticsScreen
 import three.two.bit.ppt.reality.ui.realtor.MyListingsScreen
 import three.two.bit.ppt.reality.ui.savedsearches.SavedSearchesScreen
 import three.two.bit.ppt.reality.ui.search.SearchScreen
+import three.two.bit.ppt.reality.util.FormatUtils
 
 /**
  * Navigation routes for Reality Portal.
@@ -126,6 +131,7 @@ fun RealityNavHost(
     listingRepository: ListingRepository,
     favoritesRepository: FavoritesRepository,
     inquiryRepository: InquiryRepository,
+    portalListingsRepository: PortalListingsRepository,
     startDestination: String = Screen.Home.route,
 ) {
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -436,9 +442,25 @@ fun RealityNavHost(
                 )
             }
             composable(Screen.MyListings.route) {
+                // Load the caller's own listings via GET /api/v1/my/listings. The screen owns the
+                // client-side status-chip filter, so we fetch the full page (limit 100) unfiltered
+                // and let it slice locally. On failure (incl. 401 when signed out) we fall back to
+                // the empty state the screen already renders.
+                var listings by remember { mutableStateOf<List<RealtorListing>>(emptyList()) }
+                var isLoading by remember { mutableStateOf(true) }
+
+                LaunchedEffect(Unit) {
+                    isLoading = true
+                    portalListingsRepository
+                        .listMyListings(limit = 100)
+                        .onSuccess { resp -> listings = resp.listings.map { it.toRealtorListing() } }
+                        .onFailure { listings = emptyList() }
+                    isLoading = false
+                }
+
                 MyListingsScreen(
-                    listings = emptyList(),
-                    isLoading = false,
+                    listings = listings,
+                    isLoading = isLoading,
                     onBackClick = { navController.popBackStack() },
                     onCreateClick = { navController.navigate(Screen.CreateListing.route) },
                     onListingClick = { id ->
@@ -454,15 +476,89 @@ fun RealityNavHost(
                 )
             }
             composable(Screen.ListingAnalytics.route) {
+                // Realtor-wide analytics: the backend exposes analytics per listing, so the
+                // repository fans out one call per listing and folds them into portfolio totals +
+                // trends (see PortalListingsRepository.getPortfolioAnalytics).
+                val viewsLabel = stringResource(R.string.realtor_analytics_metric_views)
+                val inquiriesLabel = stringResource(R.string.realtor_analytics_metric_inquiries)
+                val favoritesLabel = stringResource(R.string.realtor_analytics_metric_favorites)
+                val listingsLabel = stringResource(R.string.realtor_analytics_metric_listings)
+                val activeLabel = stringResource(R.string.realtor_analytics_metric_active)
+
+                var metrics by remember { mutableStateOf<List<AnalyticsMetric>>(emptyList()) }
+                var isLoading by remember { mutableStateOf(true) }
+
+                LaunchedEffect(Unit) {
+                    isLoading = true
+                    portalListingsRepository
+                        .getPortfolioAnalytics()
+                        .onSuccess { p ->
+                            metrics =
+                                listOf(
+                                    AnalyticsMetric(
+                                        label = viewsLabel,
+                                        value = p.totalViews.toString(),
+                                        trend = p.viewsTrend,
+                                    ),
+                                    AnalyticsMetric(
+                                        label = inquiriesLabel,
+                                        value = p.totalInquiries.toString(),
+                                        trend = p.inquiriesTrend,
+                                    ),
+                                    AnalyticsMetric(
+                                        label = favoritesLabel,
+                                        value = p.totalFavorites.toString(),
+                                    ),
+                                    AnalyticsMetric(
+                                        label = listingsLabel,
+                                        value = p.totalListings.toString(),
+                                    ),
+                                    AnalyticsMetric(
+                                        label = activeLabel,
+                                        value = p.activeListings.toString(),
+                                    ),
+                                )
+                        }
+                        .onFailure { metrics = emptyList() }
+                    isLoading = false
+                }
+
                 ListingAnalyticsScreen(
-                    metrics = emptyList(),
-                    isLoading = false,
+                    metrics = metrics,
+                    isLoading = isLoading,
                     onBackClick = { navController.popBackStack() },
                 )
             }
         }
     }
 }
+
+/**
+ * Map a wire [PortalListing] into the [RealtorListing] the MyListings screen renders.
+ *
+ * The list endpoint (`GET /api/v1/my/listings`) is deliberately lightweight — it carries no
+ * per-row view/inquiry counters (those live behind the per-listing analytics endpoint) and no
+ * media, so [RealtorListing.views]/[RealtorListing.inquiries] stay 0 and [RealtorListing.imageUrl]
+ * stays null here rather than triggering an N+1 analytics fan-out just to fill two badges.
+ */
+private fun PortalListing.toRealtorListing(): RealtorListing =
+    RealtorListing(
+        id = id,
+        title = title,
+        formattedPrice = FormatUtils.formatPrice(price, currency),
+        transactionType = transactionType,
+        views = 0,
+        inquiries = 0,
+        status = status.replaceFirstChar { it.uppercase() },
+        meta =
+            listOfNotNull(
+                    city.takeIf { it.isNotBlank() },
+                    propertyType.takeIf { it.isNotBlank() }?.replaceFirstChar { it.uppercase() },
+                    rooms?.let { "$it rooms" },
+                )
+                .joinToString(" · "),
+        imageUrl = null,
+    )
 
 /**
  * The five tab destinations that show the persistent bottom navigation bar. Any route outside this

--- a/mobile-native/androidApp/src/main/res/values/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values/strings.xml
@@ -212,6 +212,11 @@
     <string name="realtor_create_field_price">Price</string>
     <string name="realtor_create_field_currency">Currency</string>
     <string name="realtor_analytics_title">Analytics</string>
+    <string name="realtor_analytics_metric_views">Total views</string>
+    <string name="realtor_analytics_metric_inquiries">Inquiries</string>
+    <string name="realtor_analytics_metric_favorites">Saved</string>
+    <string name="realtor_analytics_metric_listings">Listings</string>
+    <string name="realtor_analytics_metric_active">Active</string>
     <string name="realtor_create_validation_title_required">Title is required</string>
     <string name="realtor_create_validation_city_required">City is required</string>
     <string name="realtor_create_validation_price_invalid">Enter a positive price</string>

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingModels.kt
@@ -78,8 +78,8 @@ data class ListingAnalytics(
  * Realtor-wide analytics rolled up across all of the caller's listings.
  *
  * Derived client-side (the backend only exposes per-listing analytics); the realtor dashboard has
- * no listing id, so [PortalListingsRepository.getPortfolioAnalytics] fans out one analytics call per
- * listing and folds the daily series together into portfolio totals + trends.
+ * no listing id, so [PortalListingsRepository.getPortfolioAnalytics] fans out one analytics call
+ * per listing and folds the daily series together into portfolio totals + trends.
  */
 data class PortfolioAnalytics(
     val totalListings: Int = 0,

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingModels.kt
@@ -1,0 +1,92 @@
+package three.two.bit.ppt.reality.realtor
+
+import kotlinx.serialization.Serializable
+import three.two.bit.ppt.reality.api.DecimalAsLongSerializer
+
+/**
+ * Realtor "my listings" + per-listing analytics wire models.
+ *
+ * These mirror reality-server's portal-listings surface
+ * (`backend/servers/reality-server/src/routes/portal_listings.rs`), which serializes **camelCase**
+ * (`#[serde(rename_all = "camelCase")]`). Monetary fields are `rust_decimal` values emitted as JSON
+ * strings (serde-str) so they decode through [DecimalAsLongSerializer] into whole-currency units —
+ * the same convention already used by [ListingSummary]/[ListingDetail].
+ *
+ * Story 33.4 — closes the mobile MyListings / ListingAnalytics stubs now that the backend LIST +
+ * analytics endpoints exist.
+ */
+
+/** One of the signed-in portal user's own listings (`GET /api/v1/my/listings`). */
+@Serializable
+data class PortalListing(
+    val id: String,
+    val title: String,
+    val description: String? = null,
+    val propertyType: String = "",
+    val transactionType: String = "",
+    @Serializable(with = DecimalAsLongSerializer::class) val price: Long = 0,
+    val currency: String = "EUR",
+    val street: String = "",
+    val city: String = "",
+    val postalCode: String = "",
+    val country: String = "",
+    @Serializable(with = DecimalAsLongSerializer::class) val sizeSqm: Long? = null,
+    val rooms: Int? = null,
+    val floor: Int? = null,
+    val totalFloors: Int? = null,
+    val status: String = "draft",
+    val isNegotiable: Boolean = false,
+    val isPublished: Boolean = false,
+    val slug: String? = null,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+)
+
+/** Paginated response for `GET /api/v1/my/listings`. */
+@Serializable
+data class MyListingsResponse(val listings: List<PortalListing> = emptyList(), val total: Long = 0)
+
+/** One day's analytics counters (`GET /api/v1/my/listings/{id}/analytics`). */
+@Serializable
+data class DailyListingAnalytics(
+    val date: String,
+    val views: Int = 0,
+    val uniqueViews: Int = 0,
+    val favoritesAdded: Int = 0,
+    val favoritesRemoved: Int = 0,
+    val inquiries: Int = 0,
+    val phoneClicks: Int = 0,
+    val shareClicks: Int = 0,
+    val sourceWebsite: Int = 0,
+    val sourceMobile: Int = 0,
+    val sourceSearch: Int = 0,
+    val sourceDirect: Int = 0,
+)
+
+/** Analytics summary + daily series for one listing (`GET /api/v1/my/listings/{id}/analytics`). */
+@Serializable
+data class ListingAnalytics(
+    val listingId: String,
+    val totalViews: Long = 0,
+    val totalInquiries: Long = 0,
+    val totalFavorites: Long = 0,
+    val daysOnMarket: Int = 0,
+    val dailyAnalytics: List<DailyListingAnalytics> = emptyList(),
+)
+
+/**
+ * Realtor-wide analytics rolled up across all of the caller's listings.
+ *
+ * Derived client-side (the backend only exposes per-listing analytics); the realtor dashboard has
+ * no listing id, so [PortalListingsRepository.getPortfolioAnalytics] fans out one analytics call per
+ * listing and folds the daily series together into portfolio totals + trends.
+ */
+data class PortfolioAnalytics(
+    val totalListings: Int = 0,
+    val activeListings: Int = 0,
+    val totalViews: Long = 0,
+    val totalInquiries: Long = 0,
+    val totalFavorites: Long = 0,
+    val viewsTrend: List<Int> = emptyList(),
+    val inquiriesTrend: List<Int> = emptyList(),
+)

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingsRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingsRepository.kt
@@ -1,0 +1,158 @@
+package three.two.bit.ppt.reality.realtor
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import three.two.bit.ppt.reality.api.HttpClientProvider
+import three.two.bit.ppt.reality.api.asPathSegment
+
+/**
+ * Repository for a realtor's own listings + analytics (Story 33.4).
+ *
+ * Wraps reality-server's portal-listings surface
+ * (`backend/servers/reality-server/src/routes/portal_listings.rs`). Every endpoint is gated by
+ * `PortalPrincipal` and scoped to the caller's own rows, so all reads carry the session bearer
+ * token. This closes the mobile MyListings / ListingAnalytics screens, which previously rendered
+ * permanent empty stubs because no LIST / analytics HTTP surface existed.
+ */
+class PortalListingsRepository(
+    private val baseUrl: String,
+    private val sessionToken: String? = null,
+    private val client: HttpClient = HttpClientProvider.client,
+) {
+
+    private fun HttpRequestBuilder.configureRequest() {
+        sessionToken?.let { header(HttpHeaders.Authorization, "Bearer $it") }
+    }
+
+    /**
+     * List the signed-in portal user's own listings (`GET /api/v1/my/listings`).
+     *
+     * @param status optional lifecycle filter (e.g. `draft`, `active`, `paused`, `sold`, `rented`,
+     *   `archived`); omit to return all of the caller's listings.
+     * @param limit page size (server clamps to 1..=100).
+     * @param offset row offset.
+     */
+    suspend fun listMyListings(
+        status: String? = null,
+        limit: Int = 20,
+        offset: Int = 0,
+    ): Result<MyListingsResponse> {
+        return try {
+            val response =
+                client.get("$baseUrl/api/v1/my/listings") {
+                    configureRequest()
+                    status?.let { parameter("status", it) }
+                    parameter("limit", limit)
+                    parameter("offset", offset)
+                }
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.Unauthorized ->
+                    Result.failure(PortalListingException("Please sign in to view your listings"))
+                else ->
+                    Result.failure(
+                        PortalListingException("Failed to load listings: ${response.status}")
+                    )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Analytics summary + daily series for one of the caller's listings
+     * (`GET /api/v1/my/listings/{id}/analytics`). A listing the caller does not own yields 404.
+     *
+     * @param fromDate inclusive lower bound (ISO-8601 date, e.g. `2026-07-01`); omit for none.
+     * @param toDate inclusive upper bound (ISO-8601 date); omit for none.
+     */
+    suspend fun getListingAnalytics(
+        listingId: String,
+        fromDate: String? = null,
+        toDate: String? = null,
+    ): Result<ListingAnalytics> {
+        return try {
+            val response =
+                client.get(
+                    "$baseUrl/api/v1/my/listings/${listingId.asPathSegment()}/analytics"
+                ) {
+                    configureRequest()
+                    fromDate?.let { parameter("fromDate", it) }
+                    toDate?.let { parameter("toDate", it) }
+                }
+            when {
+                response.status.isSuccess() -> Result.success(response.body())
+                response.status == HttpStatusCode.Unauthorized ->
+                    Result.failure(PortalListingException("Please sign in to view analytics"))
+                response.status == HttpStatusCode.NotFound ->
+                    Result.failure(PortalListingException("Listing not found or not owned"))
+                else ->
+                    Result.failure(
+                        PortalListingException("Failed to load analytics: ${response.status}")
+                    )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Realtor-wide analytics aggregated across all of the caller's listings.
+     *
+     * The backend exposes analytics per listing but no portfolio-wide roll-up, and the realtor
+     * dashboard has no single listing id, so this fans out one analytics call per listing
+     * (concurrently) and folds the per-day series together by date into a single portfolio trend.
+     * Individual per-listing analytics failures are skipped so one bad row can't sink the whole
+     * dashboard; a failure listing the caller's listings, however, propagates.
+     */
+    suspend fun getPortfolioAnalytics(): Result<PortfolioAnalytics> {
+        val listings =
+            listMyListings(limit = 100).getOrElse {
+                return Result.failure(it)
+            }.listings
+
+        val analytics: List<ListingAnalytics> = coroutineScope {
+            listings
+                .map { listing -> async { getListingAnalytics(listing.id).getOrNull() } }
+                .awaitAll()
+                .filterNotNull()
+        }
+
+        var totalViews = 0L
+        var totalInquiries = 0L
+        var totalFavorites = 0L
+        val viewsByDate = HashMap<String, Int>()
+        val inquiriesByDate = HashMap<String, Int>()
+        analytics.forEach { a ->
+            totalViews += a.totalViews
+            totalInquiries += a.totalInquiries
+            totalFavorites += a.totalFavorites
+            a.dailyAnalytics.forEach { d ->
+                viewsByDate[d.date] = (viewsByDate[d.date] ?: 0) + d.views
+                inquiriesByDate[d.date] = (inquiriesByDate[d.date] ?: 0) + d.inquiries
+            }
+        }
+        // ISO-8601 dates sort lexicographically, so a plain sort gives chronological order.
+        val dates = viewsByDate.keys.sorted()
+
+        return Result.success(
+            PortfolioAnalytics(
+                totalListings = listings.size,
+                activeListings = listings.count { it.status.equals("active", ignoreCase = true) },
+                totalViews = totalViews,
+                totalInquiries = totalInquiries,
+                totalFavorites = totalFavorites,
+                viewsTrend = dates.map { viewsByDate[it] ?: 0 },
+                inquiriesTrend = dates.map { inquiriesByDate[it] ?: 0 },
+            )
+        )
+    }
+}
+
+/** Portal-listings-specific exception. */
+class PortalListingException(message: String) : Exception(message)

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingsRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/realtor/PortalListingsRepository.kt
@@ -65,8 +65,8 @@ class PortalListingsRepository(
     }
 
     /**
-     * Analytics summary + daily series for one of the caller's listings
-     * (`GET /api/v1/my/listings/{id}/analytics`). A listing the caller does not own yields 404.
+     * Analytics summary + daily series for one of the caller's listings (`GET
+     * /api/v1/my/listings/{id}/analytics`). A listing the caller does not own yields 404.
      *
      * @param fromDate inclusive lower bound (ISO-8601 date, e.g. `2026-07-01`); omit for none.
      * @param toDate inclusive upper bound (ISO-8601 date); omit for none.
@@ -78,9 +78,7 @@ class PortalListingsRepository(
     ): Result<ListingAnalytics> {
         return try {
             val response =
-                client.get(
-                    "$baseUrl/api/v1/my/listings/${listingId.asPathSegment()}/analytics"
-                ) {
+                client.get("$baseUrl/api/v1/my/listings/${listingId.asPathSegment()}/analytics") {
                     configureRequest()
                     fromDate?.let { parameter("fromDate", it) }
                     toDate?.let { parameter("toDate", it) }
@@ -112,9 +110,11 @@ class PortalListingsRepository(
      */
     suspend fun getPortfolioAnalytics(): Result<PortfolioAnalytics> {
         val listings =
-            listMyListings(limit = 100).getOrElse {
-                return Result.failure(it)
-            }.listings
+            listMyListings(limit = 100)
+                .getOrElse {
+                    return Result.failure(it)
+                }
+                .listings
 
         val analytics: List<ListingAnalytics> = coroutineScope {
             listings

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/realtor/PortalListingsRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/realtor/PortalListingsRepositoryTest.kt
@@ -1,0 +1,203 @@
+package three.two.bit.ppt.reality.realtor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Repository tests for [PortalListingsRepository] (Story 33.4).
+ *
+ * Pins the wire contract of reality-server's portal-listings surface: camelCase fields, a
+ * `rust_decimal` price serialized as a JSON string (`"200000.00"`), the 401 mapping, and the
+ * client-side portfolio-analytics aggregation that folds per-listing daily series together.
+ */
+class PortalListingsRepositoryTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private fun repoWith(status: HttpStatusCode, body: String): PortalListingsRepository {
+        val engine = MockEngine { _ ->
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return PortalListingsRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    /** A MockEngine that routes by path so aggregation across list + analytics can be exercised. */
+    private fun repoWithRouter(
+        route: (path: String) -> Pair<HttpStatusCode, String>
+    ): PortalListingsRepository {
+        val engine = MockEngine { request ->
+            val (status, body) = route(request.url.fullPath)
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return PortalListingsRepository(
+            baseUrl = "https://example.test",
+            sessionToken = "test-token",
+            client = client,
+        )
+    }
+
+    @Test
+    fun listMyListings_decodes_camelCase_and_decimal_string_price() = runTest {
+        val body =
+            """
+            {
+              "listings": [
+                {
+                  "id": "lst-1",
+                  "title": "Sunny 2BR",
+                  "propertyType": "apartment",
+                  "transactionType": "sale",
+                  "price": "200000.00",
+                  "currency": "EUR",
+                  "city": "Bratislava",
+                  "rooms": 2,
+                  "sizeSqm": "64.50",
+                  "status": "active",
+                  "isPublished": true
+                }
+              ],
+              "total": 1
+            }
+            """
+                .trimIndent()
+        val repo = repoWith(HttpStatusCode.OK, body)
+
+        val result = repo.listMyListings()
+
+        assertTrue(result.isSuccess, "expected success, got $result")
+        val resp = result.getOrThrow()
+        assertEquals(1, resp.listings.size)
+        assertEquals(1L, resp.total)
+        val listing = resp.listings.first()
+        assertEquals("lst-1", listing.id)
+        // Decimal string truncated to whole-currency units by DecimalAsLongSerializer.
+        assertEquals(200000L, listing.price)
+        assertEquals(64L, listing.sizeSqm)
+        assertEquals("active", listing.status)
+    }
+
+    @Test
+    fun listMyListings_maps_unauthorized_to_failure() = runTest {
+        val repo = repoWith(HttpStatusCode.Unauthorized, """{"error":"unauthenticated"}""")
+        val result = repo.listMyListings()
+        assertTrue(result.isFailure, "401 should surface as failure, got $result")
+        assertTrue(result.exceptionOrNull() is PortalListingException)
+    }
+
+    @Test
+    fun getListingAnalytics_decodes_summary_and_daily_series() = runTest {
+        val body =
+            """
+            {
+              "listingId": "lst-1",
+              "totalViews": 42,
+              "totalInquiries": 3,
+              "totalFavorites": 5,
+              "daysOnMarket": 12,
+              "dailyAnalytics": [
+                {"date": "2026-07-01", "views": 20, "inquiries": 1},
+                {"date": "2026-07-02", "views": 22, "inquiries": 2}
+              ]
+            }
+            """
+                .trimIndent()
+        val repo = repoWith(HttpStatusCode.OK, body)
+
+        val result = repo.getListingAnalytics("lst-1")
+
+        assertTrue(result.isSuccess, "expected success, got $result")
+        val analytics = result.getOrThrow()
+        assertEquals(42L, analytics.totalViews)
+        assertEquals(2, analytics.dailyAnalytics.size)
+        assertEquals(20, analytics.dailyAnalytics.first().views)
+    }
+
+    @Test
+    fun getListingAnalytics_maps_not_found_to_failure() = runTest {
+        val repo = repoWith(HttpStatusCode.NotFound, """{"error":"not found"}""")
+        val result = repo.getListingAnalytics("lst-x")
+        assertTrue(result.isFailure, "404 should surface as failure, got $result")
+        assertTrue(result.exceptionOrNull() is PortalListingException)
+    }
+
+    @Test
+    fun getPortfolioAnalytics_folds_per_listing_series_by_date() = runTest {
+        val listBody =
+            """
+            {
+              "listings": [
+                {"id": "lst-1", "title": "A", "price": "100000.00", "currency": "EUR", "status": "active"},
+                {"id": "lst-2", "title": "B", "price": "150000.00", "currency": "EUR", "status": "paused"}
+              ],
+              "total": 2
+            }
+            """
+                .trimIndent()
+        val analytics1 =
+            """
+            {"listingId":"lst-1","totalViews":30,"totalInquiries":2,"totalFavorites":4,
+             "dailyAnalytics":[{"date":"2026-07-01","views":10,"inquiries":1},
+                               {"date":"2026-07-02","views":20,"inquiries":1}]}
+            """
+                .trimIndent()
+        val analytics2 =
+            """
+            {"listingId":"lst-2","totalViews":15,"totalInquiries":1,"totalFavorites":3,
+             "dailyAnalytics":[{"date":"2026-07-02","views":5,"inquiries":1}]}
+            """
+                .trimIndent()
+
+        val repo = repoWithRouter { path ->
+            when {
+                path.contains("lst-1/analytics") -> HttpStatusCode.OK to analytics1
+                path.contains("lst-2/analytics") -> HttpStatusCode.OK to analytics2
+                path.contains("/my/listings") -> HttpStatusCode.OK to listBody
+                else -> HttpStatusCode.NotFound to "{}"
+            }
+        }
+
+        val result = repo.getPortfolioAnalytics()
+
+        assertTrue(result.isSuccess, "expected success, got $result")
+        val p = result.getOrThrow()
+        assertEquals(2, p.totalListings)
+        assertEquals(1, p.activeListings)
+        assertEquals(45L, p.totalViews) // 30 + 15
+        assertEquals(3L, p.totalInquiries) // 2 + 1
+        assertEquals(7L, p.totalFavorites) // 4 + 3
+        // Dates 2026-07-01 (10) and 2026-07-02 (20 + 5 = 25), sorted chronologically.
+        assertEquals(listOf(10, 25), p.viewsTrend)
+        assertEquals(listOf(1, 2), p.inquiriesTrend)
+    }
+}


### PR DESCRIPTION
## Task
MyListings and ListingAnalytics routes (Navigation.kt:440,:458) in mobile-native KMP are live in the nav graph but render hardcoded emptyList()/isLoading=false with no repository/ApiClient backing; realtor listing dashboard + analytics are permanent empty stubs in production. Wire them to the listings/analytics API. The backend gap ("gap-realtor-listings-analytics-endpoints") has since MERGED, so the listings/analytics API endpoints now exist. Discover the actual endpoint contract and wire the KMP screens (repository + ApiClient) to real data. (retry 1/2 of code-review-mobile-native-kmp-mylistings-analytics-stub)

## Owner
pm-frontend (implemented by the mobile-native/KMP specialist)

## Endpoint contract (discovered)
Backend routes merged in `backend/servers/reality-server/src/routes/portal_listings.rs`, mounted at `/api/v1/my/listings` (main.rs:490), camelCase wire, `PortalPrincipal`-gated, own-rows only:
- `GET /api/v1/my/listings?status=&limit=&offset=` -> `{ listings: [PortalListingResponse], total }`
- `GET /api/v1/my/listings/{id}/analytics?fromDate=&toDate=` -> `{ listingId, totalViews, totalInquiries, totalFavorites, daysOnMarket, dailyAnalytics: [...] }` (**per-listing** only)

## What changed
- **shared/commonMain** `realtor/PortalListingModels.kt` — wire models (`PortalListing`, `MyListingsResponse`, `ListingAnalytics`, `DailyListingAnalytics`) mirroring the camelCase DTOs; `price`/`sizeSqm` decode `rust_decimal` strings via existing `DecimalAsLongSerializer`. Plus derived `PortfolioAnalytics`.
- **shared/commonMain** `realtor/PortalListingsRepository.kt` — `listMyListings()`, `getListingAnalytics()`, and `getPortfolioAnalytics()`. The analytics **screen has no listing id** (realtor-wide dashboard) while the backend only exposes analytics per listing, so `getPortfolioAnalytics()` fans out one analytics call per listing (concurrently) and folds the daily series together by date into portfolio totals + trends; individual per-listing failures are skipped.
- **androidApp** `navigation/Navigation.kt` — both composables now load via `LaunchedEffect` + repository and map `PortalListing -> RealtorListing` / `PortfolioAnalytics -> AnalyticsMetric`. Injected `PortalListingsRepository` param on `RealityNavHost`.
- **androidApp** `MainActivity.kt` — build + inject `PortalListingsRepository` at the composition root (same `remember(sessionToken)` pattern as the other repos).
- **strings.xml** — 5 analytics metric labels.
- **shared/commonTest** `PortalListingsRepositoryTest.kt` — MockEngine tests: camelCase + decimal-string decode, 401/404 mappings, portfolio aggregation fold-by-date.

## Tested (Band A — fast check)
`cd mobile-native && /opt/gradle/bin/gradle :shared:compileKotlinJvm` — **could not run** (exit non-zero). The Gradle wrapper distribution (`services.gradle.org`) and the AGP `9.2.1` plugin + entire Kotlin/Ktor dependency graph (`dl.google.com` / Maven) are blocked by this sandbox's egress policy (HTTP 403) and the Gradle cache is cold, so the KMP compiler cannot run here at all. Per the task's verify-band guidance ("if a full device build is impossible in this environment, verify what you can, state that clearly, and still open the DRAFT PR — CI is the authoritative gate"), verification was done by static review instead:
- URLs verified against the merged backend route + mount prefix (`/api/v1/my/listings`, `/{id}/analytics`); query param names (`fromDate`/`toDate`) match the `camelCase` `IntoParams`.
- Wire field names/types match `PortalListingResponse` / `ListingAnalyticsResponse`; decimal-string handling reuses the existing `DecimalAsLongSerializer`.
- All new symbols/imports resolve against existing repo conventions (`HttpClientProvider`, `asPathSegment`, `FormatUtils.formatPrice`, `MockEngine` test harness mirrored from `FavoritesRepositoryTest`).

**CI (`mobile-native.yml`: Gradle build + unit tests) is the authoritative gate for compile + `:shared` test.**

## Built (Band B — full build)
skipped: Gradle unavailable in this environment (egress-blocked, see above) — CI runs the full build.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; endpoints already ship their own authz).

## Remote-tested
skipped

## Scope drift
None — scope-check exited 0; the entire diff is under `mobile-native/`.

## Code-reuse review
None — reuse-grep found no duplicated helpers. Reused `DecimalAsLongSerializer`, `HttpClientProvider`, `asPathSegment`, `FormatUtils.formatPrice`.

## Notes
- The list endpoint is intentionally lightweight and carries **no per-row view/inquiry counters** and no media, so `RealtorListing.views`/`.inquiries` map to 0 and `imageUrl` to null on the MyListings cards rather than triggering an N+1 analytics fan-out just to fill two badges. The primary data (listings, titles, prices, statuses) is real. Per-row counters could be a follow-up if the backend adds them to the list DTO.
- The MyListings status-chip filter stays client-side (screen owns it); the repo fetches the full page (limit 100) unfiltered.


---
_Generated by [Claude Code](https://claude.ai/code/session_011xHf4FFmwvyoHoravGe69d)_