### PR TITLE
refactor-churn-hotspots-sitemap-json-2026-07-16: make generated sitemap.json deterministic to stop churn

### DIFF
--- a/backend/crates/common/src/sitemap/mod.rs
+++ b/backend/crates/common/src/sitemap/mod.rs
@@ -140,7 +140,9 @@ pub struct UserFlow {
 /// Sitemap metadata
 #[derive(Debug, Clone, Deserialize)]
 pub struct SitemapMetadata {
-    pub generated_at: String,
+    /// Optional: the generator intentionally omits a wall-clock timestamp so the
+    /// committed, `include_str!`-embedded artifact stays deterministic.
+    pub generated_at: Option<String>,
     pub version: String,
     pub stats: SitemapStats,
 }

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -80,6 +80,7 @@
       "!**/.next",
       "!**/generated",
       "!**/*.gen.ts",
+      "!**/packages/sitemap/src/json/sitemap.json",
       "!**/pnpm-lock.yaml",
       "!**/public/mockServiceWorker.js",
       "!**/next-env.d.ts",

--- a/frontend/packages/sitemap/src/json/generate.ts
+++ b/frontend/packages/sitemap/src/json/generate.ts
@@ -24,7 +24,10 @@ function generateSitemapJson(): void {
     },
     flows: sitemap.flows,
     metadata: {
-      generated_at: new Date().toISOString(),
+      // NOTE: intentionally no wall-clock timestamp here. This file is
+      // committed and embedded into the Rust backend via include_str!, so the
+      // generator output must be deterministic — a `new Date()` value made
+      // every regeneration produce a spurious diff (churn hotspot).
       version: '1.0.0',
       stats: {
         ppt_web_routes: sitemap.routes['ppt-web'].length,
@@ -38,7 +41,9 @@ function generateSitemapJson(): void {
   };
 
   const outputPath = path.join(__dirname, 'sitemap.json');
-  fs.writeFileSync(outputPath, JSON.stringify(output, null, 2));
+  // Trailing newline keeps the artifact POSIX-clean and matches how the file
+  // is committed; the output is otherwise a stable serialization of ../data.
+  fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
 
   console.log(`Generated sitemap.json at ${outputPath}`);
   console.log('Stats:', output.metadata.stats);

--- a/frontend/packages/sitemap/src/json/sitemap.json
+++ b/frontend/packages/sitemap/src/json/sitemap.json
@@ -11,7 +11,10 @@
           "required": false
         },
         "component": "Home",
-        "tags": ["navigation", "public"]
+        "tags": [
+          "navigation",
+          "public"
+        ]
       },
       {
         "id": "ppt-login",
@@ -22,10 +25,15 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": ["auth_login"],
+        "apiEndpoints": [
+          "auth_login"
+        ],
         "component": "LoginPage",
         "feature": "UC-14",
-        "tags": ["auth", "public"]
+        "tags": [
+          "auth",
+          "public"
+        ]
       },
       {
         "id": "ppt-auth-callback",
@@ -36,11 +44,17 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": ["auth_sso_callback"],
+        "apiEndpoints": [
+          "auth_sso_callback"
+        ],
         "component": "AuthCallbackPage",
         "parentId": "ppt-login",
         "feature": "UC-14",
-        "tags": ["auth", "public", "sso"]
+        "tags": [
+          "auth",
+          "public",
+          "sso"
+        ]
       },
       {
         "id": "ppt-documents",
@@ -50,15 +64,25 @@
         "description": "Document management dashboard",
         "auth": {
           "required": true,
-          "roles": ["owner", "tenant", "manager", "organization_admin"],
+          "roles": [
+            "owner",
+            "tenant",
+            "manager",
+            "organization_admin"
+          ],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": ["documents_list"],
+        "apiEndpoints": [
+          "documents_list"
+        ],
         "component": "DocumentsPage",
         "feature": "Epic-39",
-        "tags": ["documents", "protected"]
+        "tags": [
+          "documents",
+          "protected"
+        ]
       },
       {
         "id": "ppt-document-upload",
@@ -68,16 +92,26 @@
         "description": "Document upload page",
         "auth": {
           "required": true,
-          "roles": ["owner", "manager", "organization_admin"],
+          "roles": [
+            "owner",
+            "manager",
+            "organization_admin"
+          ],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": ["documents_upload"],
+        "apiEndpoints": [
+          "documents_upload"
+        ],
         "component": "DocumentUploadPage",
         "parentId": "ppt-documents",
         "feature": "Epic-39",
-        "tags": ["documents", "protected", "create"]
+        "tags": [
+          "documents",
+          "protected",
+          "create"
+        ]
       },
       {
         "id": "ppt-document-detail",
@@ -99,11 +133,18 @@
             "required": true
           }
         },
-        "apiEndpoints": ["documents_get", "documents_get_versions"],
+        "apiEndpoints": [
+          "documents_get",
+          "documents_get_versions"
+        ],
         "component": "DocumentDetailPage",
         "parentId": "ppt-documents",
         "feature": "Epic-39",
-        "tags": ["documents", "protected", "detail"]
+        "tags": [
+          "documents",
+          "protected",
+          "detail"
+        ]
       },
       {
         "id": "ppt-news",
@@ -117,10 +158,15 @@
             "required": true
           }
         },
-        "apiEndpoints": ["news_list"],
+        "apiEndpoints": [
+          "news_list"
+        ],
         "component": "NewsListPage",
         "feature": "Epic-59",
-        "tags": ["news", "protected"]
+        "tags": [
+          "news",
+          "protected"
+        ]
       },
       {
         "id": "ppt-news-detail",
@@ -142,11 +188,17 @@
             "required": true
           }
         },
-        "apiEndpoints": ["news_get"],
+        "apiEndpoints": [
+          "news_get"
+        ],
         "component": "ArticleDetailPage",
         "parentId": "ppt-news",
         "feature": "Epic-59",
-        "tags": ["news", "protected", "detail"]
+        "tags": [
+          "news",
+          "protected",
+          "detail"
+        ]
       },
       {
         "id": "ppt-emergency",
@@ -160,10 +212,15 @@
             "required": true
           }
         },
-        "apiEndpoints": ["emergency_list"],
+        "apiEndpoints": [
+          "emergency_list"
+        ],
         "component": "EmergencyContactDirectoryPage",
         "feature": "Epic-62",
-        "tags": ["emergency", "protected"]
+        "tags": [
+          "emergency",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-accessibility",
@@ -176,7 +233,10 @@
         },
         "component": "AccessibilitySettingsPage",
         "feature": "Epic-60",
-        "tags": ["settings", "protected"]
+        "tags": [
+          "settings",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-privacy",
@@ -189,7 +249,10 @@
         },
         "component": "PrivacySettingsPage",
         "feature": "Epic-63",
-        "tags": ["settings", "protected"]
+        "tags": [
+          "settings",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-integrations",
@@ -205,7 +268,12 @@
         },
         "component": "IntegrationsPage",
         "feature": "Epic-83",
-        "tags": ["settings", "integrations", "airbnb", "protected"]
+        "tags": [
+          "settings",
+          "integrations",
+          "airbnb",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-portal-webhooks",
@@ -221,7 +289,12 @@
         },
         "component": "PortalWebhooksPage",
         "feature": "Epic-105",
-        "tags": ["settings", "syndication", "webhooks", "protected"]
+        "tags": [
+          "settings",
+          "syndication",
+          "webhooks",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-notifications",
@@ -232,10 +305,17 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["notification_preferences_list", "notification_preference_update"],
+        "apiEndpoints": [
+          "notification_preferences_list",
+          "notification_preference_update"
+        ],
         "component": "NotificationSettingsPage",
         "feature": "Epic-8A",
-        "tags": ["settings", "notifications", "protected"]
+        "tags": [
+          "settings",
+          "notifications",
+          "protected"
+        ]
       },
       {
         "id": "ppt-settings-notifications-advanced",
@@ -249,7 +329,11 @@
         "component": "AdvancedNotificationSettingsPage",
         "parentId": "ppt-settings-notifications",
         "feature": "Epic-40",
-        "tags": ["settings", "notifications", "protected"]
+        "tags": [
+          "settings",
+          "notifications",
+          "protected"
+        ]
       },
       {
         "id": "ppt-disputes",
@@ -263,10 +347,15 @@
             "required": true
           }
         },
-        "apiEndpoints": ["disputes_list"],
+        "apiEndpoints": [
+          "disputes_list"
+        ],
         "component": "DisputesPage",
         "feature": "Epic-77",
-        "tags": ["disputes", "protected"]
+        "tags": [
+          "disputes",
+          "protected"
+        ]
       },
       {
         "id": "ppt-dispute-new",
@@ -276,16 +365,26 @@
         "description": "File a new dispute",
         "auth": {
           "required": true,
-          "roles": ["owner", "tenant", "resident"],
+          "roles": [
+            "owner",
+            "tenant",
+            "resident"
+          ],
           "tenantContext": {
             "required": true
           }
         },
-        "apiEndpoints": ["disputes_create"],
+        "apiEndpoints": [
+          "disputes_create"
+        ],
         "component": "FileDisputePage",
         "parentId": "ppt-disputes",
         "feature": "Epic-77",
-        "tags": ["disputes", "protected", "create"]
+        "tags": [
+          "disputes",
+          "protected",
+          "create"
+        ]
       },
       {
         "id": "ppt-dispute-detail",
@@ -307,11 +406,17 @@
             "required": true
           }
         },
-        "apiEndpoints": ["disputes_get"],
+        "apiEndpoints": [
+          "disputes_get"
+        ],
         "component": "DisputeDetailPage",
         "parentId": "ppt-disputes",
         "feature": "Epic-77",
-        "tags": ["disputes", "protected", "detail"]
+        "tags": [
+          "disputes",
+          "protected",
+          "detail"
+        ]
       },
       {
         "id": "ppt-ai-sentiment",
@@ -321,14 +426,22 @@
         "description": "AI-derived sentiment trends and alerts from tenant communications",
         "auth": {
           "required": true,
-          "roles": ["manager", "organization_admin"],
+          "roles": [
+            "manager",
+            "organization_admin"
+          ],
           "tenantContext": {
             "required": true
           }
         },
         "component": "SentimentDashboardPage",
         "feature": "Epic-13",
-        "tags": ["ai", "sentiment", "protected", "dashboard"]
+        "tags": [
+          "ai",
+          "sentiment",
+          "protected",
+          "dashboard"
+        ]
       },
       {
         "id": "ppt-ai-predictive-maintenance",
@@ -338,14 +451,22 @@
         "description": "AI-powered equipment health monitoring and failure predictions",
         "auth": {
           "required": true,
-          "roles": ["manager", "organization_admin"],
+          "roles": [
+            "manager",
+            "organization_admin"
+          ],
           "tenantContext": {
             "required": true
           }
         },
         "component": "PredictiveMaintenancePage",
         "feature": "Epic-13",
-        "tags": ["ai", "predictive-maintenance", "protected", "dashboard"]
+        "tags": [
+          "ai",
+          "predictive-maintenance",
+          "protected",
+          "dashboard"
+        ]
       }
     ],
     "reality-web": [
@@ -359,7 +480,10 @@
           "required": false
         },
         "component": "HomePage",
-        "tags": ["navigation", "public"]
+        "tags": [
+          "navigation",
+          "public"
+        ]
       },
       {
         "id": "reality-listings",
@@ -408,9 +532,15 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": ["listings_search"],
+        "apiEndpoints": [
+          "listings_search"
+        ],
         "component": "ListingsPage",
-        "tags": ["listings", "public", "search"]
+        "tags": [
+          "listings",
+          "public",
+          "search"
+        ]
       },
       {
         "id": "reality-listing-detail",
@@ -429,10 +559,16 @@
         "auth": {
           "required": false
         },
-        "apiEndpoints": ["listings_get"],
+        "apiEndpoints": [
+          "listings_get"
+        ],
         "component": "ListingDetailPage",
         "parentId": "reality-listings",
-        "tags": ["listings", "public", "detail"]
+        "tags": [
+          "listings",
+          "public",
+          "detail"
+        ]
       },
       {
         "id": "reality-favorites",
@@ -443,9 +579,14 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["favorites_list"],
+        "apiEndpoints": [
+          "favorites_list"
+        ],
         "component": "FavoritesPage",
-        "tags": ["favorites", "protected"]
+        "tags": [
+          "favorites",
+          "protected"
+        ]
       },
       {
         "id": "reality-saved-searches",
@@ -456,9 +597,14 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["saved_searches_list"],
+        "apiEndpoints": [
+          "saved_searches_list"
+        ],
         "component": "SavedSearchesPage",
-        "tags": ["saved-searches", "protected"]
+        "tags": [
+          "saved-searches",
+          "protected"
+        ]
       },
       {
         "id": "reality-inquiries",
@@ -469,9 +615,14 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["inquiries_list"],
+        "apiEndpoints": [
+          "inquiries_list"
+        ],
         "component": "InquiriesPage",
-        "tags": ["inquiries", "protected"]
+        "tags": [
+          "inquiries",
+          "protected"
+        ]
       },
       {
         "id": "reality-auth-callback",
@@ -483,7 +634,10 @@
           "required": false
         },
         "component": "OAuthCallbackPage",
-        "tags": ["auth", "public"]
+        "tags": [
+          "auth",
+          "public"
+        ]
       },
       {
         "id": "reality-agency",
@@ -493,12 +647,20 @@
         "description": "Agency management dashboard",
         "auth": {
           "required": true,
-          "roles": ["real_estate_agent", "organization_admin"]
+          "roles": [
+            "real_estate_agent",
+            "organization_admin"
+          ]
         },
-        "apiEndpoints": ["agencies_get"],
+        "apiEndpoints": [
+          "agencies_get"
+        ],
         "component": "AgencyPage",
         "feature": "Epic-32",
-        "tags": ["agency", "protected"]
+        "tags": [
+          "agency",
+          "protected"
+        ]
       },
       {
         "id": "reality-compare",
@@ -510,7 +672,10 @@
           "required": false
         },
         "component": "ComparePage",
-        "tags": ["compare", "public"]
+        "tags": [
+          "compare",
+          "public"
+        ]
       }
     ]
   },
@@ -527,9 +692,15 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["dashboard_get"],
+        "apiEndpoints": [
+          "dashboard_get"
+        ],
         "component": "DashboardScreen",
-        "tags": ["dashboard", "protected", "navigation"]
+        "tags": [
+          "dashboard",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-faults-list",
@@ -542,10 +713,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["faults_list"],
+        "apiEndpoints": [
+          "faults_list"
+        ],
         "component": "FaultsListScreen",
         "feature": "UC-03",
-        "tags": ["faults", "protected", "navigation"]
+        "tags": [
+          "faults",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-report-fault",
@@ -557,13 +734,23 @@
         "tabIcon": "🔧",
         "auth": {
           "required": true,
-          "roles": ["owner", "tenant", "resident"]
+          "roles": [
+            "owner",
+            "tenant",
+            "resident"
+          ]
         },
-        "apiEndpoints": ["faults_create"],
+        "apiEndpoints": [
+          "faults_create"
+        ],
         "component": "ReportFaultScreen",
         "feature": "UC-03",
         "stack": "Faults",
-        "tags": ["faults", "protected", "create"]
+        "tags": [
+          "faults",
+          "protected",
+          "create"
+        ]
       },
       {
         "id": "mobile-announcements",
@@ -576,10 +763,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["announcements_list"],
+        "apiEndpoints": [
+          "announcements_list"
+        ],
         "component": "AnnouncementsScreen",
         "feature": "Epic-6",
-        "tags": ["announcements", "protected", "navigation"]
+        "tags": [
+          "announcements",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-voting",
@@ -592,10 +785,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["voting_list"],
+        "apiEndpoints": [
+          "voting_list"
+        ],
         "component": "VotingScreen",
         "feature": "UC-04",
-        "tags": ["voting", "protected", "navigation"]
+        "tags": [
+          "voting",
+          "protected",
+          "navigation"
+        ]
       },
       {
         "id": "mobile-documents",
@@ -608,10 +807,16 @@
         "auth": {
           "required": true
         },
-        "apiEndpoints": ["documents_list"],
+        "apiEndpoints": [
+          "documents_list"
+        ],
         "component": "DocumentsScreen",
         "feature": "Epic-7",
-        "tags": ["documents", "protected", "navigation"]
+        "tags": [
+          "documents",
+          "protected",
+          "navigation"
+        ]
       }
     ]
   },
@@ -623,7 +828,9 @@
         "method": "GET",
         "path": "/health",
         "description": "Health check endpoint",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -640,7 +847,9 @@
         "method": "POST",
         "path": "/api/v1/auth/login",
         "description": "Login with email and password",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "requestBody": {
           "ref": "Auth.LoginRequest",
           "contentType": "application/json",
@@ -668,7 +877,9 @@
         "method": "POST",
         "path": "/api/v1/auth/register",
         "description": "Register new user account",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "requestBody": {
           "ref": "Auth.RegisterRequest",
           "contentType": "application/json",
@@ -699,7 +910,9 @@
         "method": "POST",
         "path": "/api/v1/auth/logout",
         "description": "Logout user",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -717,7 +930,9 @@
         "method": "POST",
         "path": "/api/v1/auth/refresh",
         "description": "Refresh access token",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -739,7 +954,10 @@
         "method": "POST",
         "path": "/api/v1/auth/sso/callback",
         "description": "Exchange SSO authorization code for PPT JWT tokens (backend stub — not yet implemented)",
-        "tags": ["Authentication", "SSO"],
+        "tags": [
+          "Authentication",
+          "SSO"
+        ],
         "requestBody": {
           "ref": "Auth.SsoCallbackRequest",
           "contentType": "application/json",
@@ -771,7 +989,10 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/setup",
         "description": "Begin TOTP MFA setup — returns secret and QR URI",
-        "tags": ["Authentication", "MFA"],
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -793,7 +1014,10 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/verify",
         "description": "Verify TOTP code to complete MFA setup",
-        "tags": ["Authentication", "MFA"],
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -815,7 +1039,10 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/disable",
         "description": "Disable MFA for the authenticated user",
-        "tags": ["Authentication", "MFA"],
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -837,7 +1064,10 @@
         "method": "GET",
         "path": "/api/v1/auth/mfa/status",
         "description": "Get current MFA status for the authenticated user",
-        "tags": ["Authentication", "MFA"],
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -855,7 +1085,10 @@
         "method": "POST",
         "path": "/api/v1/auth/mfa/backup-codes/regenerate",
         "description": "Regenerate MFA backup codes",
-        "tags": ["Authentication", "MFA"],
+        "tags": [
+          "Authentication",
+          "MFA"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -877,7 +1110,9 @@
         "method": "GET",
         "path": "/api/v1/documents",
         "description": "List documents",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -912,7 +1147,9 @@
         "method": "GET",
         "path": "/api/v1/documents/:id",
         "description": "Get document details",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -944,7 +1181,9 @@
         "method": "POST",
         "path": "/api/v1/documents",
         "description": "Upload a new document",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "requestBody": {
           "contentType": "multipart/form-data",
           "required": true
@@ -973,7 +1212,9 @@
         "method": "GET",
         "path": "/api/v1/documents/:id/versions",
         "description": "Get document versions",
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1001,7 +1242,9 @@
         "method": "GET",
         "path": "/api/v1/faults",
         "description": "List faults",
-        "tags": ["Faults"],
+        "tags": [
+          "Faults"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1041,7 +1284,9 @@
         "method": "GET",
         "path": "/api/v1/faults/:id",
         "description": "Get fault details",
-        "tags": ["Faults"],
+        "tags": [
+          "Faults"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1073,7 +1318,9 @@
         "method": "POST",
         "path": "/api/v1/faults",
         "description": "Report a new fault",
-        "tags": ["Faults"],
+        "tags": [
+          "Faults"
+        ],
         "requestBody": {
           "ref": "Faults.CreateRequest",
           "contentType": "application/json",
@@ -1103,7 +1350,9 @@
         "method": "GET",
         "path": "/api/v1/voting",
         "description": "List votes",
-        "tags": ["Voting"],
+        "tags": [
+          "Voting"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1143,7 +1392,9 @@
         "method": "GET",
         "path": "/api/v1/voting/:id",
         "description": "Get vote details",
-        "tags": ["Voting"],
+        "tags": [
+          "Voting"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1175,7 +1426,9 @@
         "method": "POST",
         "path": "/api/v1/voting/:id/cast",
         "description": "Cast a vote",
-        "tags": ["Voting"],
+        "tags": [
+          "Voting"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1216,7 +1469,9 @@
         "method": "GET",
         "path": "/api/v1/announcements",
         "description": "List announcements",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1251,7 +1506,9 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id",
         "description": "Get announcement details",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1283,7 +1540,9 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/read",
         "description": "Mark announcement as read by current user",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1311,7 +1570,9 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/acknowledge",
         "description": "Acknowledge an announcement",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1339,7 +1600,9 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id/acknowledgments",
         "description": "Get acknowledgment stats for an announcement",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1367,7 +1630,9 @@
         "method": "GET",
         "path": "/api/v1/announcements/:id/comments",
         "description": "List comments for an announcement",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1395,7 +1660,9 @@
         "method": "POST",
         "path": "/api/v1/announcements/:id/comments",
         "description": "Post a comment on an announcement",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1427,7 +1694,9 @@
         "method": "DELETE",
         "path": "/api/v1/announcements/:id/comments/:commentId",
         "description": "Delete a comment on an announcement",
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1468,7 +1737,9 @@
         "method": "GET",
         "path": "/api/v1/news",
         "description": "List news articles",
-        "tags": ["News"],
+        "tags": [
+          "News"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1503,7 +1774,9 @@
         "method": "GET",
         "path": "/api/v1/news/:id",
         "description": "Get news article details",
-        "tags": ["News"],
+        "tags": [
+          "News"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1535,7 +1808,9 @@
         "method": "GET",
         "path": "/api/v1/emergency",
         "description": "List emergency contacts",
-        "tags": ["Emergency"],
+        "tags": [
+          "Emergency"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1556,7 +1831,9 @@
         "method": "GET",
         "path": "/api/v1/disputes",
         "description": "List disputes",
-        "tags": ["Disputes"],
+        "tags": [
+          "Disputes"
+        ],
         "queryParams": [
           {
             "name": "page",
@@ -1596,7 +1873,9 @@
         "method": "GET",
         "path": "/api/v1/disputes/:id",
         "description": "Get dispute details",
-        "tags": ["Disputes"],
+        "tags": [
+          "Disputes"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -1628,7 +1907,9 @@
         "method": "POST",
         "path": "/api/v1/disputes",
         "description": "File a new dispute",
-        "tags": ["Disputes"],
+        "tags": [
+          "Disputes"
+        ],
         "requestBody": {
           "ref": "Disputes.CreateRequest",
           "contentType": "application/json",
@@ -1658,7 +1939,9 @@
         "method": "GET",
         "path": "/api/v1/dashboard",
         "description": "Get dashboard data",
-        "tags": ["Dashboard"],
+        "tags": [
+          "Dashboard"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1678,7 +1961,9 @@
         "method": "GET",
         "path": "/api/v1/admin/oauth/clients",
         "description": "List all registered OAuth clients",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1696,7 +1981,9 @@
         "method": "GET",
         "path": "/api/v1/admin/oauth/clients/:clientId",
         "description": "Get a single OAuth client by ID",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1718,7 +2005,9 @@
         "method": "POST",
         "path": "/api/v1/admin/oauth/clients",
         "description": "Register a new OAuth client",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "requestBody": {
           "ref": "OAuth.RegisterClientRequest",
           "contentType": "application/json",
@@ -1745,7 +2034,9 @@
         "method": "PATCH",
         "path": "/api/v1/admin/oauth/clients/:clientId",
         "description": "Update OAuth client name, description, scopes, or status",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "requestBody": {
           "ref": "OAuth.UpdateClientRequest",
           "contentType": "application/json",
@@ -1772,7 +2063,9 @@
         "method": "DELETE",
         "path": "/api/v1/admin/oauth/clients/:clientId",
         "description": "Revoke (deactivate) an OAuth client",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "responses": [
           {
             "statusCode": 204,
@@ -1794,7 +2087,9 @@
         "method": "POST",
         "path": "/api/v1/admin/oauth/clients/:clientId/secret",
         "description": "Regenerate the client secret for an OAuth client",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1816,7 +2111,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/organizations",
         "description": "List all organizations with metrics (platform admin view)",
-        "tags": ["Platform Admin"],
+        "tags": [
+          "Platform Admin"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1834,7 +2131,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/organizations/:id",
         "description": "Get organization details with members, buildings, usage metrics, billing status",
-        "tags": ["Platform Admin"],
+        "tags": [
+          "Platform Admin"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1856,7 +2155,9 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/organizations/:id/suspend",
         "description": "Suspend an organization (cascade-invalidates all org sessions)",
-        "tags": ["Platform Admin"],
+        "tags": [
+          "Platform Admin"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1882,7 +2183,9 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/organizations/:id/reactivate",
         "description": "Reactivate a suspended organization",
-        "tags": ["Platform Admin"],
+        "tags": [
+          "Platform Admin"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1908,7 +2211,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/stats",
         "description": "Get platform-wide statistics (org counts, member counts, usage)",
-        "tags": ["Platform Admin"],
+        "tags": [
+          "Platform Admin"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1926,7 +2231,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/health/dashboard",
         "description": "Get platform health dashboard (current metrics, active alerts, thresholds)",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1944,7 +2251,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/health/alerts",
         "description": "List metric alerts with optional active-only filter",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1962,7 +2271,9 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/health/alerts/:alertId/acknowledge",
         "description": "Acknowledge an active metric alert",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -1984,7 +2295,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/health/metrics/:name/history",
         "description": "Get time-series history for a specific metric",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2002,7 +2315,9 @@
         "method": "PUT",
         "path": "/api/v1/platform-admin/health/thresholds/:name",
         "description": "Update warning and critical thresholds for a metric",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2024,7 +2339,9 @@
         "method": "GET",
         "path": "/api/v1/oauth/grants",
         "description": "List all OAuth grants for the authenticated user",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2042,7 +2359,9 @@
         "method": "DELETE",
         "path": "/api/v1/oauth/grants/:clientId",
         "description": "Revoke a specific OAuth grant for the authenticated user",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "responses": [
           {
             "statusCode": 204,
@@ -2064,7 +2383,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/announcements",
         "description": "List all platform-wide system announcements",
-        "tags": ["SystemAnnouncements"],
+        "tags": [
+          "SystemAnnouncements"
+        ],
         "queryParams": [
           {
             "name": "include_deleted",
@@ -2090,7 +2411,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/announcements/:id",
         "description": "Get a single system announcement by ID",
-        "tags": ["SystemAnnouncements"],
+        "tags": [
+          "SystemAnnouncements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2119,7 +2442,9 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/announcements",
         "description": "Create a new platform-wide system announcement",
-        "tags": ["SystemAnnouncements"],
+        "tags": [
+          "SystemAnnouncements"
+        ],
         "requestBody": {
           "ref": "SystemAnnouncements.CreateRequest",
           "contentType": "application/json",
@@ -2146,7 +2471,9 @@
         "method": "PUT",
         "path": "/api/v1/platform-admin/announcements/:id",
         "description": "Update an existing system announcement",
-        "tags": ["SystemAnnouncements"],
+        "tags": [
+          "SystemAnnouncements"
+        ],
         "requestBody": {
           "ref": "SystemAnnouncements.UpdateRequest",
           "contentType": "application/json",
@@ -2173,7 +2500,9 @@
         "method": "DELETE",
         "path": "/api/v1/platform-admin/announcements/:id",
         "description": "Soft-delete a system announcement",
-        "tags": ["SystemAnnouncements"],
+        "tags": [
+          "SystemAnnouncements"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2202,7 +2531,9 @@
         "method": "GET",
         "path": "/api/v1/onboarding/status",
         "description": "Get onboarding status with the list of tours and per-tour progress",
-        "tags": ["Onboarding"],
+        "tags": [
+          "Onboarding"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2220,7 +2551,9 @@
         "method": "GET",
         "path": "/api/v1/onboarding/tours",
         "description": "List onboarding tours for the authenticated user",
-        "tags": ["Onboarding"],
+        "tags": [
+          "Onboarding"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2238,7 +2571,9 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/start",
         "description": "Start an onboarding tour for the authenticated user",
-        "tags": ["Onboarding"],
+        "tags": [
+          "Onboarding"
+        ],
         "pathParams": [
           {
             "name": "tourId",
@@ -2263,7 +2598,9 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/steps/:stepId/complete",
         "description": "Mark a single onboarding step as complete",
-        "tags": ["Onboarding"],
+        "tags": [
+          "Onboarding"
+        ],
         "pathParams": [
           {
             "name": "tourId",
@@ -2293,7 +2630,9 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/complete",
         "description": "Mark an onboarding tour as complete",
-        "tags": ["Onboarding"],
+        "tags": [
+          "Onboarding"
+        ],
         "pathParams": [
           {
             "name": "tourId",
@@ -2318,7 +2657,9 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/skip",
         "description": "Skip an onboarding tour",
-        "tags": ["Onboarding"],
+        "tags": [
+          "Onboarding"
+        ],
         "pathParams": [
           {
             "name": "tourId",
@@ -2343,7 +2684,9 @@
         "method": "POST",
         "path": "/api/v1/onboarding/tours/:tourId/reset",
         "description": "Reset onboarding tour progress to the beginning",
-        "tags": ["Onboarding"],
+        "tags": [
+          "Onboarding"
+        ],
         "pathParams": [
           {
             "name": "tourId",
@@ -2368,7 +2711,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/feature-flags",
         "description": "List all feature flags (platform admin)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2386,7 +2731,9 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/feature-flags",
         "description": "Create a new feature flag (platform admin)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "responses": [
           {
             "statusCode": 201,
@@ -2408,7 +2755,9 @@
         "method": "GET",
         "path": "/api/v1/platform-admin/feature-flags/:id",
         "description": "Get a single feature flag with its overrides (platform admin)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2437,7 +2786,9 @@
         "method": "PUT",
         "path": "/api/v1/platform-admin/feature-flags/:id",
         "description": "Update a feature flag (platform admin)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2466,7 +2817,9 @@
         "method": "DELETE",
         "path": "/api/v1/platform-admin/feature-flags/:id",
         "description": "Delete a feature flag (platform admin)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2495,7 +2848,9 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/feature-flags/:id/toggle",
         "description": "Toggle a feature flag on/off (platform admin, audit-logged)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2524,7 +2879,9 @@
         "method": "POST",
         "path": "/api/v1/platform-admin/feature-flags/:id/overrides",
         "description": "Create a per-scope override for a feature flag (platform admin)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2553,7 +2910,9 @@
         "method": "DELETE",
         "path": "/api/v1/platform-admin/feature-flags/:id/overrides/:override_id",
         "description": "Delete a per-scope override from a feature flag (platform admin)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2587,7 +2946,9 @@
         "method": "GET",
         "path": "/api/v1/feature-flags",
         "description": "Get resolved feature flags for the current caller (org/user/role overrides applied)",
-        "tags": ["Feature Flags"],
+        "tags": [
+          "Feature Flags"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2605,7 +2966,9 @@
         "method": "GET",
         "path": "/api/v1/users/me/notification-preferences",
         "description": "Get all notification channel preferences for the current user",
-        "tags": ["Notification Preferences"],
+        "tags": [
+          "Notification Preferences"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2627,7 +2990,9 @@
         "method": "PATCH",
         "path": "/api/v1/users/me/notification-preferences/:channel",
         "description": "Enable/disable a single notification channel (push / email / in_app); requires confirmDisableAll to turn off the last active channel",
-        "tags": ["Notification Preferences"],
+        "tags": [
+          "Notification Preferences"
+        ],
         "pathParams": [
           {
             "name": "channel",
@@ -2662,7 +3027,9 @@
         "method": "GET",
         "path": "/health",
         "description": "Health check endpoint",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2679,7 +3046,9 @@
         "method": "GET",
         "path": "/api/v1/listings",
         "description": "Search property listings",
-        "tags": ["Listings"],
+        "tags": [
+          "Listings"
+        ],
         "queryParams": [
           {
             "name": "type",
@@ -2752,7 +3121,9 @@
         "method": "GET",
         "path": "/api/v1/listings/:slug",
         "description": "Get listing details by slug",
-        "tags": ["Listings"],
+        "tags": [
+          "Listings"
+        ],
         "pathParams": [
           {
             "name": "slug",
@@ -2781,7 +3152,9 @@
         "method": "GET",
         "path": "/api/v1/listings/suggestions",
         "description": "Get search suggestions",
-        "tags": ["Listings"],
+        "tags": [
+          "Listings"
+        ],
         "queryParams": [
           {
             "name": "q",
@@ -2806,7 +3179,9 @@
         "method": "GET",
         "path": "/api/v1/favorites",
         "description": "List user's favorites",
-        "tags": ["Favorites"],
+        "tags": [
+          "Favorites"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2823,7 +3198,9 @@
         "method": "POST",
         "path": "/api/v1/favorites",
         "description": "Add to favorites",
-        "tags": ["Favorites"],
+        "tags": [
+          "Favorites"
+        ],
         "requestBody": {
           "ref": "Favorites.AddRequest",
           "contentType": "application/json",
@@ -2849,7 +3226,9 @@
         "method": "DELETE",
         "path": "/api/v1/favorites/:id",
         "description": "Remove from favorites",
-        "tags": ["Favorites"],
+        "tags": [
+          "Favorites"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2877,7 +3256,9 @@
         "method": "GET",
         "path": "/api/v1/saved-searches",
         "description": "List saved searches",
-        "tags": ["SavedSearches"],
+        "tags": [
+          "SavedSearches"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2894,7 +3275,9 @@
         "method": "POST",
         "path": "/api/v1/saved-searches",
         "description": "Create saved search",
-        "tags": ["SavedSearches"],
+        "tags": [
+          "SavedSearches"
+        ],
         "requestBody": {
           "ref": "SavedSearches.CreateRequest",
           "contentType": "application/json",
@@ -2916,7 +3299,9 @@
         "method": "DELETE",
         "path": "/api/v1/saved-searches/:id",
         "description": "Delete saved search",
-        "tags": ["SavedSearches"],
+        "tags": [
+          "SavedSearches"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -2940,7 +3325,9 @@
         "method": "GET",
         "path": "/api/v1/inquiries",
         "description": "List inquiries",
-        "tags": ["Inquiries"],
+        "tags": [
+          "Inquiries"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -2957,7 +3344,9 @@
         "method": "POST",
         "path": "/api/v1/inquiries/contact/:listing_id",
         "description": "Send contact message",
-        "tags": ["Inquiries"],
+        "tags": [
+          "Inquiries"
+        ],
         "pathParams": [
           {
             "name": "listing_id",
@@ -2987,7 +3376,9 @@
         "method": "POST",
         "path": "/api/v1/inquiries/viewing/:listing_id",
         "description": "Request viewing",
-        "tags": ["Inquiries"],
+        "tags": [
+          "Inquiries"
+        ],
         "pathParams": [
           {
             "name": "listing_id",
@@ -3017,7 +3408,9 @@
         "method": "GET",
         "path": "/api/v1/sso/login",
         "description": "Initiate SSO login",
-        "tags": ["SSO"],
+        "tags": [
+          "SSO"
+        ],
         "responses": [
           {
             "statusCode": 302,
@@ -3035,7 +3428,9 @@
         "method": "GET",
         "path": "/api/v1/sso/callback",
         "description": "SSO callback",
-        "tags": ["SSO"],
+        "tags": [
+          "SSO"
+        ],
         "responses": [
           {
             "statusCode": 302,
@@ -3053,7 +3448,9 @@
         "method": "GET",
         "path": "/api/v1/sso/session",
         "description": "Get current session",
-        "tags": ["SSO"],
+        "tags": [
+          "SSO"
+        ],
         "responses": [
           {
             "statusCode": 200,
@@ -3071,7 +3468,9 @@
         "method": "GET",
         "path": "/api/v1/agencies/:id",
         "description": "Get agency details",
-        "tags": ["Agencies"],
+        "tags": [
+          "Agencies"
+        ],
         "pathParams": [
           {
             "name": "id",
@@ -3100,7 +3499,9 @@
         "method": "POST",
         "path": "/api/v1/agencies",
         "description": "Create agency",
-        "tags": ["Agencies"],
+        "tags": [
+          "Agencies"
+        ],
         "requestBody": {
           "ref": "Agencies.CreateRequest",
           "contentType": "application/json",
@@ -3114,7 +3515,9 @@
         ],
         "auth": {
           "required": true,
-          "roles": ["organization_admin"]
+          "roles": [
+            "organization_admin"
+          ]
         },
         "feature": "Epic-32"
       }
@@ -3124,11 +3527,16 @@
     {
       "id": "flow-login-basic",
       "name": "Basic Login Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User logs in with email and password",
       "category": "authentication",
       "requiredRole": "anonymous",
-      "useCases": ["UC-14.1"],
+      "useCases": [
+        "UC-14.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3210,16 +3618,25 @@
         "authenticated": true,
         "redirectedTo": "/"
       },
-      "tags": ["auth", "critical", "smoke"]
+      "tags": [
+        "auth",
+        "critical",
+        "smoke"
+      ]
     },
     {
       "id": "flow-logout",
       "name": "Logout Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User logs out of the system",
       "category": "authentication",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3261,17 +3678,27 @@
         "authenticated": false,
         "redirectedTo": "/login"
       },
-      "tags": ["auth", "smoke"]
+      "tags": [
+        "auth",
+        "smoke"
+      ]
     },
     {
       "id": "flow-document-upload",
       "name": "Document Upload Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User uploads a new document",
       "category": "documents",
       "requiredRole": "owner",
-      "prerequisites": ["flow-login-basic"],
-      "useCases": ["UC-08.1"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
+      "useCases": [
+        "UC-08.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3347,16 +3774,25 @@
       "expectedOutcome": {
         "documentUploaded": true
       },
-      "tags": ["documents", "upload", "smoke"]
+      "tags": [
+        "documents",
+        "upload",
+        "smoke"
+      ]
     },
     {
       "id": "flow-document-view",
       "name": "Document View Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User views document details",
       "category": "documents",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3398,17 +3834,27 @@
       "expectedOutcome": {
         "documentViewed": true
       },
-      "tags": ["documents", "view"]
+      "tags": [
+        "documents",
+        "view"
+      ]
     },
     {
       "id": "flow-report-fault",
       "name": "Report Fault Flow",
-      "apps": ["mobile", "api-server"],
+      "apps": [
+        "mobile",
+        "api-server"
+      ],
       "description": "User reports a new fault",
       "category": "fault_management",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
-      "useCases": ["UC-03.1"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
+      "useCases": [
+        "UC-03.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3460,16 +3906,25 @@
       "expectedOutcome": {
         "faultCreated": true
       },
-      "tags": ["faults", "create", "smoke"]
+      "tags": [
+        "faults",
+        "create",
+        "smoke"
+      ]
     },
     {
       "id": "flow-file-dispute",
       "name": "File Dispute Flow",
-      "apps": ["ppt-web", "api-server"],
+      "apps": [
+        "ppt-web",
+        "api-server"
+      ],
       "description": "User files a new dispute",
       "category": "disputes",
       "requiredRole": "tenant",
-      "prerequisites": ["flow-login-basic"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3527,17 +3982,28 @@
       "expectedOutcome": {
         "disputeFiled": true
       },
-      "tags": ["disputes", "create", "smoke"]
+      "tags": [
+        "disputes",
+        "create",
+        "smoke"
+      ]
     },
     {
       "id": "flow-cast-vote",
       "name": "Cast Vote Flow",
-      "apps": ["mobile", "api-server"],
+      "apps": [
+        "mobile",
+        "api-server"
+      ],
       "description": "User casts a vote on a poll",
       "category": "voting",
       "requiredRole": "owner",
-      "prerequisites": ["flow-login-basic"],
-      "useCases": ["UC-04.1"],
+      "prerequisites": [
+        "flow-login-basic"
+      ],
+      "useCases": [
+        "UC-04.1"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3585,12 +4051,19 @@
       "expectedOutcome": {
         "voteCast": true
       },
-      "tags": ["voting", "cast", "smoke"]
+      "tags": [
+        "voting",
+        "cast",
+        "smoke"
+      ]
     },
     {
       "id": "flow-search-listings",
       "name": "Search Listings Flow",
-      "apps": ["reality-web", "reality-server"],
+      "apps": [
+        "reality-web",
+        "reality-server"
+      ],
       "description": "User searches for property listings",
       "category": "listings",
       "requiredRole": "anonymous",
@@ -3653,16 +4126,25 @@
         "searchPerformed": true,
         "resultsDisplayed": true
       },
-      "tags": ["listings", "search", "smoke"]
+      "tags": [
+        "listings",
+        "search",
+        "smoke"
+      ]
     },
     {
       "id": "flow-add-favorite",
       "name": "Add to Favorites Flow",
-      "apps": ["reality-web", "reality-server"],
+      "apps": [
+        "reality-web",
+        "reality-server"
+      ],
       "description": "User adds a listing to favorites",
       "category": "listings",
       "requiredRole": "portal_user",
-      "prerequisites": ["flow-search-listings"],
+      "prerequisites": [
+        "flow-search-listings"
+      ],
       "steps": [
         {
           "order": 1,
@@ -3705,11 +4187,13 @@
       "expectedOutcome": {
         "favoriteAdded": true
       },
-      "tags": ["favorites", "add"]
+      "tags": [
+        "favorites",
+        "add"
+      ]
     }
   ],
   "metadata": {
-    "generated_at": "2026-07-15T08:17:56.663Z",
     "version": "1.0.0",
     "stats": {
       "ppt_web_routes": 20,

--- a/frontend/packages/sitemap/tests/sitemap.test.ts
+++ b/frontend/packages/sitemap/tests/sitemap.test.ts
@@ -13,7 +13,7 @@ import { buildUrl, SitemapTestHelper } from '../src/utils';
 describe('Sitemap Data', () => {
   describe('Routes', () => {
     it('should have ppt-web routes', () => {
-      expect(sitemap.routes['ppt-web'].length).toBe(19);
+      expect(sitemap.routes['ppt-web'].length).toBe(20);
     });
 
     it('should have reality-web routes', () => {


### PR DESCRIPTION
## Task
Churn hotspot: `frontend/packages/sitemap/src/json/sitemap.json` — +3727 lines this run. This is a churn SIGNAL, not a concrete request. sitemap.json is likely generated/data — investigate whether the growth reflects a real, safely-fixable maintainability problem. Do NOT hand-edit generated data in a way that a regenerate step would overwrite; if it's generated, the right fix may be to the generator or nothing at all.

## Owner
pm-tech-lead

## Investigation — root cause (real, safely-fixable)
`sitemap.json` **is generated**: `packages/sitemap/src/json/generate.ts` serializes `../data` (the TS source of truth) into `sitemap.json`, which is committed and embedded into the Rust backend (`crates/common/src/sitemap/mod.rs`) at compile time via `include_str!`. Two defects made it a permanent churn hotspot:

1. **Non-deterministic timestamp** — `generate.ts` stamped `generated_at: new Date().toISOString()` on every run, so every regeneration produced a spurious diff even with zero data change.
2. **Generator vs formatter fight** — the generator emits raw `JSON.stringify(…, null, 2)` (expanded arrays, no trailing newline), but Biome (which was **not** excluding this generated artifact) reformats it (collapsed arrays + trailing newline). `pnpm generate-json` and `pnpm format` flip-flopped ~870 lines on every run. Confirmed empirically: regenerating the committed file produced an 871-line diff that was purely formatting + timestamp.

The fix is to the **generator + build config**, not the data (per the task guidance).

## Change
- `generate.ts`: drop the wall-clock `generated_at`; emit a trailing newline. Regeneration is now **idempotent** (two consecutive runs are byte-identical).
- `frontend/biome.json`: exclude `**/packages/sitemap/src/json/sitemap.json` from Biome — consistent with the existing `**/generated` and `**/*.gen.ts` exclusions — so the generator solely owns the artifact's format.
- `backend/crates/common/src/sitemap/mod.rs`: `SitemapMetadata.generated_at` → `Option<String>` so the embedded JSON deserializes with the field absent. No other consumer reads it (grep-confirmed).
- `sitemap.json`: regenerated via the real generator to the new deterministic canonical form (this is the one-time diff; future regenerations produce zero churn).
- `tests/sitemap.test.ts`: fixed a **pre-existing** stale hardcoded count (`ppt-web` 19→20) that was already red on `dev` after the last route was added — the same "hardcoded counts rot" pathology the Rust test comment (`test_metadata_stats_match_loaded_collections`) warns about.

## Tested (Band A — fast check)
- `npx tsx src/json/generate.ts` ×2 + diff → **idempotent (byte-identical)**, exit 0
- `vitest run` (@ppt/sitemap) → **18 passed**, exit 0
- `tsc --noEmit` on `generate.ts` (isolated @types/node) → exit 0
- `biome check generate.ts biome.json tests/sitemap.test.ts` → clean; `sitemap.json` now ignored, exit 0
- `cargo check -p common` → exit 0
- `cargo test -p common sitemap` → **6 passed** (incl. `test_load_sitemap`, `test_metadata_stats_match_loaded_collections`), exit 0

## Built (Band B — full build)
- `cargo clippy -p common -- -D warnings` → exit 0 (public struct field type changed, so ran clippy for CI parity)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- **Scope drift = true (advisory).** `owner_role=pm-tech-lead` maps to `docs/** / .research/** / _bmad-output/**`, but a churn-hotspot fix to a generated frontend artifact inherently lives in `frontend/packages/sitemap/**`, `frontend/biome.json`, and `backend/crates/common/**`. All touched paths are the minimal set required for the fix. Reviewer to adjudicate.
- **goal-check**: the IG1/IG2/IG8 failures are plan-flow scaffolding that doesn't apply to this dispatcher churn-signal task (no `.research/plans/<slug>.md`; branch is the dispatcher-assigned `auto-impl/...`; backlog/archive is the dispatcher's responsibility). The substantive verify gate (above) is fully green.
- **Follow-up (optional):** the remaining hardcoded counts in `tests/sitemap.test.ts` (and any others) could be derived from the data length to prevent recurrence, mirroring the Rust-side `test_metadata_stats_match_loaded_collections` refactor. Also consider a CI "regenerate + `git diff --exit-code`" guard now that the generator is deterministic, to catch `src/data` ↔ `sitemap.json` drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3QVm3HVgPjVCKhUkvYpdg

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3QVm3HVgPjVCKhUkvYpdg)_