### PR TITLE
gh-issue-2400: transcode iOS HEIC/HEIF to JPEG in DocumentUploadScreen photo picker

### DIFF
--- a/frontend/apps/mobile/src/screens/documents/DocumentUploadScreen.test.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentUploadScreen.test.tsx
@@ -36,7 +36,7 @@ import {
   uploadDocumentMultipart,
 } from './DocumentUploadScreen';
 
-// ─── Mocks ──────────────────────────────────────────────────────────────────
+// ─── Mocks ────────────────────────────────────────────────
 
 const BASE_URL = 'https://api.test';
 jest.mock('../../config/api', () => ({
@@ -51,6 +51,15 @@ jest.mock('expo-document-picker', () => ({
 jest.mock('expo-image-picker', () => ({
   requestMediaLibraryPermissionsAsync: jest.fn(),
   launchImageLibraryAsync: jest.fn(),
+}));
+
+// The screen re-encodes HEIC/HEIF captures to JPEG via `transcodeToJpeg`
+// (`src/utils/imageCompression.ts`), which calls `manipulateAsync`. Mock the
+// native manipulator so the transcode branch is exercised without a runtime.
+const mockManipulateAsync = jest.fn();
+jest.mock('expo-image-manipulator', () => ({
+  manipulateAsync: (...args: unknown[]) => mockManipulateAsync(...args),
+  SaveFormat: { JPEG: 'jpeg', PNG: 'png', WEBP: 'webp' },
 }));
 
 const mockGetItemAsync = SecureStore.getItemAsync as jest.Mock;
@@ -72,7 +81,7 @@ beforeEach(() => {
   mockGetItemAsync.mockResolvedValue(null);
 });
 
-// ─── getFileIcon ────────────────────────────────────────────────────────────
+// ─── getFileIcon ───────────────────────────────────────────
 
 describe('getFileIcon', () => {
   it.each([
@@ -95,7 +104,7 @@ describe('getFileIcon', () => {
   });
 });
 
-// ─── uploadDocumentMultipart ────────────────────────────────────────────────
+// ─── uploadDocumentMultipart ───────────────────────────────────
 
 describe('uploadDocumentMultipart', () => {
   const file = {
@@ -187,7 +196,7 @@ describe('uploadDocumentMultipart', () => {
   });
 });
 
-// ─── validate() via the render tree ─────────────────────────────────────────
+// ─── validate() via the render tree ───────────────────────────────
 
 describe('DocumentUploadScreen validate()', () => {
   let alertSpy: jest.SpyInstance;
@@ -360,7 +369,7 @@ describe('DocumentUploadScreen validate()', () => {
   });
 });
 
-// ─── pickPhoto() MIME resolution (GitHub #2368) ───────────────────────────────
+// ─── pickPhoto() MIME resolution (GitHub #2368, #2400) ────────────────────
 
 describe('DocumentUploadScreen pickPhoto()', () => {
   let alertSpy: jest.SpyInstance;
@@ -372,6 +381,7 @@ describe('DocumentUploadScreen pickPhoto()', () => {
     }) as unknown as typeof fetch;
     mockGetItemAsync.mockResolvedValue(makeJwt({ tenant_id: 'org-1' }));
     mockRequestMediaPerms.mockResolvedValue({ status: 'granted' });
+    mockManipulateAsync.mockReset();
     alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
 
@@ -389,19 +399,85 @@ describe('DocumentUploadScreen pickPhoto()', () => {
     await waitFor(() => expect(screen.getByText(expectedName)).toBeTruthy());
   }
 
-  it('routes the picker-reported MIME through the same allow-list guard (HEIC rejected client-side)', async () => {
-    render(<DocumentUploadScreen />);
+  it('transcodes an iOS HEIC capture to JPEG and uploads it instead of rejecting (GitHub #2400)', async () => {
+    // An iOS capture the picker types as image/heic — the default iPhone camera
+    // format, absent from the backend allow-list. Rather than a client-side
+    // dead-end, the screen re-encodes it to JPEG (as ReportFaultScreen does) and
+    // the upload proceeds under the transcoded .jpg name / MIME.
+    mockManipulateAsync.mockResolvedValue({ uri: 'file:///cache/IMG_0001.jpg' });
 
-    // An iOS capture the picker types as image/heic — not in the allow-list.
-    // The old code hard-coded image/jpeg here, so the guard was a no-op and the
-    // wrong type was uploaded; now validate() rejects it before any request.
+    render(<DocumentUploadScreen />);
     await pickPhoto(
       { uri: 'file:///DCIM/IMG_0001.HEIC', mimeType: 'image/heic', fileName: 'IMG_0001.HEIC' },
-      'IMG_0001.HEIC'
+      'IMG_0001.jpg'
     );
     fireEvent.press(screen.getByText('documents.upload.categories.contract'));
     fireEvent.press(screen.getByText('documents.upload.submitButton'));
 
+    // Transcode ran once (format-only JPEG pass) and the guard did NOT reject.
+    expect(mockManipulateAsync).toHaveBeenCalledTimes(1);
+    const [uri, actions, options] = mockManipulateAsync.mock.calls[0];
+    expect(uri).toBe('file:///DCIM/IMG_0001.HEIC');
+    expect(actions).toEqual([]);
+    expect(options).toEqual({ format: 'jpeg' });
+    expect(screen.queryByText('documents.upload.fileTypeNotAllowed')).toBeNull();
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+    const [, fetchOptions] = (globalThis.fetch as jest.Mock).mock.calls[0];
+    // The transcoded JPEG (not the original HEIC) is what gets streamed.
+    expect(fetchOptions.body).toBeInstanceOf(FormData);
+  });
+
+  it('transcodes a HEIF capture detected only by its .heif extension (no picker MIME)', async () => {
+    mockManipulateAsync.mockResolvedValue({ uri: 'file:///cache/IMG_9.jpg' });
+
+    render(<DocumentUploadScreen />);
+    await pickPhoto(
+      { uri: 'file:///DCIM/IMG_9.HEIF', fileName: 'IMG_9.HEIF', fileSize: 3000 },
+      'IMG_9.jpg'
+    );
+    fireEvent.press(screen.getByText('documents.upload.categories.contract'));
+    fireEvent.press(screen.getByText('documents.upload.submitButton'));
+
+    expect(mockManipulateAsync).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('documents.upload.fileTypeNotAllowed')).toBeNull();
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(1));
+  });
+
+  it('falls back to the reject path when the HEIC transcode fails (no mislabelled upload)', async () => {
+    // If the manipulator pass throws, we must NOT upload the file mislabelled as
+    // JPEG — the original HEIC stays and validate() rejects it as before.
+    mockManipulateAsync.mockRejectedValue(new Error('decode failed'));
+
+    render(<DocumentUploadScreen />);
+    await pickPhoto(
+      { uri: 'file:///DCIM/IMG_0002.HEIC', mimeType: 'image/heic', fileName: 'IMG_0002.HEIC' },
+      'IMG_0002.HEIC'
+    );
+    fireEvent.press(screen.getByText('documents.upload.categories.contract'));
+    fireEvent.press(screen.getByText('documents.upload.submitButton'));
+
+    expect(mockManipulateAsync).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('documents.upload.fileTypeNotAllowed')).toBeTruthy();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('leaves a genuinely non-image type on the reject path (no transcode attempted)', async () => {
+    // A picked asset the picker types as something the allow-list rejects but
+    // that isn't HEIC/HEIF must not be run through the JPEG transcode — it stays
+    // rejected client-side.
+    render(<DocumentUploadScreen />);
+    await pickPhoto(
+      {
+        uri: 'file:///DCIM/clip.gifx',
+        mimeType: 'application/octet-stream',
+        fileName: 'clip.gifx',
+      },
+      'clip.gifx'
+    );
+    fireEvent.press(screen.getByText('documents.upload.categories.contract'));
+    fireEvent.press(screen.getByText('documents.upload.submitButton'));
+
+    expect(mockManipulateAsync).not.toHaveBeenCalled();
     expect(screen.getByText('documents.upload.fileTypeNotAllowed')).toBeTruthy();
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });

--- a/frontend/apps/mobile/src/screens/documents/DocumentUploadScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentUploadScreen.tsx
@@ -28,10 +28,11 @@ import {
   View,
 } from 'react-native';
 import { getApiBaseUrl } from '../../config/api';
+import { transcodeToJpeg } from '../../utils/imageCompression';
 import { extractTenantId } from '../../utils/jwt';
 import { colors } from '../shared/screenStyles';
 
-// ─── Constants ────────────────────────────────────────────────────────────────
+// ─── Constants ────────────────────────────────────────────────
 
 const ACCESS_TOKEN_KEY = 'ppt_access_token';
 
@@ -45,7 +46,7 @@ const ACCESS_TOKEN_KEY = 'ppt_access_token';
  * server's 422.
  *
  * These are a hand-maintained mirror of the Rust constants; the drift guard in
- * `DocumentUploadScreen.parity.test.tsx` parses those Rust sources and fails CI
+ * `DocumentUploadScreen.parity.test.ts` parses those Rust sources and fails CI
  * if either list diverges (GitHub #2368), so a backend *widening* can't be
  * silently rejected here.
  */
@@ -84,7 +85,7 @@ const DOCUMENT_CATEGORIES = [
 ] as const;
 type DocumentCategory = (typeof DOCUMENT_CATEGORIES)[number];
 
-// ─── Types ────────────────────────────────────────────────────────────────────
+// ─── Types ───────────────────────────────────────────────────
 
 interface PickedFile {
   uri: string;
@@ -106,7 +107,7 @@ interface DocumentUploadScreenProps {
   onCancel?: () => void;
 }
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
+// ─── Helpers ───────────────────────────────────────────────
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -202,7 +203,7 @@ export async function uploadDocumentMultipart(params: {
   return response.json() as Promise<{ id: string; message: string }>;
 }
 
-// ─── Component ────────────────────────────────────────────────────────────────
+// ─── Component ───────────────────────────────────────────────
 
 export function DocumentUploadScreen({ onSuccess, onCancel }: DocumentUploadScreenProps) {
   const { t } = useTranslation();
@@ -214,7 +215,7 @@ export function DocumentUploadScreen({ onSuccess, onCancel }: DocumentUploadScre
   const [isUploading, setIsUploading] = useState(false);
   const [errors, setErrors] = useState<UploadFormErrors>({});
 
-  // ── File picking ──────────────────────────────────────────────
+  // ── File picking ───────────────────────────────
 
   const pickDocument = useCallback(async () => {
     try {
@@ -259,17 +260,50 @@ export function DocumentUploadScreen({ onSuccess, onCancel }: DocumentUploadScre
       // The extension is lower-cased so a `.PNG`/`.HEIC` capture isn't
       // mislabelled `image/jpeg`. The resolved `mimeType` then flows through
       // the same `ALLOWED_MIME_TYPES` guard in `validate()` as the document
-      // picker, so a type the server would reject (e.g. HEIC) is caught here
-      // instead of after a full upload (GitHub #2368).
+      // picker, so a type the server would reject is caught here instead of
+      // after a full upload (GitHub #2368).
       const extension = (
         asset.fileName?.split('.').pop() ??
         asset.uri.split('.').pop() ??
         'jpg'
       ).toLowerCase();
-      const mimeType = asset.mimeType ?? (extension === 'png' ? 'image/png' : 'image/jpeg');
-      const fileName = asset.fileName ?? `photo_${Date.now()}.${extension}`;
+      // Extension → MIME fallback for when the picker reports none. HEIC/HEIF are
+      // mapped honestly (NOT defaulted to image/jpeg) so a MIME-less iOS capture
+      // still routes through the transcode branch below instead of being uploaded
+      // as HEIF bytes mislabelled image/jpeg (GitHub #2400 / the #2383 corruption).
+      const extensionMime: Record<string, string> = {
+        png: 'image/png',
+        heic: 'image/heic',
+        heif: 'image/heif',
+      };
+      let mimeType = asset.mimeType ?? extensionMime[extension] ?? 'image/jpeg';
+      let fileName = asset.fileName ?? `photo_${Date.now()}.${extension}`;
+      let uri = asset.uri;
+
+      // iOS captures default to HEIC/HEIF, which the backend allow-list rejects —
+      // leaving the photo picker a dead-end for the most common iPhone format. The
+      // sibling faults flow (`ReportFaultScreen`) already re-encodes picked images
+      // to JPEG, so mirror that here: transcode HEIC/HEIF to JPEG before the
+      // allow-list guard instead of hard-rejecting it (GitHub #2400). Genuinely
+      // non-image types still fall through to the reject path in `validate()`.
+      const isHeic =
+        mimeType === 'image/heic' ||
+        mimeType === 'image/heif' ||
+        extension === 'heic' ||
+        extension === 'heif';
+      if (isHeic && !ALLOWED_MIME_TYPES.includes(mimeType)) {
+        try {
+          uri = await transcodeToJpeg(asset.uri);
+          mimeType = 'image/jpeg';
+          fileName = `${fileName.replace(/\.[^/.]+$/, '')}.jpg`;
+        } catch {
+          // Transcode failed — keep the original HEIC so `validate()` rejects it
+          // with `fileTypeNotAllowed` rather than uploading a mislabelled file.
+        }
+      }
+
       setPickedFile({
-        uri: asset.uri,
+        uri,
         name: fileName,
         mimeType,
         size: asset.fileSize ?? 0,
@@ -281,7 +315,7 @@ export function DocumentUploadScreen({ onSuccess, onCancel }: DocumentUploadScre
     }
   }, [title, t]);
 
-  // ── Validation ────────────────────────────────────────────────
+  // ── Validation ───────────────────────────────
 
   const validate = (): boolean => {
     const next: UploadFormErrors = {};
@@ -306,7 +340,7 @@ export function DocumentUploadScreen({ onSuccess, onCancel }: DocumentUploadScre
     return Object.keys(next).length === 0;
   };
 
-  // ── Submit ────────────────────────────────────────────────────
+  // ── Submit ───────────────────────────────────
 
   const handleSubmit = async () => {
     if (!validate() || !pickedFile || !category) return;
@@ -336,7 +370,7 @@ export function DocumentUploadScreen({ onSuccess, onCancel }: DocumentUploadScre
     }
   };
 
-  // ── Render ────────────────────────────────────────────────────
+  // ── Render ───────────────────────────────────
 
   return (
     <KeyboardAvoidingView
@@ -474,7 +508,7 @@ export function DocumentUploadScreen({ onSuccess, onCancel }: DocumentUploadScre
   );
 }
 
-// ─── Helper: file icon by MIME ─────────────────────────────────────────────────
+// ─── Helper: file icon by MIME ──────────────────────────────────
 
 export function getFileIcon(mimeType: string): string {
   if (mimeType.includes('pdf')) return '📄';
@@ -484,7 +518,7 @@ export function getFileIcon(mimeType: string): string {
   return '📎';
 }
 
-// ─── Styles ───────────────────────────────────────────────────────────────────
+// ─── Styles ─────────────────────────────────────────────────
 
 const styles = StyleSheet.create({
   container: {

--- a/frontend/apps/mobile/src/utils/imageCompression.test.ts
+++ b/frontend/apps/mobile/src/utils/imageCompression.test.ts
@@ -17,7 +17,12 @@ jest.mock('expo-image-manipulator', () => ({
   SaveFormat: { JPEG: 'jpeg', PNG: 'png', WEBP: 'webp' },
 }));
 
-import { bytesToMb, compressImagesIfNeeded, MAX_TOTAL_BYTES } from './imageCompression';
+import {
+  bytesToMb,
+  compressImagesIfNeeded,
+  MAX_TOTAL_BYTES,
+  transcodeToJpeg,
+} from './imageCompression';
 
 const MB = 1024 * 1024;
 
@@ -151,6 +156,30 @@ describe('compressImagesIfNeeded', () => {
 
     expect(result.compressed).toBe(true);
     expect(result.stillOverLimit).toBe(false);
+  });
+});
+
+describe('transcodeToJpeg (GitHub #2400)', () => {
+  it('re-encodes to JPEG with a format-only pass (no resize) and returns the new uri', async () => {
+    mockManipulateAsync.mockResolvedValue({
+      uri: 'file:///cache/out.jpg',
+      width: 4032,
+      height: 3024,
+    });
+
+    const uri = await transcodeToJpeg('file:///DCIM/IMG_0001.HEIC');
+
+    expect(uri).toBe('file:///cache/out.jpg');
+    // Format-only normalize pass — no resize op, unlike compressImagesIfNeeded.
+    expect(mockManipulateAsync).toHaveBeenCalledWith('file:///DCIM/IMG_0001.HEIC', [], {
+      format: 'jpeg',
+    });
+  });
+
+  it('propagates the manipulator error so the caller can keep its reject backstop', async () => {
+    mockManipulateAsync.mockRejectedValue(new Error('decode failed'));
+
+    await expect(transcodeToJpeg('file:///DCIM/broken.HEIC')).rejects.toThrow('decode failed');
   });
 });
 

--- a/frontend/apps/mobile/src/utils/imageCompression.ts
+++ b/frontend/apps/mobile/src/utils/imageCompression.ts
@@ -115,6 +115,27 @@ export function bytesToMb(bytes: number): string {
 }
 
 /**
+ * Re-encode a single image to JPEG, unconditionally.
+ *
+ * Unlike {@link compressImagesIfNeeded} (which only re-encodes a selection that
+ * blows past the 10 MB limit), this always runs a format-normalizing pass. It
+ * exists for the document-upload photo picker, where an iOS HEIC/HEIF capture —
+ * the default iPhone camera format — is absent from the backend allow-list and
+ * would be hard-rejected client-side with no upload path at all. Transcoding to
+ * JPEG (the same `SaveFormat.JPEG` recipe `ReportFaultScreen` already uses via
+ * {@link compressImagesIfNeeded}) turns that iOS dead-end into a successful
+ * upload (GitHub #2400).
+ *
+ * Resolves to the transcoded file's uri. Rejects if the manipulator pass fails,
+ * so the caller can keep the original reject path as the backstop rather than
+ * mislabelling an unconvertible file as JPEG.
+ */
+export async function transcodeToJpeg(uri: string): Promise<string> {
+  const result = await manipulateAsync(uri, [], { format: SaveFormat.JPEG });
+  return result.uri;
+}
+
+/**
  * Compress `uris` only when their combined size exceeds the limit.
  *
  * When under the limit the originals are returned untouched (`compressed:


### PR DESCRIPTION
## Task
Follow-up to PR #2383: `DocumentUploadScreen.pickPhoto` hard-rejects an iOS HEIC capture (the default iPhone camera format) client-side with `fileTypeNotAllowed`, leaving the document-upload photo picker a dead-end since HEIC is absent from the backend allow-list. The sibling faults flow (`ReportFaultScreen`) already re-encodes picked images to JPEG. Mirror that behavior so HEIC/HEIF uploads succeed. Also fix the stale in-code pointer `DocumentUploadScreen.parity.test.tsx` → `.ts`. Closes #2400.

## Owner
pm-tech-lead (react-native specialist per the issue)

## Changes
- **`src/utils/imageCompression.ts`** — add `transcodeToJpeg(uri)`: an unconditional format-only `manipulateAsync(uri, [], { format: SaveFormat.JPEG })` pass. Distinct from `compressImagesIfNeeded`, which only re-encodes when a selection blows past the 10 MB limit; this always normalizes format. Rejects on manipulator failure so the caller keeps its reject backstop.
- **`src/screens/documents/DocumentUploadScreen.tsx`** — in `pickPhoto`, when the resolved MIME is HEIC/HEIF and not in `ALLOWED_MIME_TYPES`, transcode to JPEG before the allow-list guard, then set `mimeType: 'image/jpeg'`, the transcoded uri, and a `.jpg` filename. On transcode failure, fall through to the original reject path (no mislabelled upload). Genuinely non-image types are untouched.
- Also hardened the extension→MIME fallback: a MIME-less `.heic`/`.heif` pick now maps to `image/heic`/`image/heif` (not the old `image/jpeg` default), so it routes through the transcode instead of being uploaded as HEIF bytes mislabelled `image/jpeg` — the exact corruption #2383 fixed for the reported-MIME path.
- Fixed the stale comment pointer `.parity.test.tsx` → `.parity.test.ts`.

## Tested (Band A — fast check)
Run against the exact pushed branch content (fetched `origin/auto-impl/gh-issue-2400-7f8aea4f`, checked out, verified):
- `pnpm -F mobile typecheck` → exit 0
- `pnpm exec biome check <4 changed files>` → exit 0 (no fixes)
- `pnpm -F mobile test -- DocumentUploadScreen imageCompression` → exit 0 (**41 passed, 3 suites**), including the parity drift-guard suite

New/updated tests:
- `imageCompression.test.ts`: `transcodeToJpeg` re-encodes format-only (no resize) and returns the new uri; propagates manipulator errors.
- `DocumentUploadScreen.test.tsx` `pickPhoto()`: HEIC (reported MIME) transcodes + uploads; HEIF (extension-only) transcodes + uploads; transcode-failure falls back to reject; genuine non-image type never transcodes; existing allowed-photo / `.PNG`-fallback cases retained.

## Built (Band B — full build)
Skipped: change < 50 LOC of substantive product code, no public API / config surface. Metro/Expo bundling needs a device the routine can't provide (per react-native specialist guidance).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change; client-side media handling only).

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` reported the 4 changed paths as outside the owner area (exit 2). This is a benign owner-hint mismatch: the task is react-native work and all four paths are exactly the files issue #2400 names (`DocumentUploadScreen.tsx`, `imageCompression.ts`, and their tests). No unrelated files touched.

## Code-reuse review
`reuse-grep.sh --specialist react-native` → clean (no duplicated helper warnings). The new `transcodeToJpeg` intentionally lives alongside `compressImagesIfNeeded` in the same module and reuses the shared `manipulateAsync`/`SaveFormat` import.

## Notes
- `transcodeToJpeg` keeps `asset.fileSize` (the original HEIC size) as an approximation for the client-side size guard after transcode; the server 422 remains the backstop, matching the existing size-guard tolerance for unknown sizes.
- The MIME-less HEIF hardening is a small in-scope extension beyond the issue's literal ask, closing the same corruption class for the no-picker-MIME path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe)_