### PR TITLE
dx-stalled-review-pr-988-retry2: @ppt/sitemap default export for CJS resolution (E2E framework DX)

### DIFF
--- a/frontend/packages/sitemap/package.json
+++ b/frontend/packages/sitemap/package.json
@@ -8,11 +8,13 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
     },
     "./json": {
       "types": "./src/json/sitemap.json",
-      "import": "./src/json/sitemap.json"
+      "import": "./src/json/sitemap.json",
+      "default": "./src/json/sitemap.json"
     }
   },
   "scripts": {

--- a/frontend/packages/sitemap/tests/sitemap.test.ts
+++ b/frontend/packages/sitemap/tests/sitemap.test.ts
@@ -14,7 +14,7 @@ import { buildUrl, SitemapTestHelper } from '../src/utils';
 describe('Sitemap Data', () => {
   describe('Routes', () => {
     it('should have ppt-web routes', () => {
-      expect(sitemap.routes['ppt-web'].length).toBe(19);
+      expect(sitemap.routes['ppt-web'].length).toBe(20);
     });
 
     it('should have reality-web routes', () => {

--- a/frontend/packages/sitemap/tests/sitemap.test.ts
+++ b/frontend/packages/sitemap/tests/sitemap.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import {
   getEndpoint,
@@ -124,5 +125,32 @@ describe('Test Helpers', () => {
       expect(tabs[0]).toHaveProperty('name');
       expect(tabs[0]).toHaveProperty('screens');
     });
+  });
+});
+
+describe('Package exports (CJS resolvability)', () => {
+  // Regression guard for the @ppt/e2e framework rollout (PR #988): reality-web
+  // is a Next.js app with no `"type": "module"`, so Playwright loads its config
+  // via CommonJS `require()`. If @ppt/sitemap's `exports` map only offers
+  // `types` + `import`, a CJS `require()` cannot resolve the package
+  // ("No exports main defined"), which forced reality-web into a `.mts` config
+  // workaround. A `default` condition (mirroring @ppt/e2e) keeps the package
+  // resolvable under both ESM and CJS. Removing it re-breaks CJS consumers.
+  const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+    exports: Record<string, Record<string, string>>;
+  };
+
+  it('every export entry exposes a `default` condition for CJS require()', () => {
+    for (const [subpath, conditions] of Object.entries(pkg.exports)) {
+      expect(conditions, `exports["${subpath}"] must define a default condition`).toHaveProperty(
+        'default'
+      );
+    }
+  });
+
+  it('the `default` condition matches the `import` target for each entry', () => {
+    for (const conditions of Object.values(pkg.exports)) {
+      expect(conditions.default).toBe(conditions.import);
+    }
   });
 });


### PR DESCRIPTION
## Task
Stalled review — PR #988 (Epic: reusable Playwright E2E framework `@ppt/e2e` + sitemap FlowRunner) sat open 10d with no reviewDecision. Investigate the current state of that work: is the framework code on a branch that needs landing, is there a small DX/test-infra improvement extractable, or is PR #988 obsolete? Land the smallest correct, verifiable improvement toward the E2E-framework goal.

## Investigation findings
- **PR #988 is already MERGED** (2026-06-16, by martin-janci; head `feature/epic-e2e-web-framework`). The framework (`@ppt/e2e`, `FlowRunner`, spec factories, per-app suites, `frontend-e2e.yml`) is on `dev`. Nothing to land; not obsolete.
- Its own "Caveats / follow-ups" flagged a **cleaner long-term fix**: reality-web is stuck on a `playwright.config.mts` workaround because `@ppt/sitemap` ships an import-only `exports` map that a CommonJS `require()` cannot resolve. reality-web's `.mts` docstring documents this exact root cause ("sitemap ships an import-only `exports` map, which a CJS `require()` cannot resolve").
- The sibling package `@ppt/e2e` **already** carries a `default` export condition; `@ppt/sitemap` was the single missing piece. This is the smallest correct, verifiable extractable improvement toward the E2E goal.

## Change
- `frontend/packages/sitemap/package.json`: add a `default` condition to both `exports` entries (`.` and `./json`), mirroring `@ppt/e2e`. Strictly additive — existing `types`/`import` resolution is unchanged.
- `frontend/packages/sitemap/tests/sitemap.test.ts`: add a "Package exports (CJS resolvability)" regression test asserting every export exposes a `default` condition matching `import` (fails on `dev`). Also bump a **pre-existing** stale assertion `ppt-web` route count 19 → 20 (a route was added in #2345 without updating the test) so the suite is green.

This does **not** yet convert reality-web's `.mts` config to `.ts` (that needs a Playwright run to verify and is left as a follow-up); it removes the underlying resolution blocker the workaround was built around.

## Tested (Band A — fast check)
- `pnpm -F @ppt/sitemap test` → `Test Files 1 passed (1) · Tests 20 passed (20)` (exit 0)
- `pnpm -F @ppt/sitemap typecheck` (`tsc --noEmit`) → exit 0
- `pnpm exec biome check packages/sitemap/{package.json,tests/sitemap.test.ts}` → `Checked 2 files, no fixes` (exit 0)

### Behavioral proof (load-bearing)
From `packages/e2e` (the real consumer that transitively imports sitemap):
- WITH fix: `require.resolve('@ppt/sitemap')` → `RESOLVED -> .../sitemap/src/index.ts`
- WITHOUT fix (exports reverted): `require.resolve('@ppt/sitemap')` → `ERR_PACKAGE_PATH_NOT_EXPORTED`

The new regression test also flips red→green with the fix (verified before/after).

## Built (Band B — full build)
Skipped: change is <10 LOC of substantive edits (package.json export condition + a test), no build-output-affecting config. The additive `default` condition cannot alter existing ESM/types resolution; behavioral proof above covers the CJS path directly.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). `frontend.yml` runs the sitemap vitest suite, verified green locally.

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Scope drift
`scope_drift=false` — scope-check vs `origin/dev` exits 0; both changed files are under `frontend/packages/sitemap/` (pm-frontend area).

## Code-reuse review
`code_reuse_warn=none` — reuse-grep clean. The change deliberately reuses the `default`-condition pattern already present in `@ppt/e2e`.

## Notes for the reviewer
- **PR #988 required no landing** — this task pivoted to the extractable DX follow-up it flagged.
- IG1/IG2/IG4–IG6/IG8 goal-checks are plan-flow gates (`.research/plans/<slug>.md`, `impl/<slug>` branch naming) that are structurally N/A to this dispatcher stalled-review task on a pre-assigned `auto-impl/` branch. IG3 (TDD evidence) passes: separate `test:` then `fix:` commits, test fails on `dev`.
- The 19→20 route-count bump is an incidental fix to a pre-existing failing assertion in the same file (unrelated to #988), included so the suite lands green.
- Follow-up (out of scope here): convert `reality-web/playwright.config.mts` → `.ts` now that CJS resolution works, and consider the same `default` condition audit across other `@ppt/*` packages.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3QVm3HVgPjVCKhUkvYpdg)_