### PR TITLE
gh-issue-2405: delete orphaned `packages` i18n namespace from cs/de/hu/pl/sk

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -622,19 +622,6 @@
     "draftMinutesAgo": "před {{count}}m",
     "draftRestored": "Obnovili jsme váš uložený návrh."
   },
-  "packages": {
-    "title": "Správa zásilek",
-    "subtitle": "Sledování a správa zásilek v budově",
-    "loading": "Načítají se zásilky...",
-    "loadError": "Nepodařilo se načíst zásilky",
-    "registerPackage": "Zaregistrovat zásilku",
-    "filterAll": "Vše",
-    "filterPickedUp": "Vyzvednuté",
-    "noPackages": "Žádné zásilky",
-    "noPackagesFound": "Zásilky nebyly nalezeny",
-    "receiveError": "Nepodařilo se označit zásilku jako přijatou.",
-    "pickupError": "Nepodařilo se označit zásilku jako vyzvednutou."
-  },
   "financial": {
     "title": "Finance",
     "invoices": "Faktury",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -575,19 +575,6 @@
     "draftMinutesAgo": "vor {{count}}m",
     "draftRestored": "Ihr gespeicherter Entwurf wurde wiederhergestellt."
   },
-  "packages": {
-    "title": "Paketverwaltung",
-    "subtitle": "Pakete im Gebäude verfolgen und verwalten",
-    "loading": "Pakete werden geladen...",
-    "loadError": "Pakete konnten nicht geladen werden",
-    "registerPackage": "Paket registrieren",
-    "filterAll": "Alle",
-    "filterPickedUp": "Abgeholt",
-    "noPackages": "Keine Pakete",
-    "noPackagesFound": "Keine Pakete gefunden",
-    "receiveError": "Paket konnte nicht als empfangen markiert werden.",
-    "pickupError": "Paket konnte nicht als abgeholt markiert werden."
-  },
   "financial": {
     "title": "Finanzen",
     "invoices": "Rechnungen",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -575,19 +575,6 @@
     "draftMinutesAgo": "{{count}} perce",
     "draftRestored": "A mentett piszkozatot visszaállítottuk."
   },
-  "packages": {
-    "title": "Csomagkezelés",
-    "subtitle": "Épület csomagjainak nyomon követése és kezelése",
-    "loading": "Csomagok betöltése...",
-    "loadError": "Nem sikerült betölteni a csomagokat",
-    "registerPackage": "Csomag regisztrálása",
-    "filterAll": "Összes",
-    "filterPickedUp": "Átvett",
-    "noPackages": "Nincsenek csomagok",
-    "noPackagesFound": "Nem találhatók csomagok",
-    "receiveError": "Nem sikerült a csomagot átvettként megjelölni.",
-    "pickupError": "Nem sikerült a csomagot felvettként megjelölni."
-  },
   "financial": {
     "title": "Pénzügyek",
     "invoices": "Számlák",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -577,19 +577,6 @@
     "draftMinutesAgo": "{{count}}m temu",
     "draftRestored": "Przywrócono zapisany szkic."
   },
-  "packages": {
-    "title": "Zarządzanie przesyłkami",
-    "subtitle": "Śledzenie i zarządzanie przesyłkami w budynku",
-    "loading": "Ładowanie przesyłek...",
-    "loadError": "Nie udało się załadować przesyłek",
-    "registerPackage": "Zarejestruj przesyłkę",
-    "filterAll": "Wszystkie",
-    "filterPickedUp": "Odebrane",
-    "noPackages": "Brak przesyłek",
-    "noPackagesFound": "Nie znaleziono przesyłek",
-    "receiveError": "Nie udało się oznaczyć przesyłki jako odebranej.",
-    "pickupError": "Nie udało się oznaczyć przesyłki jako podjętej."
-  },
   "financial": {
     "title": "Finanse",
     "invoices": "Faktury",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -624,19 +624,6 @@
     "draftMinutesAgo": "pred {{count}}m",
     "draftRestored": "Obnovili sme váš uložený návrh."
   },
-  "packages": {
-    "title": "Správa zásielok",
-    "subtitle": "Sledovanie a správa zásielok v budove",
-    "loading": "Načítavajú sa zásielky...",
-    "loadError": "Nepodarilo sa načítať zásielky",
-    "registerPackage": "Zaregistrovať zásielku",
-    "filterAll": "Všetky",
-    "filterPickedUp": "Vyzdvihnuté",
-    "noPackages": "Žiadne zásielky",
-    "noPackagesFound": "Zásielky sa nenašli",
-    "receiveError": "Nepodarilo sa označiť zásielku ako prijatú.",
-    "pickupError": "Nepodarilo sa označiť zásielku ako vyzdvihnutú."
-  },
   "financial": {
     "title": "Financie",
     "invoices": "Faktúry",

--- a/frontend/apps/ppt-web/src/i18n/deadNamespaceI18n.test.ts
+++ b/frontend/apps/ppt-web/src/i18n/deadNamespaceI18n.test.ts
@@ -1,0 +1,51 @@
+/// <reference types="vitest/globals" />
+/**
+ * Dead i18n namespace parity regression (#2405, follow-up to #2395).
+ *
+ * PR #2395 removed the retired `delegation` and `packages` namespaces from
+ * `en.json`, claiming en was the sole holder and that parity with the other
+ * five locales was "restored". That was correct for `delegation` (en-only) but
+ * factually wrong for `packages`: the identical 11-key dead block still lived in
+ * cs/de/hu/pl/sk, so removing it from `en` (the `fallbackLng`) actually inverted
+ * parity — en lacked a namespace the other five still carried. The features are
+ * retired (see `src/features/unwired-features.ts`); there are zero `packages.` /
+ * `delegation.` references in any `.tsx`, so nothing failed at runtime and the
+ * dead keys simply persisted.
+ *
+ * This test locks the cleanup in: neither retired top-level namespace may exist
+ * in ANY of the six locale bundles. It fails on `main` (cs/de/hu/pl/sk still
+ * carry `packages`) and passes once the block is deleted from all five.
+ */
+
+import cs from '../../messages/cs.json';
+import de from '../../messages/de.json';
+import en from '../../messages/en.json';
+import hu from '../../messages/hu.json';
+import pl from '../../messages/pl.json';
+import sk from '../../messages/sk.json';
+
+type Json = Record<string, unknown>;
+
+const BUNDLES: Record<string, Json> = { en, sk, cs, de, pl, hu };
+
+/** Retired feature namespaces that must not appear in any locale bundle. */
+const DEAD_NAMESPACES = ['packages', 'delegation'] as const;
+
+describe('dead i18n namespaces are gone from every locale', () => {
+  // Guard the locale set itself: a newly added bundle must be listed here or the
+  // sweep below would silently skip it.
+  it('covers exactly the six shipped locale bundles', () => {
+    expect(Object.keys(BUNDLES).sort()).toEqual(['cs', 'de', 'en', 'hu', 'pl', 'sk']);
+  });
+
+  for (const [locale, bundle] of Object.entries(BUNDLES)) {
+    for (const ns of DEAD_NAMESPACES) {
+      it(`${locale}.json has no top-level "${ns}" namespace`, () => {
+        expect(
+          Object.hasOwn(bundle, ns),
+          `${locale}.json still carries the retired "${ns}" namespace`
+        ).toBe(false);
+      });
+    }
+  }
+});


### PR DESCRIPTION
## What & why

Follow-up to PR #2395, which removed the retired `packages` / `delegation` i18n namespaces from `en.json` and claimed en was the sole holder ("restores en.json to key parity with the other five locales"). That was correct for `delegation` (en-only) but **factually wrong for `packages`**: the identical 11-key dead block still lived in `cs/de/hu/pl/sk`. Removing it from `en` — the `fallbackLng` (`src/i18n/config.ts` `defaultLocale='en'`, `src/i18n/index.ts` `fallbackLng`) — actually **inverted** parity: en lacked a namespace the other five still carried.

This PR completes the cleanup by deleting the top-level `packages` namespace (11 leaf keys each, ~55 total) from the five non-en locale bundles, achieving the key parity #2395 intended.

Closes #2405.

## Scope

- `frontend/apps/ppt-web/messages/{cs,de,hu,pl,sk}.json` — delete the top-level `packages` block (13 lines / 11 leaf keys each).
- The feature is retired (`src/features/unwired-features.ts`); confirmed **zero** `packages.` / `delegation.` references in any `.tsx`/`.ts` (only the retired-features comment). Pure dead-key removal — no runtime surface.

## Verification (IG3)

- **Failing-on-dev test:** `src/i18n/deadNamespaceI18n.test.ts` asserts neither `packages` nor `delegation` top-level namespace exists in any of the six locale bundles. Verified it **fails on the pre-fix tree** (sk/cs/de/hu/pl still carry `packages`) and **passes** after the deletion.
- `pnpm --filter @ppt/web typecheck` — green.
- `biome check` on changed files — green (`Checked 7 files … No fixes applied`).
- `vitest run src/i18n/deadNamespaceI18n.test.ts` — 13 passed.

Commits: `test:` (locks the parity, fails on dev) then `fix:` (removes the dead keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ur6ffnwStGLizR3fwKXdM

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ur6ffnwStGLizR3fwKXdM)_