### PR TITLE
gh-issue-2406: validate IdSchema at screen-map init write boundary

### DIFF
--- a/frontend/packages/screen-map/src/init-write.ts
+++ b/frontend/packages/screen-map/src/init-write.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { CandidateScreen } from './scan.js';
+import { ScreenMapFrontmatterSchema } from './schema.js';
 import type { Platform, Product, ScreenMapFrontmatter } from './types.js';
 import { writeScreenMapString } from './write.js';
 
@@ -43,9 +44,26 @@ export async function bulkWriteScreenMaps(
         continue;
       }
     }
+    const frontmatter = buildFrontmatter(concept);
+    // Final serialization boundary: ids can be mutated after `scanCandidates`
+    // by interactive grouping (rename/merge in grouping.ts) with no re-check,
+    // so the scan-side IdSchema guard is not the sole line of defense. Validate
+    // the full frontmatter here — this covers the id kebab-case regex AND the
+    // product-prefix `superRefine` — so a grouping-supplied id like
+    // `ppt/Foo Bar`, `ppt/UPPER`, or a product-mismatched `reality/x` can never
+    // write a screen-map that immediately fails `screens validate` (see #2406,
+    // follow-up to #2367/#2380).
+    const parsed = ScreenMapFrontmatterSchema.safeParse(frontmatter);
+    if (!parsed.success) {
+      throw new Error(
+        `invalid screen-map frontmatter for "${concept.id}": ${parsed.error.issues
+          .map((i) => `${i.path.join('.')}: ${i.message}`)
+          .join('; ')}`
+      );
+    }
     const screen = {
       filePath: file,
-      frontmatter: buildFrontmatter(concept),
+      frontmatter,
       body: buildBody(concept),
     };
     const serialized = writeScreenMapString(screen);

--- a/frontend/packages/screen-map/tests/init-write.test.ts
+++ b/frontend/packages/screen-map/tests/init-write.test.ts
@@ -78,6 +78,31 @@ describe('bulkWriteScreenMaps', () => {
     expect(result.skipped).toHaveLength(0);
   });
 
+  it('rejects a grouping-mutated invalid id at the write boundary (no file written)', async () => {
+    // Interactive grouping (grouping.ts rename/merge) can set an arbitrary
+    // user-supplied id after `scanCandidates` runs its IdSchema guard, so the
+    // write boundary must re-validate. These ids all have a non-empty slug —
+    // they pass the pre-existing `no slug` check — but fail IdSchema / the
+    // product-prefix superRefine, and must never be written (#2406).
+    const cases: CandidateScreen[] = [
+      // whitespace + uppercase in slug (rename to "Foo Bar")
+      { id: 'ppt/Foo Bar', name: 'Foo Bar', product: 'ppt', source: 'user' },
+      // uppercase slug
+      { id: 'ppt/UPPER', name: 'Upper', product: 'ppt', source: 'user' },
+      // product-prefix mismatch: id says reality, product says ppt
+      { id: 'reality/x', name: 'X', product: 'ppt', source: 'user' },
+    ];
+    for (const c of cases) {
+      await expect(bulkWriteScreenMaps([c], tmpRoot)).rejects.toThrow(
+        /invalid screen-map frontmatter/
+      );
+      // The guard must throw before writeFile — nothing lands on disk.
+      const slug = c.id.split('/')[1];
+      const leaked = path.join(tmpRoot, c.product, `${slug}.md`);
+      await expect(readFile(leaked, 'utf8')).rejects.toThrow();
+    }
+  });
+
   it('preserves user-edited screen-maps even when force=true', async () => {
     const c: CandidateScreen[] = [{ id: 'ppt/foo', name: 'Foo', product: 'ppt', source: 'user' }];
     await bulkWriteScreenMaps(c, tmpRoot);


### PR DESCRIPTION
## Task
Follow-up: screen-map init write boundary doesn't validate ids against IdSchema, so grouping rename/merge ids still slip through (PR #2380). Move/duplicate the IdSchema validation to the real serialization boundary in `frontend/packages/screen-map` `init-write.ts` so grouping-mutated ids (`grouping.ts` merge/rename) can't write invalid screen-maps. Closes #2406.

## Approach
`bulkWriteScreenMaps` previously guarded only against an empty slug (`init-write.ts:26-29`). Ids mutated after `scanCandidates` by interactive grouping (`grouping.ts` `rename` sets `target.id = decision.to`; `merge` sets `id: decision.into`) are user-supplied and never re-validated, so a rename/merge to `ppt/Foo Bar`, `ppt/UPPER`, or a product-mismatched `reality/x` (all with a non-empty slug) wrote a screen-map that immediately failed `screens validate` — the #2367 class re-entering via grouping.

Fix: build the frontmatter, then `ScreenMapFrontmatterSchema.safeParse(fm)` before serialize (`init-write.ts:47-63`). This single guard covers the id kebab-case regex (`IdSchema`) **and** the product-prefix `superRefine`, and covers both `scanCandidates` output and grouping-mutated ids — the scan-side loop becomes belt-and-suspenders. On failure it throws a clear per-issue message before `writeFile`, so no invalid file lands on disk.

## Owner
pm-tech-lead

## Tested (Band A — fast check)
- `pnpm -F @ppt/screen-map exec vitest run tests/init-write.test.ts` → exit 0 (5 passed)
- `pnpm -F @ppt/screen-map exec vitest run` (full suite) → exit 0 (18 files, 82 passed, 1 skipped)
- `pnpm -F @ppt/screen-map typecheck` (tsc --noEmit) → exit 0
- `npx @biomejs/biome check <changed files>` → exit 0 (no fixes)

## IG3 — regression proof
New test `rejects a grouping-mutated invalid id at the write boundary (no file written)` drives `ppt/Foo Bar`, `ppt/UPPER`, and product-mismatched `reality/x` through `bulkWriteScreenMaps`, asserting it rejects and writes nothing. Verified it **fails on `dev`** (src fix stashed → 1 failed) and **passes with the fix** (5 passed).

## Built (Band B — full build)
skipped: change <50 LOC (44 lines across 2 files), no public API/config/migration touch. Package typecheck + full unit suite green.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (dev-tooling for screen-map authoring; no security/auth/billing/data-integrity change).

## Scope drift
None — `scope-check.sh --owner pm-tech-lead` exit 0. Only `frontend/packages/screen-map/{src,tests}/init-write*` touched.

## Code-reuse review
none — reuses the existing `ScreenMapFrontmatterSchema` / `IdSchema` from `schema.ts`; no new helper introduced.

## Notes
- The finding's low-severity test suggestion (b) is satisfied: the new test drives pre-built invalid ids (bypassing `slugifyName`) straight through the write guard, which the scan-side test could not exercise.
- `push_files` collapsed the local `test:`/`fix:` commit pair into one commit; the test-fails-on-dev evidence is captured above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ur6ffnwStGLizR3fwKXdM

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ur6ffnwStGLizR3fwKXdM)_