### PR TITLE
gh-issue-2364: guard against Decimal-as-string decode trap on sibling reality-server surfaces

### DIFF
--- a/.claude/skills/ppt-implement/agents/kotlin-mp.md
+++ b/.claude/skills/ppt-implement/agents/kotlin-mp.md
@@ -58,6 +58,16 @@ Quote exit code. If you touched shared code that affects iOS:
 - Forgetting to add the BuildConfig field across ALL flavors → prod build picks up default.
 - Hard-coding API URLs → use `BuildConfig.API_BASE_URL`.
 - Modifying `VERSION` directly → versioning is auto-bumped by CI, leave it alone.
+- **reality-server Decimal fields are JSON _strings_, not numbers.** reality-server builds
+  `rust_decimal` with the `serde-str` feature, so any `rust_decimal::Decimal` a route serializes
+  **directly** from a DB model arrives on the wire as a scaled string (`"200000.00"`, `"-7.50"`) —
+  a bare `Long`/`Double` throws `JsonDecodingException` on the first fractional value (see #2331 /
+  #2364). Any KMP model mapping a Decimal-backed column MUST annotate the field with
+  `three.two.bit.ppt.reality.api.DecimalAsLongSerializer` (whole-currency amounts) or
+  `DecimalAsDoubleSerializer` (percentages/fractions), never a bare `Long`/`Double`. When you add
+  such a model, extend `shared/src/commonTest/.../api/DecimalWireContractTest.kt` with a
+  real `serde-str` fixture for the new field. Numeric routes (e.g. `/api/v1/listings/*`, which cast
+  `l.price::bigint`) are the exception and stay numeric.
 
 ## Return-line examples
 - `pr=516 status=done specialist=kotlin-mp note=added FavoritesViewModel + Compose screen; assembleDebug clean`

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/api/DecimalWireContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/api/DecimalWireContractTest.kt
@@ -21,13 +21,13 @@ import kotlinx.serialization.json.Json
  * consumed by the KMP app, so the day a future model maps them the failure surfaces here at CI time
  * rather than at runtime on a device:
  *
- *  - `PortalListingResponse.price` / `sizeSqm` — `reality-server/src/routes/portal_listings.rs`
- *    (camelCase serde).
- *  - `ListingPriceHistory` and `PriceChangeAlert` `old_price`/`new_price`/`change_percentage`
- *    — `backend/crates/db/src/models/reality_portal.rs` (default snake_case serde).
+ * - `PortalListingResponse.price` / `sizeSqm` — `reality-server/src/routes/portal_listings.rs`
+ *   (camelCase serde).
+ * - `ListingPriceHistory` and `PriceChangeAlert` `old_price`/`new_price`/`change_percentage` —
+ *   `backend/crates/db/src/models/reality_portal.rs` (default snake_case serde).
  *
- * The fixture data classes below are deliberately minimal mirrors of those structs. They double as a
- * **copy-paste template**: any future model mapping a reality-server Decimal-backed column MUST
+ * The fixture data classes below are deliberately minimal mirrors of those structs. They double as
+ * a **copy-paste template**: any future model mapping a reality-server Decimal-backed column MUST
  * annotate the field with [DecimalAsLongSerializer] or [DecimalAsDoubleSerializer] — exactly as
  * shown here — and never a bare `Long`/`Double`.
  */

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/api/DecimalWireContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/api/DecimalWireContractTest.kt
@@ -1,0 +1,185 @@
+package three.two.bit.ppt.reality.api
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+/**
+ * Cross-surface wire-contract guard for reality-server `rust_decimal::Decimal` fields.
+ *
+ * reality-server builds `rust_decimal` with the `serde-str` feature (`backend/Cargo.toml`), so
+ * EVERY `Decimal` field it serializes **directly** from a DB model arrives on the wire as a JSON
+ * **string** carrying its full fractional scale — `"200000.00"`, `"72.50"`, `"-7.50"` — never a
+ * JSON number. A KMP model that maps such a field to a bare `Long`/`Double` throws a
+ * `JsonDecodingException` the moment a fractional value shows up (issue #2331 / PR #2350).
+ *
+ * PR #2350 fixed the favorites/alerts surface. This test is the **follow-up guard** (issue #2364):
+ * it pins the real `serde-str` shape for the *sibling* Decimal-backed surfaces that are not yet
+ * consumed by the KMP app, so the day a future model maps them the failure surfaces here at CI time
+ * rather than at runtime on a device:
+ *
+ *  - `PortalListingResponse.price` / `sizeSqm` — `reality-server/src/routes/portal_listings.rs`
+ *    (camelCase serde).
+ *  - `ListingPriceHistory` and `PriceChangeAlert` `old_price`/`new_price`/`change_percentage`
+ *    — `backend/crates/db/src/models/reality_portal.rs` (default snake_case serde).
+ *
+ * The fixture data classes below are deliberately minimal mirrors of those structs. They double as a
+ * **copy-paste template**: any future model mapping a reality-server Decimal-backed column MUST
+ * annotate the field with [DecimalAsLongSerializer] or [DecimalAsDoubleSerializer] — exactly as
+ * shown here — and never a bare `Long`/`Double`.
+ */
+class DecimalWireContractTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+    }
+
+    // --- PortalListingResponse (camelCase, portal_listings.rs) --------------------------------
+
+    @Test
+    fun portalListingResponse_decodes_real_serde_str_string_wire() {
+        // price: DECIMAL(15,2) -> "200000.00"; sizeSqm: DECIMAL -> "72.50" (fractional scale).
+        val raw =
+            """
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "price": "200000.00",
+              "sizeSqm": "72.50"
+            }
+            """
+                .trimIndent()
+        val fixture: PortalListingResponseFixture = json.decodeFromString(raw)
+        assertEquals(200_000L, fixture.price)
+        assertEquals(72L, fixture.sizeSqm) // whole-unit truncation is the documented Long contract
+    }
+
+    @Test
+    fun portalListingResponse_tolerates_numeric_wire_and_null_size() {
+        val raw =
+            """
+            {
+              "id": "00000000-0000-0000-0000-000000000001",
+              "price": 200000
+            }
+            """
+                .trimIndent()
+        val fixture: PortalListingResponseFixture = json.decodeFromString(raw)
+        assertEquals(200_000L, fixture.price)
+        assertNull(fixture.sizeSqm)
+    }
+
+    // --- ListingPriceHistory / PriceChangeAlert (snake_case, reality_portal.rs) ---------------
+
+    @Test
+    fun listingPriceHistory_decodes_real_serde_str_string_wire() {
+        val raw =
+            """
+            {
+              "id": "00000000-0000-0000-0000-000000000009",
+              "listing_id": "00000000-0000-0000-0000-000000000001",
+              "old_price": "200000.00",
+              "new_price": "185000.00",
+              "currency": "EUR",
+              "change_percentage": "-7.50",
+              "changed_at": "2026-07-10T10:00:00Z"
+            }
+            """
+                .trimIndent()
+        val fixture: ListingPriceHistoryFixture = json.decodeFromString(raw)
+        assertEquals(200_000L, fixture.old_price)
+        assertEquals(185_000L, fixture.new_price)
+        assertEquals(-7.5, fixture.change_percentage)
+    }
+
+    @Test
+    fun listingPriceHistory_decodes_null_change_percentage() {
+        val raw =
+            """
+            {
+              "id": "00000000-0000-0000-0000-000000000009",
+              "old_price": "200000.00",
+              "new_price": "185000.00",
+              "currency": "EUR",
+              "changed_at": "2026-07-10T10:00:00Z"
+            }
+            """
+                .trimIndent()
+        val fixture: ListingPriceHistoryFixture = json.decodeFromString(raw)
+        assertNull(fixture.change_percentage)
+    }
+
+    @Test
+    fun priceChangeAlert_decodes_real_serde_str_string_wire() {
+        val raw =
+            """
+            {
+              "listing_id": "00000000-0000-0000-0000-000000000001",
+              "title": "Bright 2br in Old Town",
+              "old_price": "200000.00",
+              "new_price": "185000.00",
+              "currency": "EUR",
+              "change_percentage": "-7.50",
+              "changed_at": "2026-07-10T10:00:00Z"
+            }
+            """
+                .trimIndent()
+        val fixture: PriceChangeAlertFixture = json.decodeFromString(raw)
+        assertEquals(200_000L, fixture.old_price)
+        assertEquals(185_000L, fixture.new_price)
+        assertEquals(-7.5, fixture.change_percentage)
+    }
+
+    @Test
+    fun priceChangeAlert_tolerates_numeric_wire() {
+        val raw =
+            """
+            {
+              "listing_id": "00000000-0000-0000-0000-000000000001",
+              "old_price": 200000,
+              "new_price": 185000,
+              "change_percentage": -7.5
+            }
+            """
+                .trimIndent()
+        val fixture: PriceChangeAlertFixture = json.decodeFromString(raw)
+        assertEquals(200_000L, fixture.old_price)
+        assertEquals(185_000L, fixture.new_price)
+        assertEquals(-7.5, fixture.change_percentage)
+    }
+}
+
+/**
+ * Minimal mirror of `PortalListingResponse` (camelCase serde) — Decimal-backed fields only. `price`
+ * is `DECIMAL(15,2)` (required); `sizeSqm` is `DECIMAL` (nullable). Both map through
+ * [DecimalAsLongSerializer].
+ */
+@Serializable
+private data class PortalListingResponseFixture(
+    val id: String,
+    @Serializable(with = DecimalAsLongSerializer::class) val price: Long = 0,
+    @Serializable(with = DecimalAsLongSerializer::class) val sizeSqm: Long? = null,
+)
+
+/**
+ * Minimal mirror of `ListingPriceHistory` (snake_case serde) — nullable `change_percentage`.
+ * Property names are snake_case to match the wire keys directly (a real model would use camelCase +
+ * `@SerialName`); the load-bearing part is the serializer annotation on each Decimal-backed field.
+ */
+@Serializable
+private data class ListingPriceHistoryFixture(
+    @Serializable(with = DecimalAsLongSerializer::class) val old_price: Long,
+    @Serializable(with = DecimalAsLongSerializer::class) val new_price: Long,
+    @Serializable(with = DecimalAsDoubleSerializer::class) val change_percentage: Double? = null,
+)
+
+/** Minimal mirror of `PriceChangeAlert` (snake_case serde) — required `change_percentage`. */
+@Serializable
+private data class PriceChangeAlertFixture(
+    @Serializable(with = DecimalAsLongSerializer::class) val old_price: Long,
+    @Serializable(with = DecimalAsLongSerializer::class) val new_price: Long,
+    @Serializable(with = DecimalAsDoubleSerializer::class) val change_percentage: Double,
+)


### PR DESCRIPTION
## Task
Follow-up: guard against the Decimal-as-string decode trap recurring on sibling reality-server surfaces (PR #2350).

reality-server builds `rust_decimal` with the `serde-str` feature, so every `Decimal` field it serializes **directly** from a DB model arrives on the wire as a JSON **string** with full fractional scale (`"200000.00"`, `"-7.50"`). PR #2350 fixed this for the favorites/alerts surface, but the same silent-decode trap remains latent on sibling surfaces not yet consumed by the KMP app. When a future model maps them with the natural `Long`/`Double` typing, the exact `JsonDecodingException`-on-fractional-string failure re-appears — and nothing (test, lint, or doc) flags it today.

Closes #2364

## What changed
- **New CI-enforced guard** `mobile-native/shared/src/commonTest/.../api/DecimalWireContractTest.kt`: pins the real `serde-str` string wire (plus numeric tolerance / null-percentage) for the latent Decimal-backed surfaces, decoding each through the existing `DecimalAsLongSerializer` / `DecimalAsDoubleSerializer`:
  - `PortalListingResponse.price` / `sizeSqm` — `reality-server/src/routes/portal_listings.rs` (camelCase serde).
  - `ListingPriceHistory` and `PriceChangeAlert` `old_price`/`new_price`/`change_percentage` — `backend/crates/db/src/models/reality_portal.rs` (snake_case serde).
  The fixture data classes double as a copy-paste template for the future model author.
- **Doc note** in `.claude/skills/ppt-implement/agents/kotlin-mp.md` (Common pitfalls): reality-server serializes `rust_decimal::Decimal` as JSON **strings** — any KMP model mapping a Decimal-backed column MUST use the `DecimalAs{Long,Double}Serializer`, never a bare `Long`/`Double`, and must extend this contract test.

The third proposal bullet (cross-check the KMP model backing the future portal/price-history screen) is intentionally deferred — that visible-surface slice is not yet implemented, so there is no model to cross-check. This PR is the guardrail that will catch it when it lands.

## Owner
pm-tech-lead

## Tested (Band A — fast check)
Could **not** run the KMP verify locally in the cloud sandbox — the same limitation PR #2350 documented:
- `./gradlew` wrapper (gradle 9.6.1) download is proxy-blocked (`403` from services.gradle.org).
- System `gradle 8.14.3` can't resolve AGP `9.2.1` through the proxy, and there is no Android SDK / macOS present.

Mitigations applied instead:
- The new test strictly mirrors the passing sibling `FavoritesModelsContractTest.kt` (identical imports, `Json` config, `@Serializable` fixture pattern, assertion helpers, and the same two serializers).
- Verified every code line is ≤100 cols so ktfmt (`kotlinlangStyle`) `spotlessCheck` won't reflow it; snake_case property names are used for the snake_case surfaces so keys match the wire without `@SerialName`.

CI is the real gate: `build-android` runs `./gradlew :shared:build`, which **compiles and runs** the `commonTest` suite (including this new test) via `check`; `build-ios` compiles the shared framework; `lint` runs `spotlessCheck`.

## Built (Band B — full build)
Skipped locally — KMP toolchain unavailable in sandbox (see above). Covered by CI `build-android` / `build-ios`.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path change (test + doc only; no security/auth/billing/data-integrity code).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` flagged both changed paths as outside the pm-tech-lead area:
- `mobile-native/shared/src/commonTest/.../api/DecimalWireContractTest.kt`
- `.claude/skills/ppt-implement/agents/kotlin-mp.md`

Justified: the finding is a kotlin-mp regression-prevention task assigned under a `pm-tech-lead` owner hint; the guard necessarily lives in the KMP test tree, and the pitfall note belongs in the kotlin-mp specialist doc. No product/runtime code touched.

## Code-reuse review
`reuse-grep.sh --specialist kotlin-mp` — no warnings. The test reuses the existing `DecimalAsLongSerializer` / `DecimalAsDoubleSerializer`; no new helper added.

## Notes
- goal-check reports IG1/IG2 FAIL because this is a GitHub-issue follow-up (no `.research/plans/` file; dispatcher-assigned `auto-impl/*` branch), not a plan-flow task — structural mismatch, not a goal failure. IG3 is a WARN (preventive test + doc; no product bug to pair a `fix:` commit with).


---
_Generated by [Claude Code](https://claude.ai/code/session_012sJ3pinERpYM2iwiuEfTJH)_