### PR TITLE
gh-issue-2361: mobile login clears whole query cache (cross-tenant stale data)

### DIFF
--- a/frontend/apps/mobile/src/contexts/AuthContext.tsx
+++ b/frontend/apps/mobile/src/contexts/AuthContext.tsx
@@ -140,11 +140,16 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
         await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshToken);
         await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
 
-        // Drop the cached tenant id (issue #2329). `useTenantId` caches the
-        // JWT's `tenant_id` claim with `staleTime: Infinity`, so without this a
-        // login that follows a session which wasn't explicitly logged out would
-        // keep serving the previous org's tenant id.
-        queryClient.removeQueries({ queryKey: ['auth', 'tenant-id'] });
+        // A login always begins a fresh session, so no previous org's cached
+        // data may survive it (issue #2361). Removing only the ['auth',
+        // 'tenant-id'] key fixed tenant-id resolution (issue #2329) but left
+        // every other cached query from the prior org in place — the mobile
+        // read-query keys (['buildings','list'], ['documents','list',…],
+        // ['faults','list'], etc.) are NOT tenant-scoped, so after a login that
+        // follows a session which wasn't explicitly logged out, TanStack Query
+        // would serve user A's data to user B until a background refetch (or
+        // never, if offline). Clear the whole cache to mirror logout().
+        queryClient.clear();
 
         setState((prev) => ({
           ...prev,

--- a/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
+++ b/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
@@ -195,6 +195,33 @@ describe('AuthContext integration', () => {
       expect(queryClient.getQueryData(['auth', 'tenant-id'])).toBeUndefined();
     });
 
+    it('clears non-tenant-scoped cached data on login so no prior org data survives (issue #2361)', async () => {
+      primeSecureStore();
+      // Mobile read-query keys are NOT tenant-scoped, so a login that follows a
+      // session which wasn't explicitly logged out must wipe the whole cache —
+      // otherwise the previous org's list/detail data is served under identical
+      // keys until a background refetch (or forever, if offline).
+      queryClient.setQueryData(['auth', 'tenant-id'], 'org-stale');
+      queryClient.setQueryData(['documents', 'list'], [{ id: 'doc-A' }]);
+      queryClient.setQueryData(['buildings', 'list'], [{ id: 'b-A' }]);
+      mockFetchOnce({
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        user: sampleUser,
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      await act(async () => {
+        await result.current.login('jane@example.com', 'pw');
+      });
+
+      expect(queryClient.getQueryData(['auth', 'tenant-id'])).toBeUndefined();
+      expect(queryClient.getQueryData(['documents', 'list'])).toBeUndefined();
+      expect(queryClient.getQueryData(['buildings', 'list'])).toBeUndefined();
+    });
+
     it('throws on bad credentials and leaves the state unauthenticated', async () => {
       primeSecureStore();
       mockFetchOnce({ message: 'Invalid credentials' }, 401);


### PR DESCRIPTION
## Task
Follow-up: login cache eviction is incomplete vs. logout — prior org's tenant-scoped data survives into the new session (PR #2352).

`AuthContext.logout()` wipes the whole cache with `queryClient.clear()`, but `login()` only evicted the single `['auth','tenant-id']` key. Mobile read-query keys (`['buildings','list']`, `['documents','list',…]`, `['faults','list']`, `['announcements','list']`, `['voting','list']`, `['leases']`, etc.) are **not** tenant-scoped, so a login that follows a session which was not explicitly logged out let TanStack Query serve the previous org's list/detail data under those identical keys until a background refetch replaced it (or forever, if the device is offline / the refetch fails). Made `login()` symmetric with `logout()` by clearing the whole cache.

Closes #2361

## Owner
pm-tech-lead

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` → exit 0
- `pnpm -F mobile test -- src/test/integration/auth.integration.test.tsx` → exit 0 (17 passed, incl. new "clears non-tenant-scoped cached data on login … (issue #2361)")
- `pnpm exec biome check apps/mobile/src/contexts/AuthContext.tsx apps/mobile/src/test/integration/auth.integration.test.tsx` → exit 0

## Built (Band B — full build)
skipped: change <50 LOC (2 files, 37 insertions), no public API/config touch — one-line cache-eviction swap plus a test.

## CI parity (Band C — hot-path only)
skipped: no server-side security/auth/billing/data-integrity change. This is a client-side cache-hygiene fix; server RLS already scopes all refetches (the issue is a transient client-side stale-display window, not a server breach).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` flags both changed files as outside the pm-tech-lead owner areas:
- `frontend/apps/mobile/src/contexts/AuthContext.tsx`
- `frontend/apps/mobile/src/test/integration/auth.integration.test.tsx`

Justified: the task carried `owner_role=pm-tech-lead` but is a react-native change by nature — issue #2361 names exactly these two files and suggests the `react-native` specialist. No files outside `frontend/apps/mobile/` were touched.

## Code-reuse review
`reuse-grep.sh --specialist react-native` → no warnings. No new helper added; the change swaps `removeQueries({queryKey})` for the existing `queryClient.clear()` (already used by `logout()`).

## Notes
- The production change is a single line (`queryClient.clear()` mirroring `logout()`), plus an updated comment referencing #2361.
- New test seeds `['documents','list']` and `['buildings','list']` (non-tenant-scoped keys) plus the tenant-id key, then asserts all are `undefined` after `login()` — this case fails on `dev` (those entries survive the old single-key eviction) and passes here.
- Specialist: react-native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTDxM6cC3xRnktQ6gSE5cF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTDxM6cC3xRnktQ6gSE5cF)_