### PR TITLE
gh-issue-2370: localize create-schedule report labels + backend error toast (Closes #2370)

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1057,7 +1057,19 @@
       "created": "Plán byl úspěšně vytvořen.",
       "createFailed": "Plán se nepodařilo vytvořit.",
       "updated": "Plán byl úspěšně aktualizován.",
-      "updateFailed": "Plán se nepodařilo aktualizovat."
+      "updateFailed": "Plán se nepodařilo aktualizovat.",
+      "createErrors": {
+        "emptyName": "Název plánu nesmí být prázdný.",
+        "invalidFrequency": "Zvolená frekvence není podporována.",
+        "invalidRecipientEmail": "Jedna nebo více e-mailových adres příjemců je neplatná.",
+        "invalidTimezone": "Vyberte platné časové pásmo."
+      }
+    },
+    "builtin": {
+      "faults": "Statistika závad",
+      "voting": "Účast na hlasování",
+      "occupancy": "Obsazenost",
+      "consumption": "Spotřeba"
     },
     "execution": {
       "downloadFailed": "Nepodařilo se stáhnout zprávu.",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1006,7 +1006,19 @@
       "created": "Zeitplan erfolgreich erstellt.",
       "createFailed": "Zeitplan konnte nicht erstellt werden.",
       "updated": "Zeitplan erfolgreich aktualisiert.",
-      "updateFailed": "Zeitplan konnte nicht aktualisiert werden."
+      "updateFailed": "Zeitplan konnte nicht aktualisiert werden.",
+      "createErrors": {
+        "emptyName": "Der Name des Zeitplans darf nicht leer sein.",
+        "invalidFrequency": "Die gewählte Häufigkeit wird nicht unterstützt.",
+        "invalidRecipientEmail": "Eine oder mehrere E-Mail-Adressen der Empfänger sind ungültig.",
+        "invalidTimezone": "Bitte wählen Sie eine gültige Zeitzone."
+      }
+    },
+    "builtin": {
+      "faults": "Störungsstatistik",
+      "voting": "Abstimmungsbeteiligung",
+      "occupancy": "Belegung",
+      "consumption": "Verbrauch"
     },
     "execution": {
       "downloadFailed": "Bericht konnte nicht heruntergeladen werden.",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3375,7 +3375,19 @@
       "created": "Schedule created successfully.",
       "createFailed": "Failed to create schedule.",
       "updated": "Schedule updated successfully.",
-      "updateFailed": "Failed to update schedule."
+      "updateFailed": "Failed to update schedule.",
+      "createErrors": {
+        "emptyName": "The schedule name must not be empty.",
+        "invalidFrequency": "The selected frequency is not supported.",
+        "invalidRecipientEmail": "One or more recipient email addresses are invalid.",
+        "invalidTimezone": "Please select a valid timezone."
+      }
+    },
+    "builtin": {
+      "faults": "Fault statistics",
+      "voting": "Voting participation",
+      "occupancy": "Occupancy",
+      "consumption": "Consumption"
     },
     "execution": {
       "downloadFailed": "Failed to download report.",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1006,7 +1006,19 @@
       "created": "Ütemezés sikeresen létrehozva.",
       "createFailed": "Nem sikerült létrehozni az ütemezést.",
       "updated": "Ütemezés sikeresen frissítve.",
-      "updateFailed": "Nem sikerült frissíteni az ütemezést."
+      "updateFailed": "Nem sikerült frissíteni az ütemezést.",
+      "createErrors": {
+        "emptyName": "Az ütemezés neve nem lehet üres.",
+        "invalidFrequency": "A kiválasztott gyakoriság nem támogatott.",
+        "invalidRecipientEmail": "Egy vagy több címzett e-mail-címe érvénytelen.",
+        "invalidTimezone": "Kérjük, válasszon érvényes időzónát."
+      }
+    },
+    "builtin": {
+      "faults": "Hibastatisztika",
+      "voting": "Szavazási részvétel",
+      "occupancy": "Kihasználtság",
+      "consumption": "Fogyasztás"
     },
     "execution": {
       "downloadFailed": "Nem sikerült letölteni a jelentést.",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1012,7 +1012,19 @@
       "created": "Harmonogram został utworzony.",
       "createFailed": "Nie udało się utworzyć harmonogramu.",
       "updated": "Harmonogram został zaktualizowany.",
-      "updateFailed": "Nie udało się zaktualizować harmonogramu."
+      "updateFailed": "Nie udało się zaktualizować harmonogramu.",
+      "createErrors": {
+        "emptyName": "Nazwa harmonogramu nie może być pusta.",
+        "invalidFrequency": "Wybrana częstotliwość nie jest obsługiwana.",
+        "invalidRecipientEmail": "Co najmniej jeden adres e-mail odbiorcy jest nieprawidłowy.",
+        "invalidTimezone": "Wybierz prawidłową strefę czasową."
+      }
+    },
+    "builtin": {
+      "faults": "Statystyka usterek",
+      "voting": "Frekwencja w głosowaniu",
+      "occupancy": "Obłożenie",
+      "consumption": "Zużycie"
     },
     "execution": {
       "downloadFailed": "Nie udało się pobrać raportu.",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1059,7 +1059,19 @@
       "created": "Plán bol úspešne vytvorený.",
       "createFailed": "Nepodarilo sa vytvoriť plán.",
       "updated": "Plán bol úspešne aktualizovaný.",
-      "updateFailed": "Nepodarilo sa aktualizovať plán."
+      "updateFailed": "Nepodarilo sa aktualizovať plán.",
+      "createErrors": {
+        "emptyName": "Názov plánu nesmie byť prázdny.",
+        "invalidFrequency": "Zvolená frekvencia nie je podporovaná.",
+        "invalidRecipientEmail": "Jedna alebo viac e-mailových adries príjemcov je neplatná.",
+        "invalidTimezone": "Vyberte platné časové pásmo."
+      }
+    },
+    "builtin": {
+      "faults": "Štatistika porúch",
+      "voting": "Účasť na hlasovaní",
+      "occupancy": "Obsadenosť",
+      "consumption": "Spotreba"
     },
     "execution": {
       "downloadFailed": "Nepodarilo sa stiahnuť správu.",

--- a/frontend/apps/ppt-web/src/features/reports/builtinReports.ts
+++ b/frontend/apps/ppt-web/src/features/reports/builtinReports.ts
@@ -17,15 +17,44 @@
 export interface BuiltinReport {
   /** Stable, well-known, non-nil UUID persisted as the schedule's `report_id`. */
   id: string;
-  /** i18n-independent display name shown in the report selector. */
+  /**
+   * i18n key resolved with `t()` in the report selector (issue #2370). Every
+   * locale must define `reports.builtin.{faults,voting,occupancy,consumption}`.
+   */
+  labelKey: string;
+  /**
+   * English dev fallback for the selector label — only rendered if the i18n key
+   * is missing. The UI must show `t(labelKey, name)`, never `name` alone, or the
+   * 5 non-English locales leak English (issue #2370).
+   */
   name: string;
   /** The backend report generator this schedule fires. */
   type: 'faults' | 'voting' | 'occupancy' | 'consumption';
 }
 
 export const BUILTIN_REPORTS: readonly BuiltinReport[] = [
-  { id: 'a0000000-0000-4000-8000-000000000001', name: 'Fault statistics', type: 'faults' },
-  { id: 'a0000000-0000-4000-8000-000000000002', name: 'Voting participation', type: 'voting' },
-  { id: 'a0000000-0000-4000-8000-000000000003', name: 'Occupancy', type: 'occupancy' },
-  { id: 'a0000000-0000-4000-8000-000000000004', name: 'Consumption', type: 'consumption' },
+  {
+    id: 'a0000000-0000-4000-8000-000000000001',
+    labelKey: 'reports.builtin.faults',
+    name: 'Fault statistics',
+    type: 'faults',
+  },
+  {
+    id: 'a0000000-0000-4000-8000-000000000002',
+    labelKey: 'reports.builtin.voting',
+    name: 'Voting participation',
+    type: 'voting',
+  },
+  {
+    id: 'a0000000-0000-4000-8000-000000000003',
+    labelKey: 'reports.builtin.occupancy',
+    name: 'Occupancy',
+    type: 'occupancy',
+  },
+  {
+    id: 'a0000000-0000-4000-8000-000000000004',
+    labelKey: 'reports.builtin.consumption',
+    name: 'Consumption',
+    type: 'consumption',
+  },
 ] as const;

--- a/frontend/apps/ppt-web/src/features/reports/components/ScheduleForm.tsx
+++ b/frontend/apps/ppt-web/src/features/reports/components/ScheduleForm.tsx
@@ -6,6 +6,7 @@
 
 import type { CreateReportSchedule, ReportFormat, ScheduleFrequency } from '@ppt/api-client';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { BUILTIN_REPORTS } from '../builtinReports';
 
 interface ScheduleFormProps {
@@ -79,6 +80,7 @@ interface FormErrors {
 }
 
 export function ScheduleForm({ initialData, onSubmit, onCancel, isSubmitting }: ScheduleFormProps) {
+  const { t } = useTranslation();
   const [reportId, setReportId] = useState(initialData?.report_id || '');
   const [name, setName] = useState(initialData?.name || '');
   const [frequency, setFrequency] = useState<ScheduleFrequency>(initialData?.frequency || 'weekly');
@@ -123,7 +125,7 @@ export function ScheduleForm({ initialData, onSubmit, onCancel, isSubmitting }: 
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!validate()) return;
@@ -131,20 +133,28 @@ export function ScheduleForm({ initialData, onSubmit, onCancel, isSubmitting }: 
     const dow = frequency === 'weekly' ? dayOfWeek : undefined;
     const dom = frequency === 'monthly' ? dayOfMonth : undefined;
 
-    onSubmit({
-      report_id: reportId,
-      name,
-      frequency,
-      day_of_week: dow,
-      day_of_month: dom,
-      time,
-      timezone,
-      format,
-      recipients: recipients.split(',').map((e) => e.trim()),
-      // Cron-canonical from birth (issue #2324, finding 3): the backend prefers
-      // this over the legacy frequency/time fields when computing next_run_at.
-      cron_expression: deriveCron(frequency, time, dayOfWeek, dayOfMonth),
-    });
+    // Await + swallow: the parent's onSubmit rejects on a backend error (so it
+    // can keep this form open) and surfaces the reason via a toast. Firing it
+    // fire-and-forget left that rejection unhandled on every failed create
+    // (issue #2370); awaiting and catching here handles it at the form level.
+    try {
+      await onSubmit({
+        report_id: reportId,
+        name,
+        frequency,
+        day_of_week: dow,
+        day_of_month: dom,
+        time,
+        timezone,
+        format,
+        recipients: recipients.split(',').map((e) => e.trim()),
+        // Cron-canonical from birth (issue #2324, finding 3): the backend prefers
+        // this over the legacy frequency/time fields when computing next_run_at.
+        cron_expression: deriveCron(frequency, time, dayOfWeek, dayOfMonth),
+      });
+    } catch {
+      // Intentionally swallowed — the parent already reported the failure.
+    }
   };
 
   return (
@@ -168,7 +178,7 @@ export function ScheduleForm({ initialData, onSubmit, onCancel, isSubmitting }: 
           <option value="">Select a report</option>
           {BUILTIN_REPORTS.map((report) => (
             <option key={report.id} value={report.id}>
-              {report.name}
+              {t(report.labelKey, report.name)}
             </option>
           ))}
         </select>

--- a/frontend/apps/ppt-web/src/routes/groups/reports.create-schedule.route.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/reports.create-schedule.route.test.tsx
@@ -15,13 +15,16 @@
  * Only the api-client hooks + `useToast` + `useAuth` are mocked.
  */
 
+import { ApiError } from '@ppt/api-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import i18n from 'i18next';
 import type { ReactNode } from 'react';
 import { Suspense } from 'react';
 import { MemoryRouter, Routes } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import sk from '../../../messages/sk.json';
 import { BUILTIN_REPORTS } from '../../features/reports/builtinReports';
 import { reportRoutes } from './reports';
 
@@ -107,6 +110,63 @@ describe('ReportsPageRoute create-schedule wiring (gap-81-1)', () => {
     );
     await waitFor(() => {
       expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    });
+  });
+
+  // issue #2370: the create-failure toast must show a *localized* message keyed
+  // on the backend error `code`, not the raw English `ApiError.message`.
+  it('shows a localized error toast keyed on the backend error code (not raw English)', async () => {
+    const rawBackendMessage = 'Schedule name must not be empty';
+    mockCreateMutateAsync.mockRejectedValue(new ApiError(400, rawBackendMessage, 'EMPTY_NAME'));
+    const user = userEvent.setup();
+
+    renderReportsRoute();
+
+    await user.click(await screen.findByRole('button', { name: /schedules/i }, { timeout: 5000 }));
+    await user.click(await screen.findByRole('button', { name: /new schedule/i }));
+
+    const builtin = BUILTIN_REPORTS[0];
+    await user.selectOptions(screen.getByRole('combobox', { name: /report/i }), builtin.id);
+    await user.type(screen.getByLabelText(/schedule name/i), 'Weekly Revenue Summary');
+    await user.type(screen.getByLabelText(/recipients/i), 'owner@example.com');
+
+    await user.click(screen.getByRole('button', { name: /save schedule/i }));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+    });
+    const toastArg = mockShowToast.mock.calls.at(-1)?.[0] as { message: string };
+    // The localized copy for EMPTY_NAME, not the untranslated server literal.
+    expect(toastArg.message).toBe(i18n.t('reports.schedule.createErrors.emptyName'));
+    expect(toastArg.message).not.toBe(rawBackendMessage);
+  });
+
+  // issue #2370: the report selector labels must be translated per-locale, not
+  // rendered from the hardcoded English `name`.
+  describe('localized report selector labels', () => {
+    afterAll(async () => {
+      await i18n.changeLanguage('en');
+    });
+
+    it('renders the report options in the active (non-English) locale', async () => {
+      i18n.addResourceBundle('sk', 'translation', sk, true, true);
+      await i18n.changeLanguage('sk');
+      const user = userEvent.setup();
+
+      renderReportsRoute();
+
+      await user.click(
+        await screen.findByRole('button', { name: /schedules|naplánova/i }, { timeout: 5000 })
+      );
+      await user.click(await screen.findByRole('button', { name: /new schedule|naplánova/i }));
+
+      // The Slovak label for the "faults" built-in report — proves the option
+      // is resolved via i18n, not the English `BuiltinReport.name`.
+      const skFaults = sk.reports.builtin.faults;
+      expect(skFaults).not.toBe(BUILTIN_REPORTS[0].name);
+      await waitFor(() => {
+        expect(screen.getByRole('option', { name: skFaults })).toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/apps/ppt-web/src/routes/groups/reports.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/reports.tsx
@@ -12,6 +12,7 @@ import type {
   TrendAnalysis,
 } from '@ppt/api-client';
 import {
+  ApiError,
   useCreateSchedule,
   useDownloadReport,
   useReportExecutionHistory,
@@ -25,6 +26,20 @@ import { Route, useNavigate, useParams } from 'react-router-dom';
 import { ProtectedRoute, useToast } from '../../components';
 import { useAuth } from '../../contexts';
 import { ReportsPage, ScheduleDetailPage } from '../lazyRoutes';
+
+/**
+ * Map a backend `ErrorResponse.code` from the create-schedule endpoint to a
+ * localized message key (issue #2370). Piping the raw `error.message` into the
+ * toast leaked English into the 5 non-English locales, since the backend
+ * messages are English literals. Unknown codes fall back to the generic
+ * `reports.schedule.createFailed` copy.
+ */
+const CREATE_SCHEDULE_ERROR_KEYS: Record<string, string> = {
+  EMPTY_NAME: 'reports.schedule.createErrors.emptyName',
+  INVALID_FREQUENCY: 'reports.schedule.createErrors.invalidFrequency',
+  INVALID_RECIPIENT_EMAIL: 'reports.schedule.createErrors.invalidRecipientEmail',
+  INVALID_TIMEZONE: 'reports.schedule.createErrors.invalidTimezone',
+};
 
 /**
  * Reports page route — wires pause/resume/update schedule hooks (Story 81.1).
@@ -55,13 +70,17 @@ function ReportsPageRoute() {
         message: t('reports.schedule.created', 'Schedule created successfully.'),
       });
     } catch (e) {
-      // Surface the backend's specific error (e.g. INVALID_FREQUENCY) instead of
-      // a fixed string so the user sees why creation failed (issue #2324).
-      const detail = e instanceof Error && e.message ? e.message : undefined;
+      // Surface *why* creation failed (issue #2324) but via a localized message
+      // keyed on the backend error `code`, not the raw English `error.message`
+      // which leaked untranslated copy into non-English locales (issue #2370).
+      const code = e instanceof ApiError ? e.code : undefined;
+      const messageKey = code ? CREATE_SCHEDULE_ERROR_KEYS[code] : undefined;
       showToast({
         type: 'error',
         title: t('common.error'),
-        message: detail ?? t('reports.schedule.createFailed', 'Failed to create schedule.'),
+        message: messageKey
+          ? t(messageKey)
+          : t('reports.schedule.createFailed', 'Failed to create schedule.'),
       });
       throw e;
     }

--- a/frontend/packages/api-client/src/reports/api.ts
+++ b/frontend/packages/api-client/src/reports/api.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FaultCategoryCount, FaultPriorityCount, FaultStatusCount } from '../faults/types';
+import { ApiError } from '../lib/fetch';
 import type {
   AnalyticsParams,
   AnalyticsSummary,
@@ -40,8 +41,14 @@ async function fetchApi<T>(url: string, options?: RequestInit): Promise<T> {
   });
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ message: 'Request failed' }));
-    throw new Error(error.message || `HTTP ${response.status}`);
+    const error = (await response.json().catch(() => ({ message: 'Request failed' }))) as {
+      code?: string;
+      message?: string;
+    };
+    // Preserve the backend `ErrorResponse.code` (e.g. EMPTY_NAME,
+    // INVALID_RECIPIENT_EMAIL) so callers can map it to a localized message
+    // instead of leaking the raw English `message` into a toast (issue #2370).
+    throw new ApiError(response.status, error.message || `HTTP ${response.status}`, error.code);
   }
 
   return response.json();


### PR DESCRIPTION
## Task
Follow-up: create-schedule UI leaks untranslated English into 5 non-English locales (report selector labels + backend error toast) (PR #2338). Closes #2370.

Two user-facing strings on the create-schedule path bypassed i18n and rendered English for the 5 non-English locales (cs/de/hu/pl/sk):

1. **Report selector labels** — `features/reports/builtinReports.ts` hardcoded English `name` values that `ScheduleForm` rendered verbatim as `<option>` labels.
2. **Create-failure toast** — `routes/groups/reports.tsx` piped the raw English backend `error.message` into the toast, so any real backend validation error showed untranslated server copy.

## Owner
`pm-tech-lead` (hint) — implemented by specialist **react-web**.

## Changes
- **`builtinReports.ts`** — added a stable `labelKey` (`reports.builtin.{faults,voting,occupancy,consumption}`) per built-in report; kept `name` as a documented English dev fallback.
- **`ScheduleForm.tsx`** — resolves the option label with `t(report.labelKey, report.name)`. Also made `handleSubmit` `await`+`catch` `onSubmit` (see Notes — latent unhandled-rejection fix).
- **`reports.tsx`** — maps the backend `ErrorResponse.code` (`EMPTY_NAME`, `INVALID_FREQUENCY`, `INVALID_RECIPIENT_EMAIL`, `INVALID_TIMEZONE`) to a localized key via `CREATE_SCHEDULE_ERROR_KEYS`, falling back to `reports.schedule.createFailed` — no longer leaks the raw English `error.message`.
- **`packages/api-client/src/reports/api.ts`** — routes the reports `fetchApi` through the **existing shared `ApiError`** (already exported from `@ppt/api-client`, already carries `code`) instead of a plain `Error`, so the backend error `code` survives to the toast. Reuse, not a new error type.
- **All 6 locale files** (`en/sk/cs/de/pl/hu`) — added `reports.builtin.*` and `reports.schedule.createErrors.*`. Key parity verified across all 6.

## Code-reuse review
No new helper introduced; deliberately reused the shared `ApiError` (`packages/api-client/src/lib/fetch.ts`) rather than adding a reports-local error class. `reuse-grep.sh` clean.

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2 because `pm-tech-lead` is an architecture *hint* role that doesn't map to any frontend owner-area — so every file flags as "drift". All touched files are legitimately within the **react-web** specialist's ownership (`apps/ppt-web/**` + `packages/api-client/**`). No actual out-of-area code was touched.

## Tested (Band A — fast check)
- `pnpm -F @ppt/api-client build` → exit 0
- `pnpm -F @ppt/web typecheck` (`tsc --noEmit` + e2e tsconfig) → exit 0
- `pnpm biome check <11 changed files>` → exit 0 (the per-package `lint` script uses a broken/absent eslint config — repo lint gate is Biome per CLAUDE.md/CI)
- `vitest run` reports suite (`src/features/reports` + `src/routes/groups/reports`) → **66 passed**, incl. 3 in the create-schedule route test (2 new regression tests)
- `vitest run` api-client `src/reports` → 3 passed

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → exit 0, built in ~9.5s

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (i18n/UI display + client-side error mapping; no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- **Latent unhandled-rejection fix (in scope).** The route intentionally re-throws after toasting so `ReportsPage` keeps the create form open on error, but `ScheduleForm` fired `onSubmit` fire-and-forget — so every failed create left an unhandled promise rejection. `ScheduleForm.handleSubmit` now `await`s and `catch`es `onSubmit` (the parent already surfaces the reason via toast), removing the rejection in both prod and tests while preserving form-open-on-error.
- **`INVALID_FREQUENCY`** is now effectively unreachable from the UI (the frequency dropdown is restricted to daily/weekly/monthly) but is mapped for completeness/defense-in-depth.
- **TDD evidence:** split into a `test:` commit (fails on the pre-fix source) and a `fix:` commit. `goal-check` IG3 passes. Its IG1 (no `.research/plans` file) and IG2 (expects an `impl/` branch, but the dispatcher mandated `auto-impl/gh-issue-2370-65aea911`) FAILs are plan-flow/branch-naming artifacts, not applicable to this gh-issue dispatcher task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015v36u2fEFyyt7xUAVTGnAc

---
_Generated by [Claude Code](https://claude.ai/code/session_015v36u2fEFyyt7xUAVTGnAc)_