### PR TITLE
gap-83-2-rate-availability-push-integration-deferred: persist Booking.com push sync state on connection

### DIFF
--- a/backend/crates/db/src/repositories/rental/oauth.rs
+++ b/backend/crates/db/src/repositories/rental/oauth.rs
@@ -591,4 +591,32 @@ impl RentalRepository {
 
         Ok(())
     }
+
+    /// Record a failed Booking.com rate/availability push (or reservation
+    /// sync) on the connection so operators see it in the platform-status
+    /// dashboard (which reads `sync_error`). This is the push-side counterpart
+    /// of [`Self::update_connection_last_sync`], mirroring
+    /// [`Self::mark_airbnb_token_error`] but scoped to `platform = 'booking'`.
+    /// Unlike `update_connection_last_sync` it leaves `last_sync_at` untouched,
+    /// because a failed push did not successfully sync anything.
+    pub async fn mark_booking_sync_error(
+        &self,
+        connection_id: Uuid,
+        error: &str,
+    ) -> Result<(), SqlxError> {
+        sqlx::query(
+            r#"
+            UPDATE rental_platform_connections SET
+                sync_error = $2,
+                updated_at = NOW()
+            WHERE id = $1 AND platform = 'booking'
+            "#,
+        )
+        .bind(connection_id)
+        .bind(error)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
 }

--- a/backend/servers/api-server/src/routes/integrations/booking_channel.rs
+++ b/backend/servers/api-server/src/routes/integrations/booking_channel.rs
@@ -414,7 +414,37 @@ pub async fn push_booking_listing(
     let avail_pushed = outcome.availability_pushed as i32;
     let rates_pushed = outcome.rates_pushed as i32;
 
-    match classify_listing_push(&outcome) {
+    let result = classify_listing_push(&outcome);
+
+    // Persist the push outcome on the connection so the platform-status
+    // dashboard reflects the latest push and surfaces failures. This was the
+    // piece deferred from the gap-83-2 push story — the pull flow in
+    // `install.rs` already stamps `last_sync_at`, but the push flow did not.
+    // Best-effort (`let _ =`): a bookkeeping-write hiccup must not turn a push
+    // that already reached Booking.com into an error response (mirrors the
+    // `let _ =` pattern in the pull flow).
+    match sync_persistence(&result) {
+        SyncPersistence::Synced => {
+            let _ = rental_repo
+                .update_connection_last_sync(connection.id, chrono::Utc::now())
+                .await;
+        }
+        SyncPersistence::SyncedWithError(message) => {
+            let _ = rental_repo
+                .update_connection_last_sync(connection.id, chrono::Utc::now())
+                .await;
+            let _ = rental_repo
+                .mark_booking_sync_error(connection.id, &message)
+                .await;
+        }
+        SyncPersistence::Errored(message) => {
+            let _ = rental_repo
+                .mark_booking_sync_error(connection.id, &message)
+                .await;
+        }
+    }
+
+    match result {
         ListingPushResult::Success => {
             tracing::info!(
                 org_id = %path.org_id,
@@ -554,6 +584,35 @@ fn classify_listing_push(outcome: &PushOutcome) -> ListingPushResult {
         ListingPushResult::TotalFailure(message)
     } else {
         ListingPushResult::Partial(message)
+    }
+}
+
+/// What to persist on the Booking.com connection after a listing push.
+///
+/// The gap-83-2 push flow deferred the connection-state bookkeeping that the
+/// reservation *pull* flow (`install.rs`) already does — stamping
+/// `last_sync_at` on success and surfacing a `sync_error` on failure so the
+/// platform-status dashboard (`statistics::MAX(last_sync_at)` / `sync_error`)
+/// reflects the latest push. Deriving the persistence action from the
+/// [`ListingPushResult`] in a pure function keeps that decision unit-testable
+/// without a live Postgres (the DB write itself is best-effort in the handler).
+#[derive(Debug, PartialEq, Eq)]
+enum SyncPersistence {
+    /// Fully applied — stamp `last_sync_at`, clear any prior error.
+    Synced,
+    /// Half-applied — stamp `last_sync_at` *and* record the partial error so
+    /// the half-synced channel is visible to operators.
+    SyncedWithError(String),
+    /// Nothing applied — record the error, leave `last_sync_at` untouched.
+    Errored(String),
+}
+
+/// Map a [`ListingPushResult`] to the connection-state write it implies.
+fn sync_persistence(result: &ListingPushResult) -> SyncPersistence {
+    match result {
+        ListingPushResult::Success => SyncPersistence::Synced,
+        ListingPushResult::Partial(msg) => SyncPersistence::SyncedWithError(msg.clone()),
+        ListingPushResult::TotalFailure(msg) => SyncPersistence::Errored(msg.clone()),
     }
 }
 
@@ -809,6 +868,38 @@ mod tests {
                 assert!(msg.contains("availability:") && msg.contains("rates:"));
             }
             other => panic!("expected TotalFailure, got {other:?}"),
+        }
+    }
+
+    // ---- sync_persistence (ListingPushResult → connection-state write) ----
+
+    #[test]
+    fn sync_persistence_records_last_sync_on_success() {
+        assert_eq!(
+            sync_persistence(&ListingPushResult::Success),
+            SyncPersistence::Synced
+        );
+    }
+
+    #[test]
+    fn sync_persistence_records_last_sync_and_error_on_partial() {
+        // A half-synced channel must stamp last_sync_at AND surface the error,
+        // so operators can see something applied but reconciliation is needed.
+        let result = ListingPushResult::Partial("rates: rate plan not found".to_string());
+        match sync_persistence(&result) {
+            SyncPersistence::SyncedWithError(msg) => assert!(msg.contains("rates:")),
+            other => panic!("expected SyncedWithError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sync_persistence_records_only_error_on_total_failure() {
+        // Nothing applied → record the error but leave last_sync_at untouched
+        // (Errored variant), so the dashboard does not falsely report a sync.
+        let result = ListingPushResult::TotalFailure("availability: auth rejected".to_string());
+        match sync_persistence(&result) {
+            SyncPersistence::Errored(msg) => assert!(msg.contains("availability:")),
+            other => panic!("expected Errored, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Task

rate/availability push integration deferred, under story 83-2-booking-integration (Booking.com OAuth and Sync). Implement the deferred rate/availability push piece as a tractable, well-scoped increment.

**What was deferred (and is now landed):** the Booking.com rate/availability *push* flow (`booking_channel::push_booking_listing`) sent `OTA_HotelAvailNotifRQ` / `OTA_HotelRateAmountNotifRQ` but never recorded the outcome on the platform connection. As a result `last_sync_at` was never stamped after a push and push failures never surfaced in the platform-status dashboard (`repositories/rental/statistics.rs` reads `MAX(last_sync_at)` / `sync_error`). The reservation *pull* flow in `install.rs` already did this bookkeeping (`update_connection_last_sync`); the push side was the missing half.

## Owner

pm-backend

## Changes

- `db`: add `RentalRepository::mark_booking_sync_error(connection_id, error)` — the push-side counterpart of the existing `update_connection_last_sync`, scoped to `platform = 'booking'` (mirrors the existing `mark_airbnb_token_error`). Leaves `last_sync_at` untouched because a failed push synced nothing. Runtime-checked `sqlx::query` — no offline data change.
- `api-server` (`booking_channel.rs`): after the push, derive the connection-state write from the push classification via a pure `sync_persistence()` fn — `Synced` (stamp `last_sync_at`, clear error) / `SyncedWithError` (stamp `last_sync_at` + record partial error) / `Errored` (record error only) — and apply it best-effort (`let _ =`, mirroring `install.rs`) so a bookkeeping hiccup can't turn a push that already reached Booking.com into an error response.
- unit tests for the mapping (DB-free), alongside the existing `classify_listing_push` tests.

## Tested (Band A — fast check)

- `cargo check -p db` → exit 0
- `cargo check -p api-server` → exit 0
- `cargo test -p api-server --lib routes::integrations::booking_channel` → **31 passed; 0 failed** (incl. 3 new `sync_persistence_*` tests)

## Built (Band B — full build)

Public API added (`db` gains a `pub` repo method), so Band B ran:
- `cargo clippy -p db -p api-server --all-targets -- -D warnings` → exit 0 (clean)

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no auth/billing/data-integrity change; the write is best-effort connection bookkeeping already authorized by the existing `verify_org_access` + `verify_manager_role_in_org` guards).

## Remote-tested

skipped (no ppt-bridge MCP in session).

## Notes

- Scope drift: none (`scope-check --owner pm-backend` → exit 0; both files under `backend/**`).
- Code-reuse: none (`reuse-grep` → exit 0; reuses existing `update_connection_last_sync`, parallels `mark_airbnb_token_error`).
- Environment note for reviewers: `utoipa-swagger-ui`'s build script downloads the Swagger UI archive from `github.com`, which is egress-blocked in the implementer sandbox (HTTP 403). Local verification used a valid `v5.17.14.zip` reconstructed from the allowed npm `swagger-ui-dist@5.17.14` package into the `swagger-ui-5.17.14/dist/**` layout the build script expects (via `SWAGGER_UI_DOWNLOAD_URL=file://…`). CI/Docker have direct network access and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3QVm3HVgPjVCKhUkvYpdg)_