### PR TITLE
gh-issue-2402: fix /sign reload regression + strip only the token param

### DIFF
--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tokenHygiene.test.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tokenHygiene.test.tsx
@@ -11,8 +11,13 @@
  *
  *   1. still hands the token to `useSignContext` (capture happens before the
  *      URL is rewritten, so the render context still loads), and
- *   2. strips `?token=…` from the visible URL/history on mount, and
- *   3. installs a page-scoped `<meta name="referrer" content="no-referrer">`.
+ *   2. strips only the `token` key from the visible URL/history on mount,
+ *      keeping any other query params + fragment, and
+ *   3. installs a page-scoped `<meta name="referrer" content="no-referrer">`, and
+ *   4. persists the token to sessionStorage so a full page reload (which
+ *      re-requests `/sign` with no `?token`) still finds it — the pre-#2402
+ *      regression where a valid link showed "invalid link" after F5 — and
+ *      clears that copy once the signature is submitted (#2402).
  *
  * Only the @ppt/api-client signer hooks (the network boundary) are mocked.
  */
@@ -23,7 +28,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { DocumentSignPage } from './DocumentSignPage';
 
 // ─── network boundary: @ppt/api-client signer hooks ─────────────────────────
-const { useSignContextMock } = vi.hoisted(() => ({ useSignContextMock: vi.fn() }));
+const { useSignContextMock, useSubmitSignatureMock } = vi.hoisted(() => ({
+  useSignContextMock: vi.fn(),
+  useSubmitSignatureMock: vi.fn(),
+}));
 
 vi.mock('@ppt/api-client', () => {
   class SignErrorStub extends Error {
@@ -36,14 +44,11 @@ vi.mock('@ppt/api-client', () => {
   return {
     SignError: SignErrorStub,
     useSignContext: (token?: string) => useSignContextMock(token),
-    useSubmitSignature: () => ({
-      mutate: vi.fn(),
-      isPending: false,
-      isSuccess: false,
-      isError: false,
-    }),
+    useSubmitSignature: (token: string) => useSubmitSignatureMock(token),
   };
 });
+
+const SIGN_TOKEN_STORAGE_KEY = 'signToken';
 
 function renderAt(url: string) {
   window.history.replaceState({}, '', url);
@@ -64,7 +69,15 @@ describe('DocumentSignPage token hygiene', () => {
       isError: false,
       error: undefined,
     });
-    // Clean out any meta[name=referrer] a previous test may have left.
+    useSubmitSignatureMock.mockReset();
+    useSubmitSignatureMock.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+      isError: false,
+    });
+    // Each test starts from a clean tab: no persisted token, no stray meta tag.
+    window.sessionStorage.clear();
     for (const m of Array.from(document.head.querySelectorAll('meta[name="referrer"]'))) {
       m.remove();
     }
@@ -85,6 +98,19 @@ describe('DocumentSignPage token hygiene', () => {
     expect(window.location.pathname).toBe('/sign');
   });
 
+  it('strips only the token key, preserving other query params and the fragment', () => {
+    renderAt('/sign?token=tok-abc-123&lang=de&ref=email#terms');
+    // token removed…
+    expect(window.location.search).not.toContain('token');
+    // …but lang/ref and the hash survive.
+    const params = new URLSearchParams(window.location.search);
+    expect(params.get('lang')).toBe('de');
+    expect(params.get('ref')).toBe('email');
+    expect(window.location.hash).toBe('#terms');
+    // and the token still reached the render-context hook.
+    expect(useSignContextMock).toHaveBeenCalledWith('tok-abc-123');
+  });
+
   it('installs a no-referrer meta tag while mounted and removes it on unmount', () => {
     const { unmount } = renderAt('/sign?token=tok-abc-123');
     const meta = document.head.querySelector('meta[name="referrer"]');
@@ -99,5 +125,45 @@ describe('DocumentSignPage token hygiene', () => {
     expect(useSignContextMock).toHaveBeenCalledWith(undefined);
     expect(window.location.pathname).toBe('/sign');
     expect(window.location.search).toBe('');
+  });
+
+  // ─── reload regression (#2402) ────────────────────────────────────────────
+
+  it('persists the captured token to sessionStorage for reload survival', () => {
+    renderAt('/sign?token=tok-abc-123');
+    expect(window.sessionStorage.getItem(SIGN_TOKEN_STORAGE_KEY)).toBe('tok-abc-123');
+  });
+
+  it('re-seeds the token from sessionStorage on a reload with no ?token in the URL', () => {
+    // Simulate a prior visit having stashed the token, then a full reload where
+    // the URL no longer carries it (the address bar was already stripped).
+    window.sessionStorage.setItem(SIGN_TOKEN_STORAGE_KEY, 'tok-from-reload');
+    renderAt('/sign');
+    // Pre-fix this called useSignContext(undefined) → "invalid signing link".
+    expect(useSignContextMock).toHaveBeenCalledWith('tok-from-reload');
+  });
+
+  it('clears the persisted token after a successful submit', () => {
+    window.sessionStorage.setItem(SIGN_TOKEN_STORAGE_KEY, 'tok-abc-123');
+    useSignContextMock.mockReturnValue({
+      data: {
+        subject: 'Lease',
+        signer_name: 'Jane Signer',
+        signer_email: 'jane@example.com',
+        signer_status: 'pending',
+      },
+      isLoading: false,
+      isError: false,
+      error: undefined,
+    });
+    useSubmitSignatureMock.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+      data: { status: 'completed', message: 'Signed.' },
+    });
+    renderAt('/sign?token=tok-abc-123');
+    expect(window.sessionStorage.getItem(SIGN_TOKEN_STORAGE_KEY)).toBeNull();
   });
 });

--- a/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx
@@ -57,6 +57,45 @@ function isTerminalSignerStatus(status: string): boolean {
   return status === 'signed' || status === 'declined';
 }
 
+/**
+ * sessionStorage key holding the captured signing token.
+ *
+ * We strip `?token=…` from the URL on mount for hygiene, but the token then
+ * lives only in component state — a full page reload (F5, session restore,
+ * back-then-forward) re-requests `/sign` with no token and the signer would hit
+ * "invalid link" even though the link is still valid (GET does not consume the
+ * nonce). Persisting to sessionStorage lets an in-tab reload re-seed the token;
+ * it survives reloads, is cleared when the tab closes, and we clear it
+ * ourselves after a successful submit.
+ */
+const SIGN_TOKEN_STORAGE_KEY = 'signToken';
+
+/** sessionStorage access can throw (private mode / disabled) — degrade gracefully. */
+function readStoredToken(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return window.sessionStorage.getItem(SIGN_TOKEN_STORAGE_KEY) ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+function storeToken(value: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(SIGN_TOKEN_STORAGE_KEY, value);
+  } catch {
+    /* storage unavailable — fall back to state-only (reload will fail, as before) */
+  }
+}
+function clearStoredToken(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.removeItem(SIGN_TOKEN_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
 /** Card shell so every state (loading / error / form / done) shares one frame. */
 function SignCard({ children }: { children: React.ReactNode }) {
   return (
@@ -84,15 +123,31 @@ export function DocumentSignPage() {
   // from history after the signer walks away, and it rides the `Referer` header
   // on any outbound navigation. We therefore:
   //   1. capture it once into component state (survives the URL rewrite),
-  //   2. strip it from the visible URL + history via replaceState (no nav), and
+  //      seeding from sessionStorage so an in-tab reload still finds it,
+  //   2. strip ONLY the `token` key from the visible URL + history via
+  //      replaceState (no nav), preserving any other query params + fragment, and
   //   3. hold a page-scoped `<meta name="referrer" content="no-referrer">` so
   //      the token can never leak via `Referer` while this page is mounted.
-  const [token] = useState<string | undefined>(() => searchParams.get('token') ?? undefined);
+  const [token] = useState<string | undefined>(
+    () => searchParams.get('token') ?? readStoredToken()
+  );
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    if (new URLSearchParams(window.location.search).has('token')) {
-      window.history.replaceState({}, '', window.location.pathname);
+    const params = new URLSearchParams(window.location.search);
+    const urlToken = params.get('token');
+    if (urlToken) {
+      // Persist before stripping so a full page reload can re-seed the token.
+      storeToken(urlToken);
+      // Strip only the token key — keep other params (locale/lang, tracking id)
+      // and the URL fragment intact instead of discarding the whole query string.
+      params.delete('token');
+      const qs = params.toString();
+      window.history.replaceState(
+        {},
+        '',
+        window.location.pathname + (qs ? `?${qs}` : '') + window.location.hash
+      );
     }
     const meta = document.createElement('meta');
     meta.name = 'referrer';
@@ -106,6 +161,14 @@ export function DocumentSignPage() {
   const { data: context, isLoading, isError, error: contextError } = useSignContext(token);
 
   const submit = useSubmitSignature(token ?? '');
+
+  // Once the signature is recorded the token is spent — drop the persisted copy
+  // so a later reload doesn't replay a now-consumed nonce into an error state.
+  useEffect(() => {
+    if (submit.isSuccess) {
+      clearStoredToken();
+    }
+  }, [submit.isSuccess]);
 
   const [typedName, setTypedName] = useState('');
   const [nameError, setNameError] = useState<string>();


### PR DESCRIPTION
## Task
Follow-up to PR #2378 post-merge review (#2402). The URL-strip fix was sound but incomplete. This PR lands the two **scoped, highest-value** findings and intentionally defers the larger transport change.

Addressed here (`DocumentSignPage.tsx`, public `/sign` signer page):

- **regression — medium (reload breaks the signer flow).** After mount, `replaceState` removed the token while it lived only in `useState`; any full page reload (F5, session restore, back-then-forward) re-requested `/sign` with no token and the signer hit "invalid signing link" even though the link was still valid (GET does not consume the nonce). Fix: persist the captured token in `sessionStorage` (survives in-tab reload, cleared on tab close), seed the `useState` initializer from it, and clear it after a successful submit.
- **correctness — low (url-strip scope).** `replaceState(..., window.location.pathname)` discarded the entire query string + fragment. Fix: strip only the `token` key, preserving other params (locale/`lang`, tracking id) and the `#fragment`.

Deferred (not in this PR): the **security — medium** transport finding (token still sent as a query parameter on every network hop / the initial `GET /sign?token=` document load, captured verbatim in access logs). Per the issue and the skill's scope guidance, that needs a coordinated `@ppt/api-client` + `rust-backend` change (header/body transport, or a one-shot `?token` → httpOnly cookie → 302 redirect) and warrants its own follow-up rather than being bundled into this frontend-only fix.

## Owner
pm-tech-lead (implemented by the `react-web` specialist)

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports **exit 2** because `pm-tech-lead` maps to `docs/**` / `.research/**` / `_bmad-output/**`, while the actual work is a frontend fix under `frontend/apps/ppt-web/src/features/documents/pages/`. The drift is expected and justified: the issue's own "Suggested specialist" is `react-web`; the owner hint was advisory. Files touched:
- `frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tsx`
- `frontend/apps/ppt-web/src/features/documents/pages/DocumentSignPage.tokenHygiene.test.tsx`

## Code-reuse review
`reuse-grep.sh --specialist react-web` — no warnings. The new `readStoredToken`/`storeToken`/`clearStoredToken` are page-local sessionStorage helpers with no existing equivalent.

## Tested (Band A — fast check)
- `pnpm -F @ppt/web typecheck` → exit 0
- `pnpm exec biome check <both changed files>` → exit 0 (repo lint is Biome per CLAUDE.md / `frontend.yml`; the per-app `lint` script points at an ESLint config that isn't present in the tree — pre-existing, unrelated)
- `pnpm exec vitest run DocumentSignPage.tokenHygiene.test.tsx` → **8 passed**. Two new tests (`re-seeds the token from sessionStorage on a reload…`, `strips only the token key, preserving other query params and the fragment`) fail on `dev` and pass here → IG3 regression coverage.

## Built (Band B — full build)
- `pnpm -F @ppt/web build` (Vite production build) → exit 0, built in ~6s.

## CI parity (Band C — hot-path)
Public credential-bearing signing flow, so treated as hot-path. Ran the frontend gate commands directly (typecheck + Biome + vitest + build above) — `act` not installed. All green.

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- No API surface, backend, or i18n-key changes; the `useSignContext`/`useSubmitSignature` call sites are unchanged.
- The deferred security transport finding should be filed/kept as a separate `react-web` + `rust-backend` follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe)_