### PR TITLE
gh-issue-2363: strip signing token from /sign URL + suppress Referer

### DIFF
--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tokenHygiene.test.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tokenHygiene.test.tsx
@@ -1,0 +1,103 @@
+/// <reference types="vitest/globals" />
+/**
+ * Regression tests for signing-token hygiene on the public `/sign` page
+ * (follow-up #2363, security finding from PR #2347 post-merge review).
+ *
+ * The single-use HMAC signing token arrives in `?token=…` and is the ONLY
+ * credential for this auth-less route. Leaving it in the URL leaks it: on a
+ * shared/kiosk browser it stays recoverable from history after the signer
+ * leaves, and it rides the `Referer` header on outbound navigation. These
+ * tests lock in that `DocumentSignPage`:
+ *
+ *   1. still hands the token to `useSignContext` (capture happens before the
+ *      URL is rewritten, so the render context still loads), and
+ *   2. strips `?token=…` from the visible URL/history on mount, and
+ *   3. installs a page-scoped `<meta name="referrer" content="no-referrer">`.
+ *
+ * Only the @ppt/api-client signer hooks (the network boundary) are mocked.
+ */
+
+import { render } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocumentSignPage } from './DocumentSignPage';
+
+// ─── network boundary: @ppt/api-client signer hooks ─────────────────────────
+const { useSignContextMock } = vi.hoisted(() => ({ useSignContextMock: vi.fn() }));
+
+vi.mock('@ppt/api-client', () => {
+  class SignErrorStub extends Error {
+    code: string;
+    constructor(code: string) {
+      super(code);
+      this.code = code;
+    }
+  }
+  return {
+    SignError: SignErrorStub,
+    useSignContext: (token?: string) => useSignContextMock(token),
+    useSubmitSignature: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    }),
+  };
+});
+
+function renderAt(url: string) {
+  window.history.replaceState({}, '', url);
+  return render(
+    <BrowserRouter>
+      <DocumentSignPage />
+    </BrowserRouter>
+  );
+}
+
+describe('DocumentSignPage token hygiene', () => {
+  beforeEach(() => {
+    useSignContextMock.mockReset();
+    // Default: still loading — we only care about token plumbing here.
+    useSignContextMock.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: undefined,
+    });
+    // Clean out any meta[name=referrer] a previous test may have left.
+    for (const m of Array.from(document.head.querySelectorAll('meta[name="referrer"]'))) {
+      m.remove();
+    }
+  });
+
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('passes the token from the URL to useSignContext before stripping it', () => {
+    renderAt('/sign?token=tok-abc-123');
+    expect(useSignContextMock).toHaveBeenCalledWith('tok-abc-123');
+  });
+
+  it('strips ?token from the visible URL/history on mount', () => {
+    renderAt('/sign?token=tok-abc-123');
+    expect(window.location.search).toBe('');
+    expect(window.location.pathname).toBe('/sign');
+  });
+
+  it('installs a no-referrer meta tag while mounted and removes it on unmount', () => {
+    const { unmount } = renderAt('/sign?token=tok-abc-123');
+    const meta = document.head.querySelector('meta[name="referrer"]');
+    expect(meta).not.toBeNull();
+    expect(meta?.getAttribute('content')).toBe('no-referrer');
+    unmount();
+    expect(document.head.querySelector('meta[name="referrer"]')).toBeNull();
+  });
+
+  it('leaves the URL untouched when no token is present', () => {
+    renderAt('/sign');
+    expect(useSignContextMock).toHaveBeenCalledWith(undefined);
+    expect(window.location.pathname).toBe('/sign');
+    expect(window.location.search).toBe('');
+  });
+});

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx
@@ -77,7 +77,31 @@ function SignCard({ children }: { children: React.ReactNode }) {
 export function DocumentSignPage() {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
-  const token = searchParams.get('token') ?? undefined;
+
+  // Lift the single-use HMAC signing token OUT of the URL on first mount. The
+  // `?token=…` value is the only credential for this public route, so leaving it
+  // in the address bar is a leak: on a shared/kiosk browser it stays recoverable
+  // from history after the signer walks away, and it rides the `Referer` header
+  // on any outbound navigation. We therefore:
+  //   1. capture it once into component state (survives the URL rewrite),
+  //   2. strip it from the visible URL + history via replaceState (no nav), and
+  //   3. hold a page-scoped `<meta name="referrer" content="no-referrer">` so
+  //      the token can never leak via `Referer` while this page is mounted.
+  const [token] = useState<string | undefined>(() => searchParams.get('token') ?? undefined);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (new URLSearchParams(window.location.search).has('token')) {
+      window.history.replaceState({}, '', window.location.pathname);
+    }
+    const meta = document.createElement('meta');
+    meta.name = 'referrer';
+    meta.content = 'no-referrer';
+    document.head.appendChild(meta);
+    return () => {
+      meta.remove();
+    };
+  }, []);
 
   const { data: context, isLoading, isError, error: contextError } = useSignContext(token);
 


### PR DESCRIPTION
## Task
Follow-up: signer adopts an e-signature without ever seeing the document; signing token left in the URL/history (PR #2347).

Closes #2363

Two findings were reported. This PR lands the **security/low** finding (token hygiene), which is fully page-side and self-contained. The **correctness/medium** finding (render the PDF above the adopt-&-sign form) is deferred — see `## Deferred (blocked dependency)`.

## What changed
`DocumentSignPage.tsx` (`/sign`, the auth-less public signing page) now protects the single-use HMAC signing token — the page's only credential:

1. **Capture-then-strip** — the `?token=…` value is lifted into component state once on mount (via a `useState` initializer, so it survives the URL rewrite), then removed from the visible address bar + history with `window.history.replaceState({}, '', pathname)`. It can no longer be recovered from a shared/kiosk browser's history after the signer walks away.
2. **No-referrer** — a page-scoped `<meta name="referrer" content="no-referrer">` is installed while the page is mounted (removed on unmount), so the token can't ride the `Referer` header on outbound navigation.

The render context still loads correctly because the token is captured before the URL is rewritten and is passed to `useSignContext(token)` exactly as before.

## Owner
pm-tech-lead (hint). Actual work is `react-web` — matches the issue's own "Suggested specialist" for the page-side slice.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm exec biome check <changed files>` → exit 0 (repo lint tool is Biome; the app's `eslint`-based `lint` script is broken repo-wide on `dev` — missing `eslint.config.js`, unrelated to this change)
- `vitest run DocumentSignPage.tokenHygiene.test.tsx` → 4 passed

### TDD evidence (IG3)
New regression test `DocumentSignPage.tokenHygiene.test.tsx` committed separately (`test:`) before the fix (`fix:`). Verified it **fails on `dev`**: with the un-patched page, 2 of 4 assertions fail (URL still contains `?token=`, no `meta[name=referrer]`); both pass after the fix.

## Built (Band B — full build)
Skipped: change is < 50 LOC, no public API / config / migration touch.

## CI parity (Band C — hot-path only)
Not run locally (`just`/`act` not installed here). This is auth-adjacent (signing-token hygiene) so CI's frontend job should be watched on this PR.

## Remote-tested
Skipped.

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports **drift** (exit 2): both changed files live under `frontend/apps/ppt-web/`, outside the `pm-tech-lead` owner area. This is expected/justified — `pm-tech-lead` was only the dispatcher's owner hint; the issue itself designates `react-web` for this slice. Files:
- `frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx`
- `frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tokenHygiene.test.tsx`

## Code-reuse review
`reuse-grep.sh --specialist react-web` → no warnings. No new auth/crypto/http helpers introduced.

## Deferred (blocked dependency)
The correctness/medium finding — rendering the document PDF above the adopt-&-sign form — is **not** in this PR. As the issue itself notes, "the backend piece is the blocker": the public `SignRenderContext` carries no document URL, and there is no token-scoped public document-fetch endpoint. That needs a `rust-backend` task to add e.g. `GET /api/v1/signatures/sign/document?token=…` (HMAC-nonce authorized, no nonce consumption) before the page can wire a `useSignDocument(token)` hook. Recommend a follow-up backend issue; the page-side wiring is small once the URL exists.

## Notes
- Token hygiene is a strict security improvement with no behavior change to the signing flow.
- The `no-referrer` meta is belt-and-suspenders: after `replaceState` the URL no longer carries the token, so `Referer` would already only expose `/sign`.


---
_Generated by [Claude Code](https://claude.ai/code/session_012sJ3pinERpYM2iwiuEfTJH)_