### PR TITLE
gh-issue-2367: validate every synthesized candidate id against IdSchema in scanCandidates

### DIFF
--- a/frontend/packages/screen-map/src/scan.ts
+++ b/frontend/packages/screen-map/src/scan.ts
@@ -1,7 +1,9 @@
+import { createHash } from 'node:crypto';
 import { readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { mobileScreens, pptWebRoutes, realityWebRoutes } from '@ppt/sitemap';
 import type { DesignSource } from './design-source/index.js';
+import { IdSchema } from './schema.js';
 import type { Platform, Product } from './types.js';
 
 export interface CandidateScreen {
@@ -59,6 +61,20 @@ export async function scanCandidates(opts: ScanOptions): Promise<CandidateScreen
       product,
       source: 'user',
     });
+  }
+
+  // Boundary guard: every synthesized id is written verbatim by `screens init`
+  // (and the filename is slugged from it), so an id that fails `IdSchema` here
+  // produces a screen-map that immediately fails `screens validate` (see #2367,
+  // follow-up to #2344). Per-source slugging can still emit an invalid id — a
+  // name with no Latin/alphanumeric characters (e.g. a non-Latin Figma frame
+  // name, or `--add ""`) slugifies to empty, yielding a bare `ppt/`. Validate
+  // each candidate's id at the boundary and fall back to a stable, non-empty,
+  // schema-valid slug rather than letting the invalid id escape.
+  for (const c of out) {
+    if (!IdSchema.safeParse(c.id).success) {
+      c.id = `${c.product}/${slugifyName(c.name)}`;
+    }
   }
   return out;
 }
@@ -167,12 +183,23 @@ async function scanDesignSource(
 }
 
 function slugifyName(s: string): string {
-  return s
+  const slug = s
     .toLowerCase()
     .normalize('NFKD')
     .replace(/\p{Mn}/gu, '')
     .replace(/[^a-z0-9\s-]/g, '')
     .trim()
     .replace(/\s+/g, '-')
-    .replace(/-+/g, '-');
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  // Never return an empty (or hyphen-only) slug: a name with no Latin
+  // alphanumerics (non-Latin script, pure emoji/symbols) would otherwise
+  // collapse to '' and yield a bare `<product>/`, which fails IdSchema. Fall
+  // back to a stable content hash so the id stays deterministic and unique.
+  return slug || `screen-${hashShort(s)}`;
+}
+
+/** Short, stable hex digest used as a deterministic slug fallback. */
+function hashShort(s: string): string {
+  return createHash('sha1').update(s).digest('hex').slice(0, 8);
 }

--- a/frontend/packages/screen-map/tests/scan.test.ts
+++ b/frontend/packages/screen-map/tests/scan.test.ts
@@ -144,6 +144,45 @@ describe('scanCandidates', () => {
     expect(candidates[0].name).toBe('Faults assignment modal');
   });
 
+  it('synthesizes schema-valid ids for non-Latin / symbol-only names (#2367)', async () => {
+    // These names slugify to the empty string under the old boundary-less
+    // logic, yielding a bare `ppt/` that `screens init` writes and then
+    // `screens validate` rejects. The boundary guard must keep every id valid.
+    const names = ['🎉', '物件詳細', '→', '   ', '---'];
+    const candidates = await scanCandidates({
+      product: 'ppt',
+      repoRoot: '/',
+      sources: {
+        sitemap: false,
+        useCases: false,
+        epics: false,
+        designSource: undefined,
+        userAdd: names,
+      },
+    });
+    expect(candidates).toHaveLength(names.length);
+    for (const c of candidates) {
+      // No bare `ppt/` — the slug segment is always non-empty.
+      expect(c.id).not.toBe('ppt/');
+      expect(c.id.split('/')[1]).not.toBe('');
+      // Every synthesized id passes the schema `screens init` will re-check.
+      expect(IdSchema.safeParse(c.id).success).toBe(true);
+    }
+    // Fallback ids are deterministic for a given name.
+    const again = await scanCandidates({
+      product: 'ppt',
+      repoRoot: '/',
+      sources: {
+        sitemap: false,
+        useCases: false,
+        epics: false,
+        designSource: undefined,
+        userAdd: ['🎉'],
+      },
+    });
+    expect(again[0].id).toBe(candidates[0].id);
+  });
+
   it('extracts design frames from a DesignSource adapter', async () => {
     const { ZipAdapter } = await import('../src/design-source/zip-adapter.js');
     const fixturePath = path.join(fixturesDir, 'designs-2026-q2.zip');


### PR DESCRIPTION
## Task
Follow-up: validate every synthesized candidate id against IdSchema in `scanCandidates` (PR #2344). Closes #2367.

PR #2344 fixed one instance of a class bug for the epic path: `scanCandidates()` synthesizes candidate `id`s that `screens init` writes **verbatim** (and slugs the filename from), so a source emitting a schema-invalid id produces a screen-map that immediately fails `screens validate`. The other sources (`scanSitemap`, `scanUseCases`, `scanDesignSource`, `userAdd`) all build ids via `slugifyName()`, which strips everything outside `[a-z0-9\s-]`. A name with no Latin alphanumerics slugifies to the empty string → bare `ppt/` → `IdSchema` reject. Reachable via `--add ""` and, more plausibly, non-Latin Figma design-source frame names (Reality Portal is i18n: sk/cs/de/en).

## Fix (guard the class at the boundary)
`frontend/packages/screen-map/src/scan.ts`:
- `slugifyName()` never returns an empty/hyphen-only slug — it now strips leading/trailing hyphens and falls back to a stable content-hash slug `screen-<sha1[:8]>`, so no source can emit a bare `<product>/`.
- `scanCandidates()` re-validates every candidate `id` against the exported `IdSchema` at the boundary (after all sources run) and re-slugs its `name` on failure — a single guard covering all current and future sources rather than per-source patches.

## Owner
`pm-tech-lead` (hint). Real specialist: `generic` (screen-map tooling — `frontend/packages/screen-map`), same as PR #2344.

## Tested (Band A — fast check)
- `pnpm -F @ppt/screen-map exec vitest run tests/scan.test.ts` → 8 passed (exit 0)
- `pnpm -F @ppt/screen-map typecheck` (tsc --noEmit) → exit 0
- `biome check packages/screen-map/src/scan.ts tests/scan.test.ts` → exit 0
- `pnpm -F @ppt/screen-map test` (full package) → 18 files, 81 passed / 1 skipped (exit 0)

**TDD evidence (IG3):** the new `test:` commit's regression test (non-Latin / emoji / CJK / symbol-only / whitespace-only / hyphen-only names) **fails on `dev`** (`expect(c.id).not.toBe('ppt/')` — bare `ppt/`) and passes after the `fix:` commit. Verified by reverting `scan.ts` to `dev` and re-running: 1 failed → restored → 8 passed. Also asserts fallback ids are deterministic for a given name.

## Built (Band B — full build)
Skipped: change is ~30 LOC of internal tooling, no public API / migration / build-output config touched. Band B for the `generic` specialist is n/a.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change — this is dev-tooling for the screen-map generator).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` exited 2, flagging both changed files:
- `frontend/packages/screen-map/src/scan.ts`
- `frontend/packages/screen-map/tests/scan.test.ts`

This is a false positive from the `owner_role` **hint**: `pm-tech-lead`'s owner-areas don't include frontend tooling, but the true specialist for this task is `generic`/screen-map and these two files ARE exactly the task scope (the file the issue names + its test). No unrelated files touched. Reviewer to confirm.

## Code-reuse review
`reuse-grep.sh --specialist generic` → clean (no duplicated helper warnings). Reuses the already-exported `IdSchema` from `schema.ts` (no re-implementation).

## Notes
- Design choice: guard once at the `scanCandidates()` boundary rather than editing each of the 4 source functions, so the invariant holds for future sources too.
- `slugifyName` hardening (edge-hyphen strip + non-empty fallback) is defence-in-depth so the bare `<product>/` can never even reach the boundary check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015v36u2fEFyyt7xUAVTGnAc

---
_Generated by [Claude Code](https://claude.ai/code/session_015v36u2fEFyyt7xUAVTGnAc)_