### PR TITLE
gh-issue-2404: guard against src/data ↔ sitemap.json drift (Closes #2404)

### DIFF
--- a/frontend/packages/sitemap/src/json/generate.ts
+++ b/frontend/packages/sitemap/src/json/generate.ts
@@ -6,11 +6,21 @@ import { sitemap } from '../data';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+/** Absolute path of the committed sitemap.json artifact. */
+export const SITEMAP_JSON_PATH = path.join(__dirname, 'sitemap.json');
+
 /**
- * Generate sitemap.json for non-TypeScript consumers (e.g., Rust backend tests)
+ * Build the sitemap.json payload for non-TypeScript consumers (e.g., Rust
+ * backend tests) from `../data`.
+ *
+ * Pure: no wall-clock timestamp, no filesystem access — the same `../data`
+ * input always yields the same object. This determinism is load-bearing:
+ * the file is committed and embedded into the Rust backend via `include_str!`,
+ * so a `new Date()` value made every regeneration produce a spurious diff
+ * (churn hotspot). See PR #2397.
  */
-function generateSitemapJson(): void {
-  const output = {
+export function buildSitemapJson() {
+  return {
     routes: {
       'ppt-web': sitemap.routes['ppt-web'],
       'reality-web': sitemap.routes['reality-web'],
@@ -24,10 +34,6 @@ function generateSitemapJson(): void {
     },
     flows: sitemap.flows,
     metadata: {
-      // NOTE: intentionally no wall-clock timestamp here. This file is
-      // committed and embedded into the Rust backend via include_str!, so the
-      // generator output must be deterministic — a `new Date()` value made
-      // every regeneration produce a spurious diff (churn hotspot).
       version: '1.0.0',
       stats: {
         ppt_web_routes: sitemap.routes['ppt-web'].length,
@@ -39,14 +45,28 @@ function generateSitemapJson(): void {
       },
     },
   };
-
-  const outputPath = path.join(__dirname, 'sitemap.json');
-  // Trailing newline keeps the artifact POSIX-clean and matches how the file
-  // is committed; the output is otherwise a stable serialization of ../data.
-  fs.writeFileSync(outputPath, `${JSON.stringify(output, null, 2)}\n`);
-
-  console.log(`Generated sitemap.json at ${outputPath}`);
-  console.log('Stats:', output.metadata.stats);
 }
 
-generateSitemapJson();
+/**
+ * Serialize the payload exactly as it is committed to disk: 2-space indent plus
+ * a trailing newline (keeps the artifact POSIX-clean). This is the single
+ * source of truth for the on-disk bytes — both the generator below and the
+ * drift-guard test (`tests/sitemap.test.ts`) call it, so they agree
+ * byte-for-byte.
+ */
+export function serializeSitemapJson(): string {
+  return `${JSON.stringify(buildSitemapJson(), null, 2)}\n`;
+}
+
+function writeSitemapJson(): void {
+  fs.writeFileSync(SITEMAP_JSON_PATH, serializeSitemapJson());
+  console.log(`Generated sitemap.json at ${SITEMAP_JSON_PATH}`);
+  console.log('Stats:', buildSitemapJson().metadata.stats);
+}
+
+// Only write when executed directly (`tsx src/json/generate.ts`), not when the
+// pure builders above are imported by the drift-guard test.
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
+if (invokedPath === __filename) {
+  writeSitemapJson();
+}

--- a/frontend/packages/sitemap/tests/sitemap.test.ts
+++ b/frontend/packages/sitemap/tests/sitemap.test.ts
@@ -9,6 +9,7 @@ import {
   getScreen,
   sitemap,
 } from '../src';
+import { SITEMAP_JSON_PATH, serializeSitemapJson } from '../src/json/generate';
 import { buildUrl, SitemapTestHelper } from '../src/utils';
 
 describe('Sitemap Data', () => {
@@ -152,5 +153,24 @@ describe('Package exports (CJS resolvability)', () => {
     for (const conditions of Object.values(pkg.exports)) {
       expect(conditions.default).toBe(conditions.import);
     }
+  });
+});
+
+describe('sitemap.json drift guard', () => {
+  // Anti-regression guard for the determinism fix (PR #2397, follow-up #2404).
+  // `frontend/biome.json` excludes the generated artifact from lint/format, so
+  // an author who edits `src/data` but forgets `pnpm generate-json` would ship a
+  // stale committed JSON that every other gate passes — the exact silent-drift
+  // class PR #2397 set out to kill. This case rebuilds the output from
+  // `src/data` via the same pure serializer the generator uses and byte-compares
+  // it against the committed file, covering both "regenerating yields identical
+  // bytes" (idempotence / IG3) and "committed JSON is not stale".
+  it('committed sitemap.json byte-matches a fresh build from src/data', () => {
+    const built = serializeSitemapJson();
+    const committed = readFileSync(SITEMAP_JSON_PATH, 'utf8');
+    expect(
+      built,
+      'src/json/sitemap.json is out of sync with src/data — run `pnpm --filter @ppt/sitemap generate-json` and commit the result'
+    ).toBe(committed);
   });
 });


### PR DESCRIPTION
## Task
Follow-up: sitemap determinism has no CI/test guard against `src/data` ↔ `sitemap.json` drift (Closes #2404).

PR #2397 made `frontend/packages/sitemap/src/json/sitemap.json` generation deterministic but left no automated anti-regression guard. Because `frontend/biome.json` excludes the generated artifact from lint/format, an author who edits `src/data` and forgets `pnpm generate-json` ships a stale committed JSON that every existing gate passes — the exact silent-drift class PR #2397 set out to kill. The Rust `test_metadata_stats_match_loaded_collections` only checks the JSON's internal consistency, and the existing TS tests read `../src`, never the JSON.

## Approach
Chose the issue's recommended cheaper alternative (in-suite Vitest guard) over a new `frontend.yml` CI step — no new workflow, runs inside the existing `pnpm test` gate.

- **`src/json/generate.ts`** — refactored into pure builders:
  - `buildSitemapJson()` — pure payload from `../data` (no timestamp, no FS).
  - `serializeSitemapJson()` — single source of truth for the on-disk bytes (2-space indent + trailing newline).
  - `SITEMAP_JSON_PATH` — exported artifact path.
  - The file-write side effect now runs **only on direct `tsx` invocation** (`process.argv[1] === __filename`), so importing the builders in a test does not overwrite the committed file.
- **`tests/sitemap.test.ts`** — new `sitemap.json drift guard` case rebuilds via `serializeSitemapJson()` and byte-compares against the committed file. Covers both idempotence (IG3) and staleness, with a remediation hint in the assertion message.

## Owner
pm-tech-lead (task is frontend tooling / DX — implemented by the `react-web` specialist per the issue's own recommendation).

## Tested (Band A — fast check)
- `pnpm generate-json` + `git diff --exit-code src/json/sitemap.json` → **no diff** (generator still idempotent; direct-invocation guard works).
- `pnpm -F @ppt/sitemap test` → **21 passed** (was 20; +1 drift guard), exit 0.
- Negative proof: artificially bumped the committed JSON's `version` → guard **failed** with the remediation message, then restored clean.
- `pnpm -F @ppt/sitemap typecheck` → exit 0.
- `pnpm biome check` on both changed files → exit 0, no fixes.

## Built (Band B — full build)
Skipped: change is small (~40 LOC of substantive code, all within one package), no public runtime API / migration / config output change. Band A typecheck (`tsc --noEmit`) already covers the package's build path (`tsc`).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security / auth / billing / data-integrity change).

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` exited 2 — the diff touches `frontend/packages/sitemap/**`, which is outside the `pm-tech-lead` review-lens mapping. This is expected: `pm-tech-lead` was the routing hint, but the work is frontend tooling and the issue itself names `react-web` as the specialist. No unrelated files were touched — only `generate.ts` and its test. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist react-web` → no warnings. The refactor consolidates the payload logic into one reused serializer rather than duplicating it in the test.

## Notes
No CI workflow changes; the guard rides the existing `frontend.yml` `pnpm test` gate. Closes #2404.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe)_