### PR TITLE
gh-issue-2357: deny-path regression test for GET /ai/chat/escalated role gate

### DIFF
--- a/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
+++ b/backend/servers/api-server/tests/ai_automation_batch2_tests.rs
@@ -19,7 +19,10 @@ use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use common::{create_authenticated_user_with_org, TestApp, TestUser};
+use common::{
+    create_authenticated_user, create_authenticated_user_with_org, seed_membership, seed_org,
+    TestApp, TestUser,
+};
 
 const UUID: &str = "00000000-0000-0000-0000-000000000001";
 
@@ -246,6 +249,80 @@ async fn test_list_chat_escalated_returns_200(pool: PgPool) {
         ))
         .await;
     assert_eq!(resp.status, StatusCode::OK, "list escalated sessions");
+}
+
+/// Deny-path regression for the #2317 role gate on `GET /api/v1/ai/chat/escalated`.
+///
+/// `list_escalated_messages` is deliberately org-scoped and NOT owner-scoped, so
+/// the handler's `!is_super_admin() && !has_role(Manager)` check is the *only*
+/// thing preventing a plain resident from reading every colleague's escalated
+/// AI-chat messages. The positive `test_list_chat_escalated_returns_200` above
+/// only passes because `create_authenticated_user_with_org` seeds the caller as
+/// `org_admin` (which clears the Manager bar), so nothing there pins the refusal.
+/// This test seeds a below-Manager `resident` and asserts 403 — if the gate is
+/// ever removed or weakened, this fails where the admin-role positive test would
+/// keep sailing through at 200. (Follow-up #2357 to PR #2356 / #2317.)
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_list_chat_escalated_forbidden_for_resident(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::default();
+    let (token, _refresh) = create_authenticated_user(&app, &user).await;
+
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&app.pool)
+        .await
+        .expect("resolve user id");
+    let org_id = seed_org(&app.pool, "ai-chat-4-resident").await;
+    seed_membership(&app.pool, org_id, user_id, "resident").await;
+
+    let resp = app
+        .execute(authed(
+            &token,
+            Method::GET,
+            "/api/v1/ai/chat/escalated",
+            None,
+            org_id,
+        ))
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "a below-Manager resident must be refused escalated-message review"
+    );
+}
+
+/// Positive companion to the deny-path test: a `manager`-role member (the exact
+/// boundary the gate checks) must pass. Together these pin both sides of the
+/// `has_role(TenantRole::Manager)` boundary. (Follow-up #2357.)
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn test_list_chat_escalated_allowed_for_manager(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::default();
+    let (token, _refresh) = create_authenticated_user(&app, &user).await;
+
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&app.pool)
+        .await
+        .expect("resolve user id");
+    let org_id = seed_org(&app.pool, "ai-chat-4-manager").await;
+    seed_membership(&app.pool, org_id, user_id, "manager").await;
+
+    let resp = app
+        .execute(authed(
+            &token,
+            Method::GET,
+            "/api/v1/ai/chat/escalated",
+            None,
+            org_id,
+        ))
+        .await;
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "a Manager-role member must be allowed escalated-message review"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Task
Follow-up: role gate on GET /ai/chat/escalated shipped without a deny-path regression test (PR #2356). Add a deny-path (`resident` → 403) test alongside the existing positive test in `backend/servers/api-server/tests/ai_automation_batch2_tests.rs`, plus an optional positive `manager` case to pin both sides of the `has_role(Manager)` boundary.

Closes #2357

## Owner
pm-tech-lead

## What changed
`backend/servers/api-server/tests/ai_automation_batch2_tests.rs` only (78 insertions):

- `test_list_chat_escalated_forbidden_for_resident` — registers a user, seeds them as a `resident` member (not `org_admin`), and asserts `GET /api/v1/ai/chat/escalated` returns **403 FORBIDDEN**. This is the deny-path the shipped PR lacked: `list_escalated_messages` is org-scoped (not owner-scoped), so the handler role gate is the *only* thing stopping a plain resident from reading every colleague's escalated AI messages. The pre-existing `test_list_chat_escalated_returns_200` only passes because the shared helper seeds `org_admin`, which clears the Manager bar — nothing pinned the refusal.
- `test_list_chat_escalated_allowed_for_manager` — seeds a `manager` member and asserts **200 OK**, pinning the positive side of the exact `has_role(TenantRole::Manager)` boundary.

Reuses the established `create_authenticated_user` + `seed_org` + `seed_membership` pattern (same as the resident deny-path test in `documents_core_crud_tests.rs`). No production code touched.

### Boundary confirmed against source
- `common/src/tenant.rs` `level()`: Manager = 80, Resident = 30.
- `rls_connection.rs` `has_role(r)` = `self.level() >= r.level()` → Manager passes (80≥80), Resident fails (30<80).
- `routes/ai/sessions.rs:908` gate `!is_super_admin() && !has_role(Manager)` returns `StatusCode::FORBIDDEN`.

## Tested (Band A — fast check)
- `cargo test -p api-server --test ai_automation_batch2_tests --no-run` — **could not complete in sandbox**: the transitive build dep `utoipa-swagger-ui` build script downloads `swagger-ui` from `github.com`, which this session's egress policy blocks (only the target repo is enabled → the download returns a JSON access-denied body, `InvalidArchive("Could not find EOCD")`). This is environmental, unrelated to the change. CI is the authoritative gate.
- `rustfmt --edition 2021 --check servers/api-server/tests/ai_automation_batch2_tests.rs` — **exit 0** (file parses, correctly formatted).
- Static verification: added imports (`create_authenticated_user`, `seed_org`, `seed_membership`) confirmed `pub` in `tests/common/mod.rs`; test structure mirrors the proven `documents_core_crud_tests.rs` resident deny-path fixture.

## Built (Band B — full build)
Skipped: test-only change (no production code, no public API/migration/config). Full compile blocked by the sandbox egress limitation noted above — deferred to CI.

## CI parity (Band C — hot-path only)
Skipped: no production behavior change. (The change *tests* a security gate but modifies only test code.)

## Remote-tested
Skipped.

## Scope drift
`scope-check.sh --owner pm-tech-lead` flags `backend/servers/api-server/tests/ai_automation_batch2_tests.rs` as outside the mapped area for `pm-tech-lead` (exit 2). The single changed file is exactly the test file the issue asked to modify; the drift is only that the `pm-tech-lead` owner-area map doesn't include this backend test path. Reviewer to adjudicate.

## Notes
- Diff is a single test file (+78 / −1). Code-reuse pre-flight (`reuse-grep.sh`) returned no warnings.
- The two new tests pin both sides of the `has_role(Manager)` boundary so a future removal/weakening of the gate fails the suite instead of silently regressing (the admin-role positive test alone would keep returning 200).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTDxM6cC3xRnktQ6gSE5cF)_