### PR TITLE
gh-issue-2369: sync category enabled badge on optimistic trigger toggle

### DIFF
--- a/frontend/packages/api-client/src/granular-notifications/hooks.test.ts
+++ b/frontend/packages/api-client/src/granular-notifications/hooks.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression tests for the granular-trigger optimistic patch (#2369).
+ *
+ * `useUpdateNotificationTrigger.onMutate` used to patch only `preferences[]`,
+ * leaving each category's `enabledEvents` rollup — the source of the
+ * "X of Y enabled" badge (NotificationTriggersPage) — stale until the
+ * settle-invalidate refetch resolved. These tests pin that the pure patch
+ * helper recomputes `categories[].enabledEvents` in lockstep with the toggled
+ * channels, matching the backend predicate (at least one channel on).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyTriggerOptimisticPatch } from './hooks';
+import type { EventTriggerPreference, EventTriggersResponse } from './types';
+
+function pref(
+  overrides: Partial<EventTriggerPreference> &
+    Pick<EventTriggerPreference, 'eventType' | 'category'>
+): EventTriggerPreference {
+  return {
+    displayName: overrides.eventType,
+    isPriority: false,
+    pushEnabled: false,
+    emailEnabled: false,
+    inAppEnabled: false,
+    ...overrides,
+  };
+}
+
+function fixture(): EventTriggersResponse {
+  const preferences: EventTriggerPreference[] = [
+    // fault: one trigger with its last-remaining channel (push) still on.
+    pref({ eventType: 'fault.assigned', category: 'fault', pushEnabled: true }),
+    // fault: a fully-off trigger.
+    pref({ eventType: 'fault.resolved', category: 'fault' }),
+    // vote: fully on.
+    pref({
+      eventType: 'vote.opened',
+      category: 'vote',
+      pushEnabled: true,
+      emailEnabled: true,
+      inAppEnabled: true,
+    }),
+  ];
+  return {
+    preferences,
+    categories: [
+      { category: 'fault', displayName: 'fault', totalEvents: 2, enabledEvents: 1 },
+      { category: 'vote', displayName: 'vote', totalEvents: 1, enabledEvents: 1 },
+    ],
+  };
+}
+
+describe('applyTriggerOptimisticPatch', () => {
+  it('applies the channel patch to the matching preference only', () => {
+    const next = applyTriggerOptimisticPatch(fixture(), 'fault.assigned', { pushEnabled: false });
+    expect(next.preferences.find((p) => p.eventType === 'fault.assigned')?.pushEnabled).toBe(false);
+    // Untouched trigger is unchanged.
+    expect(next.preferences.find((p) => p.eventType === 'vote.opened')?.pushEnabled).toBe(true);
+  });
+
+  it('decrements enabledEvents when the last channel of a trigger is turned off', () => {
+    const next = applyTriggerOptimisticPatch(fixture(), 'fault.assigned', { pushEnabled: false });
+    // fault.assigned had only push on; turning it off drops the category to 0.
+    expect(next.categories.find((c) => c.category === 'fault')?.enabledEvents).toBe(0);
+    // Other categories are untouched.
+    expect(next.categories.find((c) => c.category === 'vote')?.enabledEvents).toBe(1);
+  });
+
+  it('increments enabledEvents when the first channel of a trigger is turned on', () => {
+    const next = applyTriggerOptimisticPatch(fixture(), 'fault.resolved', { emailEnabled: true });
+    // fault.resolved was fully off; enabling one channel adds it to the rollup.
+    expect(next.categories.find((c) => c.category === 'fault')?.enabledEvents).toBe(2);
+  });
+
+  it('leaves enabledEvents unchanged when a still-enabled trigger keeps another channel on', () => {
+    const next = applyTriggerOptimisticPatch(fixture(), 'vote.opened', { pushEnabled: false });
+    // vote.opened still has email + in-app on, so it stays counted.
+    expect(next.categories.find((c) => c.category === 'vote')?.enabledEvents).toBe(1);
+  });
+
+  it('does not mutate the previous response object', () => {
+    const previous = fixture();
+    const snapshot = JSON.parse(JSON.stringify(previous));
+    applyTriggerOptimisticPatch(previous, 'fault.assigned', { pushEnabled: false });
+    expect(previous).toEqual(snapshot);
+  });
+});

--- a/frontend/packages/api-client/src/granular-notifications/hooks.ts
+++ b/frontend/packages/api-client/src/granular-notifications/hooks.ts
@@ -10,12 +10,49 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getEventTriggers, resetEventTriggers, updateEventTrigger } from './api';
-import type { EventTriggersResponse, UpdateTriggerRequest } from './types';
+import type { EventTriggerPreference, EventTriggersResponse, UpdateTriggerRequest } from './types';
 
 export const notificationTriggerKeys = {
   all: ['notification-triggers'] as const,
   events: () => [...notificationTriggerKeys.all, 'events'] as const,
 };
+
+/**
+ * A trigger counts as "enabled" when at least one channel is on — mirroring the
+ * backend rollup (`push_enabled || email_enabled || in_app_enabled`, see
+ * `api-server/src/routes/granular_notifications.rs::list_event_preferences`).
+ */
+function isTriggerEnabled(pref: EventTriggerPreference): boolean {
+  return pref.pushEnabled || pref.emailEnabled || pref.inAppEnabled;
+}
+
+/**
+ * Apply a single-trigger channel patch to a cached response, keeping the
+ * per-category `enabledEvents` rollups in sync with the patched preferences.
+ *
+ * Without recomputing `categories[].enabledEvents`, an optimistic patch that
+ * flips a trigger's *last channel off* (or its *first channel on*) leaves the
+ * "X of Y enabled" badge stale until the settle-invalidate refetch resolves —
+ * a visible flicker on slow networks (#2369). The predicate matches the backend
+ * exactly, so this stays consistent with the server rollup that replaces it on
+ * settle.
+ */
+export function applyTriggerOptimisticPatch(
+  previous: EventTriggersResponse,
+  eventType: string,
+  patch: UpdateTriggerRequest
+): EventTriggersResponse {
+  const preferences = previous.preferences.map((pref) =>
+    pref.eventType === eventType ? { ...pref, ...patch } : pref
+  );
+  const categories = previous.categories.map((category) => ({
+    ...category,
+    enabledEvents: preferences.filter(
+      (pref) => pref.category === category.category && isTriggerEnabled(pref)
+    ).length,
+  }));
+  return { ...previous, preferences, categories };
+}
 
 /** Fetch the full set of notification triggers (event types) and category rollups. */
 export function useNotificationTriggers() {
@@ -29,8 +66,9 @@ export function useNotificationTriggers() {
 /**
  * Toggle a single channel on one trigger, with an optimistic cache patch so the
  * checkbox flips immediately and rolls back on error (the `advanced-notifications`
- * pattern). The settle-invalidate keeps the category `enabledEvents` rollups in
- * sync with the server.
+ * pattern). The patch also recomputes the category `enabledEvents` rollups so the
+ * "X of Y enabled" badge tracks the toggle instantly (#2369); the settle-invalidate
+ * then reconciles both against the server.
  */
 export function useUpdateNotificationTrigger() {
   const queryClient = useQueryClient();
@@ -46,12 +84,10 @@ export function useUpdateNotificationTrigger() {
       );
 
       if (previous) {
-        queryClient.setQueryData<EventTriggersResponse>(notificationTriggerKeys.events(), {
-          ...previous,
-          preferences: previous.preferences.map((pref) =>
-            pref.eventType === eventType ? { ...pref, ...patch } : pref
-          ),
-        });
+        queryClient.setQueryData<EventTriggersResponse>(
+          notificationTriggerKeys.events(),
+          applyTriggerOptimisticPatch(previous, eventType, patch)
+        );
       }
 
       return { previous };


### PR DESCRIPTION
## Task
Follow-up: optimistic trigger toggle desyncs the category "X of Y enabled" badge (PR #2337) (Closes #2369)

`useUpdateNotificationTrigger.onMutate` applied its optimistic patch only to `previous.preferences[]`, not to `previous.categories[].enabledEvents`. The per-category badge (`NotificationTriggersPage`, `notificationTriggers.enabledCount`) renders `summary.enabledEvents`, i.e. the server rollup — so when a toggle changed whether an event counts as enabled (last channel off / first channel on) the checkbox flipped instantly but the "X of Y enabled" badge stayed stale until the `onSettled` invalidate/refetch resolved (visible flicker on slow networks).

## Fix (issue option b)
Extended the optimistic patch to recompute the affected `categories[].enabledEvents` alongside `preferences[]`, keeping `NotificationTriggersPage` a dumb renderer of the server rollup. The patch is self-correcting: the `onSettled` invalidate still reconciles both against the server.

- Extracted a pure, exported `applyTriggerOptimisticPatch(previous, eventType, patch)` in `frontend/packages/api-client/src/granular-notifications/hooks.ts` and call it from `onMutate`.
- The "enabled" predicate (`pushEnabled || emailEnabled || inAppEnabled`, at least one channel on) matches the backend rollup verbatim — `api-server/src/routes/granular_notifications.rs::list_event_preferences` groups by category with `if pref.push_enabled || pref.email_enabled || pref.in_app_enabled { enabled += 1 }`. So the optimistic value equals the value that replaces it on settle.

## Owner
pm-tech-lead (hint) — real specialist: react-web

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client test:run granular-notifications` → exit 0 (5 passed; new regression test `hooks.test.ts`)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm -F @ppt/api-client typecheck` → exit 0
- `npx biome check <changed files>` → exit 0 (after autofix: import line reflow)

## Built (Band B — full build)
- `pnpm -F @ppt/api-client build` (`tsc`) → exit 0. Change is a shared package touched by ppt-web; `@ppt/web` typecheck resolves against it cleanly. (No Vite prod build run — <50 LOC, no public-API/config change beyond one new exported helper.)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — pure client-side cache UX).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 because the `pm-tech-lead` owner hint does not map to frontend paths. The changed files —
- `frontend/packages/api-client/src/granular-notifications/hooks.ts`
- `frontend/packages/api-client/src/granular-notifications/hooks.test.ts`

are squarely the **react-web** specialist's area (the issue names react-web as the suggested specialist and points at exactly these files). Not real drift — an owner-hint/area mismatch.

## Code-reuse review
`reuse-grep.sh --specialist react-web` → no warnings. The new `applyTriggerOptimisticPatch` / `isTriggerEnabled` helpers are module-local and have no existing equivalent.

## Notes
- Chose issue option (b) over (a): keeps the source of truth as the server rollup (self-corrects on settle if the predicate ever drifts from the backend) and keeps the page presentational.
- Regression test covers: last-channel-off decrements, first-channel-on increments, still-enabled trigger unchanged, patch touches only the matching preference, and no mutation of the previous object.


---
_Generated by [Claude Code](https://claude.ai/code/session_015v36u2fEFyyt7xUAVTGnAc)_