### PR TITLE
gh-issue-2413: fix cross-tenant IDOR in government_portal connection get/update/delete/test

### DIFF
--- a/backend/crates/db/src/repositories/government_portal.rs
+++ b/backend/crates/db/src/repositories/government_portal.rs
@@ -47,15 +47,21 @@ impl GovernmentPortalRepository {
         .await
     }
 
-    /// Get a specific portal connection.
+    /// Get a specific portal connection scoped to its owning organization.
+    ///
+    /// Tenant scoping is enforced at the query level (`organization_id = $2`) so
+    /// that a connection `id` belonging to another org is treated as
+    /// non-existent rather than leaking its credentials (cross-tenant IDOR, #2413).
     pub async fn get_connection(
         &self,
         id: Uuid,
+        organization_id: Uuid,
     ) -> Result<Option<GovernmentPortalConnection>, SqlxError> {
         sqlx::query_as::<_, GovernmentPortalConnection>(
-            "SELECT * FROM government_portal_connections WHERE id = $1",
+            "SELECT * FROM government_portal_connections WHERE id = $1 AND organization_id = $2",
         )
         .bind(id)
+        .bind(organization_id)
         .fetch_optional(&self.pool)
         .await
     }
@@ -93,11 +99,16 @@ impl GovernmentPortalRepository {
         .await
     }
 
-    /// Update a portal connection.
+    /// Update a portal connection scoped to its owning organization.
+    ///
+    /// Returns `Ok(None)` when no connection with `id` exists **for the given
+    /// organization**, so a cross-org `id` cannot overwrite another tenant's
+    /// credentials (cross-tenant IDOR, #2413).
     #[allow(clippy::too_many_arguments)]
     pub async fn update_connection(
         &self,
         id: Uuid,
+        organization_id: Uuid,
         portal_name: Option<&str>,
         api_endpoint: Option<&str>,
         portal_username: Option<&str>,
@@ -105,23 +116,24 @@ impl GovernmentPortalRepository {
         is_active: Option<bool>,
         auto_submit: Option<bool>,
         test_mode: Option<bool>,
-    ) -> Result<GovernmentPortalConnection, SqlxError> {
+    ) -> Result<Option<GovernmentPortalConnection>, SqlxError> {
         sqlx::query_as::<_, GovernmentPortalConnection>(
             r#"
             UPDATE government_portal_connections SET
-                portal_name = COALESCE($2, portal_name),
-                api_endpoint = COALESCE($3, api_endpoint),
-                portal_username = COALESCE($4, portal_username),
-                oauth_client_id = COALESCE($5, oauth_client_id),
-                is_active = COALESCE($6, is_active),
-                auto_submit = COALESCE($7, auto_submit),
-                test_mode = COALESCE($8, test_mode),
+                portal_name = COALESCE($3, portal_name),
+                api_endpoint = COALESCE($4, api_endpoint),
+                portal_username = COALESCE($5, portal_username),
+                oauth_client_id = COALESCE($6, oauth_client_id),
+                is_active = COALESCE($7, is_active),
+                auto_submit = COALESCE($8, auto_submit),
+                test_mode = COALESCE($9, test_mode),
                 updated_at = now()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             RETURNING *
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .bind(portal_name)
         .bind(api_endpoint)
         .bind(portal_username)
@@ -129,47 +141,72 @@ impl GovernmentPortalRepository {
         .bind(is_active)
         .bind(auto_submit)
         .bind(test_mode)
-        .fetch_one(&self.pool)
+        .fetch_optional(&self.pool)
         .await
     }
 
-    /// Delete a portal connection.
-    pub async fn delete_connection(&self, id: Uuid) -> Result<bool, SqlxError> {
-        let result = sqlx::query("DELETE FROM government_portal_connections WHERE id = $1")
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
+    /// Delete a portal connection scoped to its owning organization.
+    ///
+    /// Returns `false` when no connection with `id` exists for the given
+    /// organization (cross-tenant IDOR guard, #2413).
+    pub async fn delete_connection(
+        &self,
+        id: Uuid,
+        organization_id: Uuid,
+    ) -> Result<bool, SqlxError> {
+        let result = sqlx::query(
+            "DELETE FROM government_portal_connections WHERE id = $1 AND organization_id = $2",
+        )
+        .bind(id)
+        .bind(organization_id)
+        .execute(&self.pool)
+        .await?;
 
         Ok(result.rows_affected() > 0)
     }
 
     /// Test connection to a portal (updates last_connection_test).
-    pub async fn record_connection_test(&self, id: Uuid, success: bool) -> Result<(), SqlxError> {
-        sqlx::query(
+    ///
+    /// Scoped to the owning organization; returns `false` when no matching
+    /// connection exists for `organization_id`, so a cross-org `id` cannot be
+    /// probed/mutated (cross-tenant IDOR guard, #2413).
+    pub async fn record_connection_test(
+        &self,
+        id: Uuid,
+        success: bool,
+        organization_id: Uuid,
+    ) -> Result<bool, SqlxError> {
+        let result = sqlx::query(
             r#"
             UPDATE government_portal_connections
             SET last_connection_test = now()
-            WHERE id = $1
+            WHERE id = $1 AND organization_id = $2
             "#,
         )
         .bind(id)
+        .bind(organization_id)
         .execute(&self.pool)
         .await?;
+
+        if result.rows_affected() == 0 {
+            return Ok(false);
+        }
 
         if success {
             sqlx::query(
                 r#"
                 UPDATE government_portal_connections
                 SET last_successful_submission = now()
-                WHERE id = $1
+                WHERE id = $1 AND organization_id = $2
                 "#,
             )
             .bind(id)
+            .bind(organization_id)
             .execute(&self.pool)
             .await?;
         }
 
-        Ok(())
+        Ok(true)
     }
 
     // ========================================================================

--- a/backend/crates/db/tests/government_portal_connection_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/government_portal_connection_cross_org_idor_tests.rs
@@ -1,0 +1,157 @@
+//! Cross-tenant IDOR regression tests for government portal connections (#2413).
+//!
+//! Before the fix, the single-row repo methods keyed only on `id`, so any
+//! authenticated user of any org could read/mutate/delete/probe another org's
+//! portal connection — exposing and hijacking portal credentials
+//! (`portal_username`, `oauth_client_id`, `api_endpoint`) — by enumerating
+//! UUIDs. The handlers in `api-server/src/routes/government_portal.rs` now
+//! thread the verified `TenantExtractor.tenant_id` and the repo methods scope
+//! every query with `AND organization_id = $N`.
+//!
+//! The CI pool runs as a superuser that bypasses (FORCE) RLS, so these tests
+//! exercise the application-layer ownership keying directly — exactly the gap
+//! RLS would not catch in CI, and the reason the app-level scope is the primary
+//! fix for this table (its RLS policy keys on the never-set `app.current_tenant_id`
+//! GUC and the repo connects via a context-less owner pool).
+//!
+//! Run with:
+//! ```bash
+//! cargo test -p db --test government_portal_connection_cross_org_idor_tests
+//! ```
+
+use db::models::{CreatePortalConnection, GovernmentPortalType};
+use db::repositories::GovernmentPortalRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Gov Portal {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@govportal.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Gov Portal User', 'active', NOW(), 'staff')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+fn sample_connection() -> CreatePortalConnection {
+    CreatePortalConnection {
+        portal_type: GovernmentPortalType::TaxAuthority,
+        portal_name: "Org B Tax Authority".to_string(),
+        portal_code: Some("SK-TAX".to_string()),
+        country_code: "SK".to_string(),
+        api_endpoint: Some("https://secret-b.example/api".to_string()),
+        portal_username: Some("org-b-secret-user".to_string()),
+        oauth_client_id: Some("org-b-oauth-client".to_string()),
+        auto_submit: false,
+        test_mode: true,
+    }
+}
+
+#[sqlx::test]
+async fn connection_by_id_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "idor-a").await;
+    let org_b = seed_org(&pool, "idor-b").await;
+    let user_b = seed_user(&pool, "gov-b@idor.test").await;
+
+    let repo = GovernmentPortalRepository::new(pool.clone());
+
+    // org_b owns a connection holding sensitive credentials.
+    let conn = repo
+        .create_connection(org_b, sample_connection(), user_b)
+        .await
+        .expect("create connection for org_b");
+
+    // --- get: org_a must NOT be able to read org_b's connection ---
+    let leaked = repo
+        .get_connection(conn.id, org_a)
+        .await
+        .expect("get_connection (cross-org) query ok");
+    assert!(
+        leaked.is_none(),
+        "cross-org get_connection leaked another org's portal credentials"
+    );
+
+    // The owner can still read it.
+    let owned = repo
+        .get_connection(conn.id, org_b)
+        .await
+        .expect("get_connection (owner) query ok");
+    assert!(owned.is_some(), "owner get_connection should return the row");
+
+    // --- update: org_a must NOT be able to overwrite org_b's connection ---
+    let hijacked = repo
+        .update_connection(
+            conn.id,
+            org_a,
+            Some("HIJACKED"),
+            Some("https://attacker.example/api"),
+            Some("attacker"),
+            Some("attacker-client"),
+            Some(false),
+            Some(true),
+            Some(false),
+        )
+        .await
+        .expect("update_connection (cross-org) query ok");
+    assert!(
+        hijacked.is_none(),
+        "cross-org update_connection overwrote another org's connection"
+    );
+
+    // Confirm org_b's data is untouched after the failed cross-org update.
+    let after = repo
+        .get_connection(conn.id, org_b)
+        .await
+        .expect("get_connection (owner) after update ok")
+        .expect("owner row still exists");
+    assert_eq!(after.portal_name, "Org B Tax Authority");
+    assert_eq!(after.portal_username.as_deref(), Some("org-b-secret-user"));
+
+    // --- record_connection_test: org_a must NOT be able to probe it ---
+    let tested_cross = repo
+        .record_connection_test(conn.id, true, org_a)
+        .await
+        .expect("record_connection_test (cross-org) query ok");
+    assert!(
+        !tested_cross,
+        "cross-org record_connection_test touched another org's connection"
+    );
+
+    // --- delete: org_a must NOT be able to delete org_b's connection ---
+    let deleted_cross = repo
+        .delete_connection(conn.id, org_a)
+        .await
+        .expect("delete_connection (cross-org) query ok");
+    assert!(
+        !deleted_cross,
+        "cross-org delete_connection removed another org's connection"
+    );
+
+    // The owner can delete it.
+    let deleted_owner = repo
+        .delete_connection(conn.id, org_b)
+        .await
+        .expect("delete_connection (owner) query ok");
+    assert!(deleted_owner, "owner delete_connection should succeed");
+}

--- a/backend/crates/db/tests/government_portal_connection_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/government_portal_connection_cross_org_idor_tests.rs
@@ -97,7 +97,10 @@ async fn connection_by_id_is_scoped_to_owning_org(pool: PgPool) {
         .get_connection(conn.id, org_b)
         .await
         .expect("get_connection (owner) query ok");
-    assert!(owned.is_some(), "owner get_connection should return the row");
+    assert!(
+        owned.is_some(),
+        "owner get_connection should return the row"
+    );
 
     // --- update: org_a must NOT be able to overwrite org_b's connection ---
     let hijacked = repo

--- a/backend/servers/api-server/src/routes/government_portal.rs
+++ b/backend/servers/api-server/src/routes/government_portal.rs
@@ -104,11 +104,12 @@ async fn list_connections(
 async fn get_connection(
     State(state): State<AppState>,
     _auth: AuthUser,
+    tenant: TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<GovernmentPortalConnection>, (StatusCode, Json<ErrorResponse>)> {
     let connection = state
         .government_portal_repo
-        .get_connection(id)
+        .get_connection(id, tenant.tenant_id)
         .await
         .map_err(|e| {
             (
@@ -161,6 +162,7 @@ async fn create_connection(
 async fn update_connection(
     State(state): State<AppState>,
     auth: AuthUser,
+    tenant: TenantExtractor,
     Path(id): Path<Uuid>,
     Json(request): Json<UpdatePortalConnection>,
 ) -> Result<Json<GovernmentPortalConnection>, (StatusCode, Json<ErrorResponse>)> {
@@ -168,6 +170,7 @@ async fn update_connection(
         .government_portal_repo
         .update_connection(
             id,
+            tenant.tenant_id,
             request.portal_name.as_deref(),
             request.api_endpoint.as_deref(),
             request.portal_username.as_deref(),
@@ -181,6 +184,15 @@ async fn update_connection(
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
+            )
+        })?
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new(
+                    "CONNECTION_NOT_FOUND",
+                    "Portal connection not found",
+                )),
             )
         })?;
 
@@ -197,11 +209,12 @@ async fn update_connection(
 async fn delete_connection(
     State(state): State<AppState>,
     auth: AuthUser,
+    tenant: TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let deleted = state
         .government_portal_repo
-        .delete_connection(id)
+        .delete_connection(id, tenant.tenant_id)
         .await
         .map_err(|e| {
             (
@@ -233,14 +246,15 @@ async fn delete_connection(
 async fn test_connection(
     State(state): State<AppState>,
     auth: AuthUser,
+    tenant: TenantExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Json<TestConnectionResponse>, (StatusCode, Json<ErrorResponse>)> {
     // In a real implementation, this would actually test the connection
     // For now, we just record the test and return success
 
-    state
+    let exists = state
         .government_portal_repo
-        .record_connection_test(id, true)
+        .record_connection_test(id, true, tenant.tenant_id)
         .await
         .map_err(|e| {
             (
@@ -248,6 +262,16 @@ async fn test_connection(
                 Json(ErrorResponse::new("DATABASE_ERROR", e.to_string())),
             )
         })?;
+
+    if !exists {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new(
+                "CONNECTION_NOT_FOUND",
+                "Portal connection not found",
+            )),
+        ));
+    }
 
     info!(
         user_id = %auth.user_id,


### PR DESCRIPTION
## Summary

Closes #2413. Fixes a **live cross-tenant IDOR** on government portal connections: the single-row handlers (`get`/`update`/`delete`/`test_connection`) took the row `id` straight from the path with no tenant scoping, so any authenticated user of any org could read, overwrite, delete, or probe another org's connection — leaking/hijacking portal credentials (`portal_username`, `oauth_client_id`, `api_endpoint`) — by enumerating UUIDs.

## Root cause

- Handlers `get_connection` / `update_connection` / `delete_connection` / `test_connection` only extracted `AuthUser` + `Path(id)` and called the repo with just `id`, unlike their siblings `list_connections` / `create_connection` which scope by `tenant.tenant_id`.
- The matching repo methods ran `WHERE id = $1` with no `organization_id` filter.
- RLS does not save it: `government_portal_connections` has `ENABLE` (not `FORCE`) RLS, and the api-server connects as the table **owner**, for whom non-FORCE RLS is bypassed (same owner-bypass class as migration `00179`).

## Fix (primary: app-level tenant scoping — mirrors `list_connections`)

- **Repo** (`crates/db/src/repositories/government_portal.rs`): thread `organization_id` into `get_connection` / `update_connection` / `delete_connection` / `record_connection_test`; every query is now `WHERE id = $1 AND organization_id = $2`. `get`/`update` return `Option`; `delete`/`test` return `bool`.
- **Handlers** (`servers/api-server/src/routes/government_portal.rs`): add `TenantExtractor` and pass `tenant.tenant_id`. A foreign-org or absent row maps to `404 CONNECTION_NOT_FOUND` — no "not yours" disclosure.

## IG3 evidence (failing-on-`dev` test + fix)

- `test:` commit adds `crates/db/tests/government_portal_connection_cross_org_idor_tests.rs`, an `#[sqlx::test]` that seeds two orgs, creates a connection under org B, and asserts org A cannot get/update/delete/test it while org B can. On `dev` the repo methods key only on `id`, so the test cannot pass (and does not compile against the vulnerable signatures); the `fix:` commit makes it green.
- The CI pool runs as a superuser that bypasses FORCE RLS, so this test exercises the application-layer ownership keying directly — the same rationale as the existing `portal_imports_cross_org_idor_tests.rs`.

## Verification

- `cargo fmt -p db -p api-server --check` — clean.
- `cargo check -p db --tests` — compiles (repo + new IDOR test).
- `cargo clippy -p db --tests` — clean, no new warnings.
- ⚠️ `cargo check -p api-server` and running the `#[sqlx::test]` could **not** be completed in this sandbox: the `utoipa-swagger-ui` build script downloads the Swagger UI archive from GitHub, which the environment's egress policy blocks (HTTP 403), and no Postgres is available for `sqlx::test`. The api-server change is a mechanical mirror of the already-working `list_connections`/`create_connection` handlers (same `TenantExtractor` + `tenant.tenant_id` pattern, all imports already present). Full `api-server` compile + the sqlx test will run on CI (`backend.yml`).

## Scope note — RLS backstop intentionally deferred

The issue suggested also adding `ALTER TABLE government_portal_connections FORCE ROW LEVEL SECURITY`. That is **not safe as a standalone change here** and would break the feature: this table's policy (`00062`) keys on `current_setting('app.current_tenant_id')`, but `set_request_context` (`00006`) only sets `app.current_org_id`, and `GovernmentPortalRepository` runs on a plain, context-less owner pool (`db.clone()`) that never sets that GUC. Forcing RLS would make the policy evaluate `organization_id = NULL` → deny-all for **every** gov-portal query (list/create/stats/submissions included). A proper RLS backstop requires first migrating the whole repo to RLS-context connections (mirroring the policy GUC), which is a larger follow-up. The app-level scoping in this PR fully closes the live IDOR on its own.

## CI surface

`backend.yml` (`cargo fmt` / `clippy` / `cargo test`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ur6ffnwStGLizR3fwKXdM

---
_Generated by [Claude Code](https://claude.ai/code/session_011Ur6ffnwStGLizR3fwKXdM)_