### PR TITLE
gh-issue-2401: reconcile favorites client to real reality-server DTO (fix no-op optimistic toggle)

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/favorites/page.test.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/favorites/page.test.tsx
@@ -51,21 +51,32 @@ import FavoritesPage from './page';
 
 const LISTING_ID = 'listing-1';
 
+// The real reality-server `GET /api/v1/favorites` response: the
+// `{ favorites: [...] }` envelope (FavoritesResponse) with snake_case,
+// flattened listing fields (PortalFavoriteWithListing — no nested `listing`,
+// no `data` envelope) and Decimal prices as strings. Feeding this exact shape
+// makes the test fail if the client's casing/envelope mapping regresses.
 function favoritesPayload(priceAlertEnabled: boolean) {
   return {
-    data: [
+    favorites: [
       {
         id: 'fav-1',
-        listingId: LISTING_ID,
-        listing: { id: LISTING_ID, title: 'Sunny 2-bedroom apartment' },
-        addedAt: '2026-07-01T00:00:00Z',
+        listing_id: LISTING_ID,
+        title: 'Sunny 2-bedroom apartment',
+        current_price: '185000.00',
+        original_price: '199000.00',
+        currency: 'EUR',
+        city: 'Bratislava',
+        property_type: 'apartment',
+        transaction_type: 'sale',
+        photo_url: null,
+        status: 'active',
+        price_changed: true,
+        price_change_percentage: '-7.04',
         price_alert_enabled: priceAlertEnabled,
+        created_at: '2026-07-01T00:00:00Z',
       },
     ],
-    total: 1,
-    page: 1,
-    pageSize: 12,
-    totalPages: 1,
   };
 }
 

--- a/frontend/packages/reality-api-client/src/favorites/hooks.ts
+++ b/frontend/packages/reality-api-client/src/favorites/hooks.ts
@@ -9,12 +9,16 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { getApiBase } from '../config';
+import type { ListingSummary } from '../listings/types';
 import type {
   CreateSavedSearchRequest,
   FavoriteAlertsResponse,
   FavoriteAlertsWireResponse,
+  FavoriteListing,
+  FavoritesWireResponse,
   MarkAllFavoriteAlertsReadResponse,
   PaginatedFavorites,
+  PortalFavoriteWire,
   SavedSearch,
   UpdateFavoriteRequest,
   UpdateSavedSearchRequest,
@@ -22,19 +26,72 @@ import type {
 
 // Favorites Hooks
 
+/**
+ * Map a wire favorite (reality-server `PortalFavoriteWithListing` — snake_case,
+ * flattened listing fields, Decimal prices as strings) into the client
+ * {@link FavoriteListing} view-model the UI consumes. The list DTO carries only
+ * a subset of `ListingSummary`; fields it doesn't provide (`slug`, `area`, …)
+ * are defaulted so the card can render from what the favorites endpoint gives.
+ */
+function mapWireFavorite(w: PortalFavoriteWire): FavoriteListing {
+  const listing: ListingSummary = {
+    id: w.listing_id,
+    title: w.title,
+    // The favorites list DTO carries no slug; fall back to the listing id so
+    // the card link is at least a stable identifier rather than `undefined`.
+    slug: w.listing_id,
+    propertyType: w.property_type as ListingSummary['propertyType'],
+    transactionType: w.transaction_type as ListingSummary['transactionType'],
+    status: w.status as ListingSummary['status'],
+    price: toNumeric(w.current_price) ?? 0,
+    currency: w.currency,
+    // Not carried by the favorites list DTO.
+    area: 0,
+    address: { city: w.city, country: '' },
+    primaryPhoto: w.photo_url
+      ? {
+          id: w.listing_id,
+          url: w.photo_url,
+          thumbnailUrl: w.photo_url,
+          isPrimary: true,
+          order: 0,
+        }
+      : undefined,
+    isFeatured: false,
+    createdAt: w.created_at,
+    updatedAt: w.created_at,
+  };
+
+  return {
+    id: w.id,
+    listingId: w.listing_id,
+    listing,
+    addedAt: w.created_at,
+    price_alert_enabled: w.price_alert_enabled,
+  };
+}
+
 export function useFavorites(page = 1, pageSize = 20) {
   return useQuery({
     queryKey: ['favorites', page, pageSize],
     queryFn: async (): Promise<PaginatedFavorites> => {
-      const params = new URLSearchParams();
-      params.set('page', String(page));
-      params.set('pageSize', String(pageSize));
-
-      const response = await fetch(`${getApiBase()}/api/v1/favorites?${params}`, {
+      const response = await fetch(`${getApiBase()}/api/v1/favorites`, {
         credentials: 'include',
       });
       if (!response.ok) throw new Error('Failed to fetch favorites');
-      return response.json();
+
+      // reality-server answers with the unpaginated `{ favorites: [...] }`
+      // envelope (`FavoritesResponse`), each row snake_case with flattened
+      // listing fields — NOT a `{ data: [{ listingId, listing }] }` shape.
+      // Normalize to the client view-model, then paginate client-side.
+      const wire: FavoritesWireResponse = await response.json();
+      const all = (wire.favorites ?? []).map(mapWireFavorite);
+      const total = all.length;
+      const totalPages = Math.max(1, Math.ceil(total / pageSize));
+      const start = (page - 1) * pageSize;
+      const data = all.slice(start, start + pageSize);
+
+      return { data, total, page, pageSize, totalPages };
     },
   });
 }

--- a/frontend/packages/reality-api-client/src/favorites/types.ts
+++ b/frontend/packages/reality-api-client/src/favorites/types.ts
@@ -6,7 +6,52 @@
 
 import type { ListingFilters, ListingSummary } from '../listings/types';
 
-// Favorite Listing
+/**
+ * A favorite row exactly as it arrives **on the wire** from
+ * `GET /api/v1/favorites`.
+ *
+ * Field names mirror the reality-server `PortalFavoriteWithListing` DTO
+ * verbatim (`backend/crates/db/src/models/reality_portal.rs`): snake_case (that
+ * struct has no `#[serde(rename_all = "camelCase")]`), with the listing fields
+ * **flattened** onto the favorite — there is no nested `listing` object. The
+ * price fields are `rust_decimal::Decimal`, serialized as JSON **strings**
+ * (e.g. `"180000.00"`), so they arrive as strings, not numbers.
+ * `useFavorites` normalizes this raw shape into {@link FavoriteListing} at the
+ * client boundary — do not consume this interface directly in components.
+ */
+export interface PortalFavoriteWire {
+  id: string;
+  listing_id: string;
+  title: string;
+  current_price: string | number;
+  original_price?: string | number | null;
+  currency: string;
+  city: string;
+  property_type: string;
+  transaction_type: string;
+  photo_url?: string | null;
+  status: string;
+  price_changed: boolean;
+  price_change_percentage?: string | number | null;
+  price_alert_enabled: boolean;
+  created_at: string;
+}
+
+/**
+ * Raw response of `GET /api/v1/favorites` — the reality-server
+ * `FavoritesResponse { favorites: Vec<PortalFavoriteWithListing> }` envelope.
+ * Unpaginated: the route returns every favorite in one `favorites` array.
+ */
+export interface FavoritesWireResponse {
+  favorites: PortalFavoriteWire[];
+}
+
+/**
+ * A favorite normalized into the client view-model that the favorites UI
+ * consumes: the flattened wire listing fields (see {@link PortalFavoriteWire})
+ * are lifted into a nested {@link ListingSummary} and the Decimal price strings
+ * are coerced to numbers. This is the shape components read.
+ */
 export interface FavoriteListing {
   id: string;
   listingId: string;
@@ -49,7 +94,10 @@ export interface UpdateSavedSearchRequest {
   alertFrequency?: 'daily' | 'weekly' | 'instant';
 }
 
-// Paginated Response
+// Paginated Response.
+// NOTE: `GET /api/v1/favorites` is unpaginated on the wire (it returns the full
+// `{ favorites: [...] }` array); `useFavorites` derives this page envelope
+// client-side by slicing that array.
 export interface PaginatedFavorites {
   data: FavoriteListing[];
   total: number;


### PR DESCRIPTION
## Task
Follow-up: favorites optimistic toggle + test built on a client shape that diverges from the reality-server DTO — update no-ops in prod (Closes #2401).

Root cause (from #2401): the hand-written favorites client assumed a `{ data: [{ listingId, listing }] }` camelCase envelope, but `GET /api/v1/favorites` returns `FavoritesResponse { favorites: Vec<PortalFavoriteWithListing> }` — snake_case, listing fields **flattened** onto the favorite (no nested `listing`), Decimal prices as JSON strings. So against the real server the PR #2382 optimistic price-alert flip **and** its `onError` rollback never matched a row and were silent no-ops, and `page.test.tsx` fabricated the fictional shape so it stayed green regardless.

## Fix (option (b) from the issue — client-side, no wire/contract change)
- `useFavorites` now reads the real `{ favorites }` envelope and normalizes each row into the client view-model through a `mapWireFavorite` anti-corruption layer (mirrors the existing `FavoriteAlertsWire` → `FavoriteAlert` pattern in the same file; reuses the existing `toNumeric` Decimal-string coercion). Since the route is unpaginated, pagination is derived client-side.
- Added `PortalFavoriteWire` / `FavoritesWireResponse` types mirroring the Rust `PortalFavoriteWithListing` DTO (documented against `backend/crates/db/src/models/reality_portal.rs`). Because the cache now holds the normalized `{ data, listingId }` shape, the existing optimistic `onMutate`/`onError` logic in `useUpdateFavorite` works unchanged.
- `page.test.tsx` `favoritesPayload()` now emits the real wire shape (`{ favorites: [{ listing_id, title, current_price, ... }] }`), so the end-to-end guard fails on any casing/envelope regression — closing the false-confidence gap from #2365.

Note: the favorites list DTO carries only a subset of `ListingSummary` (no `slug`/`area`/…); the mapper defaults those. That deeper data-completeness gap is the pre-existing Epic 44 / #2348 root cause and is out of scope for this follow-up — this change makes the card strictly better (title/price/photo/city now populate) and, critically, makes the toggle actually work.

## Owner
pm-tech-lead (implemented by the `nextjs-web` specialist — frontend-only fix)

## Tested (Band A — fast check)
- `pnpm -F @ppt/reality-api-client typecheck` → exit 0
- `pnpm -F reality-web typecheck` → exit 0
- `biome check` (3 changed files) → exit 0 (2 pre-existing unused-`url` warnings in the test's fetchMock, not introduced here)
- `pnpm -F reality-web exec vitest run favorites/page.test.tsx` → 2 passed
- **IG3 regression evidence:** reverting only the hook mapping to the old `return response.json()` makes the test fail (import/runtime error — `data.data` undefined); restoring it → 2 passed. The `test:` commit precedes the `fix:` commit on the branch.

## Built (Band B — full build)
- `pnpm -F reality-web build` → exit 0 (public type surface changed in a shared package, so full build run)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing change; touches favorites view-model only)

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2: the diff is entirely under `frontend/` (`reality-api-client` + `reality-web`), outside `pm-tech-lead`'s backend/architecture areas. Expected — the correct specialist for this favorites fix is `nextjs-web`; `pm-tech-lead` was only the dispatcher's routing hint. Files: `frontend/packages/reality-api-client/src/favorites/{types,hooks}.ts`, `frontend/apps/reality-web/src/app/[locale]/favorites/page.test.tsx`.

## Code-reuse review
`reuse-grep.sh` clean. The mapper reuses the existing `toNumeric` helper and follows the established `FavoriteAlertsWire` normalization pattern rather than adding new helpers.

## Remote-tested
skipped (no ppt-bridge in session)

## Notes
- Goal-check IG1/IG2 report FAIL because this is a gh-issue dispatcher task (no `.research/plans/` file) on the mandated `auto-impl/gh-issue-2401-*` branch, not the plan-flow naming — structurally N/A. IG3 passes.
- Blast radius is contained: `useFavorites` / `PaginatedFavorites` / `FavoriteListing` are consumed only by the favorites page + hooks + its test.

Closes #2401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe)_