### PR TITLE
gh-issue-2417: fix scheduler-RLS comments citing wrong migration number (00216 → 00218)

### DIFF
--- a/backend/crates/db/src/repositories/report_schedule.rs
+++ b/backend/crates/db/src/repositories/report_schedule.rs
@@ -679,7 +679,7 @@ impl ReportScheduleRepository {
     /// silently returns 0 rows. The caller must supply an executor (a
     /// checked-out connection) with `set_global_read_context(TRUE)` applied so
     /// the cross-org `report_schedules_global_read` SELECT policy (migration
-    /// 00216) grants visibility. Follows the executor-passing shape of
+    /// 00218) grants visibility. Follows the executor-passing shape of
     /// `WorkflowRepository::list_due_schedules`.
     pub async fn get_due_schedules<'e, E>(
         &self,

--- a/backend/crates/db/tests/report_schedule_scheduler_rls_tests.rs
+++ b/backend/crates/db/tests/report_schedule_scheduler_rls_tests.rs
@@ -13,7 +13,7 @@
 //!   * `record_execution()`'s INSERT failed its WITH CHECK,
 //!   * `advance_after_run()`'s UPDATE matched 0 rows → RowNotFound.
 //!
-//! Migration 00216 adds an `is_global_read_context()` SELECT-only leg to both
+//! Migration 00218 adds an `is_global_read_context()` SELECT-only leg to both
 //! tables, and the scheduler now reads due work under the global-read context
 //! and writes under each schedule's own tenant context.
 //!


### PR DESCRIPTION
## Task
Follow-up: scheduler-RLS doc + test comments cite wrong migration number (00216 → should be 00218) (PR #2340). Two in-tree comments cite migration 00216 for the `report_schedules_global_read` policy which actually lives in migration 00218: (1) `backend/crates/db/src/repositories/report_schedule.rs` `get_due_schedules` doc comment "migration 00216" → "00218"; (2) `backend/crates/db/tests/report_schedule_scheduler_rls_tests.rs` module header "Migration 00216 adds an is_global_read_context() SELECT-only leg" → "Migration 00218 …". Docs-only nit.

Closes #2417

## Owner
pm-tech-lead (specialist: rust-backend)

## Change
Two doc-comment edits only — 4 characters each:
- `report_schedule.rs::get_due_schedules` rustdoc: `(migration 00216)` → `(migration 00218)`
- `report_schedule_scheduler_rls_tests.rs` module header: `Migration 00216` → `Migration 00218`

Verified against the migrations dir: `00218_report_schedules_worker_rls.sql` is the file that adds the `is_global_read_context()` SELECT-only leg / `report_schedules_global_read` policy, while `00216_document_embeddings_super_admin_policy.sql` is the unrelated parallel-PR migration on a different table. The sibling `scheduler.rs` comment already correctly says 00218, so this restores internal consistency.

## Tested (Band A — fast check)
`cd backend && cargo check -p db --tests` → exit 0 (Finished in 4m 34s)

## Built (Band B — full build)
skipped: change is 2 doc-comment lines (<50 LOC), no public API / migration / config touch.

## CI parity (Band C — hot-path only)
skipped: docs-only comment change, no security/auth/billing/data-integrity behavior.

## Scope drift
scope-check flagged the two `backend/crates/db/**` files as outside the `pm-tech-lead` owner area (`docs/**`, `.research/**`, `_bmad-output/**`). This is expected/justified: `pm-tech-lead` is the architect hint, the resolved specialist is `rust-backend`, and both files are exactly the ones named in issue #2417. No off-task files touched (diff is 2 files, 2 insertions, 2 deletions).

## Code-reuse review
none (reuse-grep clean; no new symbols added).

## Notes
Pure documentation fix; no runtime behavior changes. The issue also suggests a process note (assign migration numbers at merge time or add a CI check for comment/policy mismatch) — out of scope for this docs-only PR, left for the reviewer/backlog.

---
_Generated by [Claude Code](https://claude.ai/code/session_017PeimLgKWKWVhcYYT6MsnW)_