### PR TITLE
gh-issue-2365: cover AC-5 favorite price-alert toggle + optimistic OFF state

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/favorites/page.test.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/favorites/page.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Favorites page — AC-5 "watch price" toggle tests (Story 84.3, #2365).
+ *
+ * PR #2348 wired the per-favorite price-alert toggle
+ * (`PATCH /api/v1/favorites/{listingId}` → `useUpdateFavorite` → the checkbox
+ * on this page) but shipped it with no test that actually executes — the two
+ * backend authz tests are `#[ignore]`-quarantined and there was no frontend
+ * coverage at all. These tests render the REAL page and drive the toggle end
+ * to end, pinning:
+ *   1. the checkbox reflects the favorite's `price_alert_enabled` from GET,
+ *   2. toggling it OFF fires `PATCH …/{listingId}` with
+ *      `{ price_alert_enabled: false }`,
+ *   3. the optimistic cache update (added for #2365) flips the checkbox
+ *      immediately and rolls back when the PATCH fails.
+ *
+ * Only framework / heavy-UI boundaries are mocked (auth-context so
+ * ProtectedRoute renders its children, and the ListingCard / Header / Footer
+ * chrome). The favorites data path and `useUpdateFavorite` are the real thing.
+ */
+/// <reference types="vitest/globals" />
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// ProtectedRoute (via useAuth) — pretend the visitor is authenticated so the
+// grid renders instead of the login gate.
+vi.mock('@/lib/auth-context', () => ({
+  useAuth: () => ({
+    isLoading: false,
+    isAuthenticated: true,
+    user: { id: 'u-1' },
+    login: vi.fn(),
+    logout: vi.fn(),
+    refreshSession: vi.fn(),
+  }),
+}));
+
+// Heavy presentational chrome — irrelevant to the toggle behaviour under test.
+vi.mock('@/components/listings', () => ({
+  ListingCard: ({ listing }: { listing: { title?: string } }) => (
+    <div data-testid="listing-card">{listing?.title}</div>
+  ),
+}));
+vi.mock('@/components/ui', () => ({
+  Header: () => <header />,
+  Footer: () => <footer />,
+}));
+
+import FavoritesPage from './page';
+
+const LISTING_ID = 'listing-1';
+
+function favoritesPayload(priceAlertEnabled: boolean) {
+  return {
+    data: [
+      {
+        id: 'fav-1',
+        listingId: LISTING_ID,
+        listing: { id: LISTING_ID, title: 'Sunny 2-bedroom apartment' },
+        addedAt: '2026-07-01T00:00:00Z',
+        price_alert_enabled: priceAlertEnabled,
+      },
+    ],
+    total: 1,
+    page: 1,
+    pageSize: 12,
+    totalPages: 1,
+  };
+}
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <FavoritesPage />
+    </QueryClientProvider>
+  );
+}
+
+describe('FavoritesPage — AC-5 watch-price toggle (#2365)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the checkbox checked from GET and fires PATCH { price_alert_enabled: false } on toggle-off', async () => {
+    // GET starts subscribed; PATCH + the invalidation refetch persist the OFF
+    // state, so the round-trip mirrors the real backend list DTO.
+    let alertEnabled = true;
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (method === 'PATCH') {
+        alertEnabled = JSON.parse(String(init?.body)).price_alert_enabled;
+        return Promise.resolve({ ok: true, status: 200, json: async () => ({}) });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => favoritesPayload(alertEnabled),
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderPage();
+
+    const checkbox = await screen.findByRole('checkbox');
+    expect(checkbox).toBeChecked();
+
+    fireEvent.click(checkbox);
+
+    // PATCH hit the per-favorite endpoint with the unsubscribe body.
+    await waitFor(() => {
+      const patch = fetchMock.mock.calls.find(([, init]) => init?.method === 'PATCH');
+      expect(patch).toBeDefined();
+      expect(patch?.[0]).toMatch(new RegExp(`/api/v1/favorites/${LISTING_ID}$`));
+      expect(JSON.parse(String(patch?.[1]?.body))).toEqual({ price_alert_enabled: false });
+    });
+
+    // After the round-trip the checkbox stays unchecked (state persisted).
+    await waitFor(() => expect(checkbox).not.toBeChecked());
+  });
+
+  it('optimistically unchecks immediately and rolls back to checked when the PATCH fails', async () => {
+    // Gate the PATCH so it stays pending long enough to observe the optimistic
+    // flip deterministically, then reject it to exercise the rollback.
+    let rejectPatch: (() => void) | undefined;
+    const patchGate = new Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>(
+      (resolve) => {
+        rejectPatch = () => resolve({ ok: false, status: 500, json: async () => ({}) });
+      }
+    );
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if ((init?.method ?? 'GET') === 'PATCH') return patchGate;
+      return Promise.resolve({ ok: true, status: 200, json: async () => favoritesPayload(true) });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderPage();
+
+    expect(await screen.findByRole('checkbox')).toBeChecked();
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    // Optimistic update flips it off while the PATCH is still in flight.
+    await waitFor(() => expect(screen.getByRole('checkbox')).not.toBeChecked());
+
+    // Server rejects → onError rollback + onSettled refetch restore the checked
+    // state, so the UI never lies about a change that didn't persist.
+    rejectPatch?.();
+    await waitFor(() => expect(screen.getByRole('checkbox')).toBeChecked());
+  });
+});

--- a/frontend/packages/reality-api-client/src/favorites/hooks.ts
+++ b/frontend/packages/reality-api-client/src/favorites/hooks.ts
@@ -106,6 +106,12 @@ export function useRemoveFavorite() {
  *
  * Consumes `PATCH /api/v1/favorites/{listingId}`. The body is partial-merged
  * server-side, so passing only `price_alert_enabled` leaves notes untouched.
+ *
+ * Optimistically flips `price_alert_enabled` on the matching row in every
+ * cached `['favorites', …]` page so the toggle reflects the user's intent
+ * immediately, rolling the snapshot back if the PATCH fails. This removes the
+ * dependency on the page's `?? true` fallback masking a transiently-absent
+ * field after refetch (see #2365).
  */
 export function useUpdateFavorite() {
   const queryClient = useQueryClient();
@@ -126,7 +132,41 @@ export function useUpdateFavorite() {
       });
       if (!response.ok) throw new Error('Failed to update favorite');
     },
-    onSuccess: () => {
+    onMutate: async ({ listingId, data }) => {
+      // Only the price-alert toggle has a visible cached surface to update
+      // optimistically; a notes-only edit has nothing to reflect here.
+      if (data.price_alert_enabled == null) return { previous: [] };
+
+      await queryClient.cancelQueries({ queryKey: ['favorites'] });
+
+      // Snapshot every matching `['favorites', page, pageSize]` cache entry so
+      // we can roll back on error.
+      const previous = queryClient.getQueriesData<PaginatedFavorites>({
+        queryKey: ['favorites'],
+      });
+
+      queryClient.setQueriesData<PaginatedFavorites>({ queryKey: ['favorites'] }, (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          data: old.data.map((favorite) =>
+            favorite.listingId === listingId
+              ? { ...favorite, price_alert_enabled: data.price_alert_enabled ?? undefined }
+              : favorite
+          ),
+        };
+      });
+
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      // Restore the pre-mutation snapshot so a failed toggle doesn't leave the
+      // checkbox showing an un-persisted state.
+      for (const [queryKey, data] of context?.previous ?? []) {
+        queryClient.setQueryData(queryKey, data);
+      }
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['favorites'] });
       queryClient.invalidateQueries({ queryKey: FAVORITE_ALERTS_KEY });
     },


### PR DESCRIPTION
## Task
Follow-up: AC-5 price-alert toggle shipped with no executing test + non-persisting OFF state (PR #2348) (Closes #2365)

Two findings from the post-merge review of PR #2348:
- **test-coverage (medium):** the AC-5 "watch price" toggle (`PATCH /api/v1/favorites/{listingId}` → `useUpdateFavorite` → the checkbox on `favorites/page.tsx`) shipped with no executing test — the backend authz tests are `#[ignore]`-quarantined and there was zero frontend coverage.
- **correctness (low):** `useUpdateFavorite` had no optimistic update, so an unsubscribe depended on the page's `?? true` fallback and could silently snap back to checked after refetch if the field were ever absent.

## Owner
`pm-tech-lead` (hint). Real specialist: **nextjs-web** — the change is entirely in reality-web + the reality-api-client package it consumes.

## Changes
- `frontend/packages/reality-api-client/src/favorites/hooks.ts` — `useUpdateFavorite` now does an optimistic cache update: `onMutate` flips `price_alert_enabled` on the matching row across every cached `['favorites', …]` page (snapshotting for rollback), `onError` restores the snapshot, `onSettled` invalidates `['favorites']` + `['favorite-alerts']`. The toggle reflects intent immediately and no longer relies on the `?? true` fallback masking a transiently-absent field.
- `frontend/apps/reality-web/src/app/[locale]/favorites/page.test.tsx` (new) — renders the real `FavoritesPage` and drives the toggle end-to-end:
  1. checkbox reflects `price_alert_enabled` from GET; toggling OFF fires `PATCH …/{listingId}` with `{ price_alert_enabled: false }` and the OFF state persists;
  2. optimistic update unchecks immediately while the PATCH is in flight, and rolls back to checked when the PATCH fails.

## Failing-first evidence (IG3)
With the hook change stashed (original `useUpdateFavorite`), the optimistic/rollback test fails (checkbox stays checked — no `onMutate`), while the PATCH-body test passes. With the fix applied, both pass. Verified via `git stash push -- hooks.ts` → `test:run` → 1 failed / 1 passed → restore → 2 passed.

## Tested (Band A — fast check)
- `pnpm -F reality-web test:run src/app/[locale]/favorites/page.test.tsx` → **2 passed** (exit 0)
- `pnpm -F reality-web typecheck` (`tsc --noEmit`) → exit 0
- `pnpm -F @ppt/reality-api-client typecheck` (`tsc --noEmit`) → exit 0
- `biome check` on both changed files → exit 0 (formatting autofixed). Note: reality-web's `lint` script (`next lint`) is misconfigured in this workspace and errors on arg parsing; the repo's real lint gate is Biome per CLAUDE.md, which is clean.

## Built (Band B — full build)
Skipped: behavior-only change to a client (`'use client'`) hook + a new test; no public hook signature, config, or SSR surface changed. Full-project `tsc --noEmit` (which catches import-time type errors) is already green.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` returned exit 2 because both changed files are frontend (`reality-web` + `reality-api-client`), outside the `pm-tech-lead` architecture-lens area. This is expected — `pm-tech-lead` was only a routing hint; the actual specialist is `nextjs-web`, whose area these files are. Drift is benign.
- `frontend/apps/reality-web/src/app/[locale]/favorites/page.test.tsx`
- `frontend/packages/reality-api-client/src/favorites/hooks.ts`

## Code-reuse review
`reuse-grep.sh --specialist nextjs-web` — no warnings (no new auth/crypto/http helper added).

## Notes
- IG goal-check IG1/IG2 hard-fail because this is a dispatcher `gh-issue` task on the pre-assigned `auto-impl/…` branch with no `.research/plans/<slug>.md` (and the task forbids touching `.research/**`). Those checks target the plan-slug flow and are inapplicable here; IG3 failing-first is satisfied (see above).
- The backend `#[ignore]`-quarantined `update_favorite` authz tests (BIT-351/BIT-352) are intentionally left out of scope — the issue frames de-quarantining them as a separate follow-up once BIT-352 lands. This PR adds the missing *frontend* green guard.


---
_Generated by [Claude Code](https://claude.ai/code/session_015v36u2fEFyyt7xUAVTGnAc)_