### PR TITLE
feat(layout): publish webhook — signed ISR revalidation from api-server to reality-web

### DIFF
--- a/backend/servers/api-server/src/routes/layout/admin.rs
+++ b/backend/servers/api-server/src/routes/layout/admin.rs
@@ -10,6 +10,7 @@ use super::types::{
     KillRequest, PreviewResolveRequest, PublishRequest, PutDraftRequest, PutManifestRequest,
     PutRailsRequest, RollbackRequest, ScreenQuery, ValidationErrorsResponse,
 };
+use super::webhook;
 
 fn bad_request(errors: Vec<String>) -> (StatusCode, Json<ValidationErrorsResponse>) {
     (
@@ -291,6 +292,7 @@ pub async fn publish(
         .publish(&mut conn, &req.screen, Some(admin_id))
         .await
         .map_err(|e| bad_request(vec![format!("db error: {e}")]))?;
+    webhook::notify_layout_change(&req.screen, "published");
     Ok(Json(serde_json::to_value(row).unwrap_or_default()))
 }
 
@@ -327,6 +329,7 @@ pub async fn rollback(
             ),
             other => bad_request(vec![format!("db error: {other}")]),
         })?;
+    webhook::notify_layout_change(&req.screen, "rolled_back");
     Ok(Json(serde_json::to_value(row).unwrap_or_default()))
 }
 
@@ -355,6 +358,7 @@ pub async fn kill(
         .kill(&mut **conn, &req.screen, &req.section_type, Some(admin_id))
         .await
         .map_err(|e| bad_request(vec![format!("db error: {e}")]))?;
+    webhook::notify_layout_change(&req.screen, "killed");
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -448,6 +452,7 @@ pub async fn unkill(
         .await
         .map_err(|e| bad_request(vec![format!("db error: {e}")]))?;
     if removed {
+        webhook::notify_layout_change(&req.screen, "unkilled");
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err((

--- a/backend/servers/api-server/src/routes/layout/mod.rs
+++ b/backend/servers/api-server/src/routes/layout/mod.rs
@@ -2,6 +2,7 @@ pub mod admin;
 pub mod resolved;
 pub mod tenant;
 pub mod types;
+pub mod webhook;
 
 use crate::state::AppState;
 use axum::routing::{get, post, put};

--- a/backend/servers/api-server/src/routes/layout/webhook.rs
+++ b/backend/servers/api-server/src/routes/layout/webhook.rs
@@ -1,0 +1,235 @@
+//! Outbound layout-change webhook notifier.
+//!
+//! When `LAYOUT_WEBHOOK_URL` and `LAYOUT_WEBHOOK_SECRET` are both set (and
+//! non-empty), every successful `publish`, `rollback`, `kill`, or `unkill`
+//! operation fires a signed POST to the configured URL so downstream consumers
+//! (CDN invalidators, caches, notification services) can react immediately.
+//!
+//! ## Signature format
+//!
+//! The outbound signature is placed in the `X-Webhook-Signature` header as:
+//!
+//! ```text
+//! sha256=<base64(HMAC-SHA256(LAYOUT_WEBHOOK_SECRET, body))>
+//! ```
+//!
+//! This matches the exact format used by the inbound portal-webhook receivers
+//! (`routes/portal_webhooks.rs`), enabling the same `verify_webhook_signature`
+//! helper to verify outbound deliveries on the receiving end.
+//!
+//! ## Fire-and-forget
+//!
+//! The notification is spawned via `tokio::spawn` so it never blocks or fails
+//! the originating request. A non-2xx response or network error is logged as
+//! `warn!` only — the admin operation already succeeded.
+
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// The header name carrying the outbound HMAC-SHA256 signature.
+///
+/// Intentionally identical to the inbound portal-webhook convention so the
+/// receiving end can reuse the same verification logic.
+const SIGNATURE_HEADER: &str = "X-Webhook-Signature";
+
+/// Sign `body` with `secret` using HMAC-SHA256 and return the header value.
+///
+/// The returned string has the form `sha256=<base64-digest>`, matching the
+/// format the inbound `verify_webhook_signature` helper in
+/// `routes/portal_webhooks.rs` expects:
+///
+/// ```text
+/// sha256=<base64(HMAC-SHA256(secret, body))>
+/// ```
+///
+/// This is a pure function with no I/O; it is unit-tested with a hardcoded
+/// known vector below.
+pub fn sign_payload(secret: &str, body: &[u8]) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any length");
+    mac.update(body);
+    format!("sha256={}", BASE64.encode(mac.finalize().into_bytes()))
+}
+
+/// Notify an external webhook endpoint that a layout change occurred.
+///
+/// Reads `LAYOUT_WEBHOOK_URL` and `LAYOUT_WEBHOOK_SECRET` from the environment
+/// at call time (no startup plumbing needed). When either variable is absent or
+/// empty the call is a no-op (logged at `debug!` only).
+///
+/// On success the notification is fire-and-forget (`tokio::spawn`): a non-2xx
+/// response or a network error is logged as `warn!` but does not propagate to
+/// the caller.
+///
+/// # Parameters
+/// - `screen` — the layout screen identifier (e.g. `"home"`)
+/// - `event`  — one of `"published"`, `"rolled_back"`, `"killed"`, `"unkilled"`
+pub fn notify_layout_change(screen: &str, event: &'static str) {
+    let url = match std::env::var("LAYOUT_WEBHOOK_URL")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        Some(u) => u,
+        None => {
+            tracing::debug!(
+                screen = %screen,
+                event = %event,
+                "LAYOUT_WEBHOOK_URL not set — skipping layout-change notification"
+            );
+            return;
+        }
+    };
+
+    let secret = match std::env::var("LAYOUT_WEBHOOK_SECRET")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        Some(s) => s,
+        None => {
+            tracing::debug!(
+                screen = %screen,
+                event = %event,
+                "LAYOUT_WEBHOOK_SECRET not set — skipping layout-change notification"
+            );
+            return;
+        }
+    };
+
+    // Owned copies so the spawned task is `'static`.
+    let screen = screen.to_owned();
+
+    let body = serde_json::json!({ "screen": screen, "event": event })
+        .to_string()
+        .into_bytes();
+
+    let signature = sign_payload(&secret, &body);
+
+    tokio::spawn(async move {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build();
+
+        let client = match client {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "layout-change webhook: failed to build HTTP client"
+                );
+                return;
+            }
+        };
+
+        match client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header(SIGNATURE_HEADER, &signature)
+            .body(body)
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                tracing::debug!(
+                    screen = %screen,
+                    event = %event,
+                    status = %resp.status(),
+                    "layout-change webhook delivered"
+                );
+            }
+            Ok(resp) => {
+                tracing::warn!(
+                    screen = %screen,
+                    event = %event,
+                    status = %resp.status(),
+                    "layout-change webhook returned non-2xx"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    screen = %screen,
+                    event = %event,
+                    error = %e,
+                    "layout-change webhook delivery failed"
+                );
+            }
+        }
+    });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Known-vector: pin the exact output of `sign_payload` so regressions in
+    /// the algorithm or encoding are caught immediately.
+    ///
+    /// Vector computed independently:
+    ///   secret = "test-secret"
+    ///   body   = b"{\"screen\":\"home\",\"event\":\"published\"}"
+    ///   digest = HMAC-SHA256(secret, body) as standard base64
+    ///
+    /// Verified with:
+    ///   echo -n '{"screen":"home","event":"published"}' \
+    ///     | openssl dgst -sha256 -hmac "test-secret" -binary | base64
+    const KNOWN_SECRET: &str = "test-secret";
+    const KNOWN_BODY: &[u8] = b"{\"screen\":\"home\",\"event\":\"published\"}";
+    /// Pre-computed expected value for the known vector above.
+    /// Verified with: echo -n '{"screen":"home","event":"published"}' \
+    ///   | openssl dgst -sha256 -hmac "test-secret" -binary | base64
+    const KNOWN_EXPECTED: &str = "sha256=TXF7Uzi0HS1OSbiy8iK/1JuQ3mJUYzTt+tSYZy9tdfk=";
+
+    #[test]
+    fn sign_payload_known_vector() {
+        let sig = sign_payload(KNOWN_SECRET, KNOWN_BODY);
+        assert_eq!(
+            sig, KNOWN_EXPECTED,
+            "sign_payload must produce the pinned known-vector output byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn sign_payload_different_secret_produces_different_output() {
+        let sig1 = sign_payload("secret-a", KNOWN_BODY);
+        let sig2 = sign_payload("secret-b", KNOWN_BODY);
+        assert_ne!(
+            sig1, sig2,
+            "different secrets must produce different signatures"
+        );
+    }
+
+    #[test]
+    fn sign_payload_different_body_produces_different_output() {
+        let sig1 = sign_payload(KNOWN_SECRET, b"body-one");
+        let sig2 = sign_payload(KNOWN_SECRET, b"body-two");
+        assert_ne!(
+            sig1, sig2,
+            "different bodies must produce different signatures"
+        );
+    }
+
+    #[test]
+    fn sign_payload_format_has_sha256_prefix() {
+        let sig = sign_payload(KNOWN_SECRET, KNOWN_BODY);
+        assert!(
+            sig.starts_with("sha256="),
+            "signature must start with 'sha256=' prefix, got: {sig}"
+        );
+    }
+
+    #[test]
+    fn sign_payload_digest_is_valid_base64() {
+        let sig = sign_payload(KNOWN_SECRET, KNOWN_BODY);
+        let b64_part = sig.trim_start_matches("sha256=");
+        assert!(
+            BASE64.decode(b64_part).is_ok(),
+            "the portion after 'sha256=' must be valid standard base64, got: {b64_part}"
+        );
+    }
+}

--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -54,6 +54,8 @@ over `grep -r <noun> backend/`.
   `api-server/src/routes/layout/` (admin + tenant + resolved) and
   `reality-server/src/routes/layout.rs` (public resolved).
   Spec: `docs/superpowers/specs/2026-07-19-layout-content-manager-design.md`.
+  Publish webhook: `api-server/src/routes/layout/webhook.rs` → `reality-web/src/app/api/layout-revalidate`
+  (POST, HMAC-SHA256 signature, Next.js ISR revalidation). Envs: `LAYOUT_WEBHOOK_URL`, `LAYOUT_WEBHOOK_SECRET`.
   Frontend: `ppt-web/src/features/layout/` + `reality-web/src/lib/layout.ts` +
   `reality-web/src/components/listings/LayoutSections.tsx` (registries, defensive
   renderers, checked-in web manifests for PUT /platform-admin/layout/manifests).

--- a/docs/superpowers/plans/2026-07-20-layout-publish-webhook.md
+++ b/docs/superpowers/plans/2026-07-20-layout-publish-webhook.md
@@ -1,0 +1,90 @@
+# Layout Publish Webhook Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On any layout mutation that changes resolved output (publish, rollback, kill, unkill), api-server fires a signed webhook; reality-web verifies it and `revalidateTag`s the affected layout tags — so ISR pages refresh within seconds of a publish instead of waiting out `revalidate: 60` (spec §7 delivery row; deferred from the defensive-rendering plan).
+
+**Architecture:** (1) api-server gains a tiny outbound notifier (`routes/layout/webhook.rs`): env-configured (`LAYOUT_WEBHOOK_URL` + `LAYOUT_WEBHOOK_SECRET`; unset → debug-log no-op), HMAC-SHA256-signed body per the repo's existing `X-Webhook-Signature` convention, fired fire-and-forget via `tokio::spawn` + reqwest (5 s timeout) from the publish/rollback/kill/unkill handlers AFTER their DB success — never affecting the response. (2) reality-web gains `POST /api/layout-revalidate` (route handler): constant-time HMAC verification against its own `LAYOUT_WEBHOOK_SECRET` (unset → 503 disabled), maps the screen to tags, calls `revalidateTag`. (3) reality-web's layout fetch always includes the GLOBAL tag (`layout:listing-detail`) alongside the host-scoped one, so one webhook invalidates all hosts.
+
+**Tech Stack:** Rust (hmac/sha2 workspace deps, reqwest, tokio), Next.js route handler + Node `crypto.timingSafeEqual`, Vitest.
+
+## Global Constraints
+
+- **Branch:** `feature/layout-publish-webhook` from `dev` (after #2430 merges; if pending, branch from `feature/layout-preview-bridge` and rebase later — note which).
+- **Signature scheme:** MATCH the repo's existing inbound convention — read `require_portal_webhook_verification` in `backend/servers/api-server/src/routes/portal_webhooks.rs` + its helper in `state.rs` for the exact header (`X-Webhook-Signature`) and encoding (hex vs `sha256=` prefix) — the outbound signer and the reality-web verifier must both use exactly that format (ADAPT: report the exact format found).
+- **Fire-and-forget:** the notifier NEVER changes handler outcomes. `tokio::spawn`ed; errors logged `tracing::warn!`, success `tracing::debug!`. Payload: `{"screen": "<screen>", "event": "publish"|"rollback"|"kill"|"unkill"}`.
+- **Env names:** api-server `LAYOUT_WEBHOOK_URL`, `LAYOUT_WEBHOOK_SECRET`; reality-web `LAYOUT_WEBHOOK_SECRET` (same secret value operationally). All unset-safe: outbound no-ops; inbound returns 503 `{error:'disabled'}`.
+- **Tag mapping** (reality-web, single source of truth fn): screen `reality/listing-detail` → `['layout:listing-detail']`; generic rule `layout:<part after '/'>`. The layout fetch in `src/lib/layout.ts` changes its tags to ALWAYS include the global tag: host present → `[host:…:layout:listing-detail, layout:listing-detail]`, else `[layout:listing-detail]` (update its existing tests accordingly).
+- Only reality screens matter to ISR, but the notifier fires for ALL screens (cheap; the receiver revalidates harmless unused tags for ppt screens — keep it simple).
+- Gates: backend `cargo fmt --all && cargo check -p api-server && cargo clippy -p api-server --all-targets -- -D warnings` (fmt EXPLICITLY — a missing fmt broke CI on the previous branch) + RLS script; frontend `pnpm -F @ppt/reality-web test` + `pnpm check && pnpm typecheck`. Known pre-existing failures untouched.
+- Commit scopes: `feat(api-server)`, `feat(reality-web)`, `docs(...)`. ADAPT rule as before.
+
+## File Structure
+
+```
+backend/servers/api-server/src/routes/layout/webhook.rs   # sign_payload + notify_layout_change
+backend/servers/api-server/src/routes/layout/mod.rs       # pub mod webhook;
+backend/servers/api-server/src/routes/layout/admin.rs     # notify calls in 4 handlers
+frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
+frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+frontend/apps/reality-web/src/lib/layout.ts               # global tag always included
+frontend/apps/reality-web/src/lib/layout.test.ts          # tag assertions updated
+docs/repo-map.md
+```
+
+---
+
+### Task 1: api-server outbound notifier
+
+**Files:**
+- Create: `backend/servers/api-server/src/routes/layout/webhook.rs`
+- Modify: `backend/servers/api-server/src/routes/layout/mod.rs` (`pub mod webhook;`)
+- Modify: `backend/servers/api-server/src/routes/layout/admin.rs` (after each successful DB mutation in `publish`, `rollback`, `kill`, `unkill`: `webhook::notify_layout_change(&req.screen, "<event>");`)
+- Modify (if needed): `backend/servers/api-server/Cargo.toml` — `hmac`/`sha2` from workspace deps if not already present (check; `sha2` is in `common`'s deps, api-server may need its own entries).
+
+**Interfaces:**
+- Produces: `pub fn sign_payload(secret: &str, body: &[u8]) -> String` (pure — exact format per the repo convention, ADAPT) and `pub fn notify_layout_change(screen: &str, event: &'static str)` — reads env each call (no state plumbing); when both vars set, spawns a task: reqwest POST to the URL, headers `Content-Type: application/json` + `X-Webhook-Signature: <sign_payload(...)>` (header name per convention), body `{"screen":…,"event":…}`, 5 s timeout, log warn on non-2xx/error. When either var unset → `tracing::debug!` and return.
+- Test: `#[cfg(test)]` unit tests for `sign_payload` (known-vector: fixed secret + body → assert the exact expected string, computed once and hardcoded; plus different-secret ≠ same output). No network tests.
+
+- [ ] **Step 1:** Read the existing verification helper to pin the signature format; write the failing sign_payload tests; implement; wire the four call sites (AFTER `Ok`-path DB success, before building the response value is fine — but only on success paths).
+- [ ] **Step 2:** Verify FOREGROUND: `cd backend && cargo fmt --all && cargo check -p api-server && cargo clippy -p api-server --all-targets -- -D warnings && cargo test -p api-server webhook` + RLS script.
+- [ ] **Step 3:** Commit — `feat(api-server): signed layout-change webhook notifier`
+
+---
+
+### Task 2: reality-web receiver + global tag (TDD)
+
+**Files:**
+- Create: `frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts`
+- Test: `frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts`
+- Modify: `frontend/apps/reality-web/src/lib/layout.ts` + `layout.test.ts` (global tag always present)
+
+**Interfaces:**
+- Route handler contract: `POST` only. Read raw body text FIRST (signature is over raw bytes). `LAYOUT_WEBHOOK_SECRET` unset → 503 `{error:'disabled'}`. Missing/malformed `X-Webhook-Signature` header or HMAC mismatch (Node `crypto.createHmac('sha256', secret)` + `timingSafeEqual` on equal-length buffers — guard length first) → 401 `{error:'invalid signature'}`. Body must parse as `{screen: string}` → else 422. Tags = `layoutTagsFor(screen)` exported helper (`['layout:' + screen.split('/')[1]]`, plus nothing else; screens without `/` → 422). `revalidateTag(tag)` for each (import from `next/cache`); respond 200 `{revalidated: true, tags}`.
+- Signature format MUST mirror Task 1's (coordinate via the plan: whatever Task 1 reports as the convention — the Task 2 implementer reads Task 1's report file for the pinned format).
+- Tests (mock `next/cache`'s `revalidateTag` via `vi.mock`; drive the exported `POST` with constructed `Request` objects; set/unset env via `vi.stubEnv`): secret unset → 503; bad signature → 401 and revalidateTag NOT called; valid signature (compute with Node crypto in the test) → 200, revalidateTag called with `layout:listing-detail`; screen without slash → 422; GET not exported.
+- `layout.ts` tags change + test update: fetch call's `next.tags` asserted to include the global tag in both host/no-host cases.
+
+- [ ] **Step 1:** TDD; run `pnpm -F @ppt/reality-web test` (route + layout tests green, suite otherwise unchanged).
+- [ ] **Step 2:** Commit — `feat(reality-web): signed layout revalidation endpoint and global layout tags`
+
+---
+
+### Task 3: Gates + docs
+
+- `docs/repo-map.md` layout bullet: add `Publish webhook: api-server layout/webhook.rs → reality-web /api/layout-revalidate (LAYOUT_WEBHOOK_URL/SECRET envs).`
+- Backend + frontend full gates per Global Constraints (fmt first!).
+- Commit — `docs(repo-map): layout publish webhook pointers`
+
+---
+
+## Deliberate scope decisions
+
+- **No retry/queue** — a missed webhook self-heals via the existing `revalidate: 60` safety net (spec: on-demand primary + time-based fallback).
+- **No per-host tag fan-out from the webhook** — the global tag covers all hosts; host-scoped tags remain for listing-content invalidation.
+- **No admin UI for webhook status** — env-configured, ops-owned.
+- **ppt-web/mobile unaffected** — client-side caching already handles freshness there.
+
+## Out of scope (subsequent plans)
+
+Mobile registries/renderers; `layout_editor_*` capability; per-tenant preview.

--- a/frontend/apps/reality-web/next-config-headers.js
+++ b/frontend/apps/reality-web/next-config-headers.js
@@ -7,8 +7,6 @@
  * Called by next.config.js; exported for tests.
  */
 
-'use strict';
-
 /**
  * @typedef {{ key: string; value: string }} HeaderEntry
  */

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
@@ -7,7 +7,7 @@ vi.mock('next/cache', () => ({
 }));
 
 import { revalidateTag } from 'next/cache';
-import { POST, layoutTagsFor } from './route';
+import { layoutTagsFor, POST } from './route';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -38,6 +38,10 @@ describe('layoutTagsFor', () => {
 
   it('uses first slash split', () => {
     expect(layoutTagsFor('reality/listing-detail/extra')).toEqual(['layout:listing-detail']);
+  });
+
+  it('returns null when second segment is empty', () => {
+    expect(layoutTagsFor('foo/')).toBeNull();
   });
 });
 
@@ -103,6 +107,16 @@ describe('POST /api/layout-revalidate', () => {
   it('returns 422 when screen has no slash', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = JSON.stringify({ screen: 'listing-detail' });
+    const sig = makeSignature(SECRET, body);
+    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when second segment is empty (e.g., "foo/")', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'foo/' });
     const sig = makeSignature(SECRET, body);
     const req = makeRequest(body, { 'X-Webhook-Signature': sig });
     const res = await POST(req);

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
@@ -1,0 +1,138 @@
+import { createHmac } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock next/cache before importing the route
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}));
+
+import { revalidateTag } from 'next/cache';
+import { POST, layoutTagsFor } from './route';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSignature(secret: string, body: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(body).digest('base64');
+}
+
+function makeRequest(body: string, headers: Record<string, string> = {}): Request {
+  return new Request('http://localhost/api/layout-revalidate', {
+    method: 'POST',
+    body,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+const SECRET = 'test-secret-abc123';
+
+// ---------------------------------------------------------------------------
+// layoutTagsFor helper
+// ---------------------------------------------------------------------------
+
+describe('layoutTagsFor', () => {
+  it('returns layout tag from second segment', () => {
+    expect(layoutTagsFor('reality/listing-detail')).toEqual(['layout:listing-detail']);
+  });
+
+  it('uses first slash split', () => {
+    expect(layoutTagsFor('reality/listing-detail/extra')).toEqual(['layout:listing-detail']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST handler
+// ---------------------------------------------------------------------------
+
+describe('POST /api/layout-revalidate', () => {
+  beforeEach(() => {
+    vi.mocked(revalidateTag).mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns 503 when LAYOUT_WEBHOOK_SECRET is not set', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', '');
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    const req = makeRequest(body, { 'X-Webhook-Signature': makeSignature(SECRET, body) });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json).toEqual({ error: 'disabled' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when X-Webhook-Signature header is missing', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    const req = makeRequest(body);
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toEqual({ error: 'invalid signature' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when X-Webhook-Signature is wrong', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    const req = makeRequest(body, { 'X-Webhook-Signature': 'sha256=invalidsignature==' });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toEqual({ error: 'invalid signature' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 and revalidates layout:listing-detail on valid request', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail', event: 'published' });
+    const sig = makeSignature(SECRET, body);
+    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ revalidated: true, tags: ['layout:listing-detail'] });
+    expect(revalidateTag).toHaveBeenCalledWith('layout:listing-detail', 'default');
+    expect(revalidateTag).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 422 when screen has no slash', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'listing-detail' });
+    const sig = makeSignature(SECRET, body);
+    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when body is not valid JSON', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = 'not-json';
+    const sig = makeSignature(SECRET, body);
+    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when body is JSON but has no screen string', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ event: 'published' });
+    const sig = makeSignature(SECRET, body);
+    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const res = await POST(req);
+    expect(res.status).toBe(422);
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('does not export GET', () => {
+    // Verify by checking the module's exported keys directly
+    const routeModule = { POST, layoutTagsFor } as Record<string, unknown>;
+    expect(routeModule['GET']).toBeUndefined();
+  });
+});

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
@@ -7,8 +7,12 @@ import { NextResponse } from 'next/server';
 // Only screens that contain a slash are valid (e.g. "reality/listing-detail").
 // ---------------------------------------------------------------------------
 
-export function layoutTagsFor(screen: string): string[] {
-  return ['layout:' + screen.split('/')[1]];
+export function layoutTagsFor(screen: string): string[] | null {
+  const parts = screen.split('/');
+  const segment = parts[1];
+  // Require non-empty second segment (e.g., reject 'foo/')
+  if (!segment) return null;
+  return ['layout:' + segment];
 }
 
 // ---------------------------------------------------------------------------
@@ -55,13 +59,17 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const screen = (body as { screen: string }).screen;
 
-  // 5. Validate screen contains a slash
+  // 5. Validate screen contains a slash and has non-empty second segment
   if (!screen.includes('/')) {
     return NextResponse.json({ error: 'invalid screen' }, { status: 422 });
   }
 
   // 6. Revalidate tags
   const tags = layoutTagsFor(screen);
+  if (!tags) {
+    return NextResponse.json({ error: 'invalid screen' }, { status: 422 });
+  }
+
   for (const tag of tags) {
     revalidateTag(tag, 'default');
   }

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
@@ -1,0 +1,70 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { revalidateTag } from 'next/cache';
+import { NextResponse } from 'next/server';
+
+// ---------------------------------------------------------------------------
+// Exported helper — maps a screen id to its cache tags.
+// Only screens that contain a slash are valid (e.g. "reality/listing-detail").
+// ---------------------------------------------------------------------------
+
+export function layoutTagsFor(screen: string): string[] {
+  return ['layout:' + screen.split('/')[1]];
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/layout-revalidate
+// ---------------------------------------------------------------------------
+
+export async function POST(request: Request): Promise<NextResponse> {
+  // 1. Secret must be configured
+  const secret = process.env.LAYOUT_WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'disabled' }, { status: 503 });
+  }
+
+  // 2. Read raw body FIRST — signature is over the raw bytes
+  const rawBody = await request.text();
+
+  // 3. Verify HMAC signature
+  const header = request.headers.get('X-Webhook-Signature') ?? '';
+  const expected = 'sha256=' + createHmac('sha256', secret).update(rawBody).digest('base64');
+
+  const headerBuf = Buffer.from(header);
+  const expectedBuf = Buffer.from(expected);
+
+  // Guard unequal lengths before timingSafeEqual (it throws on length mismatch)
+  if (headerBuf.length !== expectedBuf.length || !timingSafeEqual(headerBuf, expectedBuf)) {
+    return NextResponse.json({ error: 'invalid signature' }, { status: 401 });
+  }
+
+  // 4. Parse body and validate shape
+  let body: unknown;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    return NextResponse.json({ error: 'invalid body' }, { status: 422 });
+  }
+
+  if (
+    typeof body !== 'object' ||
+    body === null ||
+    typeof (body as Record<string, unknown>).screen !== 'string'
+  ) {
+    return NextResponse.json({ error: 'invalid body' }, { status: 422 });
+  }
+
+  const screen = (body as { screen: string }).screen;
+
+  // 5. Validate screen contains a slash
+  if (!screen.includes('/')) {
+    return NextResponse.json({ error: 'invalid screen' }, { status: 422 });
+  }
+
+  // 6. Revalidate tags
+  const tags = layoutTagsFor(screen);
+  for (const tag of tags) {
+    revalidateTag(tag, 'default');
+  }
+
+  return NextResponse.json({ revalidated: true, tags });
+}

--- a/frontend/apps/reality-web/src/lib/layout.test.ts
+++ b/frontend/apps/reality-web/src/lib/layout.test.ts
@@ -19,6 +19,43 @@ describe('getResolvedLayout', () => {
     await expect(getResolvedLayout(null)).resolves.toEqual(payload);
   });
 
+  it('passes only global tag when host is null', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          screen: 'reality/listing-detail',
+          version: 1,
+          sections: [],
+        }),
+        { status: 200 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await getResolvedLayout(null);
+    const [, options] = fetchMock.mock.calls[0] as [string, { next?: { tags?: string[] } }];
+    expect(options.next?.tags).toEqual(['layout:listing-detail']);
+  });
+
+  it('passes both host-scoped and global tags when host is provided', async () => {
+    const host = 'example.rlt.sk';
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          screen: 'reality/listing-detail',
+          version: 1,
+          sections: [],
+        }),
+        { status: 200 }
+      )
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    await getResolvedLayout(host);
+    const [, options] = fetchMock.mock.calls[0] as [string, { next?: { tags?: string[] } }];
+    expect(options.next?.tags).toContain(`host:${host}:layout:listing-detail`);
+    expect(options.next?.tags).toContain('layout:listing-detail');
+    expect(options.next?.tags).toHaveLength(2);
+  });
+
   it('falls back to the default layout on non-2xx', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('nope', { status: 404 })));
     await expect(getResolvedLayout(null)).resolves.toEqual(DEFAULT_LISTING_DETAIL_LAYOUT);

--- a/frontend/apps/reality-web/src/lib/layout.ts
+++ b/frontend/apps/reality-web/src/lib/layout.ts
@@ -87,7 +87,9 @@ function resolveApiBase(host: string | null): string {
  */
 export async function getResolvedLayout(host: string | null): Promise<ResolvedScreen> {
   try {
-    const tags = host ? [`host:${host}:layout:listing-detail`] : ['layout:listing-detail'];
+    const tags = host
+      ? [`host:${host}:layout:listing-detail`, 'layout:listing-detail']
+      : ['layout:listing-detail'];
     const response = await fetch(
       `${resolveApiBase(host)}/api/v1/layout/resolved/${SCREEN}?platform=web`,
       { headers: host ? { Host: host } : {}, next: { revalidate: 60, tags } }


### PR DESCRIPTION
## Summary

Seventh slice of the Layout & Content Manager (follows #2424–#2430, all merged). Closes the ISR-freshness loop from spec §7: reality-web pages now refresh within seconds of a layout publish instead of waiting out `revalidate: 60`.

- **api-server** — `routes/layout/webhook.rs`: `sign_payload` (`X-Webhook-Signature: sha256=<base64(HMAC-SHA256(secret, body))>`, byte-for-byte the repo's existing inbound portal-webhook convention, known-vector unit tests) + `notify_layout_change` — env-gated (`LAYOUT_WEBHOOK_URL`/`LAYOUT_WEBHOOK_SECRET`; unset → debug no-op), fired fire-and-forget (`tokio::spawn`, reqwest 5 s timeout, warn-only failures) from the success paths of publish, rollback, kill, and unkill. Never touches handler outcomes.
- **reality-web** — `POST /api/layout-revalidate`: raw body read before parse, 503 when the secret is unset, length-guarded `crypto.timingSafeEqual`, 422 for malformed screens, `revalidateTag(tag, 'default')` (Next 16 two-arg API, verified against installed types). The layout fetch now always includes the global `layout:listing-detail` tag alongside the host-scoped one, so a single webhook invalidates every host (provably additive — no other consumer of these tags).
- Ops: same secret value on both sides; the `revalidate: 60` time-based fallback stays as the safety net per the spec, so a missed webhook self-heals.

## Security

Adversarial per-task review + final opus review: signature verified over exact raw bytes before parsing, constant-time compare, no secret in logs, no SSRF surface (URL/secret are operator env; the only request-controlled value is the superadmin-typed `screen`, JSON-serialized into the body only). Replay is accepted-by-design (idempotent revalidation of fixed tags) and noted. Zero blocking findings.

## Verification

Backend fmt/check/clippy clean, webhook unit tests green (50 lib tests); reality-web 12 route tests + updated tag tests green, suite otherwise unchanged (known pre-existing failures only); workspace typecheck clean.

Plan: `docs/superpowers/plans/2026-07-20-layout-publish-webhook.md`. Remaining backlog: mobile registries/renderers, `layout_editor_*` capability, per-tenant preview, ppt-web frame-protection follow-up (from #2430).