### PR TITLE
gh-issue-2399: purge persisted AsyncStorage caches on mobile session change

### DIFF
--- a/frontend/apps/mobile/src/contexts/AuthContext.tsx
+++ b/frontend/apps/mobile/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 import type { ReactNode } from 'react';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { resetLocalData } from '../services/resetLocalData';
 
 // Token storage keys
 const ACCESS_TOKEN_KEY = 'ppt_access_token';
@@ -149,6 +150,12 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
         // follows a session which wasn't explicitly logged out, TanStack Query
         // would serve user A's data to user B until a background refetch (or
         // never, if offline). Clear the whole cache to mirror logout().
+        //
+        // queryClient.clear() only wipes the in-memory cache; the AsyncStorage
+        // caches (offline queue/responses, home-screen widget data) outlive the
+        // process, so purge those first or a prior org's data survives the
+        // login (issue #2399, follow-up to #2361).
+        await resetLocalData();
         queryClient.clear();
 
         setState((prev) => ({
@@ -179,6 +186,12 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
       // its consumers kept serving the previous org's tenant id until an app
       // restart — producing persistent cross-tenant 403s / wrong cache keys.
       // Clearing everything also ensures no other org's data survives logout.
+      //
+      // Purge the AsyncStorage-backed caches too (offline queue/responses,
+      // widget data) — they persist across restarts, so clearing only the
+      // in-memory query cache would leave a prior org's data (and a prior
+      // user's queued writes) behind (issue #2399, follow-up to #2361).
+      await resetLocalData();
       queryClient.clear();
 
       setState((prev) => ({
@@ -275,6 +288,11 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
       });
 
       if (result.success) {
+        // Biometric unlock restores the SAME stored user's session, so unlike
+        // login()/logout() it deliberately does NOT call resetLocalData() /
+        // queryClient.clear() — the existing cache still belongs to this user
+        // and re-fetching it on every unlock would be wasteful and drop
+        // offline data (issue #2399).
         // Check if we have stored credentials
         const accessToken = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
         const userJson = await SecureStore.getItemAsync(USER_KEY);

--- a/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
+++ b/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
@@ -3,12 +3,13 @@ import NetInfo, { type NetInfoState } from '@react-native-community/netinfo';
 import * as SecureStore from 'expo-secure-store';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getApiBaseUrl } from '../config/api';
+import { CACHE_PREFIX, LAST_SYNC_KEY, QUEUE_KEY } from '../services/localCacheKeys';
 import { extractTenantId } from '../utils/jwt';
 
-// Storage keys
-const CACHE_PREFIX = 'ppt_cache_';
-const QUEUE_KEY = 'ppt_offline_queue';
-const LAST_SYNC_KEY = 'ppt_last_sync';
+// Storage keys. The AsyncStorage cache/queue namespaces live in
+// `services/localCacheKeys` (shared with `resetLocalData`, issue #2399). The
+// access token is a SecureStore key, not part of that purgeable namespace, so
+// it stays local here.
 const ACCESS_TOKEN_KEY = 'ppt_access_token';
 
 export interface CacheOptions {

--- a/frontend/apps/mobile/src/services/index.ts
+++ b/frontend/apps/mobile/src/services/index.ts
@@ -6,3 +6,11 @@ export {
 } from './backgroundNotifications';
 export type { Screen } from './deepLinkRouting';
 export { resolveDeepLinkTarget } from './deepLinkRouting';
+export {
+  CACHE_PREFIX,
+  LAST_SYNC_KEY,
+  QUEUE_KEY,
+  WIDGET_CONFIG_KEY,
+  WIDGET_DATA_KEY,
+} from './localCacheKeys';
+export { resetLocalData } from './resetLocalData';

--- a/frontend/apps/mobile/src/services/localCacheKeys.ts
+++ b/frontend/apps/mobile/src/services/localCacheKeys.ts
@@ -1,0 +1,22 @@
+/**
+ * Single source of truth for the AsyncStorage key namespaces that hold
+ * tenant-scoped local data (issue #2399).
+ *
+ * These caches persist across app restarts, so — unlike TanStack Query's
+ * in-memory cache — they must be purged explicitly whenever the session
+ * changes, or a prior org's data survives a login/logout (the exact
+ * cross-tenant stale-data exposure #2361 set out to close). `resetLocalData`
+ * consumes this list; `useOfflineSupport` and `WidgetDataProvider` own the
+ * reads/writes behind it, so keeping the keys here keeps all three in step.
+ */
+
+// `useOfflineSupport` — cached API responses (`ppt_cache_<key>`), the queued
+// offline mutation log, and the last-sync marker.
+export const CACHE_PREFIX = 'ppt_cache_';
+export const QUEUE_KEY = 'ppt_offline_queue';
+export const LAST_SYNC_KEY = 'ppt_last_sync';
+
+// `WidgetDataProvider` — per-building home-screen widget content and the
+// widget layout config (which references building ids, i.e. tenant data).
+export const WIDGET_CONFIG_KEY = '@ppt/widget_configs';
+export const WIDGET_DATA_KEY = '@ppt/widget_data';

--- a/frontend/apps/mobile/src/services/resetLocalData.test.ts
+++ b/frontend/apps/mobile/src/services/resetLocalData.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for `resetLocalData` (issue #2399).
+ *
+ * Uses an in-memory `@react-native-async-storage/async-storage` replacement so
+ * we can assert exactly which keys are purged and — just as importantly —
+ * which are left untouched.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { resetLocalData } from './resetLocalData';
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store = new Map<string, string>();
+  return {
+    __store: store,
+    getItem: jest.fn(async (k: string) => store.get(k) ?? null),
+    setItem: jest.fn(async (k: string, v: string) => {
+      store.set(k, v);
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      store.delete(k);
+    }),
+    getAllKeys: jest.fn(async () => Array.from(store.keys())),
+    removeMany: jest.fn(async (keys: string[]) => {
+      for (const k of keys) store.delete(k);
+    }),
+  };
+});
+
+const mockStore = (AsyncStorage as unknown as { __store: Map<string, string> }).__store;
+
+describe('resetLocalData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStore.clear();
+  });
+
+  it('purges offline cache, queue, sync marker and widget namespaces', async () => {
+    mockStore.set('ppt_cache_faults_list', '[]');
+    mockStore.set('ppt_cache_buildings', '[]');
+    mockStore.set('ppt_offline_queue', '[]');
+    mockStore.set('ppt_last_sync', '111');
+    mockStore.set('@ppt/widget_data', '{}');
+    mockStore.set('@ppt/widget_configs', '[]');
+    // Keys outside the tenant-cache namespace must survive. `ppt_access_token`
+    // starts with `ppt_` but not `ppt_cache_`, so prefix scoping must not
+    // over-match it.
+    mockStore.set('ppt_access_token', 'tok');
+    mockStore.set('some_other_key', 'x');
+
+    await resetLocalData();
+
+    expect(Array.from(mockStore.keys()).sort()).toEqual(['ppt_access_token', 'some_other_key']);
+  });
+
+  it('does not call removeMany when nothing matches', async () => {
+    mockStore.set('unrelated', '1');
+
+    await resetLocalData();
+
+    expect(AsyncStorage.removeMany).not.toHaveBeenCalled();
+    expect(mockStore.has('unrelated')).toBe(true);
+  });
+
+  it('swallows storage errors so it can never wedge login/logout', async () => {
+    (AsyncStorage.getAllKeys as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+
+    await expect(resetLocalData()).resolves.toBeUndefined();
+  });
+});

--- a/frontend/apps/mobile/src/services/resetLocalData.ts
+++ b/frontend/apps/mobile/src/services/resetLocalData.ts
@@ -1,0 +1,56 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  CACHE_PREFIX,
+  LAST_SYNC_KEY,
+  QUEUE_KEY,
+  WIDGET_CONFIG_KEY,
+  WIDGET_DATA_KEY,
+} from './localCacheKeys';
+
+/**
+ * Purge every AsyncStorage namespace that holds tenant-scoped local data
+ * (issue #2399, follow-up to #2361).
+ *
+ * `AuthContext.login`/`logout` already call `queryClient.clear()`, but that
+ * only wipes TanStack Query's **in-memory** cache. The two AsyncStorage-backed
+ * caches below outlive the process, so without this a prior org's data survives
+ * a login/logout and even an app restart:
+ *   - `ppt_cache_*` + `ppt_offline_queue` + `ppt_last_sync` (`useOfflineSupport`)
+ *   - `@ppt/widget_data` + `@ppt/widget_configs` (`WidgetDataProvider`)
+ *
+ * Server RLS still prevents an actual data breach on refetch, so the exposure
+ * this closes is stale-display + queued-write misattribution (a prior user's
+ * queued fault/meter writes replaying under the next user's token), not a
+ * server leak.
+ *
+ * Call it right where the query cache is cleared on a session change:
+ *   `await resetLocalData(); queryClient.clear();`
+ *
+ * Deliberately NOT called on biometric unlock — that restores the *same*
+ * stored user's session, so its cache is still valid and should be kept.
+ *
+ * Best-effort: storage failures are logged and swallowed so a purge hiccup can
+ * never wedge login/logout.
+ */
+export async function resetLocalData(): Promise<void> {
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const toRemove = keys.filter(
+      (key) =>
+        key.startsWith(CACHE_PREFIX) ||
+        key === QUEUE_KEY ||
+        key === LAST_SYNC_KEY ||
+        key === WIDGET_DATA_KEY ||
+        key === WIDGET_CONFIG_KEY
+    );
+
+    if (toRemove.length > 0) {
+      // `removeMany` is this project's async-storage v3 batch-delete (see the
+      // scoped-storage type stub in `types/expo-modules.d.ts`, matching
+      // `useOfflineSupport.clearCache`).
+      await AsyncStorage.removeMany(toRemove);
+    }
+  } catch (error) {
+    console.error('Failed to reset local data:', error);
+  }
+}

--- a/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
+++ b/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
@@ -18,12 +18,36 @@
  * payload contract.
  */
 
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react-native';
 import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 import type { ReactNode } from 'react';
 import { AuthProvider, useAuth } from '../../contexts/AuthContext';
+
+// AuthProvider now purges the AsyncStorage-backed tenant caches on
+// login/logout (issue #2399), so swap the shared jest stub for a real
+// in-memory store we can seed and assert against.
+jest.mock('@react-native-async-storage/async-storage', () => {
+  const store = new Map<string, string>();
+  return {
+    __store: store,
+    getItem: jest.fn(async (k: string) => store.get(k) ?? null),
+    setItem: jest.fn(async (k: string, v: string) => {
+      store.set(k, v);
+    }),
+    removeItem: jest.fn(async (k: string) => {
+      store.delete(k);
+    }),
+    getAllKeys: jest.fn(async () => Array.from(store.keys())),
+    removeMany: jest.fn(async (keys: string[]) => {
+      for (const k of keys) store.delete(k);
+    }),
+  };
+});
+
+const asyncStore = (AsyncStorage as unknown as { __store: Map<string, string> }).__store;
 
 const API_BASE = 'http://test.local';
 
@@ -89,6 +113,7 @@ function mockFetchOnce(body: unknown, status = 200) {
 describe('AuthContext integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    asyncStore.clear();
     queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     globalThis.fetch = jest.fn() as jest.Mock;
     primeSecureStore();
@@ -292,6 +317,74 @@ describe('AuthContext integration', () => {
     });
   });
 
+  describe('cross-user session reset (issue #2399)', () => {
+    // Seed the persisted, tenant-scoped AsyncStorage namespaces the way a live
+    // session would (offline responses/queue + home-screen widget data).
+    function seedPersistedTenantCaches(tag: string) {
+      asyncStore.set('ppt_cache_faults_list', JSON.stringify([{ id: `f-${tag}` }]));
+      asyncStore.set('ppt_offline_queue', JSON.stringify([{ id: `q-${tag}` }]));
+      asyncStore.set('ppt_last_sync', '111');
+      asyncStore.set('@ppt/widget_data', JSON.stringify({ w1: { data: {} } }));
+      asyncStore.set('@ppt/widget_configs', JSON.stringify([{ id: 'w1', buildingId: `b-${tag}` }]));
+    }
+
+    const persistedKeys = [
+      'ppt_cache_faults_list',
+      'ppt_offline_queue',
+      'ppt_last_sync',
+      '@ppt/widget_data',
+      '@ppt/widget_configs',
+    ];
+
+    it('purges in-memory AND persisted caches across login A -> logout -> login B', async () => {
+      const store = primeSecureStore();
+
+      // --- login as user A ---
+      mockFetchOnce({ access_token: 'a-access', refresh_token: 'a-refresh', user: sampleUser });
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      await act(async () => {
+        await result.current.login('jane@example.com', 'pw');
+      });
+
+      // Populate A's in-memory + persisted caches during the session.
+      queryClient.setQueryData(['buildings', 'list'], [{ id: 'b-A' }]);
+      seedPersistedTenantCaches('A');
+
+      // --- logout ---
+      await act(async () => {
+        await result.current.logout();
+      });
+
+      // Both cache layers are wiped by logout.
+      expect(queryClient.getQueryData(['buildings', 'list'])).toBeUndefined();
+      for (const key of persistedKeys) {
+        expect(asyncStore.has(key)).toBe(false);
+      }
+
+      // Belt-and-braces: even if data leaks back in before the next login (or
+      // the previous session was never explicitly logged out), login must purge.
+      queryClient.setQueryData(['documents', 'list'], [{ id: 'doc-A' }]);
+      seedPersistedTenantCaches('A2');
+
+      // --- login as a DIFFERENT user B ---
+      const userB = { ...sampleUser, id: 'u-2', email: 'bob@example.com' };
+      mockFetchOnce({ access_token: 'b-access', refresh_token: 'b-refresh', user: userB });
+      await act(async () => {
+        await result.current.login('bob@example.com', 'pw');
+      });
+
+      // B sees no trace of A in either layer.
+      expect(result.current.user).toEqual(userB);
+      expect(queryClient.getQueryData(['documents', 'list'])).toBeUndefined();
+      for (const key of persistedKeys) {
+        expect(asyncStore.has(key)).toBe(false);
+      }
+      // B's own freshly-issued token is persisted.
+      expect(store.get('ppt_access_token')).toBe('b-access');
+    });
+  });
+
   describe('refreshToken', () => {
     it('exchanges the stored refresh token for a new access token', async () => {
       const store = primeSecureStore({
@@ -456,6 +549,29 @@ describe('AuthContext integration', () => {
       expect(ok).toBe(true);
       expect(result.current.isAuthenticated).toBe(true);
       expect(result.current.user).toEqual(sampleUser);
+    });
+
+    it('authenticateWithBiometric deliberately preserves persisted caches (issue #2399)', async () => {
+      primeSecureStore({
+        ppt_access_token: 'stored',
+        ppt_user: JSON.stringify(sampleUser),
+        ppt_biometric_enabled: 'true',
+      });
+      mockedLocalAuth.authenticateAsync.mockResolvedValue({ success: true });
+      // A persisted cache entry belonging to the SAME stored user.
+      asyncStore.set('ppt_cache_faults_list', JSON.stringify([{ id: 'f-1' }]));
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+      await act(async () => {
+        await result.current.authenticateWithBiometric();
+      });
+
+      // Biometric unlock restores the same session, so — unlike login/logout —
+      // it must NOT purge the cache (resetLocalData is intentionally not called).
+      expect(result.current.isAuthenticated).toBe(true);
+      expect(asyncStore.has('ppt_cache_faults_list')).toBe(true);
     });
 
     it('authenticateWithBiometric is a no-op when biometric is not enabled', async () => {

--- a/frontend/apps/mobile/src/test/setup.ts
+++ b/frontend/apps/mobile/src/test/setup.ts
@@ -71,6 +71,11 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(),
   setItem: jest.fn(),
   removeItem: jest.fn(),
+  // `getAllKeys` defaults to an empty list and `removeMany` to a no-op so
+  // `resetLocalData` (called from AuthContext login/logout, issue #2399) is a
+  // harmless no-op in suites that don't drive persisted-cache behavior.
+  getAllKeys: jest.fn(async () => []),
+  removeMany: jest.fn(async () => {}),
   clear: jest.fn(),
 }));
 

--- a/frontend/apps/mobile/src/widgets/WidgetDataProvider.ts
+++ b/frontend/apps/mobile/src/widgets/WidgetDataProvider.ts
@@ -5,6 +5,7 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
+import { WIDGET_CONFIG_KEY, WIDGET_DATA_KEY } from '../services/localCacheKeys';
 import type {
   ActiveFaultsWidgetData,
   AnnouncementWidgetData,
@@ -16,9 +17,6 @@ import type {
   WidgetData,
   WidgetType,
 } from './types';
-
-const WIDGET_CONFIG_KEY = '@ppt/widget_configs';
-const WIDGET_DATA_KEY = '@ppt/widget_data';
 
 /**
  * Provides data for home screen widgets.


### PR DESCRIPTION
## Task
Follow-up: mobile login/logout clears only the in-memory query cache — AsyncStorage-persisted caches survive cross-tenant + app restart (Closes #2399).

`AuthContext` login/logout only called `queryClient.clear()` (in-memory TanStack cache). Two AsyncStorage-backed caches outlive the process and were never purged: `useOfflineSupport` (`ppt_cache_*`, `ppt_offline_queue`, `ppt_last_sync`) and `WidgetDataProvider` (`@ppt/widget_data`, `@ppt/widget_configs`). So the cross-tenant stale-data exposure #2361 set out to close still survived a login/logout and even an app restart (stale widget display + a prior user's queued fault/meter writes replaying under the next user's token). Server RLS still blocks a real server leak, hence medium.

## Fix
- New `services/localCacheKeys.ts` — single source of truth for the tenant-scoped AsyncStorage key namespaces (consumed by `useOfflineSupport` and `WidgetDataProvider`, which now import from it instead of redeclaring the keys).
- New `services/resetLocalData.ts` — purges every `ppt_cache_*` key plus `ppt_offline_queue`, `ppt_last_sync`, `@ppt/widget_data`, `@ppt/widget_configs`. Best-effort (errors logged + swallowed so it can't wedge auth).
- `AuthContext.login()` and `logout()` now `await resetLocalData()` right before `queryClient.clear()`.
- `authenticateWithBiometric()` deliberately does NOT purge — it restores the same stored user's session, so its cache is still valid (documented inline).

## Owner
pm-tech-lead hint (react-native specialist per the issue).

## Tested (Band A — fast check)
- `pnpm -F mobile typecheck` (tsc --noEmit) — exit 0
- `biome check` on all 9 changed files — exit 0 (no fixes)
- `npx jest` (full mobile suite) — 46 suites, 570 tests, all pass (includes new `resetLocalData.test.ts` unit test + the auth integration `login A -> logout -> login B` cross-layer case + biometric-preserves-cache case)

## Built (Band B — full build)
No `build` script exists for the mobile app (only `expo start` / EAS native builds, which need the Android/iOS SDK + EAS credentials + network and are not runnable in this sandbox). The change is pure TypeScript logic touching no native/config/build-output surface, so Band B is covered substantively by the full `tsc --noEmit` typecheck (whole type graph) + the full 570-test jest suite — both green.

## CI parity (Band C — hot-path only)
Skipped: client-side cache-purge, not a server-side security/auth/billing/data-integrity change. Server RLS already prevents any cross-tenant server leak; the fix closes stale-display + queued-write misattribution.

## Remote-tested
Skipped (no ppt-bridge MCP session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports exit 2 (all 9 files flagged) — but this is a role-hint artifact, NOT real out-of-area work: `pm-tech-lead` maps only to `docs/**`, `.research/**`, `_bmad-output/**` in `owner-areas.json`, whereas the actual specialist for this task is `react-native` (owner area `frontend/apps/mobile/**`). Every changed file is under `frontend/apps/mobile/src/` — exactly the react-native/mobile area. No files outside the mobile app were touched.

## Code-reuse review
`reuse-grep.sh --specialist react-native` — no warnings. The change deliberately centralizes the storage-key constants (previously duplicated string literals in `useOfflineSupport.ts` and `WidgetDataProvider.ts`) into one `localCacheKeys.ts` module rather than adding a third copy. Uses this project's async-storage v3 `removeMany` batch API (per `types/expo-modules.d.ts`), matching existing `useOfflineSupport.clearCache`.

## Notes
- goal-check.sh (the plan-based ppt-research-flow IG gate) reports IG1/IG2 fail because this is a gh-issue task (no `.research/plan`, branch name is the dispatcher-mandated `auto-impl/...`), and IG3 flags the single `fix:` commit — but the push path (`push_files`) collapses to one commit regardless, and the added tests ARE a genuine regression test (they fail on `dev`: before this fix, logout/login did not purge the persisted caches, so the new `expect(asyncStore.has('ppt_cache_faults_list')).toBe(false)` assertions fail). The binding verify gate (Band A) is green.
- Pre-existing observation (left untouched, out of scope): `useOfflineSupport.clearCache` uses `AsyncStorage.removeMany`, consistent with this repo's async-storage v3 type stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQiessYet3dFBsYw3EHBhe)_