### PR TITLE
feat(ppt-web): tenant layout editor — org-admin dashboard customization within rails

### DIFF
--- a/backend/servers/api-server/src/routes/layout/tenant.rs
+++ b/backend/servers/api-server/src/routes/layout/tenant.rs
@@ -11,7 +11,7 @@ use super::types::{PutTenantOverrideRequest, ScreenQuery, ValidationErrorsRespon
 
 #[utoipa::path(get, path = "/api/v1/layout/tenant-override", tag = "Layout",
     security(("bearer_auth" = [])), params(("screen" = String, Query, description = "Screen id")),
-    responses((status = 200, description = "Override + rails + published base for the org")))]
+    responses((status = 200, description = "Override + rails + published base + web manifest for the org")))]
 pub async fn get_tenant_override(
     State(state): State<AppState>,
     _auth: AuthUser,
@@ -62,10 +62,22 @@ pub async fn get_tenant_override(
                 errors: vec!["unknown screen".into()],
             }),
         ))?;
+    let manifest_row = repo
+        .get_manifest(&mut **pub_conn, "web")
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ValidationErrorsResponse {
+                    errors: vec![format!("db error: {e}")],
+                }),
+            )
+        })?;
     Ok(Json(serde_json::json!({
         "override": ov,
         "rails": cfg.rails,
         "published": cfg.published,
+        "manifest": manifest_row.map(|r| r.manifest),
     })))
 }
 

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -57,6 +57,7 @@ over `grep -r <noun> backend/`.
   Frontend: `ppt-web/src/features/layout/` + `reality-web/src/lib/layout.ts` +
   `reality-web/src/components/listings/LayoutSections.tsx` (registries, defensive
   renderers, checked-in web manifests for PUT /platform-admin/layout/manifests).
+  Tenant editor: `ppt-web/src/features/layout/` (/dashboard/customize, org-admin entry point).
   Editor: `admin-web/src/features/layout-editor/` (routes `/platform/layout`, `/platform/layout/manifests`).
 - `api-core` — Axum extractors, auth middleware, OpenAPI (utoipa), CORS/tracing.
 - `db` — SQLx pool, models, **~101 repositories** in `src/repositories/`, migrations (~177 sql files).

--- a/docs/screens/ppt/dashboard.md
+++ b/docs/screens/ppt/dashboard.md
@@ -103,6 +103,7 @@ UC-15 + UC-02 + UC-03 + UC-04 hub for residents on mobile (RN). The home screen 
 
 <!-- newest entries on top -->
 
+- 2026-07-20 — agent: org-admin customize entry point added (/dashboard/customize, layout tenant editor)
 - 2026-07-19 — agent: page now renders via resolved-layout section registry (defensive rendering, spec 2026-07-19-layout-content-manager-design)
 - 2026-07-15 — agent: extracted reusable `QueryErrorBanner` from DashboardScreen and swept sibling mobile screens to drop raw `error.message` leaks (#2282/#2304 follow-up, #2323); localized dashboard dates (`i18n.language`) + announcement category badge (`dashboard.category.*`); fixed cs/de `dashboard.loadError` retry-label copy; added QueryErrorBanner regression suite
 - 2026-05-09 — agent: design analyzed (ui_kits/mobile/screens.jsx — MobHomeScreen); flipped mobile redesignStatus → in-progress; attached designSource; populated functionality checklist (6 sections), states, design-specific notes; declared 4 sharedComponents; added 3 relatedScreens (faults-list / announcements / report-fault as children of dashboard)

--- a/docs/superpowers/plans/2026-07-20-layout-tenant-editor.md
+++ b/docs/superpowers/plans/2026-07-20-layout-tenant-editor.md
@@ -1,0 +1,152 @@
+# Layout Tenant Editor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Org-admin self-service layout customization in ppt-web (spec §3.4 two-role model, tenant side): a "Customize dashboard" page where OrgAdmin+ users toggle/reorder/re-mode sections and edit whitelisted props for their org's `ppt/dashboard` — strictly within the superadmin-authored rails — saving through the rails-validated `PUT /api/v1/layout/tenant-override`.
+
+**Architecture:** One small backend addition (the tenant-override GET envelope gains the platform manifest, so the tenant UI knows each section's supported modes), an api-client extension (tenant-override fetchers carrying `Authorization` + `X-Tenant-ID`, with a 422-errors-preserving error type), a pure controlled `TenantSectionEditor` in ppt-web (controls appear ONLY where rails allow: eye toggle iff hideable, ↑/↓ iff reorderable, mode select iff mode-editable, per-prop inputs iff whitelisted — everything else renders as read-only rows), and a `DashboardCustomizePage` (seed-on-load, dirty flag, Save with verbatim 422 list, reset-to-default) routed at `/dashboard/customize` behind `requiredRoles={['org_admin','super_admin']}` with a role-gated "Customize" link on the manager dashboard.
+
+**Tech Stack:** Rust/axum (one handler touch), TypeScript, TanStack Query 5, react-i18next (6 locales), Vitest + Testing Library.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-19-layout-content-manager-design.md` §3.4 (tenant powers: visibility + order + modes + whitelisted props), §6 (tenant editor = capability-restricted variant), §6.3 (server-side rails gate is the truth — the UI hides out-of-rails controls, it does not enforce). All prior slices are merged on `dev` (#2424, #2426, #2427, #2428).
+- **Branch:** `feature/layout-tenant-editor` from `dev`.
+- Contract shapes (backend, merged): GET `/api/v1/layout/tenant-override?screen=` → `{ override: Row|null, rails: Rails|{}, published: ScreenConfig|null }` where `Row.override_config` holds the `TenantOverride`; PUT body `{ screen, override_config }` with `TenantOverride { order?: string[]; sections?: Record<string, { visible?: boolean; mode?: string; props?: Record<string, unknown> }> }`; 422 → `{ errors: string[] }` (rails violations, rendered VERBATIM); 403 when role below OrgAdmin; 404 when screen unknown/unpublished. Rails: `{ hideable: string[], mode_editable: string[], reorderable: boolean, prop_whitelist: Record<string, string[]> }`.
+- **Backend envelope extension (Task 1):** GET tenant-override additionally returns `"manifest": <web manifest JSON or null>` — read via `LayoutRepository::get_manifest(&…, "web")` on the same sanctioned public connection pattern already used in that file for global tables. Additive only; existing keys unchanged.
+- Tenant calls MUST send `X-Tenant-ID` — `authenticatedFetchJson` adds only `Authorization`; mirror `packages/api-client/src/financial/api.ts` (`getToken()` + `getOrg()` from `../auth/…`, omit the header when org is null).
+- UI hides controls the rails don't grant — but NEVER renders disabled controls (house rule from the admin editor); a section with no granted controls renders as a plain read-only row. Sections listed in `published` are the universe; override may only reference them (server enforces `NotInBase`).
+- Whitelisted prop values: input text is parsed as JSON when `JSON.parse` succeeds, otherwise stored as a string (documented in a code comment + i18n hint). Empty input removes the prop from the override.
+- Effective display state = published base + override (visible/mode per section) so the editor shows what the org will get; base values render as the fallback when the override doesn't touch a field.
+- Reset-to-default = save an empty override `{}` (server keeps the row; resolver then applies no tenant delta).
+- Seed discipline: page seeds local override state from the envelope once per load (single fixed screen `ppt/dashboard`; no screen switching in this page — simpler than the admin editor; refetch after save must NOT clobber unsaved edits → same conditional dirty-clear via sent-JSON ref as the admin editor).
+- i18n: new keys under `layout.customize.*` added to ALL SIX locale files (`en,sk,cs,de,pl,hu`), `t('layout.customize.…')` (ppt-web has no defaultValue convention — keys must exist; keep en as source and translate the rest sensibly).
+- Gates: backend `cargo check -p api-server && cargo clippy -p api-server --all-targets -- -D warnings`; frontend `pnpm -F @ppt/api-client test`, `pnpm -F @ppt/web test`, workspace `pnpm check && pnpm typecheck` (known pre-existing failures: ppt-web FileDisputePage 3; do not touch). NO jest-dom matchers in any admin-web files (n/a here — ppt-web's setup DOES provide jest-dom, mirror its existing tests).
+- Commit scopes: `feat(api-server)`, `feat(api-client)`, `feat(ppt-web)`, `docs(...)`. ADAPT rule as before (mirror files named per task; logic/contracts fixed; report adaptations).
+
+## File Structure
+
+```
+backend/servers/api-server/src/routes/layout/tenant.rs   # + manifest in GET envelope
+frontend/packages/api-client/src/layout/api.ts           # + tenant-override types/fetchers
+frontend/packages/api-client/src/layout/hooks.ts         # + useTenantLayout/useSaveTenantLayoutOverride
+frontend/packages/api-client/src/layout/api.test.ts      # + tests
+frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
+frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx
+frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
+frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx
+frontend/apps/ppt-web/src/routes/groups/core.tsx         # + lazy route /dashboard/customize
+frontend/apps/ppt-web/src/features/dashboard/pages/ManagerDashboardPage.tsx  # + role-gated Customize link
+frontend/apps/ppt-web/messages/{en,sk,cs,de,pl,hu}.json  # + layout.customize.*
+docs/repo-map.md                                          # extend layout bullet
+```
+
+---
+
+### Task 1: Backend — manifest in the tenant-override envelope
+
+**Files:**
+- Modify: `backend/servers/api-server/src/routes/layout/tenant.rs` (handler `get_tenant_override`)
+
+**Interfaces:**
+- Consumes: existing handler + `LayoutRepository::get_manifest` + the file's existing sanctioned-public-connection idiom for global tables (see how `get_config` is fetched in the same handler — mirror it).
+- Produces: response JSON gains `"manifest": <manifest JSON | null>` (the `web` platform manifest's `manifest` column, or null when none uploaded). Existing keys (`override`, `rails`, `published`) unchanged. utoipa description updated.
+
+- [ ] **Step 1:** In `get_tenant_override`, after loading the config row, fetch `repo.get_manifest(<same public-conn executor as get_config>, "web")` (propagate DB errors like the neighbouring calls), and extend the `serde_json::json!({...})` with `"manifest": manifest_row.map(|r| r.manifest)`.
+- [ ] **Step 2:** Update the `#[utoipa::path]` response description to mention the manifest field.
+- [ ] **Step 3:** Verify FOREGROUND: `cd backend && cargo check -p api-server && cargo clippy -p api-server --all-targets -- -D warnings` — clean.
+- [ ] **Step 4:** Commit — `feat(api-server): include web manifest in tenant layout envelope`
+
+---
+
+### Task 2: api-client — tenant-override domain (TDD)
+
+**Files:**
+- Modify: `frontend/packages/api-client/src/layout/api.ts`
+- Modify: `frontend/packages/api-client/src/layout/hooks.ts`
+- Test: `frontend/packages/api-client/src/layout/api.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `getToken()` + `getOrg()` (mirror `financial/api.ts` for exact import paths and header idiom).
+- Produces (Tasks 3–4 rely on exact names): types `TenantSectionPatch { visible?: boolean; mode?: string; props?: Record<string, unknown> }`, `TenantOverride { order?: string[]; sections?: Record<string, TenantSectionPatch> }`, `LayoutRails { hideable: string[]; mode_editable: string[]; reorderable: boolean; prop_whitelist: Record<string, string[]> }`, `ManifestComponent { required?: boolean; supported_modes?: string[]; default_mode?: string }`, `LayoutManifest { platform: string; components: Record<string, ManifestComponent> }`, `BaseSection { type: string; visible?: boolean; mode?: string; props?: Record<string, unknown> }`, `TenantLayoutEnvelope { override: { override_config: TenantOverride } | null; rails: LayoutRails | Record<string, never>; published: { sections: BaseSection[] } | null; manifest: LayoutManifest | null }`; error `TenantLayoutError extends Error { status: number; errors: string[] }`; `fetchTenantLayout(screen): Promise<TenantLayoutEnvelope>`; `saveTenantLayoutOverride(screen, override: TenantOverride): Promise<unknown>` (throws `TenantLayoutError` carrying the 422 `errors` verbatim); hooks `useTenantLayout(screen)` and `useSaveTenantLayoutOverride(screen)` (`useMutation` invalidating the tenant-layout key on success); key factory extension `layoutKeys.tenant(screen)`.
+- Implementation note: use a local `tenantRequest` helper doing raw `fetch('/api/v1/layout/tenant-override…')` with `Authorization` (getToken) + `X-Tenant-ID` (getOrg, omitted when null) + `Content-Type`, parsing `{errors}` on non-2xx into `TenantLayoutError` — do NOT use `authenticatedFetchJson` (no org header, error body lost).
+
+- [ ] **Step 1: failing tests** — (a) `fetchTenantLayout` GETs `/api/v1/layout/tenant-override?screen=ppt%2Fdashboard` with both headers and returns the envelope; (b) omits `X-Tenant-ID` when `getOrg()` is null (mock the auth module with `vi.mock`); (c) `saveTenantLayoutOverride` PUTs `{ screen, override_config }`; (d) 422 → `TenantLayoutError` with `errors` verbatim.
+- [ ] **Step 2: implement; run** `pnpm -F @ppt/api-client test` — all green (existing 131+ too).
+- [ ] **Step 3: Commit** — `feat(api-client): tenant layout override fetchers and hooks`
+
+---
+
+### Task 3: TenantSectionEditor (pure component, TDD)
+
+**Files:**
+- Create: `frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx`
+- Test: `frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: Task 2 types (from `@ppt/api-client`).
+- Produces: controlled `props { baseSections: BaseSection[]; rails: LayoutRails; manifest: LayoutManifest | null; override: TenantOverride; onChange(next: TenantOverride): void }`. Rendering/behavior contract:
+  - Rows = published base sections, ordered by `override.order` when present (listed first, unlisted keep base order — same semantics as the resolver), else base order.
+  - Effective visible = `override.sections[type].visible ?? base.visible ?? true`; effective mode = `override.sections[type].mode ?? base.mode`.
+  - Eye toggle rendered ONLY when `type ∈ rails.hideable`; toggling patches `override.sections[type].visible` (setting it equal to the base value still records the explicit patch — simplest; server accepts it).
+  - ↑/↓ rendered ONLY when `rails.reorderable`; reorder writes the FULL current order array to `override.order`.
+  - Mode `<select>` ONLY when `type ∈ rails.mode_editable` AND the manifest lists `supported_modes` for it; options = supported modes; first option = effective mode.
+  - Per-prop inputs ONLY for names in `rails.prop_whitelist[type]`: one labeled text input per name; value shown = `JSON.stringify(override.sections[type].props?.[name])` when set (strings unquoted), else empty with the base value as placeholder; commit on blur — parse as JSON if possible else string; empty removes the prop (and drops empty `props`/section objects).
+  - Sections with no granted controls render read-only (type + effective state badges). NO disabled controls anywhere.
+  - A hidden-effective section row gets a dimmed style + "hidden" badge.
+- All strings via `t('layout.customize.…')`.
+
+- [ ] **Step 1: failing tests** (mock react-i18next key-echo): (1) hideable-only section shows the eye and no arrows/mode/props; toggling calls `onChange` with the visible patch; (2) non-granted section renders no interactive controls; (3) reorderable rails render arrows; ↓ writes full `order` array; (4) mode select renders only for mode-editable + manifest modes; change patches mode; (5) whitelisted prop input commits JSON (`5` → number 5) and plain text as string; clearing removes the prop; (6) `override.order` drives row order.
+- [ ] **Step 2: implement + pass** (`pnpm -F @ppt/web test -- TenantSectionEditor`), Biome clean. Follow ppt-web test conventions (jest-dom IS available here).
+- [ ] **Step 3: Commit** — `feat(ppt-web): tenant section editor component`
+
+---
+
+### Task 4: DashboardCustomizePage + route + link (TDD)
+
+**Files:**
+- Create: `frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx`
+- Modify: `frontend/apps/ppt-web/src/routes/groups/core.tsx` (lazy route `/dashboard/customize` wrapped in `<ProtectedRoute requiredRoles={['org_admin', 'super_admin']}>` — mirror the `SessionsPage` lazy idiom)
+- Modify: `frontend/apps/ppt-web/src/features/dashboard/pages/ManagerDashboardPage.tsx` (a "Customize" `<Link to="/dashboard/customize">` in the header, rendered only when `useAuth().user?.role` is `'org_admin' | 'super_admin'`)
+- Modify: `frontend/apps/ppt-web/messages/{en,sk,cs,de,pl,hu}.json` (`layout.customize.*` keys used by Tasks 3–4)
+- Test: `frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx` (+ extend `ManagerDashboardPage.test.tsx` for the role-gated link)
+
+**Interfaces:**
+- Consumes: `useTenantLayout('ppt/dashboard')`, `useSaveTenantLayoutOverride`, `TenantSectionEditor`, `useToast` (`src/components`), `useAuth` (`src/contexts/AuthContext`).
+- Produces behavior:
+  - Loading → spinner; envelope with `published: null` → info panel `layout.customize.notPublished` (no editor); error → error panel + retry.
+  - Editor seeded from `envelope.override?.override_config ?? {}` once per load; dirty flag on change; Save button (disabled when clean) → mutation; success toast + conditional dirty-clear via sent-JSON ref (admin-editor discipline); `TenantLayoutError` 422 → persistent verbatim `<ul>` of `errors` (role=alert), cleared on next change.
+  - Reset-to-default button (confirm) → sets local override `{}` + marks dirty (user still saves explicitly).
+  - Back link to `/dashboard/manager`.
+
+- [ ] **Step 1: failing tests** — (1) renders editor rows from the envelope's published sections (mock `@ppt/api-client` layout hooks/fetchers via `vi.mock`); (2) not-published envelope shows the info panel and no editor; (3) toggle → Save calls `saveTenantLayoutOverride('ppt/dashboard', patch)`; (4) 422 errors render verbatim; (5) ManagerDashboardPage shows the Customize link for `org_admin` and hides it for `resident` (mock `useAuth`).
+- [ ] **Step 2: implement + route + link + i18n keys (all six locales); run** `pnpm -F @ppt/web test` full — only the 3 pre-existing FileDisputePage failures remain.
+- [ ] **Step 3: Commit** — `feat(ppt-web): dashboard customize page for org admins`
+
+---
+
+### Task 5: Gates + docs
+
+**Files:**
+- Modify: `docs/repo-map.md` (layout bullet: `Tenant editor: ppt-web /dashboard/customize (features/layout/)`)
+- Modify: `docs/screens/ppt/dashboard.md` (Agent Log entry: customize entry point added) — plus a new Agent Log line only in docs that exist; note absences.
+- Test: full gates.
+
+- [ ] **Step 1:** repo-map + screen-map entries.
+- [ ] **Step 2:** `cd backend && cargo check -p api-server && cargo clippy -p api-server --all-targets -- -D warnings`; `cd frontend && pnpm check && pnpm typecheck && pnpm -F @ppt/api-client test && pnpm -F @ppt/web test`. All green modulo known pre-existing failures; `check:fix` only our files.
+- [ ] **Step 3:** Commit — `docs(repo-map): layout tenant editor pointers`
+
+---
+
+## Deliberate scope decisions (do not "fix" during implementation)
+
+- **Single screen (`ppt/dashboard`)** — a screen picker joins when more ppt screens enter the layout system.
+- **No mobile-platform tenant editing** — envelope carries the web manifest only (Task 1); mobile joins with the mobile slice.
+- **Explicit-save only** — no autosave/optimistic preview; the dashboard reflects changes on next visit (resolved endpoint is cached per org).
+- **Rails UI truthfully mirrors the server gate but does not duplicate its validation** — out-of-rails states are unreachable in the UI; the 422 path still renders verbatim as the safety net.
+- **No preview bridge** — later slice.
+
+## Out of scope (subsequent plans)
+
+1. Preview bridge (admin + tenant), platform-override editing, per-tenant view in admin-web.
+2. Mobile registries/renderers; publish webhook; `layout_editor_*` capability.

--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1685,6 +1685,23 @@
   },
   "layout": {
     "placeholderTitle": "Sekce nedostupná",
-    "placeholderBody": "Tato sekce je dočasně nedostupná."
+    "placeholderBody": "Tato sekce je dočasně nedostupná.",
+    "customize": {
+      "title": "Přizpůsobit nástěnku",
+      "back": "Zpět na nástěnku",
+      "save": "Uložit",
+      "reset": "Obnovit výchozí",
+      "resetConfirm": "Obnovit všechna přizpůsobení na výchozí rozložení? Změny budou ztraceny, dokud je neuložíte.",
+      "notPublished": "Zatím nebylo publikováno žádné rozložení. Publikujte rozložení, abyste mohli přizpůsobit.",
+      "saveSuccess": "Rozložení bylo úspěšně uloženo.",
+      "saveError": "Uložení rozložení se nezdařilo. Zkuste to znovu.",
+      "loadError": "Nepodařilo se načíst nastavení rozložení.",
+      "hidden": "Skryté",
+      "hide": "Skrýt sekci",
+      "show": "Zobrazit sekci",
+      "moveUp": "Přesunout nahoru",
+      "moveDown": "Přesunout dolů",
+      "mode": "Režim zobrazení"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1578,6 +1578,23 @@
   },
   "layout": {
     "placeholderTitle": "Abschnitt nicht verfügbar",
-    "placeholderBody": "Dieser Abschnitt ist vorübergehend nicht verfügbar."
+    "placeholderBody": "Dieser Abschnitt ist vorübergehend nicht verfügbar.",
+    "customize": {
+      "title": "Dashboard anpassen",
+      "back": "Zurück zum Dashboard",
+      "save": "Speichern",
+      "reset": "Standard wiederherstellen",
+      "resetConfirm": "Alle Anpassungen auf das Standardlayout zurücksetzen? Änderungen gehen verloren, bis Sie sie speichern.",
+      "notPublished": "Es wurde noch kein Layout veröffentlicht. Veröffentlichen Sie ein Layout, um Anpassungen zu ermöglichen.",
+      "saveSuccess": "Layout erfolgreich gespeichert.",
+      "saveError": "Layout konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
+      "loadError": "Layout-Einstellungen konnten nicht geladen werden.",
+      "hidden": "Ausgeblendet",
+      "hide": "Abschnitt ausblenden",
+      "show": "Abschnitt anzeigen",
+      "moveUp": "Nach oben verschieben",
+      "moveDown": "Nach unten verschieben",
+      "mode": "Anzeigemodus"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3867,6 +3867,23 @@
   },
   "layout": {
     "placeholderTitle": "Section unavailable",
-    "placeholderBody": "This section is temporarily unavailable."
+    "placeholderBody": "This section is temporarily unavailable.",
+    "customize": {
+      "title": "Customize Dashboard",
+      "back": "Back to Dashboard",
+      "save": "Save",
+      "reset": "Reset to Default",
+      "resetConfirm": "Reset all customisations to the default layout? This cannot be undone until you save.",
+      "notPublished": "No layout has been published yet. Publish a layout to enable customisation.",
+      "saveSuccess": "Layout saved successfully.",
+      "saveError": "Failed to save layout. Please try again.",
+      "loadError": "Failed to load layout settings.",
+      "hidden": "Hidden",
+      "hide": "Hide section",
+      "show": "Show section",
+      "moveUp": "Move up",
+      "moveDown": "Move down",
+      "mode": "Display mode"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1551,6 +1551,23 @@
   },
   "layout": {
     "placeholderTitle": "Szakasz nem elérhető",
-    "placeholderBody": "Ez a szakasz ideiglenesen nem elérhető."
+    "placeholderBody": "Ez a szakasz ideiglenesen nem elérhető.",
+    "customize": {
+      "title": "Műszerfal testreszabása",
+      "back": "Vissza a műszerfalhoz",
+      "save": "Mentés",
+      "reset": "Alapértelmezett visszaállítása",
+      "resetConfirm": "Visszaállítja az összes testreszabást az alapértelmezett elrendezésre? A változtatások elvesznek, amíg el nem menti őket.",
+      "notPublished": "Még nem lett közzétéve elrendezés. Tegyen közzé egy elrendezést a testreszabás engedélyezéséhez.",
+      "saveSuccess": "Az elrendezés sikeresen mentve.",
+      "saveError": "Az elrendezés mentése sikertelen. Kérjük, próbálja újra.",
+      "loadError": "Nem sikerült betölteni az elrendezés beállításait.",
+      "hidden": "Rejtett",
+      "hide": "Szakasz elrejtése",
+      "show": "Szakasz megjelenítése",
+      "moveUp": "Felfelé mozgatás",
+      "moveDown": "Lefelé mozgatás",
+      "mode": "Megjelenítési mód"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1557,6 +1557,23 @@
   },
   "layout": {
     "placeholderTitle": "Sekcja niedostępna",
-    "placeholderBody": "Ta sekcja jest tymczasowo niedostępna."
+    "placeholderBody": "Ta sekcja jest tymczasowo niedostępna.",
+    "customize": {
+      "title": "Dostosuj pulpit",
+      "back": "Wróć do pulpitu",
+      "save": "Zapisz",
+      "reset": "Przywróć domyślne",
+      "resetConfirm": "Przywrócić wszystkie dostosowania do domyślnego układu? Zmiany zostaną utracone do momentu zapisania.",
+      "notPublished": "Nie opublikowano jeszcze żadnego układu. Opublikuj układ, aby umożliwić dostosowanie.",
+      "saveSuccess": "Układ został pomyślnie zapisany.",
+      "saveError": "Nie udało się zapisać układu. Spróbuj ponownie.",
+      "loadError": "Nie udało się załadować ustawień układu.",
+      "hidden": "Ukryte",
+      "hide": "Ukryj sekcję",
+      "show": "Pokaż sekcję",
+      "moveUp": "Przesuń w górę",
+      "moveDown": "Przesuń w dół",
+      "mode": "Tryb wyświetlania"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1687,6 +1687,23 @@
   },
   "layout": {
     "placeholderTitle": "Sekcia nedostupná",
-    "placeholderBody": "Táto sekcia je dočasne nedostupná."
+    "placeholderBody": "Táto sekcia je dočasne nedostupná.",
+    "customize": {
+      "title": "Prispôsobiť nástenkú",
+      "back": "Späť na nástenku",
+      "save": "Uložiť",
+      "reset": "Obnoviť predvolené",
+      "resetConfirm": "Obnoviť všetky úpravy na predvolené rozloženie? Zmeny budú stratené, kým ich neuložíte.",
+      "notPublished": "Zatiaľ nebolo zverejnené žiadne rozloženie. Zverejnite rozloženie, aby ste mohli upravovať.",
+      "saveSuccess": "Rozloženie bolo úspešne uložené.",
+      "saveError": "Uloženie rozloženia zlyhalo. Skúste to znova.",
+      "loadError": "Načítanie nastavení rozloženia zlyhalo.",
+      "hidden": "Skryté",
+      "hide": "Skryť sekciu",
+      "show": "Zobraziť sekciu",
+      "moveUp": "Presunúť nahor",
+      "moveDown": "Presunúť nadol",
+      "mode": "Režim zobrazenia"
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1689,7 +1689,7 @@
     "placeholderTitle": "Sekcia nedostupná",
     "placeholderBody": "Táto sekcia je dočasne nedostupná.",
     "customize": {
-      "title": "Prispôsobiť nástenkú",
+      "title": "Prispôsobiť nástenku",
       "back": "Späť na nástenku",
       "save": "Uložiť",
       "reset": "Obnoviť predvolené",

--- a/frontend/apps/ppt-web/src/features/dashboard/pages/ManagerDashboardPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/dashboard/pages/ManagerDashboardPage.test.tsx
@@ -23,6 +23,11 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+// Stub useAuth so the page doesn't throw outside an AuthProvider.
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ user: { role: 'manager' }, isAuthenticated: true })),
+}));
+
 // Stub useActionQueue so the ActionQueue section renders without a QueryClient
 // hitting real network calls that would cascade errors.
 vi.mock('../../hooks/useActionQueue', () => ({

--- a/frontend/apps/ppt-web/src/features/dashboard/pages/ManagerDashboardPage.tsx
+++ b/frontend/apps/ppt-web/src/features/dashboard/pages/ManagerDashboardPage.tsx
@@ -9,19 +9,32 @@
 
 import { useResolvedLayout } from '@ppt/api-client';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../../../contexts/AuthContext';
 import { LayoutRenderer } from '../../layout/LayoutRenderer';
 import { DEFAULT_DASHBOARD_LAYOUT, dashboardRegistry } from '../../layout/registry';
 import './ManagerDashboardPage.css';
 
+const CUSTOMIZE_ROLES = ['org_admin', 'super_admin'] as const;
+
 export function ManagerDashboardPage() {
   const { t } = useTranslation();
   const { data: layout } = useResolvedLayout('ppt/dashboard');
+  const { user } = useAuth();
+
+  const canCustomize =
+    user?.role != null && (CUSTOMIZE_ROLES as readonly string[]).includes(user.role);
 
   return (
     <div className="dashboard-page">
       <header className="dashboard-page__header">
         <h1 className="dashboard-page__title">{t('dashboard.managerDashboard')}</h1>
         <p className="dashboard-page__subtitle">{t('dashboard.managerWelcome')}</p>
+        {canCustomize && (
+          <Link to="/dashboard/customize" className="dashboard-page__customize-link">
+            {t('layout.customize.title')}
+          </Link>
+        )}
       </header>
 
       <LayoutRenderer layout={layout ?? DEFAULT_DASHBOARD_LAYOUT} registry={dashboardRegistry} />

--- a/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx
@@ -1,0 +1,279 @@
+/// <reference types="vitest/globals" />
+/**
+ * DashboardCustomizePage — TDD tests (Task 4).
+ *
+ * Five scenarios per the task brief:
+ *  1. Renders editor rows from the envelope's published sections.
+ *  2. Not-published envelope shows info panel, no editor.
+ *  3. Toggle → Save calls saveTenantLayoutOverride('ppt/dashboard', patch).
+ *  4. 422 errors render verbatim.
+ *  5. ManagerDashboardPage shows Customize link for org_admin, hides for resident.
+ */
+import type { TenantLayoutEnvelope } from '@ppt/api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ManagerDashboardPage } from '../dashboard/pages/ManagerDashboardPage';
+import { DashboardCustomizePage } from './DashboardCustomizePage';
+
+// ---------------------------------------------------------------------------
+// Shared mutable state — mutated per test, read by the mocks
+// ---------------------------------------------------------------------------
+
+let mockEnvelope: TenantLayoutEnvelope = {
+  override: null,
+  rails: { hideable: ['hero'], mode_editable: [], reorderable: false, prop_whitelist: {} },
+  published: {
+    sections: [
+      { type: 'hero', visible: true },
+      { type: 'stats', visible: true },
+    ],
+  },
+  manifest: null,
+};
+
+// mutateAsync is replaced per test
+let mockSaveImpl: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue({});
+
+let mockAuthRole = 'org_admin';
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@ppt/api-client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useTenantLayout: vi.fn(() => ({
+      data: mockEnvelope,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    })),
+    useSaveTenantLayoutOverride: vi.fn(() => ({
+      mutateAsync: (...args: unknown[]) => mockSaveImpl(...args),
+      isPending: false,
+    })),
+    useResolvedLayout: vi.fn(() => ({ data: null, isLoading: false, isError: false })),
+    TenantLayoutError: class TenantLayoutError extends Error {
+      status: number;
+      errors: string[];
+      constructor(status: number, errors: string[]) {
+        super(`TenantLayoutError: HTTP ${status}`);
+        this.name = 'TenantLayoutError';
+        this.status = status;
+        this.errors = errors;
+      }
+    },
+  };
+});
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useTranslation: () => ({ t: (key: string) => key }),
+  };
+});
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ user: { role: mockAuthRole }, isAuthenticated: true })),
+}));
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: vi.fn(() => ({ user: { role: mockAuthRole }, isAuthenticated: true })),
+}));
+
+// Stub useActionQueue for ManagerDashboardPage
+vi.mock('../dashboard/hooks/useActionQueue', () => ({
+  useActionQueue: vi.fn(() => ({
+    items: [],
+    total: 0,
+    stats: { total: 0, urgent: 0, high: 0, medium: 0, low: 0 },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    dismissItem: vi.fn(),
+    handleAction: vi.fn(),
+    isExecuting: false,
+  })),
+}));
+
+// Stub ToastProvider
+vi.mock('../../components', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    useToast: vi.fn(() => ({ showToast: vi.fn() })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockSaveImpl = vi.fn().mockResolvedValue({});
+  mockAuthRole = 'org_admin';
+});
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <DashboardCustomizePage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderManagerDashboard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ManagerDashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: renders editor rows from the envelope's published sections
+// ---------------------------------------------------------------------------
+describe('Test 1: renders editor rows from published sections', () => {
+  it('shows a row for each published section type', async () => {
+    mockEnvelope = {
+      override: null,
+      rails: { hideable: ['hero'], mode_editable: [], reorderable: false, prop_whitelist: {} },
+      published: {
+        sections: [
+          { type: 'hero', visible: true },
+          { type: 'stats', visible: true },
+        ],
+      },
+      manifest: null,
+    };
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('hero')).toBeInTheDocument();
+      expect(screen.getByText('stats')).toBeInTheDocument();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: not-published envelope shows info panel and no editor
+// ---------------------------------------------------------------------------
+describe('Test 2: not-published envelope shows info panel, no editor', () => {
+  it('renders the not-published info panel when published is null', async () => {
+    mockEnvelope = {
+      override: null,
+      rails: { hideable: [], mode_editable: [], reorderable: false, prop_whitelist: {} },
+      published: null,
+      manifest: null,
+    };
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('layout.customize.notPublished')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('hero')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: toggle → Save calls saveTenantLayoutOverride
+// ---------------------------------------------------------------------------
+describe('Test 3: toggle → Save calls mutation', () => {
+  it('calls mutateAsync with patched override when Save is clicked after toggling', async () => {
+    const user = userEvent.setup();
+    mockSaveImpl = vi.fn().mockResolvedValue({});
+    mockEnvelope = {
+      override: null,
+      rails: { hideable: ['hero'], mode_editable: [], reorderable: false, prop_whitelist: {} },
+      published: { sections: [{ type: 'hero', visible: true }] },
+      manifest: null,
+    };
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('hero')).toBeInTheDocument());
+
+    const toggle = screen.getByRole('button', { name: /layout\.customize\.(hide|show)/ });
+    await user.click(toggle);
+
+    const saveBtn = screen.getByRole('button', { name: 'layout.customize.save' });
+    expect(saveBtn).not.toBeDisabled();
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(mockSaveImpl).toHaveBeenCalledOnce();
+    });
+    const [calledWith] = mockSaveImpl.mock.calls[0] as [unknown];
+    expect(calledWith).toMatchObject({ sections: { hero: { visible: false } } });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: 422 errors render verbatim in role=alert list
+// ---------------------------------------------------------------------------
+describe('Test 4: 422 errors render verbatim', () => {
+  it('shows error list when mutateAsync rejects with TenantLayoutError', async () => {
+    const user = userEvent.setup();
+    const { TenantLayoutError } = await import('@ppt/api-client');
+    mockSaveImpl = vi
+      .fn()
+      .mockRejectedValue(new TenantLayoutError(422, ['Field X is invalid', 'Field Y missing']));
+    mockEnvelope = {
+      override: null,
+      rails: { hideable: ['hero'], mode_editable: [], reorderable: false, prop_whitelist: {} },
+      published: { sections: [{ type: 'hero', visible: true }] },
+      manifest: null,
+    };
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('hero')).toBeInTheDocument());
+
+    const toggle = screen.getByRole('button', { name: /layout\.customize\.(hide|show)/ });
+    await user.click(toggle);
+    const saveBtn = screen.getByRole('button', { name: 'layout.customize.save' });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      const alert = document.querySelector('[role="alert"]');
+      expect(alert).toBeInTheDocument();
+      expect(alert?.textContent).toContain('Field X is invalid');
+      expect(alert?.textContent).toContain('Field Y missing');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 5: ManagerDashboardPage shows Customize link for org_admin, hides for resident
+// ---------------------------------------------------------------------------
+describe('Test 5: Customize link role-gated on ManagerDashboardPage', () => {
+  it('shows Customize link for org_admin', async () => {
+    mockAuthRole = 'org_admin';
+    renderManagerDashboard();
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'layout.customize.title' })).toBeInTheDocument();
+    });
+  });
+
+  it('hides Customize link for resident', async () => {
+    mockAuthRole = 'resident';
+    renderManagerDashboard();
+    // Give it a moment then assert absent
+    await waitFor(() => {
+      // Dashboard title should be visible (page rendered)
+      expect(screen.getByText('dashboard.managerDashboard')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('link', { name: 'layout.customize.title' })).toBeNull();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx
@@ -186,6 +186,25 @@ describe('Test 2: not-published envelope shows info panel, no editor', () => {
     });
     expect(screen.queryByText('hero')).toBeNull();
   });
+
+  it('renders read-only rows when rails is empty object without crashing', async () => {
+    mockEnvelope = {
+      override: null,
+      rails: Object.create(null),
+      published: {
+        sections: [
+          { type: 'hero', visible: true },
+          { type: 'stats', visible: true },
+        ],
+      },
+      manifest: null,
+    };
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText('hero')).toBeInTheDocument();
+      expect(screen.getByText('stats')).toBeInTheDocument();
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
@@ -7,6 +7,7 @@
  * Route: /dashboard/customize (lazy, ProtectedRoute requiredRoles org_admin|super_admin)
  */
 import {
+  type LayoutRails,
   TenantLayoutError,
   type TenantOverride,
   useSaveTenantLayoutOverride,
@@ -45,10 +46,6 @@ export function DashboardCustomizePage() {
     seedRef.current = true;
     setLocalOverride(envelope.override?.override_config ?? {});
   }
-
-  // Reset seed when envelope identity changes (e.g. after refetch invalidates cache)
-  // NOTE: this is intentionally outside useEffect to avoid a render-cycle delay;
-  // it's safe because it only sets state when the envelope identity changes.
 
   const handleChange = (next: TenantOverride) => {
     setLocalOverride(next);
@@ -113,11 +110,12 @@ export function DashboardCustomizePage() {
   }
 
   const published = envelope.published;
-  const rails = envelope.rails as {
-    hideable: string[];
-    mode_editable: string[];
-    reorderable: boolean;
-    prop_whitelist: Record<string, string[]>;
+  const rails: LayoutRails = {
+    hideable: [],
+    mode_editable: [],
+    reorderable: false,
+    prop_whitelist: {},
+    ...(envelope.rails as Partial<LayoutRails>),
   };
 
   return (

--- a/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
@@ -1,0 +1,173 @@
+/**
+ * DashboardCustomizePage — Task 4 (layout tenant-editor plan).
+ *
+ * Org-admin / super-admin only. Allows customising the ppt/dashboard layout
+ * via the tenant-override API (Task 3 envelope / Task 2 hooks).
+ *
+ * Route: /dashboard/customize (lazy, ProtectedRoute requiredRoles org_admin|super_admin)
+ */
+import {
+  TenantLayoutError,
+  type TenantOverride,
+  useSaveTenantLayoutOverride,
+  useTenantLayout,
+} from '@ppt/api-client';
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { useToast } from '../../components';
+import { TenantSectionEditor } from './TenantSectionEditor';
+
+const SCREEN = 'ppt/dashboard';
+
+export function DashboardCustomizePage() {
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+
+  // Fetch the tenant layout envelope
+  const { data: envelope, isLoading, isError, refetch } = useTenantLayout(SCREEN);
+
+  // Local editor state — seeded once per load
+  const [localOverride, setLocalOverride] = useState<TenantOverride | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+
+  // Validation errors from a 422 response — cleared on next change
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+  // Track the JSON we last sent so we can conditionally clear dirty
+  const sentJsonRef = useRef<string | null>(null);
+
+  const mutation = useSaveTenantLayoutOverride(SCREEN);
+
+  // Seed the local override once per load (when data arrives)
+  const seedRef = useRef(false);
+  if (envelope && !seedRef.current) {
+    seedRef.current = true;
+    setLocalOverride(envelope.override?.override_config ?? {});
+  }
+
+  // Reset seed when envelope identity changes (e.g. after refetch invalidates cache)
+  // NOTE: this is intentionally outside useEffect to avoid a render-cycle delay;
+  // it's safe because it only sets state when the envelope identity changes.
+
+  const handleChange = (next: TenantOverride) => {
+    setLocalOverride(next);
+    setIsDirty(true);
+    setValidationErrors([]);
+  };
+
+  const handleSave = async () => {
+    if (localOverride === null) return;
+    const json = JSON.stringify(localOverride);
+    sentJsonRef.current = json;
+    try {
+      await mutation.mutateAsync(localOverride);
+      showToast({
+        type: 'success',
+        title: t('layout.customize.saveSuccess'),
+      });
+      // Only clear dirty if the override hasn't changed since we sent
+      if (JSON.stringify(localOverride) === json) {
+        setIsDirty(false);
+      }
+    } catch (err) {
+      if (err instanceof TenantLayoutError && err.status === 422) {
+        setValidationErrors(err.errors);
+      } else {
+        showToast({
+          type: 'error',
+          title: t('layout.customize.saveError'),
+        });
+      }
+    }
+  };
+
+  const handleReset = () => {
+    if (!window.confirm(t('layout.customize.resetConfirm'))) return;
+    setLocalOverride({});
+    setIsDirty(true);
+    setValidationErrors([]);
+  };
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="dashboard-customize-page">
+        <p role="status" aria-live="polite">
+          {t('common.loading')}
+        </p>
+      </div>
+    );
+  }
+
+  // Error state
+  if (isError || !envelope) {
+    return (
+      <div className="dashboard-customize-page">
+        <p role="alert">{t('layout.customize.loadError')}</p>
+        <button type="button" onClick={() => refetch()}>
+          {t('common.retry')}
+        </button>
+      </div>
+    );
+  }
+
+  const published = envelope.published;
+  const rails = envelope.rails as {
+    hideable: string[];
+    mode_editable: string[];
+    reorderable: boolean;
+    prop_whitelist: Record<string, string[]>;
+  };
+
+  return (
+    <div className="dashboard-customize-page">
+      <header className="dashboard-customize-page__header">
+        <Link to="/dashboard/manager" className="dashboard-customize-page__back">
+          {t('layout.customize.back')}
+        </Link>
+        <h1>{t('layout.customize.title')}</h1>
+      </header>
+
+      {/* Not-published info panel */}
+      {published === null ? (
+        <p className="dashboard-customize-page__info">{t('layout.customize.notPublished')}</p>
+      ) : (
+        <>
+          {/* 422 validation errors */}
+          {validationErrors.length > 0 && (
+            <ul role="alert" className="dashboard-customize-page__errors">
+              {validationErrors.map((e) => (
+                <li key={e}>{e}</li>
+              ))}
+            </ul>
+          )}
+
+          {localOverride !== null && (
+            <TenantSectionEditor
+              baseSections={published.sections}
+              rails={rails}
+              manifest={envelope.manifest}
+              override={localOverride}
+              onChange={handleChange}
+            />
+          )}
+
+          <div className="dashboard-customize-page__actions">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!isDirty || mutation.isPending}
+              aria-label={t('layout.customize.save')}
+            >
+              {t('layout.customize.save')}
+            </button>
+            <button type="button" onClick={handleReset}>
+              {t('layout.customize.reset')}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.css
+++ b/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.css
@@ -1,0 +1,83 @@
+.tenant-editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ppt-space-2);
+}
+
+.tenant-editor__row {
+  display: flex;
+  align-items: center;
+  gap: var(--ppt-space-4);
+  padding: var(--ppt-space-3) var(--ppt-space-4);
+  border: 1px solid var(--ppt-color-border, #d0d0d0);
+  border-radius: 8px;
+  background: var(--ppt-color-surface, #fff);
+}
+
+.tenant-editor__row--hidden {
+  opacity: 0.5;
+}
+
+.tenant-editor__type {
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tenant-editor__badge {
+  font-size: var(--ppt-font-size-sm, 0.75rem);
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--ppt-color-surface-alt, #f0f0f0);
+  color: var(--ppt-color-text-secondary, #666);
+}
+
+.tenant-editor__badge--hidden {
+  background: var(--ppt-color-warning-bg, #fff3cd);
+  color: var(--ppt-color-warning-text, #856404);
+}
+
+.tenant-editor__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--ppt-space-2);
+  flex-shrink: 0;
+}
+
+.tenant-editor__btn {
+  border: 1px solid var(--ppt-color-border, #d0d0d0);
+  border-radius: 4px;
+  background: var(--ppt-color-surface, #fff);
+  cursor: pointer;
+  padding: 4px 8px;
+  font-size: var(--ppt-font-size-sm, 0.875rem);
+  line-height: 1;
+  color: var(--ppt-color-text, #111);
+}
+
+.tenant-editor__btn:hover {
+  background: var(--ppt-color-surface-alt, #f0f0f0);
+}
+
+.tenant-editor__select {
+  border: 1px solid var(--ppt-color-border, #d0d0d0);
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: var(--ppt-font-size-sm, 0.875rem);
+  background: var(--ppt-color-surface, #fff);
+  color: var(--ppt-color-text, #111);
+}
+
+.tenant-editor__input {
+  border: 1px solid var(--ppt-color-border, #d0d0d0);
+  border-radius: 4px;
+  padding: 3px 6px;
+  font-size: var(--ppt-font-size-sm, 0.875rem);
+  width: 120px;
+  background: var(--ppt-color-surface, #fff);
+  color: var(--ppt-color-text, #111);
+  font-family: monospace;
+}

--- a/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx
@@ -285,6 +285,43 @@ describe('Scenario 5: whitelisted prop input', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Scenario 5b: external override reset remounts PropInput (carried finding)
+// ---------------------------------------------------------------------------
+
+describe('Scenario 5b: external reset clears PropInput value', () => {
+  it('shows empty input after override is reset to {} via rerender', () => {
+    const { rerender } = render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero' }]}
+        rails={propRails}
+        manifest={null}
+        override={{ sections: { hero: { props: { limit: 42 } } } }}
+        onChange={vi.fn()}
+      />
+    );
+
+    // Confirm initial value shown
+    const inputBefore = screen.getByRole('textbox', { name: 'limit' }) as HTMLInputElement;
+    expect(inputBefore.value).toBe('42');
+
+    // External reset: override → {}
+    rerender(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero' }]}
+        rails={propRails}
+        manifest={null}
+        override={{}}
+        onChange={vi.fn()}
+      />
+    );
+
+    // After remount the input should show placeholder/empty (no override value)
+    const inputAfter = screen.getByRole('textbox', { name: 'limit' }) as HTMLInputElement;
+    expect(inputAfter.value).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Scenario 6: override.order drives row order
 // ---------------------------------------------------------------------------
 

--- a/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx
@@ -1,0 +1,308 @@
+import type { BaseSection, LayoutManifest, LayoutRails, TenantOverride } from '@ppt/api-client';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { TenantSectionEditor } from './TenantSectionEditor';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const base: BaseSection[] = [
+  { type: 'hero', visible: true },
+  { type: 'stats', visible: true },
+  { type: 'feed', visible: true },
+];
+
+const noRails: LayoutRails = {
+  hideable: [],
+  mode_editable: [],
+  reorderable: false,
+  prop_whitelist: {},
+};
+
+const hideableRails: LayoutRails = {
+  ...noRails,
+  hideable: ['hero'],
+};
+
+const reorderableRails: LayoutRails = {
+  ...noRails,
+  reorderable: true,
+};
+
+const modeRails: LayoutRails = {
+  ...noRails,
+  mode_editable: ['feed'],
+};
+
+const feedManifest: LayoutManifest = {
+  platform: 'web',
+  components: {
+    feed: { supported_modes: ['list', 'grid'], default_mode: 'list' },
+  },
+};
+
+const propRails: LayoutRails = {
+  ...noRails,
+  prop_whitelist: { hero: ['limit'] },
+};
+
+const emptyOverride: TenantOverride = {};
+
+// ---------------------------------------------------------------------------
+// Scenario 1: hideable-only section
+// ---------------------------------------------------------------------------
+
+describe('Scenario 1: hideable-only section', () => {
+  it('shows eye button; no arrows, no mode select, no prop input', () => {
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero', visible: true }]}
+        rails={hideableRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: /layout\.customize\.(hide|show)/ })
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /layout\.customize\.moveUp/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /layout\.customize\.moveDown/ })).toBeNull();
+    expect(screen.queryByRole('combobox')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('clicking eye calls onChange with visible patch', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero', visible: true }]}
+        rails={hideableRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={onChange}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /layout\.customize\.(hide|show)/ }));
+    expect(onChange).toHaveBeenCalledOnce();
+    const next = onChange.mock.calls[0][0] as TenantOverride;
+    expect(next.sections?.hero?.visible).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: non-granted section — no interactive controls
+// ---------------------------------------------------------------------------
+
+describe('Scenario 2: non-granted section', () => {
+  it('renders no interactive controls', () => {
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero' }]}
+        rails={noRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole('combobox')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: reorderable rails — up/down arrows; clicking ↓ writes full order
+// ---------------------------------------------------------------------------
+
+describe('Scenario 3: reorderable rails', () => {
+  it('renders up and down arrow buttons for each row', () => {
+    render(
+      <TenantSectionEditor
+        baseSections={base}
+        rails={reorderableRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getAllByRole('button', { name: 'layout.customize.moveUp' })).toHaveLength(3);
+    expect(screen.getAllByRole('button', { name: 'layout.customize.moveDown' })).toHaveLength(3);
+  });
+
+  it('clicking ↓ on first row writes full updated order array', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TenantSectionEditor
+        baseSections={base}
+        rails={reorderableRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={onChange}
+      />
+    );
+    const downButtons = screen.getAllByRole('button', { name: 'layout.customize.moveDown' });
+    await user.click(downButtons[0]);
+    const next = onChange.mock.calls[0][0] as TenantOverride;
+    expect(next.order).toEqual(['stats', 'hero', 'feed']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 4: mode select
+// ---------------------------------------------------------------------------
+
+describe('Scenario 4: mode select', () => {
+  it('renders select only for type in mode_editable with supported_modes in manifest', () => {
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'feed', mode: 'list' }]}
+        rails={modeRails}
+        manifest={feedManifest}
+        override={emptyOverride}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('combobox', { name: 'layout.customize.mode' })).toBeInTheDocument();
+  });
+
+  it('does not render select when manifest has no supported_modes', () => {
+    const manifestNoModes: LayoutManifest = {
+      platform: 'web',
+      components: { feed: {} },
+    };
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'feed' }]}
+        rails={modeRails}
+        manifest={manifestNoModes}
+        override={emptyOverride}
+        onChange={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('combobox')).toBeNull();
+  });
+
+  it('changing select patches mode in onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'feed', mode: 'list' }]}
+        rails={modeRails}
+        manifest={feedManifest}
+        override={emptyOverride}
+        onChange={onChange}
+      />
+    );
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: 'layout.customize.mode' }),
+      'grid'
+    );
+    expect(onChange).toHaveBeenCalledOnce();
+    const next = onChange.mock.calls[0][0] as TenantOverride;
+    expect(next.sections?.feed?.mode).toBe('grid');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5: whitelisted prop input
+// ---------------------------------------------------------------------------
+
+describe('Scenario 5: whitelisted prop input', () => {
+  it('commits JSON number when value is parseable', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero' }]}
+        rails={propRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole('textbox', { name: 'limit' });
+    await user.click(input);
+    await user.type(input, '5');
+    await user.tab(); // blur
+    expect(onChange).toHaveBeenCalledOnce();
+    const next = onChange.mock.calls[0][0] as TenantOverride;
+    expect(next.sections?.hero?.props?.limit).toBe(5);
+  });
+
+  it('commits plain string when value is not valid JSON', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero' }]}
+        rails={propRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole('textbox', { name: 'limit' });
+    await user.click(input);
+    await user.type(input, 'many');
+    await user.tab();
+    const next = onChange.mock.calls[0][0] as TenantOverride;
+    expect(next.sections?.hero?.props?.limit).toBe('many');
+  });
+
+  it('clearing the input removes the prop and prunes empty objects', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const overrideWithProp: TenantOverride = {
+      sections: { hero: { props: { limit: 10 } } },
+    };
+    render(
+      <TenantSectionEditor
+        baseSections={[{ type: 'hero' }]}
+        rails={propRails}
+        manifest={null}
+        override={overrideWithProp}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole('textbox', { name: 'limit' });
+    await user.clear(input);
+    await user.tab();
+    const next = onChange.mock.calls[0][0] as TenantOverride;
+    // props pruned → sections.hero has no props → sections pruned entirely
+    expect(next.sections?.hero?.props).toBeUndefined();
+    expect(next.sections?.hero).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 6: override.order drives row order
+// ---------------------------------------------------------------------------
+
+describe('Scenario 6: override.order drives row order', () => {
+  it('listed sections appear first in override.order order; unlisted keep base order', () => {
+    const override: TenantOverride = { order: ['feed', 'hero'] };
+    render(
+      <TenantSectionEditor
+        baseSections={base}
+        rails={noRails}
+        manifest={null}
+        override={override}
+        onChange={vi.fn()}
+      />
+    );
+    const rows = screen.getAllByText(/^(hero|stats|feed)$/);
+    const types = rows.map((el) => el.textContent);
+    // feed, hero listed; stats unlisted → comes after
+    expect(types).toEqual(['feed', 'hero', 'stats']);
+  });
+});

--- a/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
@@ -1,0 +1,253 @@
+import type { BaseSection, LayoutManifest, LayoutRails, TenantOverride } from '@ppt/api-client';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import './TenantSectionEditor.css';
+
+export interface TenantSectionEditorProps {
+  baseSections: BaseSection[];
+  rails: LayoutRails;
+  manifest: LayoutManifest | null;
+  override: TenantOverride;
+  onChange(next: TenantOverride): void;
+}
+
+/** Build the display order: override.order-listed first (in order), then unlisted in base order. */
+function resolveOrder(baseSections: BaseSection[], override: TenantOverride): BaseSection[] {
+  const orderList = override.order ?? [];
+  const listed = orderList
+    .map((type) => baseSections.find((s) => s.type === type))
+    .filter((s): s is BaseSection => s !== undefined);
+  const listedTypes = new Set(orderList);
+  const unlisted = baseSections.filter((s) => !listedTypes.has(s.type));
+  return [...listed, ...unlisted];
+}
+
+/** Prune sections entry if it has no keys; prune override.sections if empty. */
+function pruneSectionPatch(
+  override: TenantOverride,
+  type: string,
+  patch: Record<string, unknown>
+): TenantOverride {
+  const cleanPatch = Object.fromEntries(Object.entries(patch).filter(([, v]) => v !== undefined));
+  const hasPatch = Object.keys(cleanPatch).length > 0;
+
+  const sections = { ...(override.sections ?? {}) };
+  if (hasPatch) {
+    sections[type] = cleanPatch;
+  } else {
+    delete sections[type];
+  }
+
+  const next: TenantOverride = { ...override };
+  if (Object.keys(sections).length > 0) {
+    next.sections = sections;
+  } else {
+    delete next.sections;
+  }
+  return next;
+}
+
+interface PropInputProps {
+  type: string;
+  propName: string;
+  currentValue: unknown;
+  override: TenantOverride;
+  onChange(next: TenantOverride): void;
+}
+
+function PropInput({ type, propName, currentValue, override, onChange }: PropInputProps) {
+  const display =
+    currentValue === undefined || currentValue === null
+      ? ''
+      : typeof currentValue === 'string'
+        ? currentValue
+        : JSON.stringify(currentValue);
+
+  const [localValue, setLocalValue] = useState(display);
+
+  const commit = () => {
+    const val = localValue.trim();
+    const existingPatch = { ...(override.sections?.[type] ?? {}) };
+    const existingProps = { ...(existingPatch.props ?? {}) };
+
+    if (val === '') {
+      delete existingProps[propName];
+    } else {
+      // Try JSON parse; fall back to string
+      let parsed: unknown = val;
+      try {
+        parsed = JSON.parse(val);
+      } catch {
+        parsed = val;
+      }
+      existingProps[propName] = parsed;
+    }
+
+    const newPatch: Record<string, unknown> = { ...existingPatch };
+    if (Object.keys(existingProps).length > 0) {
+      newPatch.props = existingProps;
+    } else {
+      delete newPatch.props;
+    }
+
+    onChange(pruneSectionPatch(override, type, newPatch));
+  };
+
+  return (
+    <input
+      className="tenant-editor__input"
+      aria-label={propName}
+      value={localValue}
+      onChange={(e) => setLocalValue(e.target.value)}
+      onBlur={commit}
+    />
+  );
+}
+
+export function TenantSectionEditor({
+  baseSections,
+  rails,
+  manifest,
+  override,
+  onChange,
+}: TenantSectionEditorProps) {
+  const { t } = useTranslation();
+
+  const orderedSections = resolveOrder(baseSections, override);
+  const currentOrder = orderedSections.map((s) => s.type);
+
+  return (
+    <div className="tenant-editor">
+      {orderedSections.map((base, idx) => {
+        const { type } = base;
+        const sectionPatch = override.sections?.[type] ?? {};
+        const effectiveVisible = sectionPatch.visible ?? base.visible ?? true;
+        const effectiveMode = sectionPatch.mode ?? base.mode;
+
+        const canHide = rails.hideable.includes(type);
+        const canReorder = rails.reorderable;
+        const canEditMode =
+          rails.mode_editable.includes(type) &&
+          manifest?.components[type]?.supported_modes !== undefined &&
+          (manifest.components[type].supported_modes?.length ?? 0) > 0;
+        const propWhitelist = rails.prop_whitelist[type] ?? [];
+        const hasControls = canHide || canReorder || canEditMode || propWhitelist.length > 0;
+
+        const supportedModes = manifest?.components[type]?.supported_modes ?? [];
+
+        const toggleVisible = () => {
+          const existingPatch = { ...(override.sections?.[type] ?? {}) };
+          const next: Record<string, unknown> = { ...existingPatch, visible: !effectiveVisible };
+          onChange(pruneSectionPatch(override, type, next));
+        };
+
+        const moveUp = () => {
+          if (idx === 0) return;
+          const newOrder = [...currentOrder];
+          [newOrder[idx - 1], newOrder[idx]] = [newOrder[idx], newOrder[idx - 1]];
+          onChange({ ...override, order: newOrder });
+        };
+
+        const moveDown = () => {
+          if (idx === currentOrder.length - 1) return;
+          const newOrder = [...currentOrder];
+          [newOrder[idx], newOrder[idx + 1]] = [newOrder[idx + 1], newOrder[idx]];
+          onChange({ ...override, order: newOrder });
+        };
+
+        const changeMode = (mode: string) => {
+          const existingPatch = { ...(override.sections?.[type] ?? {}) };
+          const next: Record<string, unknown> = { ...existingPatch, mode };
+          onChange(pruneSectionPatch(override, type, next));
+        };
+
+        return (
+          <div
+            key={type}
+            className={`tenant-editor__row${!effectiveVisible ? ' tenant-editor__row--hidden' : ''}`}
+          >
+            <span className="tenant-editor__type">{type}</span>
+
+            {/* State badges */}
+            {!effectiveVisible && (
+              <span className="tenant-editor__badge tenant-editor__badge--hidden">
+                {t('layout.customize.hidden')}
+              </span>
+            )}
+            {effectiveMode && <span className="tenant-editor__badge">{effectiveMode}</span>}
+
+            {hasControls && (
+              <div className="tenant-editor__controls">
+                {/* Eye toggle */}
+                {canHide && (
+                  <button
+                    type="button"
+                    className="tenant-editor__btn"
+                    aria-label={
+                      effectiveVisible ? t('layout.customize.hide') : t('layout.customize.show')
+                    }
+                    onClick={toggleVisible}
+                  >
+                    {effectiveVisible ? '👁' : '👁\u{FE0F}\u{20E3}'}
+                  </button>
+                )}
+
+                {/* Reorder arrows */}
+                {canReorder && (
+                  <>
+                    <button
+                      type="button"
+                      className="tenant-editor__btn"
+                      aria-label={t('layout.customize.moveUp')}
+                      onClick={moveUp}
+                      disabled={idx === 0}
+                    >
+                      ↑
+                    </button>
+                    <button
+                      type="button"
+                      className="tenant-editor__btn"
+                      aria-label={t('layout.customize.moveDown')}
+                      onClick={moveDown}
+                      disabled={idx === currentOrder.length - 1}
+                    >
+                      ↓
+                    </button>
+                  </>
+                )}
+
+                {/* Mode select */}
+                {canEditMode && (
+                  <select
+                    className="tenant-editor__select"
+                    aria-label={t('layout.customize.mode')}
+                    value={effectiveMode ?? ''}
+                    onChange={(e) => changeMode(e.target.value)}
+                  >
+                    {supportedModes.map((m) => (
+                      <option key={m} value={m}>
+                        {m}
+                      </option>
+                    ))}
+                  </select>
+                )}
+
+                {/* Whitelisted prop inputs */}
+                {propWhitelist.map((propName) => (
+                  <PropInput
+                    key={propName}
+                    type={type}
+                    propName={propName}
+                    currentValue={(override.sections?.[type]?.props ?? base.props ?? {})[propName]}
+                    override={override}
+                    onChange={onChange}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
@@ -232,17 +232,26 @@ export function TenantSectionEditor({
                   </select>
                 )}
 
-                {/* Whitelisted prop inputs */}
-                {propWhitelist.map((propName) => (
-                  <PropInput
-                    key={propName}
-                    type={type}
-                    propName={propName}
-                    currentValue={(override.sections?.[type]?.props ?? base.props ?? {})[propName]}
-                    override={override}
-                    onChange={onChange}
-                  />
-                ))}
+                {/* Whitelisted prop inputs.
+                    Key includes the serialized current external value so that
+                    an external reset (override → {}) causes remount and
+                    PropInput reflects the new (empty) value rather than
+                    keeping stale internal state from useState. */}
+                {propWhitelist.map((propName) => {
+                  const currentValue = (override.sections?.[type]?.props ?? base.props ?? {})[
+                    propName
+                  ];
+                  return (
+                    <PropInput
+                      key={`${type}:${propName}:${JSON.stringify(currentValue) ?? ''}`}
+                      type={type}
+                      propName={propName}
+                      currentValue={currentValue}
+                      override={override}
+                      onChange={onChange}
+                    />
+                  );
+                })}
               </div>
             )}
           </div>

--- a/frontend/apps/ppt-web/src/routes/groups/core.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/core.tsx
@@ -45,6 +45,13 @@ const SessionsPage = lazy(() =>
   import('../../features/settings/pages/SessionsPage').then((m) => ({ default: m.SessionsPage }))
 );
 
+// Dashboard customize page (layout tenant-editor, Task 4) — lazy-loaded.
+const DashboardCustomizePage = lazy(() =>
+  import('../../features/layout/DashboardCustomizePage').then((m) => ({
+    default: m.DashboardCustomizePage,
+  }))
+);
+
 // Integrations settings page (Gap 83-1 — Airbnb OAuth & Sync) — lazy-loaded.
 const IntegrationsPage = lazy(() =>
   import('../../features/settings').then((m) => ({ default: m.IntegrationsPage }))
@@ -159,6 +166,16 @@ export function dashboardRoutes() {
       <Route path="/dashboard" element={<Navigate to="/dashboard/manager" replace />} />
       <Route path="/dashboard/manager" element={<ManagerDashboardPage />} />
       <Route path="/dashboard/resident" element={<ResidentDashboardPage />} />
+      {/* Dashboard layout customisation (Task 4, layout tenant-editor plan).
+          Org-admin / super-admin only. */}
+      <Route
+        path="/dashboard/customize"
+        element={
+          <ProtectedRoute requiredRoles={['org_admin', 'super_admin']}>
+            <DashboardCustomizePage />
+          </ProtectedRoute>
+        }
+      />
     </>
   );
 }

--- a/frontend/packages/api-client/src/layout/api.test.ts
+++ b/frontend/packages/api-client/src/layout/api.test.ts
@@ -167,16 +167,9 @@ describe('saveTenantLayoutOverride', () => {
     };
     vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
 
-    const promise = saveTenantLayoutOverride('ppt/dashboard', {});
-    await expect(promise).rejects.toThrow(TenantLayoutError);
-
-    try {
-      await saveTenantLayoutOverride('ppt/dashboard', {});
-    } catch (e) {
-      expect(e).toBeInstanceOf(TenantLayoutError);
-      const err = e as TenantLayoutError;
-      expect(err.status).toBe(422);
-      expect(err.errors).toEqual(['field x is required', 'invalid mode']);
-    }
+    const err = await saveTenantLayoutOverride('ppt/dashboard', {}).catch((e) => e);
+    expect(err).toBeInstanceOf(TenantLayoutError);
+    expect((err as TenantLayoutError).status).toBe(422);
+    expect((err as TenantLayoutError).errors).toEqual(['field x is required', 'invalid mode']);
   });
 });

--- a/frontend/packages/api-client/src/layout/api.test.ts
+++ b/frontend/packages/api-client/src/layout/api.test.ts
@@ -1,13 +1,26 @@
-import { describe, expect, it, vi } from 'vitest';
-import { fetchResolvedLayout } from './api';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  fetchResolvedLayout,
+  fetchTenantLayout,
+  saveTenantLayoutOverride,
+  TenantLayoutError,
+} from './api';
 
 vi.mock('../lib/fetch', () => ({
   authenticatedFetchJson: vi.fn(),
 }));
 
+vi.mock('../auth', () => ({
+  getToken: vi.fn(),
+  getOrg: vi.fn(),
+}));
+
+import { getOrg, getToken } from '../auth';
 import { authenticatedFetchJson } from '../lib/fetch';
 
 const mockFetch = vi.mocked(authenticatedFetchJson);
+const mockGetToken = vi.mocked(getToken);
+const mockGetOrg = vi.mocked(getOrg);
 
 describe('fetchResolvedLayout', () => {
   it('returns a valid ResolvedScreen', async () => {
@@ -54,5 +67,116 @@ describe('fetchResolvedLayout', () => {
     });
     await fetchResolvedLayout('home', 'mobile');
     expect(mockFetch).toHaveBeenCalledWith('/api/v1/layout/resolved/home?platform=mobile');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchTenantLayout / saveTenantLayoutOverride
+// ---------------------------------------------------------------------------
+
+const envelope = {
+  override: { override_config: { order: ['a', 'b'] } },
+  rails: { hideable: [], mode_editable: [], reorderable: false, prop_whitelist: {} },
+  published: null,
+  manifest: null,
+};
+
+describe('fetchTenantLayout', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    mockGetToken.mockReturnValue('tok-abc');
+    mockGetOrg.mockReturnValue('org-123');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('GETs /api/v1/layout/tenant-override with auth and tenant headers', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(envelope),
+    };
+    vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+    const result = await fetchTenantLayout('ppt/dashboard');
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/layout/tenant-override?screen=ppt%2Fdashboard',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer tok-abc',
+          'X-Tenant-ID': 'org-123',
+        }),
+      })
+    );
+    expect(result).toEqual(envelope);
+  });
+
+  it('omits X-Tenant-ID when getOrg() returns null', async () => {
+    mockGetOrg.mockReturnValue(null);
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue(envelope),
+    };
+    vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+    await fetchTenantLayout('ppt/dashboard');
+
+    const [, options] = vi.mocked(fetch).mock.calls[0];
+    const headers = (options as RequestInit).headers as Record<string, string>;
+    expect(headers['X-Tenant-ID']).toBeUndefined();
+  });
+});
+
+describe('saveTenantLayoutOverride', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    mockGetToken.mockReturnValue('tok-abc');
+    mockGetOrg.mockReturnValue('org-123');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('PUTs { screen, override_config } to /api/v1/layout/tenant-override', async () => {
+    const mockResponse = {
+      ok: true,
+      json: vi.fn().mockResolvedValue({}),
+    };
+    vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+    const override = { order: ['a'] };
+    await saveTenantLayoutOverride('ppt/dashboard', override);
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/v1/layout/tenant-override',
+      expect.objectContaining({
+        method: 'PUT',
+        body: JSON.stringify({ screen: 'ppt/dashboard', override_config: override }),
+      })
+    );
+  });
+
+  it('throws TenantLayoutError with verbatim errors on 422', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 422,
+      json: vi.fn().mockResolvedValue({ errors: ['field x is required', 'invalid mode'] }),
+    };
+    vi.mocked(fetch).mockResolvedValue(mockResponse as unknown as Response);
+
+    const promise = saveTenantLayoutOverride('ppt/dashboard', {});
+    await expect(promise).rejects.toThrow(TenantLayoutError);
+
+    try {
+      await saveTenantLayoutOverride('ppt/dashboard', {});
+    } catch (e) {
+      expect(e).toBeInstanceOf(TenantLayoutError);
+      const err = e as TenantLayoutError;
+      expect(err.status).toBe(422);
+      expect(err.errors).toEqual(['field x is required', 'invalid mode']);
+    }
   });
 });

--- a/frontend/packages/api-client/src/layout/api.ts
+++ b/frontend/packages/api-client/src/layout/api.ts
@@ -6,6 +6,7 @@
  * to their own DEFAULT_LAYOUT when this throws.
  */
 
+import { getOrg, getToken } from '../auth';
 import { authenticatedFetchJson } from '../lib/fetch';
 
 export interface ResolvedSection {
@@ -37,4 +38,116 @@ export async function fetchResolvedLayout(
     throw new Error('layout: malformed ResolvedScreen payload');
   }
   return data;
+}
+
+// ---------------------------------------------------------------------------
+// Tenant-override domain
+// ---------------------------------------------------------------------------
+
+export interface TenantSectionPatch {
+  visible?: boolean;
+  mode?: string;
+  props?: Record<string, unknown>;
+}
+
+export interface TenantOverride {
+  order?: string[];
+  sections?: Record<string, TenantSectionPatch>;
+}
+
+export interface LayoutRails {
+  hideable: string[];
+  mode_editable: string[];
+  reorderable: boolean;
+  prop_whitelist: Record<string, string[]>;
+}
+
+export interface ManifestComponent {
+  required?: boolean;
+  supported_modes?: string[];
+  default_mode?: string;
+}
+
+export interface LayoutManifest {
+  platform: string;
+  components: Record<string, ManifestComponent>;
+}
+
+export interface BaseSection {
+  type: string;
+  visible?: boolean;
+  mode?: string;
+  props?: Record<string, unknown>;
+}
+
+export interface TenantLayoutEnvelope {
+  override: { override_config: TenantOverride } | null;
+  rails: LayoutRails | Record<string, never>;
+  published: { sections: BaseSection[] } | null;
+  manifest: LayoutManifest | null;
+}
+
+export class TenantLayoutError extends Error {
+  status: number;
+  errors: string[];
+
+  constructor(status: number, errors: string[]) {
+    super(`TenantLayoutError: HTTP ${status}`);
+    this.name = 'TenantLayoutError';
+    this.status = status;
+    this.errors = errors;
+  }
+}
+
+/**
+ * Raw fetch helper for tenant-override endpoints.
+ * Adds Authorization + X-Tenant-ID headers; parses {errors} on non-2xx
+ * into TenantLayoutError. Must NOT use authenticatedFetchJson — it lacks
+ * the org header and swallows error bodies.
+ */
+async function tenantRequest<T>(url: string, options?: RequestInit): Promise<T> {
+  const token = getToken();
+  const org = getOrg();
+
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(org ? { 'X-Tenant-ID': org } : {}),
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    let errors: string[] = [];
+    try {
+      const body = await response.json();
+      if (Array.isArray(body?.errors)) {
+        errors = body.errors as string[];
+      }
+    } catch {
+      // body unparseable — leave errors as empty array
+    }
+    throw new TenantLayoutError(response.status, errors);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+/** Fetch the tenant layout envelope for a screen (GET). */
+export async function fetchTenantLayout(screen: string): Promise<TenantLayoutEnvelope> {
+  const params = new URLSearchParams({ screen });
+  return tenantRequest<TenantLayoutEnvelope>(`${API_BASE}/tenant-override?${params}`);
+}
+
+/** Save (PUT) a tenant layout override for a screen. Throws TenantLayoutError on non-2xx. */
+export async function saveTenantLayoutOverride(
+  screen: string,
+  override: TenantOverride
+): Promise<unknown> {
+  return tenantRequest<unknown>(`${API_BASE}/tenant-override`, {
+    method: 'PUT',
+    body: JSON.stringify({ screen, override_config: override }),
+  });
 }

--- a/frontend/packages/api-client/src/layout/hooks.ts
+++ b/frontend/packages/api-client/src/layout/hooks.ts
@@ -1,16 +1,24 @@
 /**
  * Layout Query Hooks
  *
- * TanStack Query hooks for resolved screen layouts.
+ * TanStack Query hooks for resolved screen layouts and tenant overrides.
  */
 
-import { useQuery } from '@tanstack/react-query';
-import { fetchResolvedLayout, type ResolvedScreen } from './api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  fetchResolvedLayout,
+  fetchTenantLayout,
+  type ResolvedScreen,
+  saveTenantLayoutOverride,
+  type TenantLayoutEnvelope,
+  type TenantOverride,
+} from './api';
 
 export const layoutKeys = {
   all: ['layout'] as const,
   resolved: (screen: string, platform: string) =>
     [...layoutKeys.all, 'resolved', screen, platform] as const,
+  tenant: (screen: string) => [...layoutKeys.all, 'tenant', screen] as const,
 };
 
 export function useResolvedLayout(screen: string, platform: 'web' | 'mobile' = 'web') {
@@ -19,5 +27,24 @@ export function useResolvedLayout(screen: string, platform: 'web' | 'mobile' = '
     queryFn: () => fetchResolvedLayout(screen, platform),
     staleTime: 60_000,
     retry: 1,
+  });
+}
+
+export function useTenantLayout(screen: string) {
+  return useQuery<TenantLayoutEnvelope>({
+    queryKey: layoutKeys.tenant(screen),
+    queryFn: () => fetchTenantLayout(screen),
+    staleTime: 60_000,
+    retry: 1,
+  });
+}
+
+export function useSaveTenantLayoutOverride(screen: string) {
+  const queryClient = useQueryClient();
+  return useMutation<unknown, Error, TenantOverride>({
+    mutationFn: (override: TenantOverride) => saveTenantLayoutOverride(screen, override),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: layoutKeys.tenant(screen) });
+    },
   });
 }


### PR DESCRIPTION
## Summary

Fifth slice of the Layout & Content Manager (follows #2424/#2426/#2427/#2428, all merged). The tenant-side editor from spec §3.4 — org admins customize their org's dashboard strictly within superadmin-authored rails:

- **api-server** — the tenant-override GET envelope now includes the web registry manifest (component modes for the UI), one handler touch on the sanctioned public connection (RLS gate stays at 0 violations).
- **`@ppt/api-client`** — tenant-override domain: `fetchTenantLayout` / `saveTenantLayoutOverride` sending `Authorization` + `X-Tenant-ID` (financial/api.ts idiom), `TenantLayoutError { status, errors }` carrying 422 rails-violations verbatim, TanStack hooks.
- **ppt-web `TenantSectionEditor`** — controlled component where controls exist ONLY where rails grant them: eye toggle iff hideable, ↑/↓ iff reorderable (edge-disabled per the shared editor pattern), mode select iff mode-editable ∩ manifest modes, per-prop inputs iff whitelisted (blur-commit, JSON-else-string, external resets clear via value-keyed inputs). Everything else renders read-only; effective state = override ?? base; order semantics are a faithful port of the resolver's listed-first merge — the preview matches what renders.
- **`/dashboard/customize`** — lazy route behind `ProtectedRoute requiredRoles={['org_admin','super_admin']}` (client gate is UX-only; the server enforces role + RLS + `validate_tenant_override`), seed-once + dirty/save machine with sent-JSON conditional clear, verbatim 422 error list, reset-to-default with confirm, defensive empty-rails normalization, role-gated Customize link on the manager dashboard. i18n in all six locales.

## Verification

- api-client 130 tests, ppt-web 1513+ green (only the 3 pre-existing FileDisputePage failures remain); backend check/clippy clean; workspace typecheck clean; Biome clean.
- 5-task subagent-driven execution with per-task reviews (caught and fixed: a 422-test double-invoke, stale prop-input state on external resets) + final opus whole-branch review (verdict: Ready for PR; its disabled-arrows finding adjudicated in favor of the plan's explicit edge-disabled allowance, its three genuine minors fixed in the last commit).

Plan: `docs/superpowers/plans/2026-07-20-layout-tenant-editor.md`. Remaining slices: preview bridge, mobile registries, publish→ISR webhook, `layout_editor_*` capability.