### PR TITLE
feat(layout-core): Layout & Content Manager contract crate

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3950,6 +3950,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
+name = "layout-core"
+version = "0.3.218"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/common",
+    "crates/layout-core",
     "crates/api-core",
     "crates/admin-core",
     "crates/db",

--- a/backend/crates/layout-core/Cargo.toml
+++ b/backend/crates/layout-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "layout-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/backend/crates/layout-core/src/lib.rs
+++ b/backend/crates/layout-core/src/lib.rs
@@ -4,6 +4,8 @@
 
 pub mod types;
 pub mod resolve;
+pub mod validate;
 
 pub use types::*;
 pub use resolve::resolve;
+pub use validate::{validate_publish, ValidationError};

--- a/backend/crates/layout-core/src/lib.rs
+++ b/backend/crates/layout-core/src/lib.rs
@@ -8,4 +8,4 @@ pub mod validate;
 
 pub use types::*;
 pub use resolve::resolve;
-pub use validate::{validate_publish, ValidationError};
+pub use validate::{validate_publish, validate_tenant_override, ValidationError};

--- a/backend/crates/layout-core/src/lib.rs
+++ b/backend/crates/layout-core/src/lib.rs
@@ -3,5 +3,7 @@
 //! Spec: docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
 
 pub mod types;
+pub mod resolve;
 
 pub use types::*;
+pub use resolve::resolve;

--- a/backend/crates/layout-core/src/lib.rs
+++ b/backend/crates/layout-core/src/lib.rs
@@ -1,0 +1,7 @@
+//! Layout & Content Manager contract: config types, merge resolver, validation.
+//!
+//! Spec: docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
+
+pub mod types;
+
+pub use types::*;

--- a/backend/crates/layout-core/src/lib.rs
+++ b/backend/crates/layout-core/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! Spec: docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
 
-pub mod types;
 pub mod resolve;
+pub mod types;
 pub mod validate;
 
-pub use types::*;
 pub use resolve::resolve;
+pub use types::*;
 pub use validate::{validate_publish, validate_tenant_override, ValidationError};

--- a/backend/crates/layout-core/src/resolve.rs
+++ b/backend/crates/layout-core/src/resolve.rs
@@ -36,13 +36,25 @@ pub fn resolve(
                 mode = def.default_mode.clone();
             }
         }
-        let _ = visible;
-        sections.push(ResolvedSection {
-            section_type: cfg.section_type.clone(),
-            mode,
-            props,
-            presentation: Presentation::Visible,
-        });
+        let alive = visible && !killed.contains(&cfg.section_type);
+        if alive {
+            sections.push(ResolvedSection {
+                section_type: cfg.section_type.clone(),
+                mode,
+                props,
+                presentation: Presentation::Visible,
+            });
+        } else if def.required {
+            // Spec §4.2 / §5: required sections never disappear — placeholder,
+            // with no mode/props (the section may be killed over bad data).
+            sections.push(ResolvedSection {
+                section_type: cfg.section_type.clone(),
+                mode: None,
+                props: Props::new(),
+                presentation: Presentation::Placeholder,
+            });
+        }
+        // optional + not alive → omitted entirely (containers own spacing, §4.3)
     }
     ResolvedScreen {
         screen: base.screen.clone(),
@@ -227,5 +239,51 @@ mod tests {
             out.sections.iter().map(|s| s.section_type.0.as_str()).collect();
         // listed first, unlisted keep base relative order
         assert_eq!(types, vec!["b.v1", "a.v1", "c.v1"]);
+    }
+
+    #[test]
+    fn hidden_and_killed_sections_collapse_or_placeholder() {
+        let mut hidden_opt = section("similar-listings.v1");
+        hidden_opt.visible = false;
+        let mut hidden_req = section("price-box.v1");
+        hidden_req.visible = false;
+        hidden_req.props =
+            BTreeMap::from([("currency".to_string(), serde_json::json!("EUR"))]);
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![
+                section("gallery.v1"),      // required, visible, killed below
+                hidden_req,                 // required, hidden → placeholder
+                hidden_opt,                 // optional, hidden → gone
+                section("mortgage-calc.v1"),// optional, killed below → gone
+                section("unknown.v9"),      // not in registry → gone
+            ],
+        };
+        let reg = registry(&[
+            ("gallery.v1", true, &[]),
+            ("price-box.v1", true, &[]),
+            ("similar-listings.v1", false, &[]),
+            ("mortgage-calc.v1", false, &[]),
+        ]);
+        let killed = BTreeSet::from([
+            SectionType::from("gallery.v1"),
+            SectionType::from("mortgage-calc.v1"),
+        ]);
+        let out = resolve(&base, Platform::Web, None, &killed, &reg);
+        let rendered: Vec<(&str, Presentation)> = out
+            .sections
+            .iter()
+            .map(|s| (s.section_type.0.as_str(), s.presentation))
+            .collect();
+        assert_eq!(
+            rendered,
+            vec![
+                ("gallery.v1", Presentation::Placeholder),   // killed required
+                ("price-box.v1", Presentation::Placeholder), // hidden required
+            ]
+        );
+        // placeholders leak no props (section may be killed for a data bug)
+        assert!(out.sections.iter().all(|s| s.props.is_empty()));
     }
 }

--- a/backend/crates/layout-core/src/resolve.rs
+++ b/backend/crates/layout-core/src/resolve.rs
@@ -163,7 +163,10 @@ mod tests {
         let mobile = resolve(&base, Platform::Mobile, None, &BTreeSet::new(), &reg);
         assert_eq!(mobile.sections[1].mode.as_deref(), Some("bottom-bar"));
         // untouched fields carry through; order preserved
-        assert_eq!(mobile.sections[0].section_type, SectionType::from("gallery.v1"));
+        assert_eq!(
+            mobile.sections[0].section_type,
+            SectionType::from("gallery.v1")
+        );
         assert_eq!(mobile.sections[0].presentation, Presentation::Visible);
         assert_eq!(mobile.screen, "reality/listing-detail");
         assert_eq!(mobile.version, 1);
@@ -173,7 +176,11 @@ mod tests {
     fn unsupported_mode_falls_back_to_default_mode() {
         let mut s = section("listing-grid.v1");
         s.mode = Some("hologram".into()); // not supported by the component
-        let base = ScreenConfig { screen: "s".into(), version: 1, sections: vec![s] };
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![s],
+        };
         let reg = registry(&[("listing-grid.v1", false, &["list", "grid"])]);
         let out = resolve(&base, Platform::Web, None, &BTreeSet::new(), &reg);
         // defensive rendering: never emit a mode the client can't render
@@ -185,7 +192,10 @@ mod tests {
         let mut a = section("a.v1");
         a.overrides.insert(
             Platform::Web,
-            SectionPatch { mode: Some("grid".into()), ..Default::default() },
+            SectionPatch {
+                mode: Some("grid".into()),
+                ..Default::default()
+            },
         );
         let base = ScreenConfig {
             screen: "ppt/dashboard".into(),
@@ -213,8 +223,11 @@ mod tests {
             )]),
         };
         let out = resolve(&base, Platform::Web, Some(&tenant), &BTreeSet::new(), &reg);
-        let types: Vec<&str> =
-            out.sections.iter().map(|s| s.section_type.0.as_str()).collect();
+        let types: Vec<&str> = out
+            .sections
+            .iter()
+            .map(|s| s.section_type.0.as_str())
+            .collect();
         assert_eq!(types, vec!["c.v1", "a.v1", "b.v1"]);
         // tenant mode beats platform mode (precedence §3.2)
         assert_eq!(out.sections[1].mode.as_deref(), Some("map"));
@@ -228,14 +241,21 @@ mod tests {
             version: 1,
             sections: vec![section("a.v1"), section("b.v1"), section("c.v1")],
         };
-        let reg = registry(&[("a.v1", false, &[]), ("b.v1", false, &[]), ("c.v1", false, &[])]);
+        let reg = registry(&[
+            ("a.v1", false, &[]),
+            ("b.v1", false, &[]),
+            ("c.v1", false, &[]),
+        ]);
         let tenant = TenantOverride {
             order: Some(vec![SectionType::from("b.v1")]),
             sections: BTreeMap::new(),
         };
         let out = resolve(&base, Platform::Web, Some(&tenant), &BTreeSet::new(), &reg);
-        let types: Vec<&str> =
-            out.sections.iter().map(|s| s.section_type.0.as_str()).collect();
+        let types: Vec<&str> = out
+            .sections
+            .iter()
+            .map(|s| s.section_type.0.as_str())
+            .collect();
         // listed first, unlisted keep base relative order
         assert_eq!(types, vec!["b.v1", "a.v1", "c.v1"]);
     }
@@ -246,17 +266,16 @@ mod tests {
         hidden_opt.visible = false;
         let mut hidden_req = section("price-box.v1");
         hidden_req.visible = false;
-        hidden_req.props =
-            BTreeMap::from([("currency".to_string(), serde_json::json!("EUR"))]);
+        hidden_req.props = BTreeMap::from([("currency".to_string(), serde_json::json!("EUR"))]);
         let base = ScreenConfig {
             screen: "s".into(),
             version: 1,
             sections: vec![
-                section("gallery.v1"),      // required, visible, killed below
-                hidden_req,                 // required, hidden → placeholder
-                hidden_opt,                 // optional, hidden → gone
-                section("mortgage-calc.v1"),// optional, killed below → gone
-                section("unknown.v9"),      // not in registry → gone
+                section("gallery.v1"),       // required, visible, killed below
+                hidden_req,                  // required, hidden → placeholder
+                hidden_opt,                  // optional, hidden → gone
+                section("mortgage-calc.v1"), // optional, killed below → gone
+                section("unknown.v9"),       // not in registry → gone
             ],
         };
         let reg = registry(&[
@@ -278,7 +297,7 @@ mod tests {
         assert_eq!(
             rendered,
             vec![
-                ("gallery.v1", Presentation::Placeholder),   // killed required
+                ("gallery.v1", Presentation::Placeholder), // killed required
                 ("price-box.v1", Presentation::Placeholder), // hidden required
             ]
         );

--- a/backend/crates/layout-core/src/resolve.rs
+++ b/backend/crates/layout-core/src/resolve.rs
@@ -11,9 +11,10 @@ pub fn resolve(
     killed: &BTreeSet<SectionType>,
     registry: &RegistryManifest,
 ) -> ResolvedScreen {
-    let _ = (tenant, killed); // applied in later layers of this function
+    let _ = killed; // applied in later layers of this function
     let mut sections = Vec::with_capacity(base.sections.len());
-    for cfg in &base.sections {
+    let ordered = order_sections(&base.sections, tenant.and_then(|t| t.order.as_deref()));
+    for cfg in ordered {
         let Some(def) = registry.components.get(&cfg.section_type) else {
             // Unknown type handling lands in Task 5.
             continue;
@@ -23,6 +24,11 @@ pub fn resolve(
         let mut props = cfg.props.clone();
         if let Some(patch) = cfg.overrides.get(&platform) {
             apply_patch(&mut visible, &mut mode, &mut props, patch);
+        }
+        if let Some(t) = tenant {
+            if let Some(patch) = t.sections.get(&cfg.section_type) {
+                apply_patch(&mut visible, &mut mode, &mut props, patch);
+            }
         }
         // Defensive mode clamp: never emit a mode the component doesn't support.
         if let Some(m) = &mode {
@@ -60,6 +66,29 @@ fn apply_patch(
     for (k, v) in &patch.props {
         props.insert(k.clone(), v.clone());
     }
+}
+
+/// Listed types first (in override order), unlisted types after, keeping base
+/// relative order. Types in `order` that don't exist in base are ignored.
+fn order_sections<'a>(
+    base: &'a [SectionConfig],
+    order: Option<&[SectionType]>,
+) -> Vec<&'a SectionConfig> {
+    let Some(order) = order else {
+        return base.iter().collect();
+    };
+    let mut out: Vec<&SectionConfig> = Vec::with_capacity(base.len());
+    for t in order {
+        if let Some(cfg) = base.iter().find(|c| &c.section_type == t) {
+            out.push(cfg);
+        }
+    }
+    for cfg in base {
+        if !order.contains(&cfg.section_type) {
+            out.push(cfg);
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -138,5 +167,65 @@ mod tests {
         let out = resolve(&base, Platform::Web, None, &BTreeSet::new(), &reg);
         // defensive rendering: never emit a mode the client can't render
         assert_eq!(out.sections[0].mode.as_deref(), Some("list"));
+    }
+
+    #[test]
+    fn tenant_override_reorders_and_patches_after_platform_layer() {
+        let mut a = section("a.v1");
+        a.overrides.insert(
+            Platform::Web,
+            SectionPatch { mode: Some("grid".into()), ..Default::default() },
+        );
+        let base = ScreenConfig {
+            screen: "ppt/dashboard".into(),
+            version: 3,
+            sections: vec![a, section("b.v1"), section("c.v1")],
+        };
+        let reg = registry(&[
+            ("a.v1", false, &["list", "grid", "map"]),
+            ("b.v1", false, &[]),
+            ("c.v1", false, &[]),
+        ]);
+        let tenant = TenantOverride {
+            order: Some(vec![
+                SectionType::from("c.v1"),
+                SectionType::from("a.v1"),
+                SectionType::from("b.v1"),
+            ]),
+            sections: BTreeMap::from([(
+                SectionType::from("a.v1"),
+                SectionPatch {
+                    mode: Some("map".into()),
+                    props: BTreeMap::from([("limit".to_string(), serde_json::json!(6))]),
+                    ..Default::default()
+                },
+            )]),
+        };
+        let out = resolve(&base, Platform::Web, Some(&tenant), &BTreeSet::new(), &reg);
+        let types: Vec<&str> =
+            out.sections.iter().map(|s| s.section_type.0.as_str()).collect();
+        assert_eq!(types, vec!["c.v1", "a.v1", "b.v1"]);
+        // tenant mode beats platform mode (precedence §3.2)
+        assert_eq!(out.sections[1].mode.as_deref(), Some("map"));
+        assert_eq!(out.sections[1].props["limit"], serde_json::json!(6));
+    }
+
+    #[test]
+    fn tenant_order_omitting_a_type_keeps_it_after_listed_ones() {
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![section("a.v1"), section("b.v1"), section("c.v1")],
+        };
+        let reg = registry(&[("a.v1", false, &[]), ("b.v1", false, &[]), ("c.v1", false, &[])]);
+        let tenant = TenantOverride {
+            order: Some(vec![SectionType::from("b.v1")]),
+            sections: BTreeMap::new(),
+        };
+        let out = resolve(&base, Platform::Web, Some(&tenant), &BTreeSet::new(), &reg);
+        let types: Vec<&str> =
+            out.sections.iter().map(|s| s.section_type.0.as_str()).collect();
+        // listed first, unlisted keep base relative order
+        assert_eq!(types, vec!["b.v1", "a.v1", "c.v1"]);
     }
 }

--- a/backend/crates/layout-core/src/resolve.rs
+++ b/backend/crates/layout-core/src/resolve.rs
@@ -1,0 +1,142 @@
+use crate::types::*;
+use std::collections::BTreeSet;
+
+/// Resolve a screen for one platform + optional tenant, against the platform's
+/// registry manifest. Precedence: base → platform override → tenant override →
+/// kill flags (spec §3.2). Tenant and kill layers are applied in Tasks 4–5.
+pub fn resolve(
+    base: &ScreenConfig,
+    platform: Platform,
+    tenant: Option<&TenantOverride>,
+    killed: &BTreeSet<SectionType>,
+    registry: &RegistryManifest,
+) -> ResolvedScreen {
+    let _ = (tenant, killed); // applied in later layers of this function
+    let mut sections = Vec::with_capacity(base.sections.len());
+    for cfg in &base.sections {
+        let Some(def) = registry.components.get(&cfg.section_type) else {
+            // Unknown type handling lands in Task 5.
+            continue;
+        };
+        let mut visible = cfg.visible;
+        let mut mode = cfg.mode.clone();
+        let mut props = cfg.props.clone();
+        if let Some(patch) = cfg.overrides.get(&platform) {
+            apply_patch(&mut visible, &mut mode, &mut props, patch);
+        }
+        // Defensive mode clamp: never emit a mode the component doesn't support.
+        if let Some(m) = &mode {
+            if !def.supported_modes.iter().any(|s| s == m) {
+                mode = def.default_mode.clone();
+            }
+        }
+        let _ = visible;
+        sections.push(ResolvedSection {
+            section_type: cfg.section_type.clone(),
+            mode,
+            props,
+            presentation: Presentation::Visible,
+        });
+    }
+    ResolvedScreen {
+        screen: base.screen.clone(),
+        version: base.version,
+        sections,
+    }
+}
+
+fn apply_patch(
+    visible: &mut bool,
+    mode: &mut Option<String>,
+    props: &mut Props,
+    patch: &SectionPatch,
+) {
+    if let Some(v) = patch.visible {
+        *visible = v;
+    }
+    if patch.mode.is_some() {
+        *mode = patch.mode.clone();
+    }
+    for (k, v) in &patch.props {
+        props.insert(k.clone(), v.clone());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn registry(entries: &[(&str, bool, &[&str])]) -> RegistryManifest {
+        RegistryManifest {
+            platform: Platform::Web,
+            components: entries
+                .iter()
+                .map(|(t, req, modes)| {
+                    (
+                        SectionType::from(*t),
+                        ComponentDef {
+                            required: *req,
+                            supported_modes: modes.iter().map(|m| m.to_string()).collect(),
+                            default_mode: modes.first().map(|m| m.to_string()),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn section(t: &str) -> SectionConfig {
+        SectionConfig {
+            section_type: SectionType::from(t),
+            visible: true,
+            mode: None,
+            props: BTreeMap::new(),
+            overrides: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn platform_override_beats_base() {
+        let mut agent = section("agent-contact.v1");
+        agent.mode = Some("sticky-sidebar".into());
+        agent.overrides.insert(
+            Platform::Mobile,
+            SectionPatch {
+                mode: Some("bottom-bar".into()),
+                ..Default::default()
+            },
+        );
+        let base = ScreenConfig {
+            screen: "reality/listing-detail".into(),
+            version: 1,
+            sections: vec![section("gallery.v1"), agent],
+        };
+        let reg = registry(&[
+            ("gallery.v1", true, &[]),
+            ("agent-contact.v1", false, &["sticky-sidebar", "bottom-bar"]),
+        ]);
+
+        let web = resolve(&base, Platform::Web, None, &BTreeSet::new(), &reg);
+        assert_eq!(web.sections[1].mode.as_deref(), Some("sticky-sidebar"));
+
+        let mobile = resolve(&base, Platform::Mobile, None, &BTreeSet::new(), &reg);
+        assert_eq!(mobile.sections[1].mode.as_deref(), Some("bottom-bar"));
+        // untouched fields carry through; order preserved
+        assert_eq!(mobile.sections[0].section_type, SectionType::from("gallery.v1"));
+        assert_eq!(mobile.sections[0].presentation, Presentation::Visible);
+        assert_eq!(mobile.screen, "reality/listing-detail");
+        assert_eq!(mobile.version, 1);
+    }
+
+    #[test]
+    fn unsupported_mode_falls_back_to_default_mode() {
+        let mut s = section("listing-grid.v1");
+        s.mode = Some("hologram".into()); // not supported by the component
+        let base = ScreenConfig { screen: "s".into(), version: 1, sections: vec![s] };
+        let reg = registry(&[("listing-grid.v1", false, &["list", "grid"])]);
+        let out = resolve(&base, Platform::Web, None, &BTreeSet::new(), &reg);
+        // defensive rendering: never emit a mode the client can't render
+        assert_eq!(out.sections[0].mode.as_deref(), Some("list"));
+    }
+}

--- a/backend/crates/layout-core/src/resolve.rs
+++ b/backend/crates/layout-core/src/resolve.rs
@@ -4,6 +4,10 @@ use std::collections::BTreeSet;
 /// Resolve a screen for one platform + optional tenant, against the platform's
 /// registry manifest. Precedence: base → platform override → tenant override →
 /// kill flags (spec §3.2). Tenant and kill layers are applied in Tasks 4–5.
+///
+/// Note: the signature will grow an /client-capabilities parameter when
+/// server-side stale-client filtering (spec §4.1) lands in the control-plane plan —
+/// do not treat the current arity as frozen.
 pub fn resolve(
     base: &ScreenConfig,
     platform: Platform,
@@ -30,9 +34,12 @@ pub fn resolve(
             }
         }
         // Defensive mode clamp: never emit a mode the component doesn't support.
+        // If the fallback default_mode is itself not in supported_modes (inconsistent
+        // manifest), clamp to None rather than emitting a mode the component never declared.
         if let Some(m) = &mode {
             if !def.supported_modes.iter().any(|s| s == m) {
-                mode = def.default_mode.clone();
+                let fallback = def.default_mode.clone();
+                mode = fallback.filter(|dm| def.supported_modes.iter().any(|s| s == dm));
             }
         }
         let alive = visible && !killed.contains(&cfg.section_type);
@@ -258,6 +265,37 @@ mod tests {
             .collect();
         // listed first, unlisted keep base relative order
         assert_eq!(types, vec!["b.v1", "a.v1", "c.v1"]);
+    }
+
+    /// Finding 1a: if default_mode itself is not in supported_modes, clamp to None.
+    #[test]
+    fn inconsistent_default_mode_clamps_to_none() {
+        // Component declares supported_modes: ["list"] but default_mode: Some("grid").
+        // Section requests mode "hologram" -> not in supported_modes -> falls back to
+        // default_mode "grid" -> but "grid" is also not in supported_modes -> must be None.
+        let mut s = section("listing-grid.v1");
+        s.mode = Some("hologram".into());
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![s],
+        };
+        let reg = RegistryManifest {
+            platform: Platform::Web,
+            components: std::collections::BTreeMap::from([(
+                SectionType::from("listing-grid.v1"),
+                ComponentDef {
+                    required: false,
+                    supported_modes: vec!["list".to_string()],
+                    default_mode: Some("grid".to_string()), // inconsistent: not in supported_modes
+                },
+            )]),
+        };
+        let out = resolve(&base, Platform::Web, None, &BTreeSet::new(), &reg);
+        assert_eq!(
+            out.sections[0].mode, None,
+            "inconsistent default_mode must clamp to None, not emit an unsupported mode"
+        );
     }
 
     #[test]

--- a/backend/crates/layout-core/src/resolve.rs
+++ b/backend/crates/layout-core/src/resolve.rs
@@ -11,7 +11,6 @@ pub fn resolve(
     killed: &BTreeSet<SectionType>,
     registry: &RegistryManifest,
 ) -> ResolvedScreen {
-    let _ = killed; // applied in later layers of this function
     let mut sections = Vec::with_capacity(base.sections.len());
     let ordered = order_sections(&base.sections, tenant.and_then(|t| t.order.as_deref()));
     for cfg in ordered {

--- a/backend/crates/layout-core/src/types.rs
+++ b/backend/crates/layout-core/src/types.rs
@@ -1,0 +1,101 @@
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Free-form props bag; values validated against component prop schemas at publish time.
+pub type Props = BTreeMap<String, serde_json::Value>;
+
+/// Semantic, versioned component type name, e.g. "price-box.v1" (spec §3.1).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SectionType(pub String);
+
+impl From<&str> for SectionType {
+    fn from(s: &str) -> Self {
+        SectionType(s.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Platform {
+    Web,
+    Mobile,
+}
+
+/// Sparse patch applied on top of a section's base config (platform or tenant layer).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SectionPatch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visible: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: Props,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SectionConfig {
+    #[serde(rename = "type")]
+    pub section_type: SectionType,
+    #[serde(default = "default_true")]
+    pub visible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: Props,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub overrides: BTreeMap<Platform, SectionPatch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScreenConfig {
+    pub screen: String,
+    pub version: u32,
+    pub sections: Vec<SectionConfig>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The illustrative config from spec §3.1 must deserialize and round-trip.
+    #[test]
+    fn screen_config_round_trips_spec_example() {
+        let json = r#"{
+          "screen": "reality/listing-detail",
+          "version": 42,
+          "sections": [
+            { "type": "gallery.v1" },
+            { "type": "agent-contact.v1", "mode": "sticky-sidebar",
+              "overrides": { "mobile": { "mode": "bottom-bar" } } },
+            { "type": "similar-listings.v1", "visible": false },
+            { "type": "mortgage-calc.v1", "props": { "maxYears": 30 } }
+          ]
+        }"#;
+        let cfg: ScreenConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.screen, "reality/listing-detail");
+        assert_eq!(cfg.version, 42);
+        assert_eq!(cfg.sections.len(), 4);
+        // "visible" defaults to true when omitted
+        assert!(cfg.sections[0].visible);
+        assert!(!cfg.sections[2].visible);
+        // platform override parsed under enum key
+        let patch = &cfg.sections[1].overrides[&Platform::Mobile];
+        assert_eq!(patch.mode.as_deref(), Some("bottom-bar"));
+        // props carried as JSON values
+        assert_eq!(cfg.sections[3].props["maxYears"], serde_json::json!(30));
+        // unknown fields are ignored (additive evolution)
+        let with_unknown = r#"{"screen":"s","version":1,"sections":[
+            {"type":"x.v1","futureField":true}]}"#;
+        assert!(serde_json::from_str::<ScreenConfig>(with_unknown).is_ok());
+        // round-trip
+        let back: ScreenConfig =
+            serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(back.sections[1].overrides[&Platform::Mobile].mode.as_deref(),
+                   Some("bottom-bar"));
+    }
+}

--- a/backend/crates/layout-core/src/types.rs
+++ b/backend/crates/layout-core/src/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// Free-form props bag; values validated against component prop schemas at publish time.
 pub type Props = BTreeMap<String, serde_json::Value>;
@@ -58,6 +58,74 @@ fn default_true() -> bool {
     true
 }
 
+/// Per-component contract published by each frontend (spec §3.3).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ComponentDef {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_modes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegistryManifest {
+    pub platform: Platform,
+    pub components: BTreeMap<SectionType, ComponentDef>,
+}
+
+/// Sparse per-org delta over a published base config (spec §3.2).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TenantOverride {
+    /// Full desired order by type. None = keep base order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<Vec<SectionType>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sections: BTreeMap<SectionType, SectionPatch>,
+}
+
+/// What tenant admins may change on a screen (spec §3.4). Authored by superadmin.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Rails {
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub hideable: BTreeSet<SectionType>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub mode_editable: BTreeSet<SectionType>,
+    #[serde(default)]
+    pub reorderable: bool,
+    /// Per-section set of prop names tenant admins may set.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub prop_whitelist: BTreeMap<SectionType, BTreeSet<String>>,
+}
+
+/// How a resolved section renders (spec §4 rules 2–3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Presentation {
+    Visible,
+    /// Required section that is hidden, killed, or failed validation.
+    Placeholder,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedSection {
+    #[serde(rename = "type")]
+    pub section_type: SectionType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: Props,
+    pub presentation: Presentation,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedScreen {
+    pub screen: String,
+    pub version: u32,
+    pub sections: Vec<ResolvedSection>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -97,5 +165,41 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
         assert_eq!(back.sections[1].overrides[&Platform::Mobile].mode.as_deref(),
                    Some("bottom-bar"));
+    }
+
+    #[test]
+    fn manifest_override_and_rails_deserialize_with_defaults() {
+        let manifest: RegistryManifest = serde_json::from_str(
+            r#"{"platform":"web","components":{
+                "gallery.v1":{"required":true},
+                "listing-grid.v1":{"supported_modes":["list","grid","map"],
+                                    "default_mode":"list"}}}"#,
+        )
+        .unwrap();
+        let gallery = &manifest.components[&SectionType::from("gallery.v1")];
+        assert!(gallery.required);
+        assert!(gallery.supported_modes.is_empty());
+        let grid = &manifest.components[&SectionType::from("listing-grid.v1")];
+        assert!(!grid.required); // required defaults to false
+        assert_eq!(grid.default_mode.as_deref(), Some("list"));
+
+        let ov: TenantOverride = serde_json::from_str(
+            r#"{"order":["b.v1","a.v1"],
+                "sections":{"a.v1":{"visible":false}}}"#,
+        )
+        .unwrap();
+        assert_eq!(ov.order.as_ref().unwrap().len(), 2);
+        assert_eq!(ov.sections[&SectionType::from("a.v1")].visible, Some(false));
+        // empty override is valid (all fields default)
+        assert!(serde_json::from_str::<TenantOverride>("{}").is_ok());
+
+        let rails: Rails = serde_json::from_str(
+            r#"{"hideable":["a.v1"],"reorderable":true,
+                "prop_whitelist":{"a.v1":["title","limit"]}}"#,
+        )
+        .unwrap();
+        assert!(rails.reorderable);
+        assert!(rails.hideable.contains(&SectionType::from("a.v1")));
+        assert!(rails.mode_editable.is_empty()); // defaults empty
     }
 }

--- a/backend/crates/layout-core/src/types.rs
+++ b/backend/crates/layout-core/src/types.rs
@@ -205,5 +205,7 @@ mod tests {
         assert!(rails.reorderable);
         assert!(rails.hideable.contains(&SectionType::from("a.v1")));
         assert!(rails.mode_editable.is_empty()); // defaults empty
+                                                 // empty JSON deserializes to default Rails (all fields have serde defaults)
+        assert!(serde_json::from_str::<Rails>("{}").is_ok());
     }
 }

--- a/backend/crates/layout-core/src/types.rs
+++ b/backend/crates/layout-core/src/types.rs
@@ -163,8 +163,12 @@ mod tests {
         // round-trip
         let back: ScreenConfig =
             serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
-        assert_eq!(back.sections[1].overrides[&Platform::Mobile].mode.as_deref(),
-                   Some("bottom-bar"));
+        assert_eq!(
+            back.sections[1].overrides[&Platform::Mobile]
+                .mode
+                .as_deref(),
+            Some("bottom-bar")
+        );
     }
 
     #[test]

--- a/backend/crates/layout-core/src/validate.rs
+++ b/backend/crates/layout-core/src/validate.rs
@@ -6,13 +6,20 @@ pub enum ValidationError {
     #[error("section {section:?} appears more than once")]
     DuplicateSection { section: SectionType },
     #[error("section {section:?} is not in the {platform:?} registry")]
-    UnknownType { section: SectionType, platform: Platform },
+    UnknownType {
+        section: SectionType,
+        platform: Platform,
+    },
     #[error("required section {section:?} is hidden in the base config")]
     RequiredHidden { section: SectionType },
     #[error("required component {section:?} is missing from the config")]
     RequiredMissing { section: SectionType },
     #[error("section {section:?} uses mode {mode:?}, unsupported on {platform:?}")]
-    UnsupportedMode { section: SectionType, mode: String, platform: Platform },
+    UnsupportedMode {
+        section: SectionType,
+        mode: String,
+        platform: Platform,
+    },
     #[error("tenant override references section {section:?} not present in the base config")]
     NotInBase { section: SectionType },
     #[error("section {section:?} is not tenant-hideable")]
@@ -35,7 +42,9 @@ pub fn validate_publish(
     let mut seen = std::collections::BTreeSet::new();
     for s in &config.sections {
         if !seen.insert(&s.section_type) {
-            errs.push(ValidationError::DuplicateSection { section: s.section_type.clone() });
+            errs.push(ValidationError::DuplicateSection {
+                section: s.section_type.clone(),
+            });
         }
     }
     for m in manifests {
@@ -54,7 +63,9 @@ pub fn validate_publish(
                 .and_then(|p| p.mode.clone())
                 .or_else(|| s.mode.clone());
             if def.required && !visible {
-                let err = ValidationError::RequiredHidden { section: s.section_type.clone() };
+                let err = ValidationError::RequiredHidden {
+                    section: s.section_type.clone(),
+                };
                 if !errs.contains(&err) {
                     errs.push(err);
                 }
@@ -164,8 +175,14 @@ mod tests {
             sections: vec![section("gallery.v1"), section("faq.v1")],
         };
         let manifests = vec![
-            manifest(Platform::Web, &[("gallery.v1", true, &[]), ("faq.v1", false, &[])]),
-            manifest(Platform::Mobile, &[("gallery.v1", true, &[]), ("faq.v1", false, &[])]),
+            manifest(
+                Platform::Web,
+                &[("gallery.v1", true, &[]), ("faq.v1", false, &[])],
+            ),
+            manifest(
+                Platform::Mobile,
+                &[("gallery.v1", true, &[]), ("faq.v1", false, &[])],
+            ),
         ];
         assert!(validate_publish(&cfg, &manifests).is_empty());
     }
@@ -180,17 +197,20 @@ mod tests {
             screen: "s".into(),
             version: 1,
             sections: vec![
-                hidden_required,          // required hidden in base → error
-                bad_mode,                 // mode unsupported on web → error
-                section("faq.v1"),        // duplicate type → error
-                section("only-web.v1"),   // missing from mobile manifest → error
+                hidden_required,        // required hidden in base → error
+                bad_mode,               // mode unsupported on web → error
+                section("faq.v1"),      // duplicate type → error
+                section("only-web.v1"), // missing from mobile manifest → error
             ],
         };
         let manifests = vec![
             manifest(
                 Platform::Web,
-                &[("gallery.v1", true, &[]), ("faq.v1", false, &["accordion"]),
-                  ("only-web.v1", false, &[])],
+                &[
+                    ("gallery.v1", true, &[]),
+                    ("faq.v1", false, &["accordion"]),
+                    ("only-web.v1", false, &[]),
+                ],
             ),
             manifest(
                 Platform::Mobile,
@@ -212,9 +232,12 @@ mod tests {
     #[test]
     fn missing_required_component_is_an_error() {
         // manifest declares a required component the config omits entirely
-        let cfg = ScreenConfig { screen: "s".into(), version: 1, sections: vec![] };
-        let manifests =
-            vec![manifest(Platform::Web, &[("gallery.v1", true, &[])])];
+        let cfg = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![],
+        };
+        let manifests = vec![manifest(Platform::Web, &[("gallery.v1", true, &[])])];
         let errs = validate_publish(&cfg, &manifests);
         assert!(errs.iter().any(|e| matches!(e,
             ValidationError::RequiredMissing { section } if section.0 == "gallery.v1")));
@@ -228,9 +251,16 @@ mod tests {
         s.visible = false;
         s.overrides.insert(
             Platform::Web,
-            SectionPatch { visible: Some(true), ..Default::default() },
+            SectionPatch {
+                visible: Some(true),
+                ..Default::default()
+            },
         );
-        let cfg = ScreenConfig { screen: "s".into(), version: 1, sections: vec![s] };
+        let cfg = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![s],
+        };
 
         let web_only = vec![manifest(Platform::Web, &[("gallery.v1", true, &[])])];
         assert!(validate_publish(&cfg, &web_only).is_empty());
@@ -242,7 +272,9 @@ mod tests {
         let errs = validate_publish(&cfg, &both);
         assert_eq!(
             errs,
-            vec![ValidationError::RequiredHidden { section: SectionType::from("gallery.v1") }]
+            vec![ValidationError::RequiredHidden {
+                section: SectionType::from("gallery.v1")
+            }]
         );
     }
 
@@ -269,7 +301,7 @@ mod tests {
                 (
                     SectionType::from("news.v1"),
                     SectionPatch {
-                        visible: Some(false),                    // ok: hideable
+                        visible: Some(false), // ok: hideable
                         props: BTreeMap::from([
                             ("limit".to_string(), serde_json::json!(5)), // ok: whitelisted
                             ("theme".to_string(), serde_json::json!("dark")), // not whitelisted
@@ -279,7 +311,10 @@ mod tests {
                 ),
                 (
                     SectionType::from("kpi.v1"),
-                    SectionPatch { visible: Some(false), ..Default::default() }, // not hideable
+                    SectionPatch {
+                        visible: Some(false),
+                        ..Default::default()
+                    }, // not hideable
                 ),
                 (
                     SectionType::from("news.v1-typo"),
@@ -287,13 +322,17 @@ mod tests {
                 ),
                 (
                     SectionType::from("faults.v1"),
-                    SectionPatch { mode: Some("compact".into()), ..Default::default() }, // ok
+                    SectionPatch {
+                        mode: Some("compact".into()),
+                        ..Default::default()
+                    }, // ok
                 ),
             ]),
         };
         let errs = validate_tenant_override(&ov, &base, &rails);
-        assert!(errs.iter().any(|e| matches!(e,
-            ValidationError::NotReorderable)));
+        assert!(errs
+            .iter()
+            .any(|e| matches!(e, ValidationError::NotReorderable)));
         assert!(errs.iter().any(|e| matches!(e,
             ValidationError::PropNotWhitelisted { section, prop }
                 if section.0 == "news.v1" && prop == "theme")));
@@ -317,7 +356,10 @@ mod tests {
             order: None,
             sections: BTreeMap::from([(
                 SectionType::from("news.v1"),
-                SectionPatch { mode: Some("grid".into()), ..Default::default() },
+                SectionPatch {
+                    mode: Some("grid".into()),
+                    ..Default::default()
+                },
             )]),
         };
         let errs = validate_tenant_override(&ov, &base, &rails);

--- a/backend/crates/layout-core/src/validate.rs
+++ b/backend/crates/layout-core/src/validate.rs
@@ -30,9 +30,17 @@ pub enum ValidationError {
     PropNotWhitelisted { section: SectionType, prop: String },
     #[error("this screen is not tenant-reorderable")]
     NotReorderable,
+    #[error("component {section:?} declares default_mode {mode:?} not in its supported_modes on {platform:?}")]
+    InvalidDefaultMode {
+        section: SectionType,
+        mode: String,
+        platform: Platform,
+    },
 }
 
 /// Publish gate (spec §6.3): empty result = publishable. Errors block publish.
+///
+/// Error ordering follows section iteration order (the order sections appear in the config).
 pub fn validate_publish(
     config: &ScreenConfig,
     manifests: &[RegistryManifest],
@@ -88,6 +96,16 @@ pub fn validate_publish(
                     errs.push(err);
                 }
             }
+            // gate inconsistent default_mode: if declared, it must be in supported_modes
+            if let Some(dm) = &def.default_mode {
+                if !def.supported_modes.contains(dm) {
+                    errs.push(ValidationError::InvalidDefaultMode {
+                        section: t.clone(),
+                        mode: dm.clone(),
+                        platform: m.platform,
+                    });
+                }
+            }
         }
     }
     errs
@@ -95,6 +113,9 @@ pub fn validate_publish(
 
 /// Server-side rails enforcement for tenant saves (spec §3.4). The UI hides
 /// out-of-rails controls, but this is the actual gate.
+///
+/// Error ordering follows alphabetical BTreeMap order (the order sections appear in the
+/// tenant override's BTreeMap).
 pub fn validate_tenant_override(
     ov: &TenantOverride,
     base: &ScreenConfig,
@@ -365,5 +386,37 @@ mod tests {
         let errs = validate_tenant_override(&ov, &base, &rails);
         assert!(errs.iter().any(|e| matches!(e,
             ValidationError::NotModeEditable { section } if section.0 == "news.v1")));
+    }
+    #[test]
+    fn invalid_default_mode_blocked_at_publish() {
+        // Component declares default_mode 'grid' which is NOT in supported_modes ['list'].
+        // validate_publish must reject this with InvalidDefaultMode.
+        let cfg = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![section("listing-grid.v1")],
+        };
+        let manifests = vec![RegistryManifest {
+            platform: Platform::Web,
+            components: std::collections::BTreeMap::from([(
+                SectionType::from("listing-grid.v1"),
+                ComponentDef {
+                    required: false,
+                    supported_modes: vec!["list".to_string()],
+                    default_mode: Some("grid".to_string()), // inconsistent: not in supported_modes
+                },
+            )]),
+        }];
+        let errs = validate_publish(&cfg, &manifests);
+        assert!(
+            errs.iter().any(|e| matches!(e,
+                ValidationError::InvalidDefaultMode { section, mode, platform }
+                    if section.0 == "listing-grid.v1"
+                    && mode == "grid"
+                    && *platform == Platform::Web
+            )),
+            "expected InvalidDefaultMode error, got: {:?}",
+            errs
+        );
     }
 }

--- a/backend/crates/layout-core/src/validate.rs
+++ b/backend/crates/layout-core/src/validate.rs
@@ -169,4 +169,30 @@ mod tests {
         assert!(errs.iter().any(|e| matches!(e,
             ValidationError::RequiredMissing { section } if section.0 == "gallery.v1")));
     }
+
+    #[test]
+    fn platform_override_changes_effective_visibility() {
+        // required section hidden in base but re-shown on web via override:
+        // no error on web; still an error on mobile (no override there).
+        let mut s = section("gallery.v1");
+        s.visible = false;
+        s.overrides.insert(
+            Platform::Web,
+            SectionPatch { visible: Some(true), ..Default::default() },
+        );
+        let cfg = ScreenConfig { screen: "s".into(), version: 1, sections: vec![s] };
+
+        let web_only = vec![manifest(Platform::Web, &[("gallery.v1", true, &[])])];
+        assert!(validate_publish(&cfg, &web_only).is_empty());
+
+        let both = vec![
+            manifest(Platform::Web, &[("gallery.v1", true, &[])]),
+            manifest(Platform::Mobile, &[("gallery.v1", true, &[])]),
+        ];
+        let errs = validate_publish(&cfg, &both);
+        assert_eq!(
+            errs,
+            vec![ValidationError::RequiredHidden { section: SectionType::from("gallery.v1") }]
+        );
+    }
 }

--- a/backend/crates/layout-core/src/validate.rs
+++ b/backend/crates/layout-core/src/validate.rs
@@ -13,6 +13,16 @@ pub enum ValidationError {
     RequiredMissing { section: SectionType },
     #[error("section {section:?} uses mode {mode:?}, unsupported on {platform:?}")]
     UnsupportedMode { section: SectionType, mode: String, platform: Platform },
+    #[error("tenant override references section {section:?} not present in the base config")]
+    NotInBase { section: SectionType },
+    #[error("section {section:?} is not tenant-hideable")]
+    NotHideable { section: SectionType },
+    #[error("section {section:?} is not tenant-mode-editable")]
+    NotModeEditable { section: SectionType },
+    #[error("prop {prop:?} on section {section:?} is not whitelisted for tenants")]
+    PropNotWhitelisted { section: SectionType, prop: String },
+    #[error("this screen is not tenant-reorderable")]
+    NotReorderable,
 }
 
 /// Publish gate (spec §6.3): empty result = publishable. Errors block publish.
@@ -66,6 +76,46 @@ pub fn validate_publish(
                 if !errs.contains(&err) {
                     errs.push(err);
                 }
+            }
+        }
+    }
+    errs
+}
+
+/// Server-side rails enforcement for tenant saves (spec §3.4). The UI hides
+/// out-of-rails controls, but this is the actual gate.
+pub fn validate_tenant_override(
+    ov: &TenantOverride,
+    base: &ScreenConfig,
+    rails: &Rails,
+) -> Vec<ValidationError> {
+    let mut errs = Vec::new();
+    if ov.order.is_some() && !rails.reorderable {
+        errs.push(ValidationError::NotReorderable);
+    }
+    static EMPTY: std::sync::OnceLock<std::collections::BTreeSet<String>> =
+        std::sync::OnceLock::new();
+    for (t, patch) in &ov.sections {
+        if !base.sections.iter().any(|s| &s.section_type == t) {
+            errs.push(ValidationError::NotInBase { section: t.clone() });
+            continue;
+        }
+        if patch.visible.is_some() && !rails.hideable.contains(t) {
+            errs.push(ValidationError::NotHideable { section: t.clone() });
+        }
+        if patch.mode.is_some() && !rails.mode_editable.contains(t) {
+            errs.push(ValidationError::NotModeEditable { section: t.clone() });
+        }
+        let whitelist = rails
+            .prop_whitelist
+            .get(t)
+            .unwrap_or_else(|| EMPTY.get_or_init(Default::default));
+        for prop in patch.props.keys() {
+            if !whitelist.contains(prop) {
+                errs.push(ValidationError::PropNotWhitelisted {
+                    section: t.clone(),
+                    prop: prop.clone(),
+                });
             }
         }
     }
@@ -194,5 +244,84 @@ mod tests {
             errs,
             vec![ValidationError::RequiredHidden { section: SectionType::from("gallery.v1") }]
         );
+    }
+
+    #[test]
+    fn rails_enforcement_rejects_out_of_rails_edits() {
+        use std::collections::BTreeSet;
+        let base = ScreenConfig {
+            screen: "ppt/dashboard".into(),
+            version: 1,
+            sections: vec![section("news.v1"), section("faults.v1"), section("kpi.v1")],
+        };
+        let rails = Rails {
+            hideable: BTreeSet::from([SectionType::from("news.v1")]),
+            mode_editable: BTreeSet::from([SectionType::from("faults.v1")]),
+            reorderable: false,
+            prop_whitelist: BTreeMap::from([(
+                SectionType::from("news.v1"),
+                BTreeSet::from(["limit".to_string()]),
+            )]),
+        };
+        let ov = TenantOverride {
+            order: Some(vec![SectionType::from("kpi.v1")]), // reorder forbidden
+            sections: BTreeMap::from([
+                (
+                    SectionType::from("news.v1"),
+                    SectionPatch {
+                        visible: Some(false),                    // ok: hideable
+                        props: BTreeMap::from([
+                            ("limit".to_string(), serde_json::json!(5)), // ok: whitelisted
+                            ("theme".to_string(), serde_json::json!("dark")), // not whitelisted
+                        ]),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    SectionType::from("kpi.v1"),
+                    SectionPatch { visible: Some(false), ..Default::default() }, // not hideable
+                ),
+                (
+                    SectionType::from("news.v1-typo"),
+                    SectionPatch::default(), // not in base
+                ),
+                (
+                    SectionType::from("faults.v1"),
+                    SectionPatch { mode: Some("compact".into()), ..Default::default() }, // ok
+                ),
+            ]),
+        };
+        let errs = validate_tenant_override(&ov, &base, &rails);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotReorderable)));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::PropNotWhitelisted { section, prop }
+                if section.0 == "news.v1" && prop == "theme")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotHideable { section } if section.0 == "kpi.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotInBase { section } if section.0 == "news.v1-typo")));
+        // exactly the four violations above — the allowed edits pass
+        assert_eq!(errs.len(), 4);
+    }
+
+    #[test]
+    fn mode_edit_on_non_editable_section_is_rejected() {
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![section("news.v1")],
+        };
+        let rails = Rails::default();
+        let ov = TenantOverride {
+            order: None,
+            sections: BTreeMap::from([(
+                SectionType::from("news.v1"),
+                SectionPatch { mode: Some("grid".into()), ..Default::default() },
+            )]),
+        };
+        let errs = validate_tenant_override(&ov, &base, &rails);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotModeEditable { section } if section.0 == "news.v1")));
     }
 }

--- a/backend/crates/layout-core/src/validate.rs
+++ b/backend/crates/layout-core/src/validate.rs
@@ -1,0 +1,172 @@
+use crate::types::*;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum ValidationError {
+    #[error("section {section:?} appears more than once")]
+    DuplicateSection { section: SectionType },
+    #[error("section {section:?} is not in the {platform:?} registry")]
+    UnknownType { section: SectionType, platform: Platform },
+    #[error("required section {section:?} is hidden in the base config")]
+    RequiredHidden { section: SectionType },
+    #[error("required component {section:?} is missing from the config")]
+    RequiredMissing { section: SectionType },
+    #[error("section {section:?} uses mode {mode:?}, unsupported on {platform:?}")]
+    UnsupportedMode { section: SectionType, mode: String, platform: Platform },
+}
+
+/// Publish gate (spec §6.3): empty result = publishable. Errors block publish.
+pub fn validate_publish(
+    config: &ScreenConfig,
+    manifests: &[RegistryManifest],
+) -> Vec<ValidationError> {
+    let mut errs = Vec::new();
+    // duplicates
+    let mut seen = std::collections::BTreeSet::new();
+    for s in &config.sections {
+        if !seen.insert(&s.section_type) {
+            errs.push(ValidationError::DuplicateSection { section: s.section_type.clone() });
+        }
+    }
+    for m in manifests {
+        for s in &config.sections {
+            let Some(def) = m.components.get(&s.section_type) else {
+                errs.push(ValidationError::UnknownType {
+                    section: s.section_type.clone(),
+                    platform: m.platform,
+                });
+                continue;
+            };
+            // effective visibility/mode on this platform (base + platform patch)
+            let patch = s.overrides.get(&m.platform);
+            let visible = patch.and_then(|p| p.visible).unwrap_or(s.visible);
+            let mode = patch
+                .and_then(|p| p.mode.clone())
+                .or_else(|| s.mode.clone());
+            if def.required && !visible {
+                let err = ValidationError::RequiredHidden { section: s.section_type.clone() };
+                if !errs.contains(&err) {
+                    errs.push(err);
+                }
+            }
+            if let Some(mode) = mode {
+                if !def.supported_modes.contains(&mode) {
+                    errs.push(ValidationError::UnsupportedMode {
+                        section: s.section_type.clone(),
+                        mode,
+                        platform: m.platform,
+                    });
+                }
+            }
+        }
+        // every required component in the manifest must be present in the config
+        for (t, def) in &m.components {
+            if def.required && !config.sections.iter().any(|s| &s.section_type == t) {
+                let err = ValidationError::RequiredMissing { section: t.clone() };
+                if !errs.contains(&err) {
+                    errs.push(err);
+                }
+            }
+        }
+    }
+    errs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn manifest(platform: Platform, entries: &[(&str, bool, &[&str])]) -> RegistryManifest {
+        RegistryManifest {
+            platform,
+            components: entries
+                .iter()
+                .map(|(t, req, modes)| {
+                    (
+                        SectionType::from(*t),
+                        ComponentDef {
+                            required: *req,
+                            supported_modes: modes.iter().map(|m| m.to_string()).collect(),
+                            default_mode: None,
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn section(t: &str) -> SectionConfig {
+        SectionConfig {
+            section_type: SectionType::from(t),
+            visible: true,
+            mode: None,
+            props: BTreeMap::new(),
+            overrides: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        let cfg = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![section("gallery.v1"), section("faq.v1")],
+        };
+        let manifests = vec![
+            manifest(Platform::Web, &[("gallery.v1", true, &[]), ("faq.v1", false, &[])]),
+            manifest(Platform::Mobile, &[("gallery.v1", true, &[]), ("faq.v1", false, &[])]),
+        ];
+        assert!(validate_publish(&cfg, &manifests).is_empty());
+    }
+
+    #[test]
+    fn publish_gate_catches_all_error_classes() {
+        let mut hidden_required = section("gallery.v1");
+        hidden_required.visible = false;
+        let mut bad_mode = section("faq.v1");
+        bad_mode.mode = Some("carousel".into());
+        let cfg = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![
+                hidden_required,          // required hidden in base → error
+                bad_mode,                 // mode unsupported on web → error
+                section("faq.v1"),        // duplicate type → error
+                section("only-web.v1"),   // missing from mobile manifest → error
+            ],
+        };
+        let manifests = vec![
+            manifest(
+                Platform::Web,
+                &[("gallery.v1", true, &[]), ("faq.v1", false, &["accordion"]),
+                  ("only-web.v1", false, &[])],
+            ),
+            manifest(
+                Platform::Mobile,
+                &[("gallery.v1", true, &[]), ("faq.v1", false, &["accordion"])],
+            ),
+        ];
+        let errs = validate_publish(&cfg, &manifests);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::RequiredHidden { section } if section.0 == "gallery.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::UnsupportedMode { section, .. } if section.0 == "faq.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::DuplicateSection { section } if section.0 == "faq.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::UnknownType { section, platform }
+                if section.0 == "only-web.v1" && *platform == Platform::Mobile)));
+    }
+
+    #[test]
+    fn missing_required_component_is_an_error() {
+        // manifest declares a required component the config omits entirely
+        let cfg = ScreenConfig { screen: "s".into(), version: 1, sections: vec![] };
+        let manifests =
+            vec![manifest(Platform::Web, &[("gallery.v1", true, &[])])];
+        let errs = validate_publish(&cfg, &manifests);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::RequiredMissing { section } if section.0 == "gallery.v1")));
+    }
+}

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -48,6 +48,9 @@ over `grep -r <noun> backend/`.
 
 **Crates** (`backend/crates/`):
 - `common` — `TenantContext`, `TenantRole` (11 roles), core errors/types. Used everywhere.
+- `layout-core` — Layout & Content Manager contract: screen configs, merge resolver
+  (base → platform → tenant → kill), publish/rails validation. Pure logic, no DB.
+  Spec: `docs/superpowers/specs/2026-07-19-layout-content-manager-design.md`.
 - `api-core` — Axum extractors, auth middleware, OpenAPI (utoipa), CORS/tracing.
 - `db` — SQLx pool, models, **~101 repositories** in `src/repositories/`, migrations (~177 sql files).
 - `integrations` — external API clients (Airbnb, Booking.com, portals).

--- a/docs/superpowers/plans/2026-07-19-layout-core-contract.md
+++ b/docs/superpowers/plans/2026-07-19-layout-core-contract.md
@@ -1,0 +1,1261 @@
+# Layout Core Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `layout-core` Rust crate — config types, layered merge resolver, and publish/rails validation for the Layout & Content Manager — as pure, DB-free, fully unit-tested logic.
+
+**Architecture:** New workspace crate `backend/crates/layout-core` implementing the contract from `docs/superpowers/specs/2026-07-19-layout-content-manager-design.md` §3–§5: screen configs are flat section lists; resolution merges `base → platform override → tenant override → kill flags` against a per-platform component registry manifest; required sections degrade to placeholders, optional ones collapse; publish and tenant-save validation are hard gates. No HTTP, no SQL — those come in the control-plane plan.
+
+**Tech Stack:** Rust 2021 (workspace `rust-version = 1.75`), serde/serde_json, thiserror. No new external dependencies.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-19-layout-content-manager-design.md` — this plan implements §3 (core model), §4 rules 1–2 (resolver side), §5 (kill semantics), §6.3 (validation gate logic only).
+- Crate must compile without a database (repo convention: DB-free compile; runtime sqlx only in `db` crate).
+- Additive-only evolution: all config structs get `#[serde(default)]`-friendly fields and must ignore unknown JSON fields (serde default behavior — do NOT add `deny_unknown_fields`).
+- `required` comes from the registry manifest, never from config (spec §3.1).
+- Merge precedence, exactly: base config → platform override → tenant override → kill flags (spec §3.2).
+- Commit scope: `feat(layout-core): …` / `test(layout-core): …` per repo Conventional Commits.
+- Pre-push gate: `cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings && cargo test -p layout-core` (run inside `backend/`).
+
+## File Structure
+
+```
+backend/crates/layout-core/
+├── Cargo.toml
+└── src/
+    ├── lib.rs        # module wiring + re-exports
+    ├── types.rs      # config, override, registry, rails, resolved types
+    ├── resolve.rs    # layered merge resolver
+    └── validate.rs   # publish gate + tenant-rails validation
+backend/Cargo.toml    # + "crates/layout-core" workspace member
+docs/repo-map.md      # + one line for the new crate
+```
+
+---
+
+### Task 1: Crate scaffold + config types + serde round-trip
+
+**Files:**
+- Create: `backend/crates/layout-core/Cargo.toml`
+- Create: `backend/crates/layout-core/src/lib.rs`
+- Create: `backend/crates/layout-core/src/types.rs`
+- Modify: `backend/Cargo.toml` (workspace `members` list, after `"crates/common"`)
+- Test: inline `#[cfg(test)]` in `types.rs`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces (used by every later task): `Platform` (enum `Web | Mobile`, serde lowercase, `Ord`), `SectionType(pub String)`, `Props = BTreeMap<String, serde_json::Value>`, `SectionPatch { visible: Option<bool>, mode: Option<String>, props: Props }`, `SectionConfig { section_type, visible, mode, props, overrides: BTreeMap<Platform, SectionPatch> }`, `ScreenConfig { screen: String, version: u32, sections: Vec<SectionConfig> }`.
+
+- [ ] **Step 1: Register the crate in the workspace**
+
+In `backend/Cargo.toml`, add to `members` after `"crates/common"`:
+
+```toml
+    "crates/layout-core",
+```
+
+- [ ] **Step 2: Create `backend/crates/layout-core/Cargo.toml`**
+
+```toml
+[package]
+name = "layout-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+```
+
+- [ ] **Step 3: Create `src/lib.rs`**
+
+```rust
+//! Layout & Content Manager contract: config types, merge resolver, validation.
+//!
+//! Spec: docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
+
+pub mod types;
+
+pub use types::*;
+```
+
+- [ ] **Step 4: Write the failing round-trip test**
+
+Create `src/types.rs` containing ONLY the test module for now:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The illustrative config from spec §3.1 must deserialize and round-trip.
+    #[test]
+    fn screen_config_round_trips_spec_example() {
+        let json = r#"{
+          "screen": "reality/listing-detail",
+          "version": 42,
+          "sections": [
+            { "type": "gallery.v1" },
+            { "type": "agent-contact.v1", "mode": "sticky-sidebar",
+              "overrides": { "mobile": { "mode": "bottom-bar" } } },
+            { "type": "similar-listings.v1", "visible": false },
+            { "type": "mortgage-calc.v1", "props": { "maxYears": 30 } }
+          ]
+        }"#;
+        let cfg: ScreenConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.screen, "reality/listing-detail");
+        assert_eq!(cfg.version, 42);
+        assert_eq!(cfg.sections.len(), 4);
+        // "visible" defaults to true when omitted
+        assert!(cfg.sections[0].visible);
+        assert!(!cfg.sections[2].visible);
+        // platform override parsed under enum key
+        let patch = &cfg.sections[1].overrides[&Platform::Mobile];
+        assert_eq!(patch.mode.as_deref(), Some("bottom-bar"));
+        // props carried as JSON values
+        assert_eq!(cfg.sections[3].props["maxYears"], serde_json::json!(30));
+        // unknown fields are ignored (additive evolution)
+        let with_unknown = r#"{"screen":"s","version":1,"sections":[
+            {"type":"x.v1","futureField":true}]}"#;
+        assert!(serde_json::from_str::<ScreenConfig>(with_unknown).is_ok());
+        // round-trip
+        let back: ScreenConfig =
+            serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(back.sections[1].overrides[&Platform::Mobile].mode.as_deref(),
+                   Some("bottom-bar"));
+    }
+}
+```
+
+- [ ] **Step 5: Run test to verify it fails**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: FAIL to compile — `ScreenConfig`, `Platform` not defined.
+
+- [ ] **Step 6: Implement the types**
+
+Add above the test module in `src/types.rs`:
+
+```rust
+/// Free-form props bag; values validated against component prop schemas at publish time.
+pub type Props = BTreeMap<String, serde_json::Value>;
+
+/// Semantic, versioned component type name, e.g. "price-box.v1" (spec §3.1).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SectionType(pub String);
+
+impl From<&str> for SectionType {
+    fn from(s: &str) -> Self {
+        SectionType(s.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Platform {
+    Web,
+    Mobile,
+}
+
+/// Sparse patch applied on top of a section's base config (platform or tenant layer).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct SectionPatch {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visible: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: Props,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SectionConfig {
+    #[serde(rename = "type")]
+    pub section_type: SectionType,
+    #[serde(default = "default_true")]
+    pub visible: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: Props,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub overrides: BTreeMap<Platform, SectionPatch>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScreenConfig {
+    pub screen: String,
+    pub version: u32,
+    pub sections: Vec<SectionConfig>,
+}
+
+fn default_true() -> bool {
+    true
+}
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: PASS (1 test).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/Cargo.toml backend/crates/layout-core
+git commit -m "feat(layout-core): scaffold crate with screen config types"
+```
+
+---
+
+### Task 2: Registry manifest, rails, tenant override + resolved-output types
+
+**Files:**
+- Modify: `backend/crates/layout-core/src/types.rs`
+- Test: inline `#[cfg(test)]` in `types.rs`
+
+**Interfaces:**
+- Consumes: Task 1 types.
+- Produces: `ComponentDef { required: bool, supported_modes: Vec<String>, default_mode: Option<String> }`, `RegistryManifest { platform: Platform, components: BTreeMap<SectionType, ComponentDef> }`, `TenantOverride { order: Option<Vec<SectionType>>, sections: BTreeMap<SectionType, SectionPatch> }`, `Rails { hideable, mode_editable: BTreeSet<SectionType>, reorderable: bool, prop_whitelist: BTreeMap<SectionType, BTreeSet<String>> }`, `Presentation` (enum `Visible | Placeholder`), `ResolvedSection { section_type, mode, props, presentation }`, `ResolvedScreen { screen, version, sections }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the existing `mod tests`:
+
+```rust
+    #[test]
+    fn manifest_override_and_rails_deserialize_with_defaults() {
+        let manifest: RegistryManifest = serde_json::from_str(
+            r#"{"platform":"web","components":{
+                "gallery.v1":{"required":true},
+                "listing-grid.v1":{"supported_modes":["list","grid","map"],
+                                    "default_mode":"list"}}}"#,
+        )
+        .unwrap();
+        let gallery = &manifest.components[&SectionType::from("gallery.v1")];
+        assert!(gallery.required);
+        assert!(gallery.supported_modes.is_empty());
+        let grid = &manifest.components[&SectionType::from("listing-grid.v1")];
+        assert!(!grid.required); // required defaults to false
+        assert_eq!(grid.default_mode.as_deref(), Some("list"));
+
+        let ov: TenantOverride = serde_json::from_str(
+            r#"{"order":["b.v1","a.v1"],
+                "sections":{"a.v1":{"visible":false}}}"#,
+        )
+        .unwrap();
+        assert_eq!(ov.order.as_ref().unwrap().len(), 2);
+        assert_eq!(ov.sections[&SectionType::from("a.v1")].visible, Some(false));
+        // empty override is valid (all fields default)
+        assert!(serde_json::from_str::<TenantOverride>("{}").is_ok());
+
+        let rails: Rails = serde_json::from_str(
+            r#"{"hideable":["a.v1"],"reorderable":true,
+                "prop_whitelist":{"a.v1":["title","limit"]}}"#,
+        )
+        .unwrap();
+        assert!(rails.reorderable);
+        assert!(rails.hideable.contains(&SectionType::from("a.v1")));
+        assert!(rails.mode_editable.is_empty()); // defaults empty
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: FAIL to compile — `RegistryManifest`, `TenantOverride`, `Rails` not defined.
+
+- [ ] **Step 3: Implement the types**
+
+Append to `src/types.rs` (above the test module). Also add `BTreeSet` to the existing `use std::collections::BTreeMap;` import, making it `use std::collections::{BTreeMap, BTreeSet};`:
+
+```rust
+/// Per-component contract published by each frontend (spec §3.3).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ComponentDef {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_modes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegistryManifest {
+    pub platform: Platform,
+    pub components: BTreeMap<SectionType, ComponentDef>,
+}
+
+/// Sparse per-org delta over a published base config (spec §3.2).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TenantOverride {
+    /// Full desired order by type. None = keep base order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<Vec<SectionType>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sections: BTreeMap<SectionType, SectionPatch>,
+}
+
+/// What tenant admins may change on a screen (spec §3.4). Authored by superadmin.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Rails {
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub hideable: BTreeSet<SectionType>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub mode_editable: BTreeSet<SectionType>,
+    #[serde(default)]
+    pub reorderable: bool,
+    /// Per-section set of prop names tenant admins may set.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub prop_whitelist: BTreeMap<SectionType, BTreeSet<String>>,
+}
+
+/// How a resolved section renders (spec §4 rules 2–3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Presentation {
+    Visible,
+    /// Required section that is hidden, killed, or failed validation.
+    Placeholder,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedSection {
+    #[serde(rename = "type")]
+    pub section_type: SectionType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: Props,
+    pub presentation: Presentation,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedScreen {
+    pub screen: String,
+    pub version: u32,
+    pub sections: Vec<ResolvedSection>,
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/crates/layout-core/src/types.rs
+git commit -m "feat(layout-core): add registry, rails, tenant override and resolved types"
+```
+
+---
+
+### Task 3: Resolver — platform merge precedence
+
+**Files:**
+- Create: `backend/crates/layout-core/src/resolve.rs`
+- Modify: `backend/crates/layout-core/src/lib.rs`
+- Test: inline `#[cfg(test)]` in `resolve.rs`
+
+**Interfaces:**
+- Consumes: all Task 1–2 types.
+- Produces: `pub fn resolve(base: &ScreenConfig, platform: Platform, tenant: Option<&TenantOverride>, killed: &BTreeSet<SectionType>, registry: &RegistryManifest) -> ResolvedScreen` and (crate-private) `fn apply_patch(visible: &mut bool, mode: &mut Option<String>, props: &mut Props, patch: &SectionPatch)`. Tasks 4–5 extend `resolve` internals; the signature is FINAL as written here.
+
+- [ ] **Step 1: Wire the module**
+
+In `src/lib.rs` add:
+
+```rust
+pub mod resolve;
+
+pub use resolve::resolve;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/resolve.rs`:
+
+```rust
+use crate::types::*;
+use std::collections::BTreeSet;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn registry(entries: &[(&str, bool, &[&str])]) -> RegistryManifest {
+        RegistryManifest {
+            platform: Platform::Web,
+            components: entries
+                .iter()
+                .map(|(t, req, modes)| {
+                    (
+                        SectionType::from(*t),
+                        ComponentDef {
+                            required: *req,
+                            supported_modes: modes.iter().map(|m| m.to_string()).collect(),
+                            default_mode: modes.first().map(|m| m.to_string()),
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn section(t: &str) -> SectionConfig {
+        SectionConfig {
+            section_type: SectionType::from(t),
+            visible: true,
+            mode: None,
+            props: BTreeMap::new(),
+            overrides: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn platform_override_beats_base() {
+        let mut agent = section("agent-contact.v1");
+        agent.mode = Some("sticky-sidebar".into());
+        agent.overrides.insert(
+            Platform::Mobile,
+            SectionPatch {
+                mode: Some("bottom-bar".into()),
+                ..Default::default()
+            },
+        );
+        let base = ScreenConfig {
+            screen: "reality/listing-detail".into(),
+            version: 1,
+            sections: vec![section("gallery.v1"), agent],
+        };
+        let reg = registry(&[
+            ("gallery.v1", true, &[]),
+            ("agent-contact.v1", false, &["sticky-sidebar", "bottom-bar"]),
+        ]);
+
+        let web = resolve(&base, Platform::Web, None, &BTreeSet::new(), &reg);
+        assert_eq!(web.sections[1].mode.as_deref(), Some("sticky-sidebar"));
+
+        let mobile = resolve(&base, Platform::Mobile, None, &BTreeSet::new(), &reg);
+        assert_eq!(mobile.sections[1].mode.as_deref(), Some("bottom-bar"));
+        // untouched fields carry through; order preserved
+        assert_eq!(mobile.sections[0].section_type, SectionType::from("gallery.v1"));
+        assert_eq!(mobile.sections[0].presentation, Presentation::Visible);
+        assert_eq!(mobile.screen, "reality/listing-detail");
+        assert_eq!(mobile.version, 1);
+    }
+
+    #[test]
+    fn unsupported_mode_falls_back_to_default_mode() {
+        let mut s = section("listing-grid.v1");
+        s.mode = Some("hologram".into()); // not supported by the component
+        let base = ScreenConfig { screen: "s".into(), version: 1, sections: vec![s] };
+        let reg = registry(&[("listing-grid.v1", false, &["list", "grid"])]);
+        let out = resolve(&base, Platform::Web, None, &BTreeSet::new(), &reg);
+        // defensive rendering: never emit a mode the client can't render
+        assert_eq!(out.sections[0].mode.as_deref(), Some("list"));
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: FAIL to compile — `resolve` not defined.
+
+- [ ] **Step 4: Implement the resolver core**
+
+Add above the test module in `src/resolve.rs`:
+
+```rust
+/// Resolve a screen for one platform + optional tenant, against the platform's
+/// registry manifest. Precedence: base → platform override → tenant override →
+/// kill flags (spec §3.2). Tenant and kill layers are applied in Tasks 4–5.
+pub fn resolve(
+    base: &ScreenConfig,
+    platform: Platform,
+    tenant: Option<&TenantOverride>,
+    killed: &BTreeSet<SectionType>,
+    registry: &RegistryManifest,
+) -> ResolvedScreen {
+    let _ = (tenant, killed); // applied in later layers of this function
+    let mut sections = Vec::with_capacity(base.sections.len());
+    for cfg in &base.sections {
+        let Some(def) = registry.components.get(&cfg.section_type) else {
+            // Unknown type handling lands in Task 5.
+            continue;
+        };
+        let mut visible = cfg.visible;
+        let mut mode = cfg.mode.clone();
+        let mut props = cfg.props.clone();
+        if let Some(patch) = cfg.overrides.get(&platform) {
+            apply_patch(&mut visible, &mut mode, &mut props, patch);
+        }
+        // Defensive mode clamp: never emit a mode the component doesn't support.
+        if let Some(m) = &mode {
+            if !def.supported_modes.iter().any(|s| s == m) {
+                mode = def.default_mode.clone();
+            }
+        }
+        sections.push(ResolvedSection {
+            section_type: cfg.section_type.clone(),
+            mode,
+            props,
+            presentation: Presentation::Visible,
+        });
+    }
+    ResolvedScreen {
+        screen: base.screen.clone(),
+        version: base.version,
+        sections,
+    }
+}
+
+fn apply_patch(
+    visible: &mut bool,
+    mode: &mut Option<String>,
+    props: &mut Props,
+    patch: &SectionPatch,
+) {
+    if let Some(v) = patch.visible {
+        *visible = v;
+    }
+    if patch.mode.is_some() {
+        *mode = patch.mode.clone();
+    }
+    for (k, v) in &patch.props {
+        props.insert(k.clone(), v.clone());
+    }
+}
+```
+
+Note: `visible` is computed but not yet consumed — visibility/placeholder handling lands in Task 5. Silence the unused-variable lint until then by adding `let _ = visible;` on the line immediately before `sections.push(...)`. Task 5 deletes that line.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/crates/layout-core/src
+git commit -m "feat(layout-core): resolver with platform merge precedence and mode clamp"
+```
+
+---
+
+### Task 4: Resolver — tenant override layer
+
+**Files:**
+- Modify: `backend/crates/layout-core/src/resolve.rs`
+- Test: inline `#[cfg(test)]` in `resolve.rs`
+
+**Interfaces:**
+- Consumes: `resolve` signature from Task 3 (unchanged).
+- Produces: tenant `order` reordering + per-section tenant patches applied after the platform layer. Rails enforcement is NOT here — it happens at save-time validation (Task 7); the resolver trusts stored overrides.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `mod tests` in `src/resolve.rs`:
+
+```rust
+    #[test]
+    fn tenant_override_reorders_and_patches_after_platform_layer() {
+        let mut a = section("a.v1");
+        a.overrides.insert(
+            Platform::Web,
+            SectionPatch { mode: Some("grid".into()), ..Default::default() },
+        );
+        let base = ScreenConfig {
+            screen: "ppt/dashboard".into(),
+            version: 3,
+            sections: vec![a, section("b.v1"), section("c.v1")],
+        };
+        let reg = registry(&[
+            ("a.v1", false, &["list", "grid", "map"]),
+            ("b.v1", false, &[]),
+            ("c.v1", false, &[]),
+        ]);
+        let tenant = TenantOverride {
+            order: Some(vec![
+                SectionType::from("c.v1"),
+                SectionType::from("a.v1"),
+                SectionType::from("b.v1"),
+            ]),
+            sections: BTreeMap::from([(
+                SectionType::from("a.v1"),
+                SectionPatch {
+                    mode: Some("map".into()),
+                    props: BTreeMap::from([("limit".to_string(), serde_json::json!(6))]),
+                    ..Default::default()
+                },
+            )]),
+        };
+        let out = resolve(&base, Platform::Web, Some(&tenant), &BTreeSet::new(), &reg);
+        let types: Vec<&str> =
+            out.sections.iter().map(|s| s.section_type.0.as_str()).collect();
+        assert_eq!(types, vec!["c.v1", "a.v1", "b.v1"]);
+        // tenant mode beats platform mode (precedence §3.2)
+        assert_eq!(out.sections[1].mode.as_deref(), Some("map"));
+        assert_eq!(out.sections[1].props["limit"], serde_json::json!(6));
+    }
+
+    #[test]
+    fn tenant_order_omitting_a_type_keeps_it_after_listed_ones() {
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![section("a.v1"), section("b.v1"), section("c.v1")],
+        };
+        let reg = registry(&[("a.v1", false, &[]), ("b.v1", false, &[]), ("c.v1", false, &[])]);
+        let tenant = TenantOverride {
+            order: Some(vec![SectionType::from("b.v1")]),
+            sections: BTreeMap::new(),
+        };
+        let out = resolve(&base, Platform::Web, Some(&tenant), &BTreeSet::new(), &reg);
+        let types: Vec<&str> =
+            out.sections.iter().map(|s| s.section_type.0.as_str()).collect();
+        // listed first, unlisted keep base relative order
+        assert_eq!(types, vec!["b.v1", "a.v1", "c.v1"]);
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: FAIL — tenant layer not applied (`mode` is `"grid"`, order unchanged).
+
+- [ ] **Step 3: Implement the tenant layer**
+
+In `resolve()`: delete the `let _ = (tenant, killed);` line and replace it with `let _ = killed;` (kills land in Task 5). Then:
+
+(a) Apply the tenant patch after the platform patch. Between the platform `apply_patch` call and the mode clamp, insert:
+
+```rust
+        if let Some(t) = tenant {
+            if let Some(patch) = t.sections.get(&cfg.section_type) {
+                apply_patch(&mut visible, &mut mode, &mut props, patch);
+            }
+        }
+```
+
+(b) Reorder before iterating. Replace `for cfg in &base.sections {` with:
+
+```rust
+    let ordered = order_sections(&base.sections, tenant.and_then(|t| t.order.as_deref()));
+    for cfg in ordered {
+```
+
+and add below `apply_patch` at the bottom of the file:
+
+```rust
+/// Listed types first (in override order), unlisted types after, keeping base
+/// relative order. Types in `order` that don't exist in base are ignored.
+fn order_sections<'a>(
+    base: &'a [SectionConfig],
+    order: Option<&[SectionType]>,
+) -> Vec<&'a SectionConfig> {
+    let Some(order) = order else {
+        return base.iter().collect();
+    };
+    let mut out: Vec<&SectionConfig> = Vec::with_capacity(base.len());
+    for t in order {
+        if let Some(cfg) = base.iter().find(|c| &c.section_type == t) {
+            out.push(cfg);
+        }
+    }
+    for cfg in base {
+        if !order.contains(&cfg.section_type) {
+            out.push(cfg);
+        }
+    }
+    out
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/crates/layout-core/src/resolve.rs
+git commit -m "feat(layout-core): apply tenant override layer in resolver"
+```
+
+---
+
+### Task 5: Resolver — visibility, kill flags, placeholders, unknown types
+
+**Files:**
+- Modify: `backend/crates/layout-core/src/resolve.rs`
+- Test: inline `#[cfg(test)]` in `resolve.rs`
+
+**Interfaces:**
+- Consumes: `resolve` signature from Task 3 (unchanged).
+- Produces: final resolver semantics per spec §4 rules 1–3 and §5 — hidden/killed optional → omitted from output; hidden/killed required → `Presentation::Placeholder` with empty props; unknown type → omitted (optional-equivalent, since `required` is unknowable without a registry entry). The control-plane plan adds render-log metrics on top; nothing else changes here.
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside `mod tests`:
+
+```rust
+    #[test]
+    fn hidden_and_killed_sections_collapse_or_placeholder() {
+        let mut hidden_opt = section("similar-listings.v1");
+        hidden_opt.visible = false;
+        let mut hidden_req = section("price-box.v1");
+        hidden_req.visible = false;
+        hidden_req.props =
+            BTreeMap::from([("currency".to_string(), serde_json::json!("EUR"))]);
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![
+                section("gallery.v1"),      // required, visible, killed below
+                hidden_req,                 // required, hidden → placeholder
+                hidden_opt,                 // optional, hidden → gone
+                section("mortgage-calc.v1"),// optional, killed below → gone
+                section("unknown.v9"),      // not in registry → gone
+            ],
+        };
+        let reg = registry(&[
+            ("gallery.v1", true, &[]),
+            ("price-box.v1", true, &[]),
+            ("similar-listings.v1", false, &[]),
+            ("mortgage-calc.v1", false, &[]),
+        ]);
+        let killed = BTreeSet::from([
+            SectionType::from("gallery.v1"),
+            SectionType::from("mortgage-calc.v1"),
+        ]);
+        let out = resolve(&base, Platform::Web, None, &killed, &reg);
+        let rendered: Vec<(&str, Presentation)> = out
+            .sections
+            .iter()
+            .map(|s| (s.section_type.0.as_str(), s.presentation))
+            .collect();
+        assert_eq!(
+            rendered,
+            vec![
+                ("gallery.v1", Presentation::Placeholder),   // killed required
+                ("price-box.v1", Presentation::Placeholder), // hidden required
+            ]
+        );
+        // placeholders leak no props (section may be killed for a data bug)
+        assert!(out.sections.iter().all(|s| s.props.is_empty()));
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: FAIL — hidden/killed sections still emitted as `Visible`.
+
+- [ ] **Step 3: Implement final presentation logic**
+
+In `resolve()`: delete the `let _ = killed;` line and the `let _ = visible;` line from Task 3. Replace the `sections.push(...)` block with:
+
+```rust
+        let alive = visible && !killed.contains(&cfg.section_type);
+        if alive {
+            sections.push(ResolvedSection {
+                section_type: cfg.section_type.clone(),
+                mode,
+                props,
+                presentation: Presentation::Visible,
+            });
+        } else if def.required {
+            // Spec §4.2 / §5: required sections never disappear — placeholder,
+            // with no mode/props (the section may be killed over bad data).
+            sections.push(ResolvedSection {
+                section_type: cfg.section_type.clone(),
+                mode: None,
+                props: Props::new(),
+                presentation: Presentation::Placeholder,
+            });
+        }
+        // optional + not alive → omitted entirely (containers own spacing, §4.3)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/crates/layout-core/src/resolve.rs
+git commit -m "feat(layout-core): kill flags, required placeholders, unknown-type filtering"
+```
+
+---
+
+### Task 6: Publish validation gate
+
+**Files:**
+- Create: `backend/crates/layout-core/src/validate.rs`
+- Modify: `backend/crates/layout-core/src/lib.rs`
+- Test: inline `#[cfg(test)]` in `validate.rs`
+
+**Interfaces:**
+- Consumes: Task 1–2 types.
+- Produces: `pub enum ValidationError` (thiserror, variants below — FINAL, Task 7 adds four more variants) and `pub fn validate_publish(config: &ScreenConfig, manifests: &[RegistryManifest]) -> Vec<ValidationError>` (empty vec = publishable). The control-plane plan maps non-empty results to HTTP 422.
+
+- [ ] **Step 1: Wire the module**
+
+In `src/lib.rs` add:
+
+```rust
+pub mod validate;
+
+pub use validate::{validate_publish, ValidationError};
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/validate.rs`:
+
+```rust
+use crate::types::*;
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn manifest(platform: Platform, entries: &[(&str, bool, &[&str])]) -> RegistryManifest {
+        RegistryManifest {
+            platform,
+            components: entries
+                .iter()
+                .map(|(t, req, modes)| {
+                    (
+                        SectionType::from(*t),
+                        ComponentDef {
+                            required: *req,
+                            supported_modes: modes.iter().map(|m| m.to_string()).collect(),
+                            default_mode: None,
+                        },
+                    )
+                })
+                .collect(),
+        }
+    }
+
+    fn section(t: &str) -> SectionConfig {
+        SectionConfig {
+            section_type: SectionType::from(t),
+            visible: true,
+            mode: None,
+            props: BTreeMap::new(),
+            overrides: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn valid_config_passes() {
+        let cfg = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![section("gallery.v1"), section("faq.v1")],
+        };
+        let manifests = vec![
+            manifest(Platform::Web, &[("gallery.v1", true, &[]), ("faq.v1", false, &[])]),
+            manifest(Platform::Mobile, &[("gallery.v1", true, &[]), ("faq.v1", false, &[])]),
+        ];
+        assert!(validate_publish(&cfg, &manifests).is_empty());
+    }
+
+    #[test]
+    fn publish_gate_catches_all_error_classes() {
+        let mut hidden_required = section("gallery.v1");
+        hidden_required.visible = false;
+        let mut bad_mode = section("faq.v1");
+        bad_mode.mode = Some("carousel".into());
+        let cfg = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![
+                hidden_required,          // required hidden in base → error
+                bad_mode,                 // mode unsupported on web → error
+                section("faq.v1"),        // duplicate type → error
+                section("only-web.v1"),   // missing from mobile manifest → error
+            ],
+        };
+        let manifests = vec![
+            manifest(
+                Platform::Web,
+                &[("gallery.v1", true, &[]), ("faq.v1", false, &["accordion"]),
+                  ("only-web.v1", false, &[])],
+            ),
+            manifest(
+                Platform::Mobile,
+                &[("gallery.v1", true, &[]), ("faq.v1", false, &["accordion"])],
+            ),
+        ];
+        let errs = validate_publish(&cfg, &manifests);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::RequiredHidden { section } if section.0 == "gallery.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::UnsupportedMode { section, .. } if section.0 == "faq.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::DuplicateSection { section } if section.0 == "faq.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::UnknownType { section, platform }
+                if section.0 == "only-web.v1" && *platform == Platform::Mobile)));
+    }
+
+    #[test]
+    fn missing_required_component_is_an_error() {
+        // manifest declares a required component the config omits entirely
+        let cfg = ScreenConfig { screen: "s".into(), version: 1, sections: vec![] };
+        let manifests =
+            vec![manifest(Platform::Web, &[("gallery.v1", true, &[])])];
+        let errs = validate_publish(&cfg, &manifests);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::RequiredMissing { section } if section.0 == "gallery.v1")));
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: FAIL to compile — `validate_publish`, `ValidationError` not defined.
+
+- [ ] **Step 4: Implement the gate**
+
+Add above the test module in `src/validate.rs`:
+
+```rust
+#[derive(Debug, Error, PartialEq)]
+pub enum ValidationError {
+    #[error("section {section:?} appears more than once")]
+    DuplicateSection { section: SectionType },
+    #[error("section {section:?} is not in the {platform:?} registry")]
+    UnknownType { section: SectionType, platform: Platform },
+    #[error("required section {section:?} is hidden in the base config")]
+    RequiredHidden { section: SectionType },
+    #[error("required component {section:?} is missing from the config")]
+    RequiredMissing { section: SectionType },
+    #[error("section {section:?} uses mode {mode:?}, unsupported on {platform:?}")]
+    UnsupportedMode { section: SectionType, mode: String, platform: Platform },
+}
+
+/// Publish gate (spec §6.3): empty result = publishable. Errors block publish.
+pub fn validate_publish(
+    config: &ScreenConfig,
+    manifests: &[RegistryManifest],
+) -> Vec<ValidationError> {
+    let mut errs = Vec::new();
+    // duplicates
+    let mut seen = std::collections::BTreeSet::new();
+    for s in &config.sections {
+        if !seen.insert(&s.section_type) {
+            errs.push(ValidationError::DuplicateSection { section: s.section_type.clone() });
+        }
+    }
+    for m in manifests {
+        for s in &config.sections {
+            let Some(def) = m.components.get(&s.section_type) else {
+                errs.push(ValidationError::UnknownType {
+                    section: s.section_type.clone(),
+                    platform: m.platform,
+                });
+                continue;
+            };
+            // effective visibility/mode on this platform (base + platform patch)
+            let patch = s.overrides.get(&m.platform);
+            let visible = patch.and_then(|p| p.visible).unwrap_or(s.visible);
+            let mode = patch
+                .and_then(|p| p.mode.clone())
+                .or_else(|| s.mode.clone());
+            if def.required && !visible {
+                let err = ValidationError::RequiredHidden { section: s.section_type.clone() };
+                if !errs.contains(&err) {
+                    errs.push(err);
+                }
+            }
+            if let Some(mode) = mode {
+                if !def.supported_modes.iter().any(|sm| *sm == mode) {
+                    errs.push(ValidationError::UnsupportedMode {
+                        section: s.section_type.clone(),
+                        mode,
+                        platform: m.platform,
+                    });
+                }
+            }
+        }
+        // every required component in the manifest must be present in the config
+        for (t, def) in &m.components {
+            if def.required && !config.sections.iter().any(|s| &s.section_type == t) {
+                let err = ValidationError::RequiredMissing { section: t.clone() };
+                if !errs.contains(&err) {
+                    errs.push(err);
+                }
+            }
+        }
+    }
+    errs
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: PASS (10 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/crates/layout-core/src
+git commit -m "feat(layout-core): publish validation gate"
+```
+
+---
+
+### Task 7: Tenant-override rails validation
+
+**Files:**
+- Modify: `backend/crates/layout-core/src/validate.rs`
+- Modify: `backend/crates/layout-core/src/lib.rs`
+- Test: inline `#[cfg(test)]` in `validate.rs`
+
+**Interfaces:**
+- Consumes: Task 6 `ValidationError` (extended here), Task 2 `Rails`/`TenantOverride`.
+- Produces: `pub fn validate_tenant_override(ov: &TenantOverride, base: &ScreenConfig, rails: &Rails) -> Vec<ValidationError>` — the server-side rails enforcement for tenant saves (spec §3.4/§6.3). New `ValidationError` variants: `NotInBase`, `NotHideable`, `NotModeEditable`, `PropNotWhitelisted`, `NotReorderable`.
+
+- [ ] **Step 1: Export the new function**
+
+In `src/lib.rs`, change the validate re-export line to:
+
+```rust
+pub use validate::{validate_publish, validate_tenant_override, ValidationError};
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append inside `mod tests` in `src/validate.rs`:
+
+```rust
+    #[test]
+    fn rails_enforcement_rejects_out_of_rails_edits() {
+        use std::collections::BTreeSet;
+        let base = ScreenConfig {
+            screen: "ppt/dashboard".into(),
+            version: 1,
+            sections: vec![section("news.v1"), section("faults.v1"), section("kpi.v1")],
+        };
+        let rails = Rails {
+            hideable: BTreeSet::from([SectionType::from("news.v1")]),
+            mode_editable: BTreeSet::from([SectionType::from("faults.v1")]),
+            reorderable: false,
+            prop_whitelist: BTreeMap::from([(
+                SectionType::from("news.v1"),
+                BTreeSet::from(["limit".to_string()]),
+            )]),
+        };
+        let ov = TenantOverride {
+            order: Some(vec![SectionType::from("kpi.v1")]), // reorder forbidden
+            sections: BTreeMap::from([
+                (
+                    SectionType::from("news.v1"),
+                    SectionPatch {
+                        visible: Some(false),                    // ok: hideable
+                        props: BTreeMap::from([
+                            ("limit".to_string(), serde_json::json!(5)), // ok: whitelisted
+                            ("theme".to_string(), serde_json::json!("dark")), // not whitelisted
+                        ]),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    SectionType::from("kpi.v1"),
+                    SectionPatch { visible: Some(false), ..Default::default() }, // not hideable
+                ),
+                (
+                    SectionType::from("news.v1-typo"),
+                    SectionPatch::default(), // not in base
+                ),
+                (
+                    SectionType::from("faults.v1"),
+                    SectionPatch { mode: Some("compact".into()), ..Default::default() }, // ok
+                ),
+            ]),
+        };
+        let errs = validate_tenant_override(&ov, &base, &rails);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotReorderable)));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::PropNotWhitelisted { section, prop }
+                if section.0 == "news.v1" && prop == "theme")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotHideable { section } if section.0 == "kpi.v1")));
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotInBase { section } if section.0 == "news.v1-typo")));
+        // exactly the four violations above — the allowed edits pass
+        assert_eq!(errs.len(), 4);
+    }
+
+    #[test]
+    fn mode_edit_on_non_editable_section_is_rejected() {
+        let base = ScreenConfig {
+            screen: "s".into(),
+            version: 1,
+            sections: vec![section("news.v1")],
+        };
+        let rails = Rails::default();
+        let ov = TenantOverride {
+            order: None,
+            sections: BTreeMap::from([(
+                SectionType::from("news.v1"),
+                SectionPatch { mode: Some("grid".into()), ..Default::default() },
+            )]),
+        };
+        let errs = validate_tenant_override(&ov, &base, &rails);
+        assert!(errs.iter().any(|e| matches!(e,
+            ValidationError::NotModeEditable { section } if section.0 == "news.v1")));
+    }
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: FAIL to compile — `validate_tenant_override` and new variants not defined.
+
+- [ ] **Step 4: Implement rails enforcement**
+
+Add the new variants to `ValidationError`:
+
+```rust
+    #[error("tenant override references section {section:?} not present in the base config")]
+    NotInBase { section: SectionType },
+    #[error("section {section:?} is not tenant-hideable")]
+    NotHideable { section: SectionType },
+    #[error("section {section:?} is not tenant-mode-editable")]
+    NotModeEditable { section: SectionType },
+    #[error("prop {prop:?} on section {section:?} is not whitelisted for tenants")]
+    PropNotWhitelisted { section: SectionType, prop: String },
+    #[error("this screen is not tenant-reorderable")]
+    NotReorderable,
+```
+
+Add the function above the test module:
+
+```rust
+/// Server-side rails enforcement for tenant saves (spec §3.4). The UI hides
+/// out-of-rails controls, but this is the actual gate.
+pub fn validate_tenant_override(
+    ov: &TenantOverride,
+    base: &ScreenConfig,
+    rails: &Rails,
+) -> Vec<ValidationError> {
+    let mut errs = Vec::new();
+    if ov.order.is_some() && !rails.reorderable {
+        errs.push(ValidationError::NotReorderable);
+    }
+    static EMPTY: std::sync::OnceLock<std::collections::BTreeSet<String>> =
+        std::sync::OnceLock::new();
+    for (t, patch) in &ov.sections {
+        if !base.sections.iter().any(|s| &s.section_type == t) {
+            errs.push(ValidationError::NotInBase { section: t.clone() });
+            continue;
+        }
+        if patch.visible.is_some() && !rails.hideable.contains(t) {
+            errs.push(ValidationError::NotHideable { section: t.clone() });
+        }
+        if patch.mode.is_some() && !rails.mode_editable.contains(t) {
+            errs.push(ValidationError::NotModeEditable { section: t.clone() });
+        }
+        let whitelist = rails
+            .prop_whitelist
+            .get(t)
+            .unwrap_or_else(|| EMPTY.get_or_init(Default::default));
+        for prop in patch.props.keys() {
+            if !whitelist.contains(prop) {
+                errs.push(ValidationError::PropNotWhitelisted {
+                    section: t.clone(),
+                    prop: prop.clone(),
+                });
+            }
+        }
+    }
+    errs
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd backend && cargo test -p layout-core`
+Expected: PASS (12 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/crates/layout-core/src
+git commit -m "feat(layout-core): tenant-override rails validation"
+```
+
+---
+
+### Task 8: Workspace gates + repo-map entry
+
+**Files:**
+- Modify: `docs/repo-map.md:54` (crates list under `backend/ (Rust workspace)`)
+- Test: full workspace static gates
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: green `fmt`/`clippy`/`test` across the workspace; repo-map documents the crate for future agents (repo rule: repo-map fixes ship in the same PR).
+
+- [ ] **Step 1: Add the repo-map line**
+
+In `docs/repo-map.md`, in the **Crates** list after the `common` bullet, add:
+
+```markdown
+- `layout-core` — Layout & Content Manager contract: screen configs, merge resolver
+  (base → platform → tenant → kill), publish/rails validation. Pure logic, no DB.
+  Spec: `docs/superpowers/specs/2026-07-19-layout-content-manager-design.md`.
+```
+
+- [ ] **Step 2: Run the full backend gate**
+
+Run: `cd backend && cargo fmt --all && cargo clippy --workspace --all-targets -- -D warnings && cargo test -p layout-core`
+Expected: fmt clean, clippy clean, 12 tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/repo-map.md backend
+git commit -m "docs(repo-map): add layout-core crate entry"
+```
+
+---
+
+## Out of scope (subsequent plans)
+
+Per the spec's rollout (§9), each of these is its own plan, in order:
+
+1. **Control plane** — migrations (`layout_configs`, `layout_config_versions`, `layout_tenant_overrides`, `layout_kill_flags`), repositories, superadmin + tenant routes, resolved `GET /layout/{screen}` endpoints in api-server + reality-server, TypeSpec.
+2. **Defensive rendering** — pilot screens (`ppt/dashboard`, `reality/listing-detail`): section registries in ppt-web/reality-web, gap-owned spacing, error boundaries, placeholder component, ISR revalidation hook.
+3. **Superadmin editor MVP** — `@ppt/layout-editor` package + admin-web mount, kill-switch UI, publish/rollback.
+4. **Tenant editor + rails authoring** — ppt-web scoped mount, rails UI in admin-web.
+5. **Live preview bridge**; then mobile manifests + RN/KMP renderers.

--- a/docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
+++ b/docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
@@ -1,0 +1,250 @@
+# Layout & Content Manager — System Design
+
+**Date:** 2026-07-19
+**Status:** Brainstorm / design proposal (not yet scheduled)
+**Scope:** All four apps (ppt-web, reality-web, accounting-web, mobile RN) + KMP mobile-native, controlled from admin-web
+
+## 1. Problem statement
+
+We want a universal framework to control **which components appear on which
+pages, in what order, and in what display mode** — across the Reality portal,
+the Property Management app, the Accounting app, and their mobile
+counterparts — from a single superadmin surface in admin-web.
+
+Requirements distilled:
+
+- Show/hide natural page components (landing-page sections, listing-detail
+  blocks, list-page widgets) without a code deploy.
+- Reorder sections and switch **display modes** (e.g. list vs grid vs map),
+  where the set of valid modes is defined by the frontend component itself.
+- **Never break a page.** Hiding an optional component collapses cleanly;
+  hiding/removing a mandatory component renders a placeholder instead.
+- Per-platform customization (web vs mobile) without forking page configs.
+- Superadmin editor with live preview, draft → publish workflow, versions,
+  rollback, audit.
+
+## 2. Prior art & the core lesson
+
+This problem class is **server-driven UI (SDUI) with a CMS-style control
+plane**. The industry record is unusually clear about what works and what
+fails:
+
+| Worked | Failed |
+|---|---|
+| Airbnb Ghost Platform — Screens → Sections, semantic components, layouts per form factor | Spotify HubFramework — generic `Row`/`Column`/`Text` primitives → "debugging archeology", deprecated |
+| Yelp CHAOS — server filters payload by client-declared capabilities; per-feature error isolation | Uber Screenflow — company-wide generic engine, never finished |
+| Duolingo — UI config and data versioned independently; stale clients render cached layout + fresh data | |
+| Shopify Shop app — typed section subtypes, per-section data loaders | |
+| DoorDash — GUI composer (Mosaic) built only *after* a year of contract hardening | |
+
+**The core lesson:** do not build a generic layout engine. Build a **section
+visibility & configuration system over semantic components we already own**.
+The server decides *which* named sections render, in *what order*, in *which
+mode*, with *what props* — every section remains a real, hand-written
+component in each frontend.
+
+Sources: [Airbnb](https://medium.com/airbnb-engineering/a-deep-dive-into-airbnbs-server-driven-ui-system-842244c5f5),
+[Yelp CHAOS](https://engineeringblog.yelp.com/2024/03/chaos-yelps-unified-framework-for-server-driven-ui.html),
+[Duolingo](https://blog.duolingo.com/server-driven-ui/),
+[Shopify](https://shopify.engineering/server-driven-ui-in-shop-app),
+[DoorDash](https://careersatdoordash.com/blog/improving-development-velocity-with-generic-server-driven-ui-components/),
+[Spotify HubFramework](https://github.com/spotify/HubFramework),
+[Uber Screenflow retro](https://artem-tyurin.medium.com/screenflow-an-unfinished-attempt-at-a-cross-platform-server-driven-ui-at-uber-749c1bc1d89).
+
+## 3. Core model
+
+Three tiers — the convergent shape across every successful implementation:
+
+```
+Screen  →  Sections (flat ordered list)  →  Section config (visibility, mode, props)
+```
+
+Flat section lists, not deep layout trees. Nesting is allowed only *inside* a
+component where genuinely needed.
+
+### 3.1 Screen config schema (illustrative)
+
+```json
+{
+  "screen": "reality/listing-detail",
+  "version": 42,
+  "sections": [
+    { "type": "gallery.v1",         "visible": true },
+    { "type": "price-box.v1",       "visible": true },
+    { "type": "agent-contact.v1",   "visible": true,
+      "mode": "sticky-sidebar",
+      "overrides": { "mobile": { "mode": "bottom-bar" } } },
+    { "type": "similar-listings.v1","visible": false },
+    { "type": "mortgage-calc.v1",   "visible": true,
+      "props": { "maxYears": 30 } }
+  ]
+}
+```
+
+Decisions baked into this shape:
+
+- **Semantic, versioned type names** (`price-box.v1`). Breaking changes mint
+  `price-box.v2`; published contracts are never mutated. Otherwise evolution
+  is additive-only (clients ignore unknown fields).
+- **One base config + sparse per-platform overrides**, not forked configs.
+  The server resolves `base + platform (+ later: audience/flag)` at request
+  time. Screen IDs should reuse the existing `docs/screens/<product>/<id>`
+  catalog.
+- **Display modes are constrained enums declared by the component**, not free
+  CSS. The frontend registry is the source of truth for which modes each
+  component supports; the admin can only pick from those.
+- **`required` is a property of the component (registry), not the config** —
+  an operator cannot make a component optional by editing config.
+
+### 3.2 Component registry
+
+Each frontend ships a registry:
+
+```
+type string → { renderer, supportedModes, required, propSchema, fallback }
+```
+
+Each platform also **publishes its registry manifest** (types + modes + prop
+schemas + minimum app version) to the backend — ideally generated through the
+existing TypeSpec → client pipeline — so the superadmin editor knows exactly
+what every platform supports without hardcoding.
+
+## 4. Resilience rules ("hiding never breaks the page")
+
+1. **Unknown type never crashes.** Registry miss → render nothing (optional)
+   or placeholder (required); log to analytics with config version + client
+   version. Preferred at scale: **server-side filtering** — the client
+   advertises supported components/versions in a request header and the
+   server omits what it can't render (Yelp's Register model). Critical for
+   RN/KMP binaries that may be months stale.
+2. **Hidden required component → placeholder.** A neutral "section
+   unavailable" block reserving sensible space. In the editor, required
+   sections carry a lock badge and simply have **no hide/delete affordance**
+   (Gutenberg lesson: no disabled buttons, no hidden unlock flows).
+3. **Hidden optional component → absent from the tree** (not
+   `visibility:hidden`), and **containers own inter-section spacing via CSS
+   `gap`**; section components ship zero external margin. This single rule
+   eliminates orphaned margins/double spacing when anything is removed.
+4. **Per-section error boundaries** (React) / isolated composables (Compose):
+   a crashing section degrades to its fallback, never the page. Optional
+   section fails → collapse; required section fails → placeholder.
+5. **Stale-client strategy (Duolingo):** version UI config and data
+   independently. A client below the config's minimum schema version keeps
+   rendering its **last-known-good cached layout** with fresh data.
+6. **Mobile activation timing:** never swap layout mid-session. Fetch config
+   in the background, **activate on next launch / next screen entry**
+   (Firebase Remote Config's hard-won rule). Ship a compiled-in default
+   config as the final offline/first-run fallback.
+
+## 5. Superadmin editor (admin-web)
+
+Model: **inline live preview + tree panel + constrained slots** —
+Storyblok/Puck-style, not free-form Webflow-style. [Puck](https://puckeditor.com)
+(MIT, React) is the best open reference and a candidate to embed rather than
+build from scratch.
+
+### 5.1 Preview bridge
+
+- Iframe the **real site in draft mode**; postMessage bridge with origin
+  validation + handshake.
+- We own both sides → tag rendered sections with `data-section-id` (skip
+  Sanity-style stega string encoding).
+- Editor pushes the **full draft config** into the iframe on every change;
+  the site re-renders optimistically (Storyblok's protocol — simplest robust
+  option). Persisted only on save/publish.
+- Draft-mode cookie/flag so the framed site fetches draft config.
+
+### 5.2 Editing surface
+
+- **Canvas overlays + labeled tree panel, synced both ways**: click a section
+  on canvas → tree row highlights + config panel opens; hover a tree row →
+  outline on canvas.
+- Tree rows carry the direct controls: **eye toggle** (visibility), **drag
+  handle + up/down arrows** (reorder; arrows double as the accessible
+  non-drag path), **mode dropdown** (populated from the registry manifest),
+  **lock badge** on required sections.
+- **Platform switcher** in the toolbar (web / mobile), like a breakpoint
+  switcher. Sections hidden on the current platform render **dimmed on
+  canvas**, not removed. Overridden sections get a badge + "reset to base".
+
+### 5.3 Workflow & governance
+
+- State machine: **Draft → (preview link) → Published**; optional scheduled
+  publish later.
+- Every publish creates an **immutable version**; one-click rollback; audit
+  log (who/what/when + diff).
+- **Publish is gated by server-side validation** — hard guarantee, not a
+  lint: schema-valid; every referenced type exists in every target platform's
+  registry; required sections present and visible; modes ∈ supported set;
+  props validate against the component's prop schema. Errors block publish;
+  warnings don't (Sanity model).
+- Roles: **schema/registry authors** (developers, via code) vs **content
+  operators** (superadmin, arrange within the rails).
+
+## 6. Placement in the PPT architecture
+
+| Piece | Where | Notes |
+|---|---|---|
+| Control plane (CRUD, draft/publish, versions, audit, validation) | **api-server** | `layout_configs` + `layout_config_versions` tables; superadmin-scoped routes behind existing admin auth |
+| Resolved read endpoint | **api-server** (ppt/acc screens) + **reality-server** (reality screens) | `GET /layout/{screen}?platform=…&app_version=…` → resolved section list; aggressively cacheable, version-bumped on publish |
+| Editor UI | **admin-web** | iframe bridge + tree panel (§5) |
+| reality-web delivery | Next.js ISR | publish webhook → `revalidateTag('layout:{screen}')`; keep a long time-based revalidate as safety net |
+| ppt-web / accounting-web delivery | TanStack Query | fetch on navigation, cache last-known-good |
+| Mobile delivery (RN + KMP) | local cache | background fetch, activate next launch/screen; compiled-in default config |
+| Registry manifests | TypeSpec pipeline | generated alongside `@ppt/api-client`; mobile-native via openapi-generator |
+| Screen catalog | `docs/screens/` | share screen IDs with the existing screen-map system |
+| Feature flags | separate layer | flags gate *whether* (kill switch, rollout %); layout config defines *what/how*. A section may reference a `flagId`; the resolver applies it. Do not merge the two systems |
+
+## 7. Known costs & pitfalls
+
+- **Complexity moves server-side; it doesn't disappear.** Resolvers absorb
+  override merging, version filtering, flag substitution, fallback logic.
+- **Testing surface multiplies** (screens × platforms × client versions ×
+  configs). Mitigation: log every section render with config + client
+  version; dashboard failure rates per (component, client-version) cell.
+- **Editor last, contract first.** DoorDash's ordering: harden the config
+  contract on one surface for a long time *before* building the GUI composer.
+- **Out of scope surfaces:** deep-native views (map), auth flows, low-churn
+  screens (settings) — no velocity to gain, real downside risk.
+- **Skeletons vs collapse:** skeletons are for *loading* with predictable
+  dimensions; a *hidden* section must collapse entirely — a skeleton implies
+  content is coming.
+
+## 8. Rollout plan
+
+1. **Contract first** — section-list schema + registry pattern on **one**
+   high-churn pilot screen: `reality/listing-detail` (exists on web + KMP).
+2. Resolved-layout endpoint + defensive rendering (gap spacing, error
+   boundaries, unknown-type fallback, required-placeholder) in reality-web.
+3. **Minimal superadmin** — tree panel, eye toggles, reorder,
+   publish/rollback. No iframe preview yet.
+4. Live iframe preview bridge; platform switcher + overrides; display modes.
+5. Extend to reality landing + list pages; then ppt-web and accounting-web
+   screens; then mobile registry manifests + KMP renderer wiring.
+
+## 9. Open questions
+
+- Embed Puck for the editor vs build the tree-panel editor natively in
+  admin-web? (Puck saves DnD/slot plumbing but adds a dependency and its
+  config model would need mapping onto ours.)
+- Should the resolved-layout endpoint live in each server, or in a single
+  shared crate consumed by api-server + reality-server (+ accounting-server
+  later)?
+- Audience targeting (per-org / per-segment layouts) — in scope for v2, and
+  does it interact with RLS/tenant context?
+- How registry manifests for KMP are published — build-time upload step vs
+  checked-in generated file.
+
+## 10. Further reading
+
+- [Airbnb Ghost Platform deep dive](https://medium.com/airbnb-engineering/a-deep-dive-into-airbnbs-server-driven-ui-system-842244c5f5)
+- [Yelp CHAOS (2024)](https://engineeringblog.yelp.com/2024/03/chaos-yelps-unified-framework-for-server-driven-ui.html) · [backend (2025)](https://engineeringblog.yelp.com/2025/07/chaos-inside-yelps-sdui-framework.html)
+- [Duolingo SDUI](https://blog.duolingo.com/server-driven-ui/)
+- [Shopify Shop app SDUI](https://shopify.engineering/server-driven-ui-in-shop-app)
+- [Lyft Canvas (protobuf SDUI)](https://eng.lyft.com/the-journey-to-server-driven-ui-at-lyft-bikes-and-scooters-c19264a0378e)
+- [Puck editor — Slots API](https://puckeditor.com/docs/api-reference/fields/slot)
+- [Contentful editable patterns (lock/whitelist UX)](https://www.contentful.com/help/studio/experiences/editable-patterns/)
+- [Sanity visual-editing architecture](https://www.sanity.io/docs/visual-editing/visual-editing-architecture)
+- [Storyblok preview bridge](https://www.storyblok.com/docs/libraries/js/preview-bridge)
+- [Firebase Remote Config loading strategies](https://firebase.google.com/docs/remote-config/loading)
+- [DivKit (Yandex, OSS native SDUI)](https://github.com/divkit/divkit)

--- a/docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
+++ b/docs/superpowers/specs/2026-07-19-layout-content-manager-design.md
@@ -1,27 +1,35 @@
 # Layout & Content Manager — System Design
 
-**Date:** 2026-07-19
-**Status:** Brainstorm / design proposal (not yet scheduled)
-**Scope:** All four apps (ppt-web, reality-web, accounting-web, mobile RN) + KMP mobile-native, controlled from admin-web
+**Date:** 2026-07-19 (revised same day after brainstorming session)
+**Status:** Design approved in brainstorm; awaiting implementation plan
+**Scope:** All four apps (ppt-web, reality-web, accounting-web, mobile RN) + KMP mobile-native; superadmin editor in admin-web; tenant-scoped editor in ppt-web
 
 ## 1. Problem statement
 
 We want a universal framework to control **which components appear on which
 pages, in what order, and in what display mode** — across the Reality portal,
 the Property Management app, the Accounting app, and their mobile
-counterparts — from a single superadmin surface in admin-web.
+counterparts.
 
-Requirements distilled:
+V1 must do three jobs (decided in brainstorm):
 
-- Show/hide natural page components (landing-page sections, listing-detail
-  blocks, list-page widgets) without a code deploy.
-- Reorder sections and switch **display modes** (e.g. list vs grid vs map),
-  where the set of valid modes is defined by the frontend component itself.
+1. **Operator tuning** — superadmin adjusts what each site shows (hide a
+   section, reorder, switch a list page to grid) without a deploy.
+2. **Per-tenant customization** — organizations get customized layouts,
+   edited both by the superadmin *and* self-service by tenant org admins
+   within superadmin-defined rails.
+3. **Kill-switch** — a broken or problematic section can be pulled from
+   production in one action, propagating on next load.
+
+Out of scope for v1: A/B testing / experimentation (a section may later
+reference a feature flag, but no flag system ships in v1).
+
+Cross-cutting requirements:
+
 - **Never break a page.** Hiding an optional component collapses cleanly;
-  hiding/removing a mandatory component renders a placeholder instead.
+  hiding/killing a mandatory component renders a placeholder instead.
 - Per-platform customization (web vs mobile) without forking page configs.
-- Superadmin editor with live preview, draft → publish workflow, versions,
-  rollback, audit.
+- Draft → publish workflow, immutable versions, rollback, audit.
 
 ## 2. Prior art & the core lesson
 
@@ -86,17 +94,33 @@ Decisions baked into this shape:
 - **Semantic, versioned type names** (`price-box.v1`). Breaking changes mint
   `price-box.v2`; published contracts are never mutated. Otherwise evolution
   is additive-only (clients ignore unknown fields).
-- **One base config + sparse per-platform overrides**, not forked configs.
-  The server resolves `base + platform (+ later: audience/flag)` at request
-  time. Screen IDs should reuse the existing `docs/screens/<product>/<id>`
-  catalog.
+- **One base config + sparse overrides**, not forked configs. Screen IDs
+  reuse the existing `docs/screens/<product>/<id>` catalog.
 - **Display modes are constrained enums declared by the component**, not free
   CSS. The frontend registry is the source of truth for which modes each
-  component supports; the admin can only pick from those.
+  component supports; editors can only pick from those.
 - **`required` is a property of the component (registry), not the config** —
-  an operator cannot make a component optional by editing config.
+  no editor can make a required component optional.
 
-### 3.2 Component registry
+### 3.2 Resolution model
+
+Resolution is a layered merge, computed server-side per request in a shared
+`layout-core` backend crate (consumed by api-server and reality-server,
+mirroring the existing `api-core` pattern):
+
+```
+platform default → superadmin base config → platform override
+                → tenant (org) override   → kill flags
+```
+
+- Tenant override rows carry `org_id` and hold only the delta (visibility,
+  order, mode, whitelisted props) — never a full forked config.
+- The resolved endpoint is cacheable per `(screen, platform, org_id,
+  config_version)`.
+- Reality-portal public screens have no org dimension unless an agency
+  context applies; the tenant layer simply doesn't contribute there.
+
+### 3.3 Component registry
 
 Each frontend ships a registry:
 
@@ -105,9 +129,25 @@ type string → { renderer, supportedModes, required, propSchema, fallback }
 ```
 
 Each platform also **publishes its registry manifest** (types + modes + prop
-schemas + minimum app version) to the backend — ideally generated through the
-existing TypeSpec → client pipeline — so the superadmin editor knows exactly
-what every platform supports without hardcoding.
+schemas + minimum app version) to the backend — generated through the
+existing TypeSpec pipeline for TS apps; for KMP, a checked-in generated file
+updated by the SDK-generation step. The editors read these manifests, so
+nothing about platform capabilities is hardcoded in admin UI.
+
+### 3.4 Editing rails (two-role model)
+
+- **Superadmin (rail author)** — defines, per screen: the section set,
+  defaults, per-platform overrides, which optional sections tenants may
+  toggle, and a **per-prop editability whitelist** (which props tenant
+  admins may set, with allowed ranges where relevant).
+- **Tenant org admin (operator)** — customizes their org's screens within
+  those rails: show/hide allowed optional sections, reorder, pick display
+  modes, and edit whitelisted props. Cannot add unknown sections, touch
+  required sections, or edit non-whitelisted props — enforced server-side at
+  save time, not just hidden in the UI.
+
+This follows Contentful's editable-patterns model: the pattern author
+explicitly whitelists what instance editors may change.
 
 ## 4. Resilience rules ("hiding never breaks the page")
 
@@ -117,8 +157,8 @@ what every platform supports without hardcoding.
    advertises supported components/versions in a request header and the
    server omits what it can't render (Yelp's Register model). Critical for
    RN/KMP binaries that may be months stale.
-2. **Hidden required component → placeholder.** A neutral "section
-   unavailable" block reserving sensible space. In the editor, required
+2. **Hidden or killed required component → placeholder.** A neutral "section
+   unavailable" block reserving sensible space. In the editors, required
    sections carry a lock badge and simply have **no hide/delete affordance**
    (Gutenberg lesson: no disabled buttons, no hidden unlock flows).
 3. **Hidden optional component → absent from the tree** (not
@@ -136,14 +176,45 @@ what every platform supports without hardcoding.
    (Firebase Remote Config's hard-won rule). Ship a compiled-in default
    config as the final offline/first-run fallback.
 
-## 5. Superadmin editor (admin-web)
+## 5. Kill-switch
 
-Model: **inline live preview + tree panel + constrained slots** —
-Storyblok/Puck-style, not free-form Webflow-style. [Puck](https://puckeditor.com)
-(MIT, React) is the best open reference and a candidate to embed rather than
-build from scratch.
+Built into the layout system, not delegated to a feature-flag service
+(decided in brainstorm — no external flag infra in v1):
 
-### 5.1 Preview bridge
+- Every section instance has a `killed` flag settable by superadmin in one
+  action, **bypassing the draft → publish gate** (it is an operational
+  control, not an editorial change). Killing a required section makes it
+  render its placeholder everywhere.
+- Kill state is stored alongside (not inside) published config versions, so
+  publishing or rolling back a config does not accidentally resurrect a
+  killed section; un-kill is an equally explicit action, and both are
+  audit-logged.
+- Propagation: next navigation / ISR revalidation on web (≤ ~1 min), next
+  launch or screen entry on mobile. No real-time push channel and no
+  mid-session layout swaps in v1.
+
+## 6. Editors
+
+One shared **`@ppt/layout-editor`** React package (in `frontend/packages/`),
+mounted in two places with different capability sets:
+
+- **admin-web — full superadmin editor:** rail authoring (section set,
+  required flags via registry, tenant-editable whitelists, per-prop
+  whitelists), base config editing, per-platform overrides, per-tenant
+  override editing, kill-switch, publish/rollback/audit.
+- **ppt-web — scoped tenant editor:** the same tree-panel component
+  restricted to the tenant's rails (visibility, order, modes, whitelisted
+  props on their org's screens). Server-side enforcement of the rails at
+  save time.
+
+Model: **tree panel + live iframe preview** (Storyblok/Puck-style, decided
+over embedding Puck — our section-list model is simpler than Puck's
+free-form target, and the two-role rails model needs custom permission
+logic either way). **No canvas drag-and-drop in v1** — tree reorder with
+drag handle + up/down arrows covers it (arrows double as the accessible
+path).
+
+### 6.1 Preview bridge
 
 - Iframe the **real site in draft mode**; postMessage bridge with origin
   validation + handshake.
@@ -153,89 +224,117 @@ build from scratch.
   the site re-renders optimistically (Storyblok's protocol — simplest robust
   option). Persisted only on save/publish.
 - Draft-mode cookie/flag so the framed site fetches draft config.
+- Canvas overlays + tree panel synced both ways: click a section on canvas →
+  tree row highlights + config panel opens; hover a tree row → outline on
+  canvas.
 
-### 5.2 Editing surface
+### 6.2 Editing surface
 
-- **Canvas overlays + labeled tree panel, synced both ways**: click a section
-  on canvas → tree row highlights + config panel opens; hover a tree row →
-  outline on canvas.
 - Tree rows carry the direct controls: **eye toggle** (visibility), **drag
-  handle + up/down arrows** (reorder; arrows double as the accessible
-  non-drag path), **mode dropdown** (populated from the registry manifest),
-  **lock badge** on required sections.
-- **Platform switcher** in the toolbar (web / mobile), like a breakpoint
-  switcher. Sections hidden on the current platform render **dimmed on
-  canvas**, not removed. Overridden sections get a badge + "reset to base".
+  handle + arrows** (reorder), **mode dropdown** (populated from the
+  registry manifest), **prop form** (from the component's prop schema,
+  filtered by whitelist in the tenant editor), **lock badge** on required
+  sections, **kill badge** on killed sections (superadmin only).
+- **Platform switcher** in the toolbar (web / mobile). Sections hidden on
+  the current platform render **dimmed on canvas**, not removed. Overridden
+  sections get a badge + "reset to base"; in superadmin's per-tenant view,
+  tenant-overridden sections badge the same way.
 
-### 5.3 Workflow & governance
+### 6.3 Workflow & governance
 
 - State machine: **Draft → (preview link) → Published**; optional scheduled
-  publish later.
+  publish later. Kill-switch bypasses this (§5).
 - Every publish creates an **immutable version**; one-click rollback; audit
-  log (who/what/when + diff).
+  log (who/what/when + diff) covering superadmin edits, tenant edits, and
+  kill/un-kill actions.
 - **Publish is gated by server-side validation** — hard guarantee, not a
   lint: schema-valid; every referenced type exists in every target platform's
   registry; required sections present and visible; modes ∈ supported set;
-  props validate against the component's prop schema. Errors block publish;
-  warnings don't (Sanity model).
-- Roles: **schema/registry authors** (developers, via code) vs **content
-  operators** (superadmin, arrange within the rails).
+  props validate against the component's prop schema; tenant saves
+  additionally validate against the rails. Errors block publish; warnings
+  don't (Sanity model).
 
-## 6. Placement in the PPT architecture
+## 7. Placement in the PPT architecture
 
 | Piece | Where | Notes |
 |---|---|---|
-| Control plane (CRUD, draft/publish, versions, audit, validation) | **api-server** | `layout_configs` + `layout_config_versions` tables; superadmin-scoped routes behind existing admin auth |
-| Resolved read endpoint | **api-server** (ppt/acc screens) + **reality-server** (reality screens) | `GET /layout/{screen}?platform=…&app_version=…` → resolved section list; aggressively cacheable, version-bumped on publish |
-| Editor UI | **admin-web** | iframe bridge + tree panel (§5) |
-| reality-web delivery | Next.js ISR | publish webhook → `revalidateTag('layout:{screen}')`; keep a long time-based revalidate as safety net |
+| Resolution logic (merge, filtering, validation) | **`layout-core` crate** (backend workspace) | shared by api-server + reality-server (+ accounting-server later), mirroring `api-core` |
+| Control plane (CRUD, rails, tenant overrides, kill, versions, audit) | **api-server** | `layout_configs`, `layout_config_versions`, `layout_tenant_overrides` (org_id-scoped), `layout_kill_flags`; superadmin routes behind admin auth, tenant routes behind org admin auth |
+| Resolved read endpoint | **api-server** (ppt/acc screens) + **reality-server** (reality screens) | `GET /layout/{screen}?platform=…&app_version=…` (+ org from tenant context) → resolved section list; cacheable per (screen, platform, org, version) |
+| Superadmin editor | **admin-web** | full `@ppt/layout-editor` |
+| Tenant editor | **ppt-web** | scoped `@ppt/layout-editor` |
+| reality-web delivery | Next.js ISR | publish/kill webhook → `revalidateTag('layout:{screen}')`; long time-based revalidate as safety net |
 | ppt-web / accounting-web delivery | TanStack Query | fetch on navigation, cache last-known-good |
 | Mobile delivery (RN + KMP) | local cache | background fetch, activate next launch/screen; compiled-in default config |
-| Registry manifests | TypeSpec pipeline | generated alongside `@ppt/api-client`; mobile-native via openapi-generator |
+| Registry manifests | TypeSpec pipeline (TS apps); checked-in generated file (KMP) | editors read manifests, nothing hardcoded |
 | Screen catalog | `docs/screens/` | share screen IDs with the existing screen-map system |
-| Feature flags | separate layer | flags gate *whether* (kill switch, rollout %); layout config defines *what/how*. A section may reference a `flagId`; the resolver applies it. Do not merge the two systems |
+| Feature flags / A/B | **not in v1** | schema reserves an optional `flagId` per section for later; no flag service shipped |
 
-## 7. Known costs & pitfalls
+## 8. Known costs & pitfalls
 
-- **Complexity moves server-side; it doesn't disappear.** Resolvers absorb
-  override merging, version filtering, flag substitution, fallback logic.
+- **Complexity moves server-side; it doesn't disappear.** The resolver
+  absorbs override merging, rails enforcement, version filtering, kill
+  application, fallback logic. `layout-core` needs thorough unit tests over
+  the merge precedence.
 - **Testing surface multiplies** (screens × platforms × client versions ×
-  configs). Mitigation: log every section render with config + client
-  version; dashboard failure rates per (component, client-version) cell.
+  orgs). Mitigation: log every section render with config + client version;
+  dashboard failure rates per (component, client-version) cell.
 - **Editor last, contract first.** DoorDash's ordering: harden the config
-  contract on one surface for a long time *before* building the GUI composer.
+  contract on the pilot screens before investing in editor polish.
 - **Out of scope surfaces:** deep-native views (map), auth flows, low-churn
   screens (settings) — no velocity to gain, real downside risk.
 - **Skeletons vs collapse:** skeletons are for *loading* with predictable
   dimensions; a *hidden* section must collapse entirely — a skeleton implies
   content is coming.
+- **Two editors, one package:** the tenant editor must be a capability-
+  restricted mount of the same component, not a fork — divergence between
+  the two editing surfaces is the maintenance trap here.
 
-## 8. Rollout plan
+## 9. Rollout plan
 
-1. **Contract first** — section-list schema + registry pattern on **one**
-   high-churn pilot screen: `reality/listing-detail` (exists on web + KMP).
-2. Resolved-layout endpoint + defensive rendering (gap spacing, error
-   boundaries, unknown-type fallback, required-placeholder) in reality-web.
-3. **Minimal superadmin** — tree panel, eye toggles, reorder,
-   publish/rollback. No iframe preview yet.
-4. Live iframe preview bridge; platform switcher + overrides; display modes.
-5. Extend to reality landing + list pages; then ppt-web and accounting-web
-   screens; then mobile registry manifests + KMP renderer wiring.
+Pilot = **two screens, one per architectural risk** (decided in brainstorm):
+`ppt/dashboard` (tenant overrides + both editors) and
+`reality/listing-detail` (public SSR/ISR + KMP delivery).
 
-## 9. Open questions
+1. **Contract first** — section-list schema, `layout-core` merge resolver
+   with full precedence tests, registry pattern + manifests for ppt-web and
+   reality-web.
+2. **Defensive rendering** on both pilot screens (gap spacing, error
+   boundaries, unknown-type fallback, required-placeholder), resolved-layout
+   endpoints, ISR revalidation hook.
+3. **Superadmin editor MVP** in admin-web — tree panel, visibility, reorder,
+   modes, props, publish/rollback, kill-switch. No iframe preview yet.
+4. **Tenant editor** in ppt-web — scoped mount + server-side rails
+   enforcement + rails authoring UI in admin-web.
+5. **Live iframe preview bridge** + platform switcher/overrides.
+6. Expand: reality landing + list pages → remaining ppt-web screens →
+   accounting-web → mobile registry manifests + RN/KMP renderer wiring.
 
-- Embed Puck for the editor vs build the tree-panel editor natively in
-  admin-web? (Puck saves DnD/slot plumbing but adds a dependency and its
-  config model would need mapping onto ours.)
-- Should the resolved-layout endpoint live in each server, or in a single
-  shared crate consumed by api-server + reality-server (+ accounting-server
-  later)?
-- Audience targeting (per-org / per-segment layouts) — in scope for v2, and
-  does it interact with RLS/tenant context?
-- How registry manifests for KMP are published — build-time upload step vs
-  checked-in generated file.
+## 10. Resolved & open questions
 
-## 10. Further reading
+Resolved in the 2026-07-19 brainstorm:
+
+- **Drivers:** operator tuning + per-tenant customization + kill-switch;
+  A/B out of v1.
+- **Tenant editing:** self-service from day one, two-role rails model.
+- **Tenant powers:** visibility + order + modes + per-prop-whitelisted props.
+- **Pilot:** `ppt/dashboard` + `reality/listing-detail`.
+- **Editor:** custom shared `@ppt/layout-editor`; Puck not embedded; no
+  canvas DnD in v1.
+- **Kill-switch:** built-in, next-load propagation, publish-gate bypass.
+- **Resolver placement:** shared `layout-core` crate.
+- **KMP manifests:** checked-in generated file.
+
+Still open (fine to settle during implementation planning):
+
+- Whether accounting-web joins the pilot expansion before or after mobile.
+- Whether tenant overrides live under RLS like other org data or in
+  admin-owned tables with explicit org_id filtering (leaning RLS for
+  consistency with the rest of the schema).
+- Draft-preview auth for the iframe (signed preview token vs admin session
+  cookie pass-through).
+
+## 11. Further reading
 
 - [Airbnb Ghost Platform deep dive](https://medium.com/airbnb-engineering/a-deep-dive-into-airbnbs-server-driven-ui-system-842244c5f5)
 - [Yelp CHAOS (2024)](https://engineeringblog.yelp.com/2024/03/chaos-yelps-unified-framework-for-server-driven-ui.html) · [backend (2025)](https://engineeringblog.yelp.com/2025/07/chaos-inside-yelps-sdui-framework.html)


### PR DESCRIPTION
## Summary

First implementation slice of the Layout & Content Manager (spec + plan included in this PR under `docs/superpowers/`):

- **`backend/crates/layout-core`** — new pure-logic workspace crate (serde/serde_json/thiserror only, DB-free):
  - Config types: `ScreenConfig` → flat `SectionConfig` list with per-platform `SectionPatch` overrides; `RegistryManifest`/`ComponentDef`, `TenantOverride`, `Rails`, resolved-output types. Additive-only serde (unknown fields ignored, no `deny_unknown_fields`).
  - `resolve()` — layered merge: base → platform override → tenant override → kill flags. Hidden/killed **required** sections degrade to `Placeholder` (mode/props stripped); optional ones collapse out of the tree; unknown types are filtered; modes are defensively clamped to the component's declared set (incl. inconsistent `default_mode` → `None`).
  - `validate_publish()` — hard publish gate: duplicates, unknown types per platform, hidden/missing required sections, unsupported modes, inconsistent manifest `default_mode`.
  - `validate_tenant_override()` — server-side rails enforcement for tenant self-service saves (hideable / mode-editable / reorderable / per-prop whitelist).
- Design spec `docs/superpowers/specs/2026-07-19-layout-content-manager-design.md` and implementation plan `docs/superpowers/plans/2026-07-19-layout-core-contract.md`; repo-map entry for the crate.

Control plane (migrations/routes/TypeSpec), defensive rendering on the pilot screens, and the editors follow in subsequent plans (spec §9).

## Verification

- `cargo test -p layout-core` — **15/15 passing** (TDD per task; each behavior test-driven)
- `cargo fmt --all` + `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Process: 8-task subagent-driven execution with per-task spec+quality reviews and a final whole-branch review (opus); both review-flagged issues (leftover stub line, `default_mode` clamp gap) fixed and re-reviewed.