### PR TITLE
gh-issue-2362: consolidate reality-web listing-detail shape validation into parseListingDetail() normalizer

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.test.ts
@@ -1,10 +1,14 @@
 /**
  * buildListingJsonLd Tests
  *
- * Regression guard for the SSR crash where a malformed/partial 200 body
- * (truthy but not a real ListingDetail) made the listing page throw while
- * dereferencing nested fields (listing.photos.map, listing.address.street).
- * buildListingJsonLd must return null instead of throwing.
+ * `buildListingJsonLd` consumes a guaranteed-shape `ListingDetail` (normalized
+ * by `parseListingDetail` at the `getListing` boundary), so it no longer
+ * defends against malformed / wrong-typed bodies — that crash-class coverage
+ * lives in `listingSchema.test.ts`. These tests assert it emits correct
+ * structured data and omits genuinely optional fields when absent.
+ *
+ * `isRenderableListing` (still defined here, consumed by the normalizer) keeps
+ * its own required-field describe block below.
  */
 
 import type { ListingDetail } from '@ppt/reality-api-client';
@@ -69,67 +73,22 @@ describe('buildListingJsonLd', () => {
     expect((jsonLd.floorSize as Record<string, unknown>).value).toBe(75);
   });
 
-  it('returns null when the body is null/undefined (not-found / network failure)', () => {
-    expect(buildListingJsonLd(null)).toBeNull();
-    expect(buildListingJsonLd(undefined)).toBeNull();
-  });
-
-  // The core regression: malformed but truthy 200 bodies must NOT throw.
-  it('returns null on an empty object body without throwing', () => {
-    expect(() => buildListingJsonLd({})).not.toThrow();
-    expect(buildListingJsonLd({})).toBeNull();
-  });
-
-  it('returns null when address is missing (would have thrown on .street)', () => {
-    const malformed = { title: 'Has title but no address', slug: 'x' };
-    expect(() => buildListingJsonLd(malformed)).not.toThrow();
-    expect(buildListingJsonLd(malformed)).toBeNull();
-  });
-
-  it('returns null when title is missing', () => {
-    const malformed = { slug: 'x', address: { city: 'Bratislava', country: 'SK' } };
-    expect(buildListingJsonLd(malformed)).toBeNull();
-  });
-
-  it('returns null on non-object bodies (string / number / array)', () => {
-    expect(buildListingJsonLd('oops')).toBeNull();
-    expect(buildListingJsonLd(42)).toBeNull();
-    expect(buildListingJsonLd([])).toBeNull();
-  });
-
-  it('builds JSON-LD without an image field when photos are missing (would have thrown on .map)', () => {
-    const noPhotos = { ...validListing, photos: undefined as unknown as ListingDetail['photos'] };
-    expect(() => buildListingJsonLd(noPhotos)).not.toThrow();
+  it('omits the image field for an empty photos array', () => {
+    const noPhotos: ListingDetail = { ...validListing, photos: [] };
     const jsonLd = buildListingJsonLd(noPhotos) as Record<string, unknown>;
-    expect(jsonLd).not.toBeNull();
     expect(jsonLd.name).toBe('Beautiful Apartment');
     expect('image' in jsonLd).toBe(false);
   });
 
-  // #2341: a partial 200 can carry wrong-typed (not just missing) collection
-  // fields. buildListingJsonLd must tolerate a non-array `photos` (skip image)
-  // and a non-object `features` (ignored — never emitted) without throwing.
-  it('tolerates wrong-typed photos/features (non-array photos, string features)', () => {
-    const malformed = {
-      ...validListing,
-      photos: {} as unknown as ListingDetail['photos'],
-      features: 'x' as unknown as ListingDetail['features'],
-    };
-    expect(() => buildListingJsonLd(malformed)).not.toThrow();
-    const jsonLd = buildListingJsonLd(malformed) as Record<string, unknown>;
-    expect(jsonLd).not.toBeNull();
-    expect(jsonLd.name).toBe('Beautiful Apartment');
-    expect('image' in jsonLd).toBe(false);
-  });
-
-  it('omits optional price/rooms/area blocks when missing', () => {
+  it('omits optional price/rooms/area blocks when those fields are absent', () => {
     const minimal = {
-      title: 'Minimal',
-      slug: 'minimal',
-      address: { city: 'Bratislava', country: 'SK' },
-    };
+      ...validListing,
+      price: undefined,
+      rooms: undefined,
+      area: undefined,
+    } as unknown as ListingDetail;
     const jsonLd = buildListingJsonLd(minimal) as Record<string, unknown>;
-    expect(jsonLd).not.toBeNull();
+    expect((jsonLd.address as Record<string, unknown>).addressLocality).toBe('Bratislava');
     expect('offers' in jsonLd).toBe(false);
     expect('numberOfRooms' in jsonLd).toBe(false);
     expect('floorSize' in jsonLd).toBe(false);

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/jsonLd.ts
@@ -41,29 +41,23 @@ export function isRenderableListing(listing: unknown): listing is ListingDetail 
 }
 
 /**
- * Build the RealEstateListing JSON-LD object defensively.
+ * Build the RealEstateListing JSON-LD object.
  *
- * Reuses {@link isRenderableListing} for the required-field check, then emits
- * optional fields (`photos`, `price`, `rooms`, `area`, …) only when present.
- * Returns `null` whenever a required field is missing or has the wrong shape.
+ * Consumes a guaranteed-shape `ListingDetail` — `getListing` runs the raw 200
+ * body through `parseListingDetail`, which validates the required fields (via
+ * {@link isRenderableListing}) and coerces `photos` to an array — so the
+ * required-field / non-array-photos defenses live at that single boundary, not
+ * here. This helper still emits the genuinely optional fields (`price`, `rooms`,
+ * `area`, `description`) only when present.
  */
-export function buildListingJsonLd(listing: unknown): object | null {
-  if (!isRenderableListing(listing)) {
-    return null;
-  }
-
-  const l = listing as Partial<ListingDetail>;
-  const address = l.address;
-
-  if (!address) {
-    return null;
-  }
+export function buildListingJsonLd(listing: ListingDetail): object {
+  const { address } = listing;
 
   const jsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': 'RealEstateListing',
-    name: l.title,
-    url: `${process.env.NEXT_PUBLIC_SITE_URL || ''}/listings/${l.slug}`,
+    name: listing.title,
+    url: `${process.env.NEXT_PUBLIC_SITE_URL || ''}/listings/${listing.slug}`,
     address: {
       '@type': 'PostalAddress',
       streetAddress: address.street,
@@ -74,33 +68,36 @@ export function buildListingJsonLd(listing: unknown): object | null {
     },
   };
 
-  if (typeof l.description === 'string') {
-    jsonLd.description = l.description;
+  if (typeof listing.description === 'string') {
+    jsonLd.description = listing.description;
   }
 
-  if (Array.isArray(l.photos)) {
-    jsonLd.image = l.photos
-      .map((p) => (p && typeof p.url === 'string' ? p.url : undefined))
-      .filter((url): url is string => typeof url === 'string');
+  // `photos` is a guaranteed array (normalized upstream); still filter out any
+  // element whose `url` is not a string.
+  const imageUrls = listing.photos
+    .map((p) => (p && typeof p.url === 'string' ? p.url : undefined))
+    .filter((url): url is string => typeof url === 'string');
+  if (imageUrls.length > 0) {
+    jsonLd.image = imageUrls;
   }
 
-  if (typeof l.price === 'number') {
+  if (typeof listing.price === 'number') {
     jsonLd.offers = {
       '@type': 'Offer',
-      price: l.price,
-      priceCurrency: typeof l.currency === 'string' ? l.currency : undefined,
-      availability: l.status === 'active' ? 'InStock' : 'OutOfStock',
+      price: listing.price,
+      priceCurrency: typeof listing.currency === 'string' ? listing.currency : undefined,
+      availability: listing.status === 'active' ? 'InStock' : 'OutOfStock',
     };
   }
 
-  if (typeof l.rooms === 'number') {
-    jsonLd.numberOfRooms = l.rooms;
+  if (typeof listing.rooms === 'number') {
+    jsonLd.numberOfRooms = listing.rooms;
   }
 
-  if (typeof l.area === 'number') {
+  if (typeof listing.area === 'number') {
     jsonLd.floorSize = {
       '@type': 'QuantitativeValue',
-      value: l.area,
+      value: listing.area,
       unitCode: 'MTK',
     };
   }

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/listingSchema.test.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/listingSchema.test.ts
@@ -1,0 +1,155 @@
+/**
+ * parseListingDetail Tests
+ *
+ * Consolidated regression guard for the SSR-500 crash class (#2276 / #2281 /
+ * #2341) where a malformed / partial 200 listing body — truthy but missing
+ * required nested fields, or carrying *wrong-typed* collection fields — crashed
+ * rendering while dereferencing `listing.address.city`,
+ * `Object.entries(listing.features)`, or `listing.photos.map`.
+ *
+ * The shape-validation logic used to be hand-rolled across four render sites,
+ * each with its own notion of "valid". `parseListingDetail` is now the single
+ * normalizer at the `getListing` boundary, so this one suite covers the crash
+ * class for every downstream consumer (metadata, JSON-LD, ListingDetailContent).
+ */
+
+import type { ListingDetail } from '@ppt/reality-api-client';
+import { describe, expect, it } from 'vitest';
+import { parseListingDetail } from './listingSchema';
+
+const validListing: ListingDetail = {
+  id: 'listing-1',
+  slug: 'beautiful-apartment',
+  title: 'Beautiful Apartment',
+  propertyType: 'apartment',
+  transactionType: 'sale',
+  status: 'active',
+  price: 150000,
+  currency: 'EUR',
+  area: 75,
+  rooms: 3,
+  address: {
+    street: 'Main St 1',
+    city: 'Bratislava',
+    district: 'Old Town',
+    postalCode: '81101',
+    country: 'SK',
+  },
+  isFeatured: false,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  description: 'A lovely place to live.',
+  features: { balcony: true, parking: false },
+  photos: [
+    {
+      id: 'p1',
+      url: 'https://cdn.example.com/p1.jpg',
+      thumbnailUrl: 'https://cdn.example.com/p1-thumb.jpg',
+      isPrimary: true,
+      order: 0,
+    },
+  ],
+  agent: { id: 'a1', name: 'Agent', email: 'a@example.com' },
+  viewCount: 0,
+  favoriteCount: 0,
+  primaryPhoto: {
+    id: 'p1',
+    url: 'https://cdn.example.com/p1.jpg',
+    thumbnailUrl: 'https://cdn.example.com/p1-thumb.jpg',
+    isPrimary: true,
+    order: 0,
+  },
+};
+
+describe('parseListingDetail', () => {
+  it('returns a normalized listing for a valid body, preserving features/photos', () => {
+    const parsed = parseListingDetail(validListing);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.title).toBe('Beautiful Apartment');
+    expect(parsed?.features).toEqual({ balcony: true, parking: false });
+    expect(parsed?.photos).toHaveLength(1);
+  });
+
+  it('accepts a minimal renderable body (title, slug, well-formed address)', () => {
+    const parsed = parseListingDetail({
+      title: 'Minimal',
+      slug: 'minimal',
+      address: { city: 'Bratislava', country: 'SK' },
+    });
+    expect(parsed).not.toBeNull();
+    // Missing collection fields are coerced to safe empties.
+    expect(parsed?.features).toEqual({});
+    expect(parsed?.photos).toEqual([]);
+  });
+
+  // These are exactly the partial 200 bodies getListing must reject so the
+  // request falls back to ListingNotFound instead of crashing SSR (#2276).
+  it('returns null for null / undefined', () => {
+    expect(parseListingDetail(null)).toBeNull();
+    expect(parseListingDetail(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty object', () => {
+    expect(parseListingDetail({})).toBeNull();
+  });
+
+  it('returns null when address is missing', () => {
+    expect(parseListingDetail({ title: 't', slug: 's' })).toBeNull();
+  });
+
+  it('returns null when address is missing city or country', () => {
+    expect(parseListingDetail({ title: 't', slug: 's', address: { city: 'X' } })).toBeNull();
+    expect(parseListingDetail({ title: 't', slug: 's', address: { country: 'SK' } })).toBeNull();
+  });
+
+  it('returns null when title or slug is missing', () => {
+    const address = { city: 'X', country: 'SK' };
+    expect(parseListingDetail({ slug: 's', address })).toBeNull();
+    expect(parseListingDetail({ title: 't', address })).toBeNull();
+  });
+
+  it('returns null for non-object bodies (string / number / array)', () => {
+    expect(parseListingDetail('oops')).toBeNull();
+    expect(parseListingDetail(42)).toBeNull();
+    expect(parseListingDetail([])).toBeNull();
+  });
+
+  // #2341: a partial 200 can carry *wrong-typed* (not just missing) collection
+  // fields. `features: "x"` fed to `Object.entries` yields per-character garbage
+  // entries; a non-array `photos` (e.g. `{}`) makes `.length` / `.map` throw.
+  // Nullish-coalescing (`?? {}` / `?? []`) does not catch a truthy wrong type —
+  // the normalizer must coerce both to a safe empty shape.
+  it('coerces a string features to {} (was #2341 Object.entries crash)', () => {
+    const parsed = parseListingDetail({
+      ...validListing,
+      features: 'x' as unknown as ListingDetail['features'],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.features).toEqual({});
+  });
+
+  it('coerces an undefined features to {}', () => {
+    const parsed = parseListingDetail({
+      ...validListing,
+      features: undefined as unknown as ListingDetail['features'],
+    });
+    expect(parsed?.features).toEqual({});
+  });
+
+  it('coerces a non-array photos ({}) to [] (was #2341 PhotoGallery crash)', () => {
+    const parsed = parseListingDetail({
+      ...validListing,
+      photos: {} as unknown as ListingDetail['photos'],
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed?.photos).toEqual([]);
+  });
+
+  it('coerces an undefined photos to []', () => {
+    const parsed = parseListingDetail({
+      ...validListing,
+      photos: undefined as unknown as ListingDetail['photos'],
+    });
+    expect(parsed?.photos).toEqual([]);
+  });
+});

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/listingSchema.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/listingSchema.ts
@@ -1,0 +1,53 @@
+/**
+ * Listing detail shape normalizer.
+ *
+ * Single source of truth for "is this 200 body a renderable listing, and if so,
+ * what is its guaranteed shape?". `getListing` returns the raw JSON body of any
+ * 200 response, so a malformed or partial 200 (an upstream/proxy partial
+ * response, or a listing carrying wrong-typed collection fields) is truthy but
+ * does not match `ListingDetail`. Dereferencing such a body during SSR
+ * (`Object.entries(listing.features)`, `listing.photos.map`) throws and crashes
+ * the request with a 500 (#2276 / #2281 / #2341).
+ *
+ * Before this normalizer the "is this body well-formed?" logic was hand-rolled
+ * across four render sites (`getListing`, `buildListingMetadata`,
+ * `buildListingJsonLd`, `ListingDetailContent`), each with a slightly different
+ * notion of "valid" — a latent-regression surface where any new nested deref
+ * re-opened the same crash class. `parseListingDetail` consolidates it: it
+ * validates the required fields once (via {@link isRenderableListing}) and
+ * coerces the two wrong-typeable collection fields — `features` → object-or-`{}`,
+ * `photos` → array-or-`[]` — so every consumer downstream of `getListing`
+ * receives a guaranteed-shape `ListingDetail` and can drop its inline defenses.
+ */
+
+import type { ListingDetail } from '@ppt/reality-api-client';
+import { isRenderableListing } from './jsonLd';
+
+/**
+ * Validate + normalize a raw 200 body into a renderable `ListingDetail`.
+ *
+ * Returns `null` when the body is missing the minimum renderable shape (title,
+ * slug, and a well-formed `address` with `city` + `country`) — the caller then
+ * falls back to `ListingNotFound` (404) instead of crashing SSR. When it
+ * returns a listing, `features` is guaranteed to be a plain object and `photos`
+ * a real array, so consumers can `Object.entries(listing.features)` and
+ * `listing.photos.map(...)` without their own type-guards.
+ */
+export function parseListingDetail(body: unknown): ListingDetail | null {
+  if (!isRenderableListing(body)) {
+    return null;
+  }
+
+  // `features` / `photos` are typed as present on `ListingDetail`, but a partial
+  // 200 can carry *wrong-typed* values (e.g. `features: "x"`, `photos: {}`), not
+  // just null/undefined. `features: "x"` makes `Object.entries` emit
+  // per-character garbage entries; a non-array `photos` makes `.length` / `.map`
+  // throw. Coerce both to a safe empty shape when malformed (#2341).
+  const features =
+    body.features && typeof body.features === 'object' && !Array.isArray(body.features)
+      ? body.features
+      : ({} as ListingDetail['features']);
+  const photos = Array.isArray(body.photos) ? body.photos : [];
+
+  return { ...body, features, photos };
+}

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.test.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.test.ts
@@ -1,10 +1,12 @@
 /**
  * buildListingMetadata Tests
  *
- * Regression guard for the SSR crash where a malformed/partial 200 body
- * (truthy but not a real ListingDetail) made generateMetadata throw while
- * reading nested fields (listing.address.city, listing.description.slice).
- * buildListingMetadata must degrade to safe fallback metadata instead.
+ * `buildListingMetadata` consumes a guaranteed-shape `ListingDetail | null`
+ * (normalized by `parseListingDetail` at the `getListing` boundary): a
+ * malformed / partial body has already become `null`, so the malformed-body
+ * crash-class coverage lives in `listingSchema.test.ts`. These tests assert it
+ * falls back for a null listing and still guards the genuinely optional
+ * `description` / `primaryPhoto` that the normalizer does not require.
  */
 
 import type { ListingDetail } from '@ppt/reality-api-client';
@@ -50,32 +52,8 @@ describe('buildListingMetadata', () => {
     expect(meta.openGraph?.images).toEqual(['https://cdn.example.com/p1.jpg']);
   });
 
-  it('falls back when the body is null/undefined (not-found / network failure)', () => {
+  it('falls back when the listing is null (not-found / network failure)', () => {
     expect(buildListingMetadata(null).title).toBe(FALLBACK_TITLE);
-    expect(buildListingMetadata(undefined).title).toBe(FALLBACK_TITLE);
-  });
-
-  // The core regression: malformed but truthy 200 bodies must NOT throw.
-  it('falls back on an empty object body without throwing', () => {
-    expect(() => buildListingMetadata({})).not.toThrow();
-    expect(buildListingMetadata({}).title).toBe(FALLBACK_TITLE);
-  });
-
-  it('falls back when address is missing (would have thrown on .city)', () => {
-    const malformed = { title: 'Has title but no address' };
-    expect(() => buildListingMetadata(malformed)).not.toThrow();
-    expect(buildListingMetadata(malformed).title).toBe(FALLBACK_TITLE);
-  });
-
-  it('falls back when title is missing', () => {
-    const malformed = { address: { city: 'Bratislava', country: 'SK' } };
-    expect(buildListingMetadata(malformed).title).toBe(FALLBACK_TITLE);
-  });
-
-  it('falls back on non-object bodies (string / number / array)', () => {
-    expect(buildListingMetadata('oops').title).toBe(FALLBACK_TITLE);
-    expect(buildListingMetadata(42).title).toBe(FALLBACK_TITLE);
-    expect(buildListingMetadata([]).title).toBe(FALLBACK_TITLE);
   });
 
   it('tolerates a missing/malformed description (would have thrown on .slice)', () => {

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.ts
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/metadata.ts
@@ -14,30 +14,25 @@ export const FALLBACK_METADATA: Metadata = {
 };
 
 /**
- * Build listing metadata defensively.
+ * Build listing metadata.
  *
- * `getListing` returns the raw JSON body of any 200 response, so a malformed
- * or partial 200 (e.g. `{}`, or a body missing `title` / `address` /
- * `description`) is truthy but does not match `ListingDetail`. Reading nested
- * fields off such a body (`listing.address.city`, `listing.description.slice`)
- * would throw during SSR and crash the request. Treat the body as `unknown`
- * and fall back to safe default metadata whenever a required field is missing
- * or the wrong shape.
+ * `getListing` normalizes the raw 200 body through `parseListingDetail`, so a
+ * malformed / partial body has already become `null` here and the required
+ * fields (`title`, `address.city`) are guaranteed present on a non-null
+ * listing — the required-field / wrong-shape defense lives at that single
+ * boundary. Fall back to safe default metadata only when the listing is absent;
+ * still guard the genuinely optional `description` / `primaryPhoto`, which the
+ * normalizer does not require.
  */
-export function buildListingMetadata(listing: unknown): Metadata {
-  if (!listing || typeof listing !== 'object') {
+export function buildListingMetadata(listing: ListingDetail | null): Metadata {
+  if (!listing) {
     return FALLBACK_METADATA;
   }
 
-  const l = listing as Partial<ListingDetail>;
-  const city = l.address?.city;
-  if (typeof l.title !== 'string' || typeof city !== 'string') {
-    return FALLBACK_METADATA;
-  }
-
-  const title = `${l.title} - ${city} | Reality Portal`;
-  const description = typeof l.description === 'string' ? l.description.slice(0, 160) : undefined;
-  const images = typeof l.primaryPhoto?.url === 'string' ? [l.primaryPhoto.url] : [];
+  const title = `${listing.title} - ${listing.address.city} | Reality Portal`;
+  const description =
+    typeof listing.description === 'string' ? listing.description.slice(0, 160) : undefined;
+  const images = typeof listing.primaryPhoto?.url === 'string' ? [listing.primaryPhoto.url] : [];
 
   return {
     title,

--- a/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/listings/[slug]/page.tsx
@@ -13,7 +13,8 @@ import type { Metadata } from 'next';
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 import { ListingDetailContent } from '@/components/listings';
-import { buildListingJsonLd, isRenderableListing } from './jsonLd';
+import { buildListingJsonLd } from './jsonLd';
+import { parseListingDetail } from './listingSchema';
 import { buildListingMetadata } from './metadata';
 
 function inferApiBaseFromHost(host: string): string | null {
@@ -77,12 +78,14 @@ async function getListing(slug: string, host: string): Promise<ListingDetail | n
     if (!response.ok) return null;
     // A 200 does not guarantee a well-formed body: an upstream/proxy partial
     // response or a malformed listing is truthy but may be missing required
-    // nested fields (`address.city`, …). Rendering such a body crashes SSR
-    // with a 500. Validate the shape here — reusing the same required-field
-    // predicate as `buildListingJsonLd` — so a bad body falls back to
-    // `ListingNotFound` (404-style) instead of taking the request down.
+    // nested fields (`address.city`, …) or carry wrong-typed collection fields
+    // (`features: "x"`, `photos: {}`). Rendering such a body crashes SSR with a
+    // 500. `parseListingDetail` is the single normalizer that validates the
+    // required shape once and coerces `features`/`photos` — a bad body falls
+    // back to `ListingNotFound` (404-style), and a good one is guaranteed-shape
+    // for every consumer downstream (metadata, JSON-LD, ListingDetailContent).
     const body: unknown = await response.json();
-    return isRenderableListing(body) ? body : null;
+    return parseListingDetail(body);
   } catch {
     return null;
   }
@@ -110,11 +113,10 @@ export default async function ListingDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  // JSON-LD structured data, built defensively: a partial/malformed 200 body
-  // is truthy but may be missing nested fields (address/photos), which would
-  // crash SSR if dereferenced directly. buildListingJsonLd returns null in
-  // that case and ListingDetailContent skips the <script> tag.
-  const jsonLd = buildListingJsonLd(listing) ?? undefined;
+  // JSON-LD structured data. `listing` is a guaranteed-shape `ListingDetail`
+  // (normalized by `parseListingDetail` in `getListing`), so `buildListingJsonLd`
+  // can dereference required fields directly.
+  const jsonLd = buildListingJsonLd(listing);
 
   return <ListingDetailContent listing={listing} jsonLd={jsonLd} />;
 }

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
@@ -1,10 +1,12 @@
 /**
  * ListingDetailContent Tests
  *
- * Regression guard for the SSR 500 where a partial/malformed 200 listing body
- * (truthy but missing nested fields) crashed rendering while dereferencing
- * `listing.address.city` or `Object.entries(listing.features)`. The component
- * must render such bodies without throwing (issue #2276).
+ * `ListingDetailContent` renders a guaranteed-shape `ListingDetail | null`:
+ * `getListing` runs every 200 body through `parseListingDetail`, which validates
+ * required fields and coerces `features` / `photos`. The malformed / wrong-typed
+ * body crash-class coverage (#2276 / #2281 / #2341) now lives at that single
+ * normalizer — see `listingSchema.test.ts`. These tests assert the happy path
+ * and the null (not-found) fallback.
  */
 
 import type { ListingDetail } from '@ppt/reality-api-client';
@@ -85,67 +87,9 @@ describe('ListingDetailContent', () => {
     expect(screen.getByText('notFound')).toBeInTheDocument();
   });
 
-  // Core regression: partial 200 bodies must NOT throw during (SSR) render.
-  it('does not throw when features is missing (Object.entries crash)', () => {
-    const partial = {
-      ...validListing,
-      features: undefined as unknown as ListingDetail['features'],
-    };
-    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
-    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
-  });
-
-  it('does not throw when photos is missing (PhotoGallery crash)', () => {
-    const partial = {
-      ...validListing,
-      photos: undefined as unknown as ListingDetail['photos'],
-    };
-    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
-    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
-  });
-
-  it('does not throw when address is missing (address.city crash)', () => {
-    const partial = {
-      ...validListing,
-      address: undefined as unknown as ListingDetail['address'],
-    };
-    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
-    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
-  });
-
-  it('does not throw on a near-empty body missing all nested fields', () => {
-    const partial = {
-      id: 'x',
-      slug: 'x',
-      title: 'Bare Listing',
-    } as unknown as ListingDetail;
-    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
-    expect(screen.getByText('Bare Listing')).toBeInTheDocument();
-  });
-
-  // #2341 (medium): a partial 200 can carry *wrong-typed* collection fields,
-  // not just null/undefined. `features: "x"` fed to `Object.entries` yields
-  // per-character garbage entries; nullish-coalescing (`?? {}`) does not catch
-  // it. The type-guard must reject a non-object `features`.
-  it('does not throw and renders no features when features is a string', () => {
-    const partial = {
-      ...validListing,
-      features: 'x' as unknown as ListingDetail['features'],
-    };
-    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
-    expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
-    // No per-character feature ("x", "0", …) leaked into the features section.
-    expect(screen.queryByText('features')).not.toBeInTheDocument();
-  });
-
-  // #2341 (medium): a non-array `photos` (e.g. `{}`) makes PhotoGallery throw
-  // on `.length` / `.map`. `?? []` does not catch a truthy non-array.
-  it('does not throw when photos is a non-array object', () => {
-    const partial = {
-      ...validListing,
-      photos: {} as unknown as ListingDetail['photos'],
-    };
-    expect(() => render(<ListingDetailContent listing={partial} />)).not.toThrow();
+  it('renders a normalized listing whose features/photos are empty', () => {
+    const empty: ListingDetail = { ...validListing, features: {}, photos: [] };
+    expect(() => render(<ListingDetailContent listing={empty} />)).not.toThrow();
     expect(screen.getByText('Beautiful Apartment')).toBeInTheDocument();
   });
 });

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
@@ -97,22 +97,17 @@ export function ListingDetailContent({ listing, jsonLd }: ListingDetailContentPr
     return tFeatures(key);
   };
 
-  // `listing.features` / `listing.photos` are typed as present, but this
-  // component is exported and a partial/malformed 200 body (from getListing's
-  // upstream, or another caller) can carry *wrong-typed* values, not just
-  // null/undefined. `features: "x"` makes `Object.entries` emit per-character
-  // garbage entries, and a non-array `photos` (e.g. `{}`) makes `PhotoGallery`
-  // throw on `.length` / `.map` — the same SSR-500 this guard exists to
-  // prevent (#2276 / #2341). Type-guard both, not just nullish-coalesce.
-  const featuresObj =
-    listing.features && typeof listing.features === 'object' && !Array.isArray(listing.features)
-      ? listing.features
-      : {};
-  const activeFeatures = Object.entries(featuresObj)
+  // `listing` is a guaranteed-shape `ListingDetail`: `getListing` runs every
+  // 200 body through `parseListingDetail`, which coerces `features` to a plain
+  // object and `photos` to an array. That single normalizer is the source of
+  // truth for the wrong-typed-collection crash class (#2276 / #2341), so this
+  // component consumes both fields directly instead of re-deriving its own
+  // type-guards.
+  const activeFeatures = Object.entries(listing.features)
     .filter(([, value]) => value === true)
     .map(([key]) => key as keyof ListingFeatures);
 
-  const photos = Array.isArray(listing.photos) ? listing.photos : [];
+  const photos = listing.photos;
 
   return (
     <div className="page-container">


### PR DESCRIPTION
## Task
Follow-up: consolidate reality-web listing-detail shape validation into one `parseListingDetail()` normalizer (PR #2351).

Closes #2362

## What changed
The "is this 200 listing body well-formed?" logic was hand-rolled across **four** independent render sites, each with its own notion of "valid" — a latent-regression surface for the #2276/#2281/#2341 SSR-500 crash class. Any new render site (or new nested deref) had to re-derive its own guard.

Introduced a single normalizer `parseListingDetail(body: unknown): ListingDetail | null` in `frontend/apps/reality-web/src/app/[locale]/listings/[slug]/listingSchema.ts` that:
- validates required fields once (delegates to the existing `isRenderableListing`), and
- coerces the two wrong-typeable collection fields: `features` → object-or-`{}`, `photos` → array-or-`[]`.

`getListing` now returns the normalized value, and the three downstream consumers take a guaranteed-shape `ListingDetail` and drop their inline defenses:
- `page.tsx` `getListing` → `return parseListingDetail(body)`.
- `metadata.ts` `buildListingMetadata(listing: ListingDetail | null)` — drops the required-field re-check; still guards the genuinely optional `description`/`primaryPhoto` (not covered by the normalizer).
- `jsonLd.ts` `buildListingJsonLd(listing: ListingDetail): object` — drops the `isRenderableListing`/`Array.isArray(photos)` defenses and the `null` return; still emits optional `price`/`rooms`/`area` only when present. `isRenderableListing` stays in this module (now consumed by the normalizer).
- `ListingDetailContent.tsx` — drops the inline `features`/`photos` type-guards.

Tests: the wrong-typed regression cases (`features: "x"`, `photos: {}`) are **retargeted** onto the normalizer in the new `listingSchema.test.ts`, so one suite now covers the crash class for all consumers. The consumer suites (`jsonLd`/`metadata`/`ListingDetailContent`) were trimmed to their now-reachable states (valid + null/optional-field cases).

Out of scope (per issue): `FALLBACK_METADATA` English hardcoding left as-is.

## Owner
pm-tech-lead (architecture lens) — implementing specialist: `nextjs-web`

## Tested (Band A — fast check)
- `pnpm -F reality-web typecheck` → exit 0
- `pnpm exec biome check <changed files>` → exit 0 (repo lint gate is Biome; `pnpm -F reality-web lint` = `next lint` mis-parses the filter arg, unrelated to this change)
- `pnpm exec vitest run <4 affected suites>` → **30 passed** (listingSchema, jsonLd, metadata, ListingDetailContent)

## Built (Band B — full build)
- `pnpm -F reality-web build` → exit 0 (Next.js production build; `/[locale]/listings/[slug]` route compiled cleanly)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (public SSR rendering hardening; no security/auth/billing/data-integrity change). CI (`frontend.yml`) is the authoritative gate.

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports exit 2 (all 9 files). This is a **benign owner-hint mismatch**, not scope creep: `pm-tech-lead` maps only to `docs/**`/`.research/**`/`_bmad-output/**` in `owner-areas.json`, so any code change trips it. Every changed file is within `frontend/apps/reality-web` listing-detail — the correct area for the `nextjs-web` specialist that implemented the task. Full diff = the 9 files listed, nothing else.

## Code-reuse review
`reuse-grep.sh` emitted only false-positive prefix matches (`makeJ`, `useN`, `useR`, `useS`, `useU`) from unrelated files in the stale-base diff — none relate to this change. The change deliberately *reuses* the existing `isRenderableListing` predicate rather than adding a new one.

## Notes
Goal-check (`goal-check.sh`) IG1/IG2/IG3 report FAIL, but these are plans-flow checks not applicable to a dispatcher gh-issue task: no `.research/plans/<slug>.md` exists (IG1), the branch is the dispatcher-mandated `auto-impl/*` name (IG2), and this is a single `refactor:` commit that retargets existing regression tests rather than a separate `test:`+`fix:` pair (IG3). The Band A + Band B verify gate is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTDxM6cC3xRnktQ6gSE5cF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTDxM6cC3xRnktQ6gSE5cF)_