### PR TITLE
feat(layout): mobile registries — RN dashboard + KMP Android listing detail

### DIFF
--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -62,6 +62,7 @@ over `grep -r <noun> backend/`.
   Tenant editor: `ppt-web/src/features/layout/` (/dashboard/customize, org-admin entry point).
   Editor: `admin-web/src/features/layout-editor/` (routes `/platform/layout`, `/platform/layout/manifests`).
   Preview bridge: `@ppt/shared` layout-preview (postMessage bridge) + `admin-web/src/features/layout-editor/PreviewPanel` (iframe, framed ppt-web); preview-resolve endpoint (`/api/v1/platform-admin/layout/preview-resolve`) returns resolved layout for local (unsaved) drafts.
+  Mobile: RN features/layout (dashboard, cached next-launch activation) + mobile-native shared/layout + Android registry dispatch; canonical mobile manifest in apps/mobile.
 - `api-core` — Axum extractors, auth middleware, OpenAPI (utoipa), CORS/tracing.
 - `db` — SQLx pool, models, **~101 repositories** in `src/repositories/`, migrations (~177 sql files).
 - `integrations` — external API clients (Airbnb, Booking.com, portals).

--- a/docs/screens/ppt/dashboard.md
+++ b/docs/screens/ppt/dashboard.md
@@ -103,6 +103,7 @@ UC-15 + UC-02 + UC-03 + UC-04 hub for residents on mobile (RN). The home screen 
 
 <!-- newest entries on top -->
 
+- 2026-07-20 — agent: RN mobile dashboard renders via cached resolved layout (next-launch activation).
 - 2026-07-20 — agent: layout preview mode (postMessage bridge) added.
 - 2026-07-20 — agent: org-admin customize entry point added (/dashboard/customize, layout tenant editor)
 - 2026-07-19 — agent: page now renders via resolved-layout section registry (defensive rendering, spec 2026-07-19-layout-content-manager-design)

--- a/docs/screens/reality/listing-detail.md
+++ b/docs/screens/reality/listing-detail.md
@@ -120,6 +120,7 @@ Single-property detail view — converts portal traffic into UC-46 inquiries (Ca
 
 <!-- newest entries on top -->
 
+- 2026-07-20 — agent: Android listing detail renders via shared resolved layout dispatch (iOS follow-up pending).
 - 2026-07-20 — agent: layout preview mode (postMessage bridge) added.
 - 2026-07-19 — agent: page now renders via resolved-layout section registry (defensive rendering, spec 2026-07-19-layout-content-manager-design)
 - 2026-06-07 — agent: reconciled screen-map with PR #1085 (reality-web listing-detail SSR metadata hardening). PR extracted a defensive `buildListingMetadata(listing: unknown)` helper + `FALLBACK_METADATA` into a new `metadata.ts` module (with `metadata.test.ts`, 8 cases) so a malformed/partial 200 body no longer throws in `generateMetadata` during SSR; `page.tsx` now delegates to it. Documented the SSR fallback in States > Error and Notes > Specific. Frontmatter unchanged: reality-web buildStatus stays `shipped` (no UI/route change) and apiStatus stays `partial` (no endpoint change — still only `listings_get`); this is a robustness fix, not a feature.

--- a/docs/superpowers/plans/2026-07-20-layout-mobile-registries.md
+++ b/docs/superpowers/plans/2026-07-20-layout-mobile-registries.md
@@ -1,0 +1,118 @@
+# Layout Mobile Registries Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the two mobile clients into the layout system (spec §9 step 6): the RN management app renders its dashboard through a section registry fed by `GET /api/v1/layout/resolved/ppt/dashboard?platform=mobile` (last-known-good cached, activate-on-next-launch), and the KMP Reality app renders listing-detail section order/visibility from reality-server's public resolved endpoint (compiled-in default, fetch-at-entry). A canonical checked-in mobile manifest covers both apps' section types.
+
+**Architecture:** (1) RN: a `features/layout` module using the app's own `apiRequest` layer (NOT `@ppt/api-client` — its relative URLs/token provider don't work on RN), an AsyncStorage-backed cache with strict activate-on-launch semantics (render what was cached at mount; fetch in background only to serve the NEXT launch — never swap mid-session, spec §4.6), an RN `LayoutSections` renderer (order, placeholder, unknown-skip-warn-once) over two managed sections (`dashboard-stats.v1`, `action-queue.v1` — the announcements/quick-actions blocks stay hardcoded below the managed area for now). (2) KMP shared: a `layout` package (serialization models, `LayoutRepository` reusing the `HttpClientProvider` singleton, compiled-in `DEFAULT_LISTING_DETAIL_LAYOUT`, a `resolveEffectiveLayout` helper with fetch-once-at-entry semantics), fully covered by commonTest (MockEngine). (3) KMP Android: `ListingDetailContent` iterates the resolved section list through a `when(type)` registry dispatch (gallery/agent-contact/listing-header/key-details/description mapped to existing composables; features/additional-info/resources are declared-but-folded — they render inside the description tabs regardless, documented), placeholder composable for `presentation=placeholder`, unknown types skipped. (4) **iOS is explicitly OUT** — no macOS builder available here; the SwiftUI dispatch is a follow-up with the same shared models. (5) A canonical mobile manifest JSON checked into the RN app covering BOTH apps' types, consistency-tested.
+
+**Tech Stack:** RN/Expo + jest-expo + AsyncStorage; Kotlin Multiplatform (kotlinx-serialization, Ktor + MockEngine, coroutines-test); Compose (Android).
+
+## Global Constraints
+
+- Spec: `…/2026-07-19-layout-content-manager-design.md` §4.5–4.6 (stale-client + activation timing), §7 (mobile delivery row), §9 step 6. All seven prior slices merged on `dev` (#2424–#2431).
+- **Branch:** `feature/layout-mobile-registries` from `dev`.
+- **Section-type contract:** mobile implements the EXISTING type names. RN dashboard: `dashboard-stats.v1` (wraps today's stats grid), `action-queue.v1` (wraps today's Pending Actions block). KMP listing-detail: `gallery.v1`→HeroGallery, `listing-header.v1`→HeaderSection, `key-details.v1`→QuickStatsStrip, `description.v1`→TabStrip+tab content, `agent-contact.v1`→StickyAgentBar+BottomActionBar; `features.v1`/`additional-info.v1`/`resources.v1` are REGISTERED no-op types on mobile (their content lives inside the description tabs) — required because `validate_publish` checks every config section against EVERY stored manifest, so the mobile manifest must know all eight or publishing the reality base config breaks.
+- **Activation semantics (both apps):** never swap layout mid-session. RN: read cached layout synchronously-ish at mount (AsyncStorage read before first managed render — render default until the read resolves, which is one frame, then STAY on whatever that read produced; the network fetch stores only for next launch). KMP: fetch once at screen entry with the repository's normal error handling; on any failure use the compiled default; no re-fetch while the screen is open.
+- **Defensive rules identical to web:** unknown type → skip + warn once; `presentation=placeholder` → neutral placeholder (i18n'd RN / stringResource-or-hardcoded-sk Android matching app conventions); malformed payload → default layout; never crash, never blank.
+- **RN fetch:** via `useApi.ts`'s `apiRequest` (absolute URL, SecureStore token, X-Tenant-ID from JWT) — do NOT import the api-client layout domain. Cache key in `src/services/localCacheKeys.ts` per its conventions (`ppt_layout_<screen>` style — match the file's naming).
+- **KMP:** follow house patterns exactly — `@Serializable` + explicit `@SerialName` for snake_case wire fields, constructor-injected repository using `HttpClientProvider.client`, `ignoreUnknownKeys` already global; `presentation` enum with `@SerialName("visible")`/`@SerialName("placeholder")` and an UNKNOWN default via `coerceInputValues`-safe design (ADAPT: check how existing enums handle unknown wire values with `ignoreUnknownKeys`; if enums throw on unknown values, model `presentation` as String + helper — report the choice). Tests in commonTest with MockEngine mirroring `ListingDetailRepositoryTest.kt`.
+- **Canonical mobile manifest:** `frontend/apps/mobile/src/features/layout/mobile-manifest.json` — platform `mobile`, components: the two dashboard types (required: true both) + all eight listing-detail types (gallery + listing-header required, rest optional; the three folded types optional). RN test asserts (a) dashboard types === RN registry keys, (b) the eight listing-detail types match a hardcoded list with a comment pointing at the KMP registry file (documented duplication — KMP tests can't read this JSON).
+- Gates: `cd frontend && pnpm -F @ppt/mobile test` + `pnpm check && pnpm typecheck`; `cd mobile-native && ./gradlew :shared:allTests` and `./gradlew build` (CI runs these in mobile-native.yml). Known pre-existing failures untouched. NO backgrounded gate commands; no piping cargo/gradle through tail.
+- Commit scopes: `feat(mobile)`, `feat(mobile-native)`, `docs(...)`. ADAPT rule as before; report adaptations.
+
+## File Structure
+
+```
+frontend/apps/mobile/src/features/layout/types.ts          # ResolvedScreen/Section types (local)
+frontend/apps/mobile/src/features/layout/layoutCache.ts    # AsyncStorage last-known-good + activate-on-launch
+frontend/apps/mobile/src/features/layout/registry.tsx      # dashboardRegistry (2 types) + DEFAULT_DASHBOARD_LAYOUT
+frontend/apps/mobile/src/features/layout/LayoutSections.tsx# RN renderer (order/placeholder/unknown-skip)
+frontend/apps/mobile/src/features/layout/useDashboardLayout.ts # mount-read + background-refresh hook
+frontend/apps/mobile/src/features/layout/mobile-manifest.json
+frontend/apps/mobile/src/features/layout/*.test.tsx        # renderer/cache/hook/manifest tests
+frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx  # refactor: managed area via LayoutSections
+frontend/apps/mobile/src/services/localCacheKeys.ts        # + layout cache key
+mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutModels.kt
+mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutRepository.kt
+mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/DefaultLayout.kt
+mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutRepositoryTest.kt
+mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutModelsContractTest.kt
+mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
+mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailContent.kt  # dispatch refactor
+mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt   # layout fetch wiring
+docs/repo-map.md
+```
+
+---
+
+### Task 1: RN layout module + dashboard refactor (TDD)
+
+**Files:** all `frontend/apps/mobile` files above.
+
+**Interfaces / behavior contract:**
+- `types.ts`: `ResolvedSection { type: string; mode?: string; props?: Record<string, unknown>; presentation: 'visible' | 'placeholder' }`, `ResolvedScreen { screen: string; version: number; sections: ResolvedSection[] }` (local copies — mobile doesn't depend on the api-client layout domain).
+- `layoutCache.ts`: `readCachedLayout(screen): Promise<ResolvedScreen | null>` (AsyncStorage `JSON.parse` guarded — malformed → null + remove), `writeCachedLayout(screen, layout)`, key from `localCacheKeys.ts`. Validation: shape-check `screen` match + `Array.isArray(sections)` before returning.
+- `useDashboardLayout(screen)`: state starts as `DEFAULT_DASHBOARD_LAYOUT`; on mount, `readCachedLayout` → if non-null, set state ONCE (the activation moment — this is launch-time activation, allowed); then fire `apiRequest<ResolvedScreen>('/api/v1/layout/resolved/'+screen+'?platform=mobile')` in the background — on success shape-check and `writeCachedLayout` ONLY (do NOT set state); failures silent (`console.warn` once). Result: session renders cache-or-default; fresh layout appears next launch (spec §4.6). Return `{ layout }`.
+- `registry.tsx`: `dashboardRegistry` mapping `dashboard-stats.v1` → the extracted stats-grid component and `action-queue.v1` → the extracted Pending Actions component (extract both from `DashboardScreen` verbatim, preserving their queries/props — components receive `{ mode?, props? }` and internally keep their existing hooks/callbacks; ADAPT to how the screen currently passes `onNavigate` — thread it via a React context or renderer prop, smallest clean change, report it). `DEFAULT_DASHBOARD_LAYOUT` lists both visible.
+- `LayoutSections.tsx`: mirrors the web renderers' semantics — order-preserving, `presentation=placeholder` → `<View accessibilityRole="alert"-free placeholder>` with i18n'd title/body (add `layout.placeholderTitle`/`layout.placeholderBody` keys to ALL SIX locale files under `src/locales/` — same keys as web apps), unknown → skip + warn once, container spacing via the parent's existing section styles (`gap`-based wrapper style).
+- `DashboardScreen.tsx`: header stays; the stats + pending-actions area becomes `<LayoutSections layout={layout} registry={dashboardRegistry} …/>`; announcements + quick-actions remain hardcoded below (deliberate — not yet managed). Existing DashboardScreen tests must stay green (ADAPT their mocks minimally; report).
+- `mobile-manifest.json` + `manifest.test.ts` per Global Constraints.
+- Tests (jest-expo, mirror `DashboardScreen.test.tsx` mocking conventions): renderer order/placeholder/unknown-skip (3+), cache read/write/malformed (3), hook activation semantics — cached layout activates at mount, successful background fetch does NOT change state but writes cache, fetch failure silent (3, use fake timers/`waitFor`), manifest consistency (1), DashboardScreen renders managed sections via default layout with fetch mocked out (existing + 1).
+
+- [ ] TDD; verify FOREGROUND and WAIT: `cd frontend && pnpm -F @ppt/mobile test` (full app suite; report pre-existing failures if any — none are known for mobile) + `pnpm typecheck` + Biome on touched files.
+- [ ] Commit — `feat(mobile): dashboard renders through cached resolved layout with next-launch activation`
+
+---
+
+### Task 2: KMP shared layout package (TDD)
+
+**Files:** the three `commonMain` files + two `commonTest` files above.
+
+**Interfaces / behavior contract:**
+- `LayoutModels.kt`: `@Serializable data class ResolvedLayoutSection(val type: String, val mode: String? = null, @SerialName("props") val props: JsonObject? = null, val presentation: String = "visible")` and `@Serializable data class ResolvedLayoutScreen(val screen: String, val version: Int, val sections: List<ResolvedLayoutSection>)` — presentation as String per the enum-unknown-value concern (helpers `isPlaceholder`/`isVisible`; unknown presentation values treated as visible — defensive). ADAPT if house style prefers enums with a safe fallback and it's provably safe under the shared Json config; report.
+- `DefaultLayout.kt`: `val DEFAULT_LISTING_DETAIL_LAYOUT = ResolvedLayoutScreen("reality/listing-detail", 0, listOf(…))` — the eight types in web base order, all visible.
+- `LayoutRepository.kt` (constructor-injected `HttpClient = HttpClientProvider.client`, `baseUrl = ApiConfig.baseUrl` — mirror `ListingRepository`'s construction exactly): `suspend fun getResolvedLayout(screen: String): ResolvedLayoutScreen` — GET `$baseUrl/api/v1/layout/resolved/$screen?platform=mobile` (public, no auth header), on ANY failure (non-2xx, network, decode, wrong screen echo, empty sections list is ALLOWED) return `DEFAULT_LISTING_DETAIL_LAYOUT` when screen == its screen else a minimal default — simplest: `getListingDetailLayout(): ResolvedLayoutScreen` fixed to the one screen, never throws. Path-encode the screen segment like other repos (`asPathSegment` on each `/`-part — check `UrlEncoding.kt`; the screen contains a literal `/` which must stay a path separator: build the URL from the two segments, ADAPT to the resolved endpoint's catch-all expectations — `reality%2Flisting-detail` would NOT match the axum `{*screen}` route the same way; use the literal path `layout/resolved/reality/listing-detail`).
+- Tests mirroring `ListingDetailRepositoryTest.kt` (MockEngine): 200 decode (order + presentation + unknown-extra-fields tolerated), non-2xx → default, malformed JSON → default, decode of `presentation:"placeholder"` + unknown presentation string → visible; `LayoutModelsContractTest.kt` pins the wire shape (encode/decode round-trip of a fixture matching the server's serde output).
+
+- [ ] TDD; verify FOREGROUND and WAIT: `cd mobile-native && ./gradlew :shared:allTests` (plus `./gradlew :shared:build` if fast). Report test counts.
+- [ ] Commit — `feat(mobile-native): shared layout models, repository and compiled default`
+
+---
+
+### Task 3: KMP Android dispatch (registry refactor)
+
+**Files:** `ListingSectionRegistry.kt` (new), `ListingDetailContent.kt` + `ListingDetailScreen.kt` (refactor).
+
+**Interfaces / behavior contract:**
+- `ListingSectionRegistry.kt`: `object ListingSectionRegistry { val supportedTypes: Set<String> = setOf(all eight) }` + a `@Composable fun LazyListScope-extension`-style dispatcher OR a plain `fun sectionItems(scope: LazyListScope, section: ResolvedLayoutSection, ctx: ListingSectionContext)` where `ListingSectionContext` bundles the params today's composables need (listing, callbacks, tab state…) — ADAPT to the existing `ListingDetailContent` parameter surface with the smallest clean restructure; the `when(section.type)` maps the five rendering types to the existing composable calls IN THEIR CURRENT FORM (no visual changes under the default layout), the three folded types to no-ops, unknown → no-op (+ one `println`/log warn — match app logging conventions), `presentation == placeholder` → `PlaceholderSection()` composable (neutral card, ~96dp min height, text "Sekcia nie je dostupná" — ADAPT to the app's string-resource conventions; if all strings are resources, add one).
+- `ListingDetailContent.kt`: the fixed `item { … }` list becomes iteration over `layout.sections` dispatching through the registry. Sticky/bottom-bar special case: `agent-contact.v1` controls BOTH `StickyAgentBar` and `BottomActionBar` visibility (hidden/killed → neither renders; placeholder → placeholder card in the list, no bars).
+- `ListingDetailScreen.kt`: obtain the layout via `remember { LayoutRepository(...) }` + `LaunchedEffect(listingId) { layout = repo.getListingDetailLayout() }` starting from `DEFAULT_LISTING_DETAIL_LAYOUT` — fetch-once-at-entry; the state may settle once shortly after entry (network vs default — acceptable at screen entry per spec §4.6's "next screen entry" activation; no re-fetch afterwards). ADAPT to how `ListingDetailViewModel` is wired if hosting the fetch there is cleaner — report the choice.
+- Behavior under the default layout must be pixel-identical to today (this is a pure restructure + dispatch).
+- Tests: shared logic is covered by Task 2; Android-side has no unit-test harness for composables (no androidTest set) — the gate is `./gradlew build` (compiles both apps) + `:shared:allTests`. State this explicitly in the report.
+
+- [ ] Verify FOREGROUND and WAIT (generous timeout — gradle builds are slow): `cd mobile-native && ./gradlew build` green.
+- [ ] Commit — `feat(mobile-native): listing detail renders through the shared resolved layout`
+
+---
+
+### Task 4: Gates + docs
+
+- `docs/repo-map.md` layout bullet: `Mobile: RN features/layout (dashboard, cached next-launch activation) + mobile-native shared/layout + Android registry dispatch; canonical mobile manifest in apps/mobile.`
+- Screen-map Agent Log entries where docs exist (ppt dashboard mobile note; reality listing-detail mobile note) — skip+note absences.
+- Full gates: `cd frontend && pnpm check && pnpm typecheck && pnpm -F @ppt/mobile test`; `cd mobile-native && ./gradlew build :shared:allTests`. Known pre-existing failures only.
+- Commit — `docs(repo-map): layout mobile registries pointers`
+
+---
+
+## Deliberate scope decisions (do not "fix" during implementation)
+
+- **iOS renderer is OUT** — no macOS builder in this environment; the shared models/repository are iOS-ready, and the SwiftUI `switch` dispatch is a documented follow-up.
+- **KMP has no persistent last-known-good cache** — no settings/DB lib exists in shared; fetch-at-entry + compiled default is the v1 semantics; persistence (multiplatform-settings) is a follow-up.
+- **RN manages only the stats + action-queue area**; announcements/quick-actions blocks stay hardcoded until those section types exist across the system.
+- **The three folded KMP types render no-op** — their content ships inside the description tabs; granular mobile control of them is future work.
+- **No mode support on mobile v1** — `mode` is carried through but no mobile section declares modes in the manifest.
+
+## Out of scope (subsequent plans)
+
+iOS SwiftUI dispatch; KMP layout persistence; `layout_editor_*` capability; per-tenant preview; ppt-web frame-protection follow-up.

--- a/frontend/apps/mobile/src/features/layout/LayoutSections.tsx
+++ b/frontend/apps/mobile/src/features/layout/LayoutSections.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { StyleSheet, Text, View } from 'react-native';
+import type { SectionRegistry } from './registry';
+import type { ResolvedScreen } from './types';
+
+const warnedTypes = new Set<string>();
+
+function PlaceholderSection() {
+  const { t } = useTranslation();
+  return (
+    <View style={styles.placeholder}>
+      <Text style={styles.placeholderTitle}>{t('layout.placeholderTitle')}</Text>
+      <Text style={styles.placeholderBody}>{t('layout.placeholderBody')}</Text>
+    </View>
+  );
+}
+
+export interface LayoutSectionsProps {
+  layout: ResolvedScreen;
+  registry: SectionRegistry;
+}
+
+export function LayoutSections({ layout, registry }: LayoutSectionsProps) {
+  return (
+    <View style={styles.container}>
+      {layout.sections.map((section) => {
+        const def = registry[section.type];
+        if (!def) {
+          if (!warnedTypes.has(section.type)) {
+            warnedTypes.add(section.type);
+            console.warn(`layout: unknown section type ${section.type} — skipped`);
+          }
+          return null;
+        }
+
+        if (section.presentation === 'placeholder') {
+          return (
+            <View key={section.type} style={styles.sectionWrapper}>
+              <PlaceholderSection />
+            </View>
+          );
+        }
+
+        const Component = def.component;
+        return (
+          <View key={section.type} style={styles.sectionWrapper}>
+            <Component mode={section.mode} props={section.props} />
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: 0 },
+  sectionWrapper: {},
+  placeholder: {
+    margin: 16,
+    padding: 16,
+    backgroundColor: '#f5f5f5',
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+  placeholderTitle: { fontSize: 16, fontWeight: '600', color: '#666', marginBottom: 4 },
+  placeholderBody: { fontSize: 14, color: '#999' },
+});

--- a/frontend/apps/mobile/src/features/layout/LayoutSections.tsx
+++ b/frontend/apps/mobile/src/features/layout/LayoutSections.tsx
@@ -24,7 +24,7 @@ export interface LayoutSectionsProps {
 export function LayoutSections({ layout, registry }: LayoutSectionsProps) {
   return (
     <View style={styles.container}>
-      {layout.sections.map((section) => {
+      {layout.sections.map((section, index) => {
         const def = registry[section.type];
         if (!def) {
           if (!warnedTypes.has(section.type)) {
@@ -36,7 +36,7 @@ export function LayoutSections({ layout, registry }: LayoutSectionsProps) {
 
         if (section.presentation === 'placeholder') {
           return (
-            <View key={section.type} style={styles.sectionWrapper}>
+            <View key={`${section.type}-${index}`} style={styles.sectionWrapper}>
               <PlaceholderSection />
             </View>
           );
@@ -44,7 +44,7 @@ export function LayoutSections({ layout, registry }: LayoutSectionsProps) {
 
         const Component = def.component;
         return (
-          <View key={section.type} style={styles.sectionWrapper}>
+          <View key={`${section.type}-${index}`} style={styles.sectionWrapper}>
             <Component mode={section.mode} props={section.props} />
           </View>
         );

--- a/frontend/apps/mobile/src/features/layout/layout.test.tsx
+++ b/frontend/apps/mobile/src/features/layout/layout.test.tsx
@@ -416,20 +416,43 @@ describe('DashboardStatsSection stat arithmetic', () => {
 
 // ─── 4. manifest consistency ──────────────────────────────────────────────────
 
+// Drift guard: these keys must exactly match the supportedTypes list in
+// mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/listing/ListingSectionRegistry.kt
+// — documented duplication because KMP tests cannot read this JSON.
+const LISTING_DETAIL_COMPONENTS = [
+  'additional-info.v1',
+  'agent-contact.v1',
+  'description.v1',
+  'features.v1',
+  'gallery.v1',
+  'key-details.v1',
+  'listing-header.v1',
+  'resources.v1',
+].sort();
+
 describe('mobile-manifest consistency', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const manifest = require('./mobile-manifest.json') as {
+    platform: string;
+    components: Record<string, { required: boolean }>;
+  };
+
   it('dashboard types in manifest are all registered in dashboardRegistry', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const manifest = require('./mobile-manifest.json') as {
-      components: Array<{ type: string; required: boolean }>;
-    };
     const registryKeys = Object.keys(dashboardRegistry);
-    const dashboardManifestTypes = manifest.components
-      .filter((c) => c.type.startsWith('dashboard-') || c.type.startsWith('action-'))
-      .map((c) => c.type);
+    const dashboardManifestTypes = Object.keys(manifest.components).filter(
+      (k) => k.startsWith('dashboard-') || k.startsWith('action-')
+    );
 
     for (const type of dashboardManifestTypes) {
       expect(registryKeys).toContain(type);
     }
+  });
+
+  it('listing-detail component keys match KMP ListingSectionRegistry.supportedTypes', () => {
+    const listingDetailKeys = Object.keys(manifest.components)
+      .filter((k) => !['dashboard-stats.v1', 'action-queue.v1'].includes(k))
+      .sort();
+    expect(listingDetailKeys).toEqual(LISTING_DETAIL_COMPONENTS);
   });
 });
 

--- a/frontend/apps/mobile/src/features/layout/layout.test.tsx
+++ b/frontend/apps/mobile/src/features/layout/layout.test.tsx
@@ -281,6 +281,139 @@ describe('useDashboardLayout hook', () => {
   });
 });
 
+// ─── 3b. useDashboardLayout — tightest activation cage ───────────────────────
+
+describe('useDashboardLayout — tightest activation cage', () => {
+  const { useDashboardLayout: realUseDashboardLayout } = jest.requireActual('./useDashboardLayout');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('serves cached layout when cache is populated AND background fetch returns a different layout', async () => {
+    // Cached layout has a distinguishable section list (action-queue only)
+    const cachedLayout: ResolvedScreen = {
+      screen: 'ppt/dashboard',
+      version: 5,
+      sections: [{ type: 'action-queue.v1', presentation: 'visible' }],
+    };
+    // Fetched layout is different (stats only, higher version)
+    const fetchedLayout: ResolvedScreen = {
+      screen: 'ppt/dashboard',
+      version: 6,
+      sections: [{ type: 'dashboard-stats.v1', presentation: 'visible' }],
+    };
+
+    (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(cachedLayout));
+    mockApiRequest.mockResolvedValue(fetchedLayout);
+    (mockAsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+    let capturedLayout: ResolvedScreen | undefined;
+    function TestComponent() {
+      const { layout } = realUseDashboardLayout('ppt/dashboard');
+      capturedLayout = layout;
+      return null;
+    }
+
+    render(<TestComponent />);
+
+    // Wait until the background fetch has written to cache
+    await waitFor(() => {
+      expect(mockAsyncStorage.setItem).toHaveBeenCalled();
+    });
+
+    // The hook's state MUST equal the CACHED layout (next-launch semantics)
+    expect(capturedLayout).toEqual(cachedLayout);
+    expect(capturedLayout).not.toEqual(fetchedLayout);
+
+    // writeCachedLayout / AsyncStorage.setItem must have been called with the FETCHED layout
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      'ppt_layout_ppt_dashboard',
+      JSON.stringify(fetchedLayout)
+    );
+  });
+});
+
+// ─── 3c. DashboardStatsSection — stat arithmetic ─────────────────────────────
+
+describe('DashboardStatsSection stat arithmetic', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('computes rendered stat values from mocked per-endpoint query results', () => {
+    // Wire up useApiQuery to return distinct data per endpoint key.
+    // Call order matches DashboardStatsSection's 4 useApiQuery calls:
+    //   1. ['dashboard', 'announcements']   → /api/v1/announcements
+    //   2. ['dashboard', 'faults-stats']    → /api/v1/faults/statistics
+    //   3. ['dashboard', 'votes']           → /api/v1/voting
+    //   4. ['dashboard', 'unread-messages'] → /api/v1/messages/unread-count
+
+    // 3 announcements → unreadAnnouncements = 3
+    const announcementsResult = queryResult({
+      data: {
+        announcements: [
+          { id: '1', title: 'Ann A', status: 'published', pinned: false, created_at: '2026-01-01' },
+          { id: '2', title: 'Ann B', status: 'published', pinned: false, created_at: '2026-01-02' },
+          { id: '3', title: 'Ann C', status: 'published', pinned: false, created_at: '2026-01-03' },
+        ],
+      },
+    });
+    // open=2, in_progress=1 → pendingFaults = 3
+    const faultsResult = queryResult({
+      data: { statistics: { open_count: 2, in_progress_count: 1 } },
+    });
+    // 2 active votes, 1 closed → activeVotes = 2
+    const votesResult = queryResult({
+      data: {
+        votes: [
+          { id: 'v1', title: 'Vote 1', status: 'active', end_at: '2026-12-31' },
+          { id: 'v2', title: 'Vote 2', status: 'active', end_at: '2026-12-31' },
+          { id: 'v3', title: 'Vote 3', status: 'closed', end_at: '2026-01-01' },
+        ],
+      },
+    });
+    // unreadCount = 7 → unreadMessages = 7
+    const unreadResult = queryResult({ data: { unreadCount: 7 } });
+
+    mockUseApiQuery
+      .mockReturnValueOnce(announcementsResult)
+      .mockReturnValueOnce(faultsResult)
+      .mockReturnValueOnce(votesResult)
+      .mockReturnValueOnce(unreadResult);
+
+    const { DashboardStatsSection } = jest.requireActual(
+      './registry'
+    ) as typeof import('./registry');
+
+    render(<DashboardStatsSection />);
+
+    // pendingFaults = open_count(2) + in_progress_count(1) = 3
+    // unreadAnnouncements = announcements.slice(0,3).length = 3
+    // Both show '3'; getAllByText confirms at least two cards with that value
+    expect(screen.getAllByText('3').length).toBeGreaterThanOrEqual(1);
+
+    // activeVotes = 2 (only 'active' status counted)
+    expect(screen.getByText('2')).toBeTruthy();
+
+    // unreadMessages = 7
+    expect(screen.getByText('7')).toBeTruthy();
+
+    // upcomingPayments is always 0, but the component renders only 4 stat cards
+    // (pendingFaults, unreadAnnouncements, activeVotes, unreadMessages); the
+    // upcomingPayments field is computed but not yet displayed — no '0' card.
+    expect(screen.queryByText('0')).toBeNull();
+  });
+});
+
 // ─── 4. manifest consistency ──────────────────────────────────────────────────
 
 describe('mobile-manifest consistency', () => {

--- a/frontend/apps/mobile/src/features/layout/layout.test.tsx
+++ b/frontend/apps/mobile/src/features/layout/layout.test.tsx
@@ -1,0 +1,345 @@
+/**
+ * layout.test.tsx — tests for layout registry, cache, hook, and DashboardScreen integration.
+ *
+ * Test sections:
+ * 1. LayoutSections renderer
+ * 2. layoutCache (AsyncStorage-backed)
+ * 3. useDashboardLayout hook
+ * 4. mobile-manifest consistency
+ * 5. DashboardScreen integration with layout
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { act, render, screen, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Text } from 'react-native';
+import { DashboardScreen } from '../../screens/dashboard/DashboardScreen';
+import { LayoutSections } from './LayoutSections';
+import { readCachedLayout, writeCachedLayout } from './layoutCache';
+import type { SectionComponentProps, SectionRegistry } from './registry';
+import { DEFAULT_DASHBOARD_LAYOUT, dashboardRegistry } from './registry';
+import type { ResolvedScreen } from './types';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../../hooks/useApi', () => ({
+  useApiQuery: jest.fn(),
+  apiRequest: jest.fn(),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { firstName: 'Ada', lastName: 'Byron' },
+    logout: jest.fn(),
+  }),
+}));
+
+// Mock useDashboardLayout for DashboardScreen tests so they don't trigger
+// extra useApiQuery / apiRequest calls that the test fixtures don't expect.
+// Note: jest.mock factory cannot reference out-of-scope variables, so we
+// inline the default layout shape here.
+jest.mock('./useDashboardLayout', () => ({
+  useDashboardLayout: jest.fn(() => ({
+    layout: {
+      screen: 'ppt/dashboard',
+      version: 0,
+      sections: [
+        { type: 'dashboard-stats.v1', presentation: 'visible' },
+        { type: 'action-queue.v1', presentation: 'visible' },
+      ],
+    },
+  })),
+}));
+
+const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
+const mockApiRequest = jest.requireMock('../../hooks/useApi').apiRequest as jest.Mock;
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function queryResult(overrides: Record<string, unknown> = {}) {
+  return {
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    isFetching: false,
+    refetch: jest.fn(),
+    ...overrides,
+  };
+}
+
+const SAMPLE_LAYOUT: ResolvedScreen = {
+  screen: 'ppt/dashboard',
+  version: 1,
+  sections: [
+    { type: 'dashboard-stats.v1', presentation: 'visible' },
+    { type: 'action-queue.v1', presentation: 'visible' },
+  ],
+};
+
+// ─── 1. LayoutSections renderer ───────────────────────────────────────────────
+
+describe('LayoutSections renderer', () => {
+  // Clear the module-level warnedTypes set between tests by re-importing or
+  // using jest.resetModules. The simpler approach: suppress and spy on warn.
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('renders sections in the correct order', () => {
+    // Simple registry with two stub sections
+    function Section1() {
+      return <Text>Section One</Text>;
+    }
+    function Section2() {
+      return <Text>Section Two</Text>;
+    }
+    const testRegistry: SectionRegistry = {
+      'sec-1': { component: Section1 },
+      'sec-2': { component: Section2 },
+    };
+    const testLayout: ResolvedScreen = {
+      screen: 'test',
+      version: 1,
+      sections: [
+        { type: 'sec-1', presentation: 'visible' },
+        { type: 'sec-2', presentation: 'visible' },
+      ],
+    };
+
+    render(<LayoutSections layout={testLayout} registry={testRegistry} />);
+
+    expect(screen.getByText('Section One')).toBeTruthy();
+    expect(screen.getByText('Section Two')).toBeTruthy();
+  });
+
+  it('renders PlaceholderSection for presentation=placeholder', () => {
+    function ASection({ mode: _mode, props: _props }: SectionComponentProps) {
+      return <Text>Real Content</Text>;
+    }
+    const testRegistry: SectionRegistry = {
+      'sec-a': { component: ASection },
+    };
+    const testLayout: ResolvedScreen = {
+      screen: 'test',
+      version: 1,
+      sections: [{ type: 'sec-a', presentation: 'placeholder' }],
+    };
+
+    render(<LayoutSections layout={testLayout} registry={testRegistry} />);
+
+    // t() returns the key in tests
+    expect(screen.getByText('layout.placeholderTitle')).toBeTruthy();
+    expect(screen.queryByText('Real Content')).toBeNull();
+  });
+
+  it('skips unknown section types and calls console.warn once', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const testLayout: ResolvedScreen = {
+      screen: 'test',
+      version: 1,
+      sections: [
+        { type: 'unknown-type.v99', presentation: 'visible' },
+        { type: 'unknown-type.v99', presentation: 'visible' },
+      ],
+    };
+
+    render(<LayoutSections layout={testLayout} registry={{}} />);
+
+    // warn-once: called exactly once even though the type appears twice
+    const layoutWarns = warnSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('unknown section type')
+    );
+    expect(layoutWarns.length).toBe(1);
+    expect(layoutWarns[0][0]).toContain('unknown-type.v99');
+    warnSpy.mockRestore();
+  });
+});
+
+// ─── 2. layoutCache ───────────────────────────────────────────────────────────
+
+describe('layoutCache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('write then read round-trips correctly', async () => {
+    (mockAsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(SAMPLE_LAYOUT));
+
+    await writeCachedLayout('ppt/dashboard', SAMPLE_LAYOUT);
+    const result = await readCachedLayout('ppt/dashboard');
+
+    expect(result).toEqual(SAMPLE_LAYOUT);
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
+      'ppt_layout_ppt_dashboard',
+      JSON.stringify(SAMPLE_LAYOUT)
+    );
+  });
+
+  it('returns null and calls removeItem for malformed JSON', async () => {
+    (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue('not-valid-json{{{');
+    (mockAsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await readCachedLayout('ppt/dashboard');
+
+    expect(result).toBeNull();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('ppt_layout_ppt_dashboard');
+  });
+
+  it('returns null and calls removeItem when screen key does not match', async () => {
+    const wrongScreen = { ...SAMPLE_LAYOUT, screen: 'ppt/other' };
+    (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(wrongScreen));
+    (mockAsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await readCachedLayout('ppt/dashboard');
+
+    expect(result).toBeNull();
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('ppt_layout_ppt_dashboard');
+  });
+});
+
+// ─── 3. useDashboardLayout hook ───────────────────────────────────────────────
+
+describe('useDashboardLayout hook', () => {
+  // Import the real hook (not mocked) by using jest.requireActual
+  const { useDashboardLayout: realUseDashboardLayout } = jest.requireActual('./useDashboardLayout');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('activates cached layout at mount', async () => {
+    (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(SAMPLE_LAYOUT));
+    mockApiRequest.mockResolvedValue(null); // fetch returns nothing valid
+
+    let capturedLayout: ResolvedScreen | undefined;
+    function TestComponent() {
+      const { layout } = realUseDashboardLayout('ppt/dashboard');
+      capturedLayout = layout;
+      return null;
+    }
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      expect(capturedLayout).toEqual(SAMPLE_LAYOUT);
+    });
+  });
+
+  it('background fetch does NOT call setLayout but writes cache', async () => {
+    const freshLayout: ResolvedScreen = { ...SAMPLE_LAYOUT, version: 2 };
+    (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(null); // no cache
+    mockApiRequest.mockResolvedValue(freshLayout);
+    (mockAsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+
+    let capturedLayout: ResolvedScreen | undefined;
+    function TestComponent() {
+      const { layout } = realUseDashboardLayout('ppt/dashboard');
+      capturedLayout = layout;
+      return null;
+    }
+
+    render(<TestComponent />);
+
+    // Wait for effect to settle
+    await waitFor(() => {
+      expect(mockAsyncStorage.setItem).toHaveBeenCalled();
+    });
+
+    // Layout should still be the DEFAULT (cache was empty, fetch doesn't set state)
+    expect(capturedLayout).toEqual(DEFAULT_DASHBOARD_LAYOUT);
+  });
+
+  it('fetch failure is silent — console.warn fires once', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+    mockApiRequest.mockRejectedValue(new Error('network'));
+
+    function TestComponent() {
+      realUseDashboardLayout('ppt/dashboard');
+      return null;
+    }
+
+    render(<TestComponent />);
+
+    await waitFor(() => {
+      const layoutWarns = warnSpy.mock.calls.filter((args) =>
+        String(args[0]).includes('layout: background fetch failed')
+      );
+      expect(layoutWarns.length).toBe(1);
+    });
+    warnSpy.mockRestore();
+  });
+});
+
+// ─── 4. manifest consistency ──────────────────────────────────────────────────
+
+describe('mobile-manifest consistency', () => {
+  it('dashboard types in manifest are all registered in dashboardRegistry', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const manifest = require('./mobile-manifest.json') as {
+      components: Array<{ type: string; required: boolean }>;
+    };
+    const registryKeys = Object.keys(dashboardRegistry);
+    const dashboardManifestTypes = manifest.components
+      .filter((c) => c.type.startsWith('dashboard-') || c.type.startsWith('action-'))
+      .map((c) => c.type);
+
+    for (const type of dashboardManifestTypes) {
+      expect(registryKeys).toContain(type);
+    }
+  });
+});
+
+// ─── 5. DashboardScreen integration ──────────────────────────────────────────
+
+describe('DashboardScreen with layout registry', () => {
+  function allSuccessQueries() {
+    return [
+      queryResult({ data: { announcements: [] } }),
+      queryResult({ data: { statistics: { open_count: 0, in_progress_count: 0 } } }),
+      queryResult({ data: { votes: [] } }),
+      queryResult({ data: { unreadCount: 0 } }),
+    ];
+  }
+
+  beforeEach(() => {
+    mockUseApiQuery.mockReset();
+    for (const r of allSuccessQueries()) {
+      mockUseApiQuery.mockReturnValueOnce(r);
+    }
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders managed sections via default layout without crashing', () => {
+    // useDashboardLayout is mocked to return DEFAULT_DASHBOARD_LAYOUT.
+    // The registry sections (DashboardStatsSection, ActionQueueSection) will
+    // try to call useApiQuery — but since they are rendered inside LayoutSections
+    // which renders the registry components, we need to provide enough mock returns.
+    // Reset and provide more mocks for the section components' own queries.
+    mockUseApiQuery.mockReset();
+    // DashboardScreen: 4 queries
+    // DashboardStatsSection: 4 queries
+    // ActionQueueSection: 1 query (votes)
+    const emptyResult = queryResult({ data: undefined });
+    for (let i = 0; i < 9; i++) {
+      mockUseApiQuery.mockReturnValueOnce(emptyResult);
+    }
+
+    render(<DashboardScreen />);
+
+    // Dashboard should render (no crash). Check for static content that's always present.
+    expect(screen.getByText('dashboard.welcomeBack')).toBeTruthy();
+    expect(screen.getByText('dashboard.recentAnnouncements')).toBeTruthy();
+  });
+});

--- a/frontend/apps/mobile/src/features/layout/layoutCache.ts
+++ b/frontend/apps/mobile/src/features/layout/layoutCache.ts
@@ -1,0 +1,39 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { LAYOUT_CACHE_KEY } from '../../services/localCacheKeys';
+import type { ResolvedScreen } from './types';
+
+export async function readCachedLayout(screen: string): Promise<ResolvedScreen | null> {
+  const key = LAYOUT_CACHE_KEY(screen);
+  try {
+    const raw = await AsyncStorage.getItem(key);
+    if (!raw) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      await AsyncStorage.removeItem(key);
+      return null;
+    }
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      (parsed as ResolvedScreen).screen !== screen ||
+      !Array.isArray((parsed as ResolvedScreen).sections)
+    ) {
+      await AsyncStorage.removeItem(key);
+      return null;
+    }
+    return parsed as ResolvedScreen;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeCachedLayout(screen: string, layout: ResolvedScreen): Promise<void> {
+  const key = LAYOUT_CACHE_KEY(screen);
+  try {
+    await AsyncStorage.setItem(key, JSON.stringify(layout));
+  } catch {
+    // silently ignore write failures
+  }
+}

--- a/frontend/apps/mobile/src/features/layout/mobile-manifest.json
+++ b/frontend/apps/mobile/src/features/layout/mobile-manifest.json
@@ -1,15 +1,15 @@
 {
   "platform": "mobile",
-  "components": [
-    { "type": "dashboard-stats.v1", "required": true },
-    { "type": "action-queue.v1", "required": true },
-    { "type": "gallery.v1", "required": true },
-    { "type": "listing-header.v1", "required": true },
-    { "type": "key-details.v1", "required": false },
-    { "type": "description.v1", "required": false },
-    { "type": "agent-contact.v1", "required": false },
-    { "type": "features.v1", "required": false },
-    { "type": "additional-info.v1", "required": false },
-    { "type": "resources.v1", "required": false }
-  ]
+  "components": {
+    "dashboard-stats.v1": { "required": true },
+    "action-queue.v1": { "required": true },
+    "gallery.v1": { "required": true },
+    "listing-header.v1": { "required": true },
+    "key-details.v1": { "required": false },
+    "description.v1": { "required": false },
+    "features.v1": { "required": false },
+    "additional-info.v1": { "required": false },
+    "resources.v1": { "required": false },
+    "agent-contact.v1": { "required": false }
+  }
 }

--- a/frontend/apps/mobile/src/features/layout/mobile-manifest.json
+++ b/frontend/apps/mobile/src/features/layout/mobile-manifest.json
@@ -1,0 +1,15 @@
+{
+  "platform": "mobile",
+  "components": [
+    { "type": "dashboard-stats.v1", "required": true },
+    { "type": "action-queue.v1", "required": true },
+    { "type": "gallery.v1", "required": true },
+    { "type": "listing-header.v1", "required": true },
+    { "type": "key-details.v1", "required": false },
+    { "type": "description.v1", "required": false },
+    { "type": "agent-contact.v1", "required": false },
+    { "type": "features.v1", "required": false },
+    { "type": "additional-info.v1", "required": false },
+    { "type": "resources.v1", "required": false }
+  ]
+}

--- a/frontend/apps/mobile/src/features/layout/registry.tsx
+++ b/frontend/apps/mobile/src/features/layout/registry.tsx
@@ -1,0 +1,243 @@
+import type React from 'react';
+import { createContext, useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useApiQuery } from '../../hooks/useApi';
+import { colors } from '../../screens/shared/screenStyles';
+import type { ResolvedScreen } from './types';
+
+// NavigateContext threads `onNavigate` to section components without prop drilling
+export const NavigateContext = createContext<((screen: string) => void) | undefined>(undefined);
+
+// --- Internal types (verbatim from DashboardScreen) ---
+interface DashboardStats {
+  pendingFaults: number;
+  unreadAnnouncements: number;
+  activeVotes: number;
+  unreadMessages: number;
+  upcomingPayments: number;
+}
+
+interface PendingAction {
+  id: string;
+  type: 'vote' | 'payment' | 'reading' | 'fault';
+  title: string;
+  dueDate?: string;
+}
+
+interface ApiVoteListResponse {
+  votes?: Array<{ id: string; title: string; status: string; end_at: string }>;
+}
+
+interface ApiFaultStatistics {
+  statistics?: { open_count?: number | null; in_progress_count?: number | null };
+}
+
+interface ApiAnnouncementListResponse {
+  announcements: Array<{
+    id: string;
+    title: string;
+    status: string;
+    pinned: boolean;
+    published_at?: string | null;
+    created_at: string;
+  }>;
+}
+
+interface ApiUnreadMessages {
+  unreadCount?: number;
+  unread_count?: number;
+  count?: number;
+}
+
+// --- Section component props ---
+export interface SectionComponentProps {
+  mode?: string;
+  props?: Record<string, unknown>;
+}
+
+// --- DashboardStatsSection ---
+export function DashboardStatsSection({ mode: _mode, props: _props }: SectionComponentProps) {
+  const { t } = useTranslation();
+  const onNavigate = useContext(NavigateContext);
+
+  const announcementsQuery = useApiQuery<ApiAnnouncementListResponse>(
+    ['dashboard', 'announcements'],
+    '/api/v1/announcements?status=published&limit=3',
+    { staleTime: 60_000 }
+  );
+  const faultsStatsQuery = useApiQuery<ApiFaultStatistics>(
+    ['dashboard', 'faults-stats'],
+    '/api/v1/faults/statistics',
+    { staleTime: 60_000 }
+  );
+  const votesQuery = useApiQuery<ApiVoteListResponse>(['dashboard', 'votes'], '/api/v1/voting', {
+    staleTime: 60_000,
+  });
+  const unreadMessagesQuery = useApiQuery<ApiUnreadMessages>(
+    ['dashboard', 'unread-messages'],
+    '/api/v1/messages/unread-count',
+    { staleTime: 30_000 }
+  );
+
+  const announcements = (announcementsQuery.data?.announcements ?? []).slice(0, 3);
+
+  const stats: DashboardStats = {
+    pendingFaults:
+      (faultsStatsQuery.data?.statistics?.open_count ?? 0) +
+      (faultsStatsQuery.data?.statistics?.in_progress_count ?? 0),
+    unreadAnnouncements: announcements.length,
+    activeVotes: (votesQuery.data?.votes ?? []).filter((v) => v.status === 'active').length,
+    unreadMessages:
+      unreadMessagesQuery.data?.unreadCount ??
+      unreadMessagesQuery.data?.unread_count ??
+      unreadMessagesQuery.data?.count ??
+      0,
+    upcomingPayments: 0,
+  };
+
+  return (
+    <View style={styles.statsGrid}>
+      <Pressable style={styles.statCard} onPress={() => onNavigate?.('Faults')}>
+        <Text style={styles.statNumber}>{stats.pendingFaults}</Text>
+        <Text style={styles.statLabel}>{t('dashboard.openFaults')}</Text>
+      </Pressable>
+      <Pressable style={styles.statCard} onPress={() => onNavigate?.('Announcements')}>
+        <Text style={styles.statNumber}>{stats.unreadAnnouncements}</Text>
+        <Text style={styles.statLabel}>{t('dashboard.newAnnouncements')}</Text>
+      </Pressable>
+      <Pressable style={styles.statCard} onPress={() => onNavigate?.('Voting')}>
+        <Text style={styles.statNumber}>{stats.activeVotes}</Text>
+        <Text style={styles.statLabel}>{t('dashboard.activeVotes')}</Text>
+      </Pressable>
+      <Pressable style={styles.statCard} onPress={() => onNavigate?.('Messages')}>
+        <Text style={styles.statNumber}>{stats.unreadMessages}</Text>
+        <Text style={styles.statLabel}>{t('dashboard.unreadMessages')}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+// --- ActionQueueSection ---
+export function ActionQueueSection({ mode: _mode, props: _props }: SectionComponentProps) {
+  const { t, i18n } = useTranslation();
+
+  const votesQuery = useApiQuery<ApiVoteListResponse>(['dashboard', 'votes'], '/api/v1/voting', {
+    staleTime: 60_000,
+  });
+
+  const pendingActions: PendingAction[] = (votesQuery.data?.votes ?? [])
+    .filter((v) => v.status === 'active')
+    .slice(0, 3)
+    .map((v) => ({
+      id: v.id,
+      type: 'vote',
+      title: v.title,
+      dueDate: v.end_at,
+    }));
+
+  const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' });
+  };
+
+  const getActionIcon = (type: PendingAction['type']): string => {
+    switch (type) {
+      case 'vote':
+        return '🗳️';
+      case 'payment':
+        return '💳';
+      case 'reading':
+        return '📊';
+      case 'fault':
+        return '🔧';
+      default:
+        return '📋';
+    }
+  };
+
+  if (pendingActions.length === 0) return null;
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>{t('dashboard.pendingActions')}</Text>
+      <View style={styles.actionsList}>
+        {pendingActions.map((action) => (
+          <Pressable key={action.id} style={styles.actionCard}>
+            <Text style={styles.actionIcon}>{getActionIcon(action.type)}</Text>
+            <View style={styles.actionContent}>
+              <Text style={styles.actionTitle}>{action.title}</Text>
+              {action.dueDate && (
+                <Text style={styles.actionDue}>
+                  {t('dashboard.due', { date: formatDate(action.dueDate) })}
+                </Text>
+              )}
+            </View>
+            <Text style={styles.actionArrow}>›</Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+// --- Registry ---
+export type SectionRegistry = Record<
+  string,
+  { component: React.ComponentType<SectionComponentProps> }
+>;
+
+export const dashboardRegistry: SectionRegistry = {
+  'dashboard-stats.v1': { component: DashboardStatsSection },
+  'action-queue.v1': { component: ActionQueueSection },
+};
+
+// --- Default layout ---
+export const DEFAULT_DASHBOARD_LAYOUT: ResolvedScreen = {
+  screen: 'ppt/dashboard',
+  version: 0,
+  sections: [
+    { type: 'dashboard-stats.v1', presentation: 'visible' },
+    { type: 'action-queue.v1', presentation: 'visible' },
+  ],
+};
+
+// --- Styles ---
+const styles = StyleSheet.create({
+  statsGrid: { flexDirection: 'row', flexWrap: 'wrap', padding: 16, gap: 12 },
+  statCard: {
+    flex: 1,
+    minWidth: '45%',
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: 16,
+    alignItems: 'center',
+    shadowColor: colors.shadow,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  statNumber: { fontSize: 28, fontWeight: 'bold', color: colors.accent },
+  statLabel: { fontSize: 12, color: colors.textMuted, marginTop: 4, textAlign: 'center' },
+  section: { padding: 16 },
+  sectionTitle: { fontSize: 18, fontWeight: '600', color: colors.text, marginBottom: 12 },
+  actionsList: { gap: 8 },
+  actionCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderRadius: 12,
+    padding: 16,
+    shadowColor: colors.shadow,
+    shadowOffset: { width: 0, height: 1 },
+    shadowOpacity: 0.05,
+    shadowRadius: 2,
+    elevation: 1,
+  },
+  actionIcon: { fontSize: 24, marginRight: 12 },
+  actionContent: { flex: 1 },
+  actionTitle: { fontSize: 15, fontWeight: '500', color: colors.text },
+  actionDue: { fontSize: 13, color: colors.warning, marginTop: 2 },
+  actionArrow: { fontSize: 24, color: colors.textSubtle },
+});

--- a/frontend/apps/mobile/src/features/layout/types.ts
+++ b/frontend/apps/mobile/src/features/layout/types.ts
@@ -1,0 +1,12 @@
+export interface ResolvedSection {
+  type: string;
+  mode?: string;
+  props?: Record<string, unknown>;
+  presentation: 'visible' | 'placeholder';
+}
+
+export interface ResolvedScreen {
+  screen: string;
+  version: number;
+  sections: ResolvedSection[];
+}

--- a/frontend/apps/mobile/src/features/layout/useDashboardLayout.ts
+++ b/frontend/apps/mobile/src/features/layout/useDashboardLayout.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react';
+import { apiRequest } from '../../hooks/useApi';
+import { readCachedLayout, writeCachedLayout } from './layoutCache';
+import { DEFAULT_DASHBOARD_LAYOUT } from './registry';
+import type { ResolvedScreen } from './types';
+
+export function useDashboardLayout(screen: string): { layout: ResolvedScreen } {
+  const [layout, setLayout] = useState<ResolvedScreen>(DEFAULT_DASHBOARD_LAYOUT);
+  const warnedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function activate() {
+      // Phase 1: read cache at mount (activation — allowed at launch time)
+      const cached = await readCachedLayout(screen);
+      if (!cancelled && cached !== null) {
+        setLayout(cached);
+      }
+
+      // Phase 2: background fetch — writes cache ONLY (never sets state)
+      try {
+        const fresh = await apiRequest<ResolvedScreen>(
+          `/api/v1/layout/resolved/${screen}?platform=mobile`
+        );
+        if (!cancelled) {
+          // Shape-check before writing
+          if (
+            fresh &&
+            typeof fresh === 'object' &&
+            fresh.screen === screen &&
+            Array.isArray(fresh.sections)
+          ) {
+            await writeCachedLayout(screen, fresh);
+          }
+        }
+      } catch (err) {
+        if (!warnedRef.current) {
+          warnedRef.current = true;
+          console.warn('layout: background fetch failed', err);
+        }
+      }
+    }
+
+    activate();
+    return () => {
+      cancelled = true;
+    };
+  }, [screen]);
+
+  return { layout };
+}

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -490,5 +490,9 @@
     "errorRoleRequired": "Prosim zadejte nazev role.",
     "errorPasswordTooShort": "Heslo musi mit alespon 4 znaky.",
     "errorInvalidDays": "Prosim zadejte platny pocet dni."
+  },
+  "layout": {
+    "placeholderTitle": "Sekce není dostupná",
+    "placeholderBody": "Tato sekce momentálně není dostupná."
   }
 }

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -450,5 +450,9 @@
     "errorRoleRequired": "Bitte geben Sie einen Rollennamen ein.",
     "errorPasswordTooShort": "Das Passwort muss mindestens 4 Zeichen lang sein.",
     "errorInvalidDays": "Bitte geben Sie eine gultige Anzahl von Tagen ein."
+  },
+  "layout": {
+    "placeholderTitle": "Abschnitt nicht verfügbar",
+    "placeholderBody": "Dieser Abschnitt ist derzeit nicht verfügbar."
   }
 }

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -490,5 +490,9 @@
     "errorRoleRequired": "Please enter a role name.",
     "errorPasswordTooShort": "Password must be at least 4 characters.",
     "errorInvalidDays": "Please enter a valid number of days."
+  },
+  "layout": {
+    "placeholderTitle": "Section unavailable",
+    "placeholderBody": "This section is currently not available."
   }
 }

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -450,5 +450,9 @@
     "errorRoleRequired": "Kerlek add meg a szerepkor nevet.",
     "errorPasswordTooShort": "A jelszonak legalabb 4 karakternek kell lennie.",
     "errorInvalidDays": "Kerlek adj meg ervenyes napszamot."
+  },
+  "layout": {
+    "placeholderTitle": "Szakasz nem elérhető",
+    "placeholderBody": "Ez a szakasz jelenleg nem elérhető."
   }
 }

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -450,5 +450,9 @@
     "errorRoleRequired": "Prosze podac nazwe roli.",
     "errorPasswordTooShort": "Haslo musi miec co najmniej 4 znaki.",
     "errorInvalidDays": "Prosze podac prawidlowa liczbe dni."
+  },
+  "layout": {
+    "placeholderTitle": "Sekcja niedostępna",
+    "placeholderBody": "Ta sekcja jest obecnie niedostępna."
   }
 }

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -490,5 +490,9 @@
     "errorRoleRequired": "Prosim zadajte nazov roly.",
     "errorPasswordTooShort": "Heslo musi mat aspon 4 znaky.",
     "errorInvalidDays": "Prosim zadajte platny pocet dni."
+  },
+  "layout": {
+    "placeholderTitle": "Sekcia nie je dostupná",
+    "placeholderBody": "Táto sekcia momentálne nie je dostupná."
   }
 }

--- a/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.test.tsx
+++ b/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.test.tsx
@@ -13,6 +13,11 @@
  * the moment ANY query errors, and a retry button that refetches all four
  * queries. i18n `t` returns the key in tests (see src/test/setup.ts), so the
  * banner asserts on the `dashboard.loadError` / `common.retry` keys.
+ *
+ * NOTE: `useDashboardLayout` and `LayoutSections` are mocked so this suite
+ * stays focused on DashboardScreen's own four-query contract and error-banner
+ * logic. Stats/actions are rendered by registry components which have their
+ * own tests in layout.test.tsx.
  */
 
 import { fireEvent, render, screen } from '@testing-library/react-native';
@@ -29,6 +34,25 @@ jest.mock('../../contexts/AuthContext', () => ({
     user: { firstName: 'Ada', lastName: 'Byron' },
     logout: jest.fn(),
   }),
+}));
+
+// Mock useDashboardLayout so the layout hook doesn't trigger additional
+// useApiQuery calls through the section registry components.
+jest.mock('../../features/layout/useDashboardLayout', () => ({
+  useDashboardLayout: jest.fn(() => ({
+    layout: {
+      screen: 'ppt/dashboard',
+      version: 0,
+      sections: [],
+    },
+  })),
+}));
+
+// Mock LayoutSections to avoid rendering registry components (which also
+// call useApiQuery) so this suite stays focused on DashboardScreen's own
+// four-query contract and error-banner logic.
+jest.mock('../../features/layout/LayoutSections', () => ({
+  LayoutSections: () => null,
 }));
 
 const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
@@ -96,15 +120,13 @@ const allSuccess = () => [
 describe('DashboardScreen error state (#2282)', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('renders no error banner and shows real stats when all queries succeed', () => {
+  it('renders no error banner and shows announcement data when all queries succeed', () => {
     mockQueries(allSuccess());
     render(<DashboardScreen />);
 
     expect(screen.queryByText('dashboard.loadError')).toBeNull();
-    // pendingFaults = open_count + in_progress_count = 3
-    expect(screen.getByText('3')).toBeTruthy();
-    // unreadMessages = unreadCount = 5
-    expect(screen.getByText('5')).toBeTruthy();
+    // The announcements section renders real data from the query
+    expect(screen.getByText('Lift maintenance')).toBeTruthy();
   });
 
   it('shows the error banner when ANY query fails (not a silent all-zero state)', () => {

--- a/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
@@ -3,30 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { QueryErrorBanner } from '../../components';
 import { useAuth } from '../../contexts/AuthContext';
+import { LayoutSections } from '../../features/layout/LayoutSections';
+import { dashboardRegistry, NavigateContext } from '../../features/layout/registry';
+import { useDashboardLayout } from '../../features/layout/useDashboardLayout';
 import { useApiQuery } from '../../hooks/useApi';
 import { colors } from '../shared/screenStyles';
-
-// Dashboard card types
-interface DashboardStats {
-  pendingFaults: number;
-  unreadAnnouncements: number;
-  activeVotes: number;
-  unreadMessages: number;
-  upcomingPayments: number;
-}
 
 interface Announcement {
   id: string;
   title: string;
   createdAt: string;
   category: 'general' | 'urgent' | 'maintenance' | 'event';
-}
-
-interface PendingAction {
-  id: string;
-  type: 'vote' | 'payment' | 'reading' | 'fault';
-  title: string;
-  dueDate?: string;
 }
 
 interface ApiAnnouncement {
@@ -66,6 +53,7 @@ interface DashboardScreenProps {
 export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
   const { t, i18n } = useTranslation();
   const { user, logout } = useAuth();
+  const { layout } = useDashboardLayout('ppt/dashboard');
 
   // Each card pulls its own count so a single slow/down endpoint doesn't
   // stall the whole dashboard. `staleTime` is short here because the
@@ -98,35 +86,6 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
       // The list endpoint doesn't expose category yet — default to general
       // so the card colour stays neutral.
       category: 'general',
-    }));
-
-  const stats: DashboardStats = {
-    pendingFaults:
-      (faultsStatsQuery.data?.statistics?.open_count ?? 0) +
-      (faultsStatsQuery.data?.statistics?.in_progress_count ?? 0),
-    unreadAnnouncements: announcements.length,
-    activeVotes: (votesQuery.data?.votes ?? []).filter((v) => v.status === 'active').length,
-    unreadMessages:
-      unreadMessagesQuery.data?.unreadCount ??
-      unreadMessagesQuery.data?.unread_count ??
-      unreadMessagesQuery.data?.count ??
-      0,
-    upcomingPayments: 0,
-  };
-
-  // The api-server has no aggregate "pending resident actions" endpoint
-  // yet. Once it exists (one feed combining vote eligibility, due
-  // payments, scheduled meter reading windows, …) this card will read
-  // from there. For now show whatever signals we already have so the
-  // card isn't silently empty.
-  const pendingActions: PendingAction[] = (votesQuery.data?.votes ?? [])
-    .filter((v) => v.status === 'active')
-    .slice(0, 3)
-    .map((v) => ({
-      id: v.id,
-      type: 'vote',
-      title: v.title,
-      dueDate: v.end_at,
     }));
 
   const isFetching =
@@ -176,147 +135,101 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
     }
   };
 
-  const getActionIcon = (type: PendingAction['type']): string => {
-    switch (type) {
-      case 'vote':
-        return '🗳️';
-      case 'payment':
-        return '💳';
-      case 'reading':
-        return '📊';
-      case 'fault':
-        return '🔧';
-      default:
-        return '📋';
-    }
-  };
-
   return (
-    <View style={styles.container}>
-      {/* Header */}
-      <View style={styles.header}>
-        <View>
-          <Text style={styles.greeting}>{t('dashboard.welcomeBack')}</Text>
-          <Text style={styles.userName}>
-            {user?.firstName} {user?.lastName}
-          </Text>
-        </View>
-        <Pressable style={styles.logoutButton} onPress={logout}>
-          <Text style={styles.logoutText}>{t('auth.logout')}</Text>
-        </Pressable>
-      </View>
-
-      <ScrollView
-        style={styles.scrollView}
-        refreshControl={
-          <RefreshControl refreshing={isFetching} onRefresh={onRefresh} tintColor={colors.accent} />
-        }
-      >
-        {/* Error banner — shown when any card's query failed so the zeroed
-            stats below aren't mistaken for a genuinely empty building (#2282).
-            Extracted to the shared QueryErrorBanner component (#2323). */}
-        {hasError && <QueryErrorBanner message={t('dashboard.loadError')} onRetry={onRefresh} />}
-
-        {/* Stats Grid */}
-        <View style={styles.statsGrid}>
-          <Pressable style={styles.statCard} onPress={() => onNavigate?.('Faults')}>
-            <Text style={styles.statNumber}>{stats.pendingFaults}</Text>
-            <Text style={styles.statLabel}>{t('dashboard.openFaults')}</Text>
-          </Pressable>
-          <Pressable style={styles.statCard} onPress={() => onNavigate?.('Announcements')}>
-            <Text style={styles.statNumber}>{stats.unreadAnnouncements}</Text>
-            <Text style={styles.statLabel}>{t('dashboard.newAnnouncements')}</Text>
-          </Pressable>
-          <Pressable style={styles.statCard} onPress={() => onNavigate?.('Voting')}>
-            <Text style={styles.statNumber}>{stats.activeVotes}</Text>
-            <Text style={styles.statLabel}>{t('dashboard.activeVotes')}</Text>
-          </Pressable>
-          <Pressable style={styles.statCard} onPress={() => onNavigate?.('Messages')}>
-            <Text style={styles.statNumber}>{stats.unreadMessages}</Text>
-            <Text style={styles.statLabel}>{t('dashboard.unreadMessages')}</Text>
+    <NavigateContext.Provider value={onNavigate}>
+      <View style={styles.container}>
+        {/* Header */}
+        <View style={styles.header}>
+          <View>
+            <Text style={styles.greeting}>{t('dashboard.welcomeBack')}</Text>
+            <Text style={styles.userName}>
+              {user?.firstName} {user?.lastName}
+            </Text>
+          </View>
+          <Pressable style={styles.logoutButton} onPress={logout}>
+            <Text style={styles.logoutText}>{t('auth.logout')}</Text>
           </Pressable>
         </View>
 
-        {/* Pending Actions */}
-        {pendingActions.length > 0 && (
+        <ScrollView
+          style={styles.scrollView}
+          refreshControl={
+            <RefreshControl
+              refreshing={isFetching}
+              onRefresh={onRefresh}
+              tintColor={colors.accent}
+            />
+          }
+        >
+          {/* Error banner — shown when any card's query failed so the zeroed
+              stats below aren't mistaken for a genuinely empty building (#2282).
+              Extracted to the shared QueryErrorBanner component (#2323). */}
+          {hasError && <QueryErrorBanner message={t('dashboard.loadError')} onRetry={onRefresh} />}
+
+          {/* Managed sections — stats grid and pending actions are now rendered
+              through the layout registry (next-launch activation pattern). */}
+          <LayoutSections layout={layout} registry={dashboardRegistry} />
+
+          {/* Recent Announcements */}
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>{t('dashboard.pendingActions')}</Text>
-            <View style={styles.actionsList}>
-              {pendingActions.map((action) => (
-                <Pressable key={action.id} style={styles.actionCard}>
-                  <Text style={styles.actionIcon}>{getActionIcon(action.type)}</Text>
-                  <View style={styles.actionContent}>
-                    <Text style={styles.actionTitle}>{action.title}</Text>
-                    {action.dueDate && (
-                      <Text style={styles.actionDue}>
-                        {t('dashboard.due', { date: formatDate(action.dueDate) })}
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>{t('dashboard.recentAnnouncements')}</Text>
+              <Pressable onPress={() => onNavigate?.('Announcements')}>
+                <Text style={styles.seeAllText}>{t('dashboard.seeAll')}</Text>
+              </Pressable>
+            </View>
+            <View style={styles.announcementsList}>
+              {announcements.map((announcement) => (
+                <Pressable key={announcement.id} style={styles.announcementCard}>
+                  <View style={styles.announcementHeader}>
+                    <View
+                      style={[
+                        styles.categoryBadge,
+                        { backgroundColor: getCategoryColor(announcement.category) },
+                      ]}
+                    >
+                      <Text style={styles.categoryText}>
+                        {t(`dashboard.category.${announcement.category}`)}
                       </Text>
-                    )}
+                    </View>
+                    <Text style={styles.announcementDate}>
+                      {formatDate(announcement.createdAt)}
+                    </Text>
                   </View>
-                  <Text style={styles.actionArrow}>›</Text>
+                  <Text style={styles.announcementTitle}>{announcement.title}</Text>
                 </Pressable>
               ))}
             </View>
           </View>
-        )}
 
-        {/* Recent Announcements */}
-        <View style={styles.section}>
-          <View style={styles.sectionHeader}>
-            <Text style={styles.sectionTitle}>{t('dashboard.recentAnnouncements')}</Text>
-            <Pressable onPress={() => onNavigate?.('Announcements')}>
-              <Text style={styles.seeAllText}>{t('dashboard.seeAll')}</Text>
-            </Pressable>
-          </View>
-          <View style={styles.announcementsList}>
-            {announcements.map((announcement) => (
-              <Pressable key={announcement.id} style={styles.announcementCard}>
-                <View style={styles.announcementHeader}>
-                  <View
-                    style={[
-                      styles.categoryBadge,
-                      { backgroundColor: getCategoryColor(announcement.category) },
-                    ]}
-                  >
-                    <Text style={styles.categoryText}>
-                      {t(`dashboard.category.${announcement.category}`)}
-                    </Text>
-                  </View>
-                  <Text style={styles.announcementDate}>{formatDate(announcement.createdAt)}</Text>
-                </View>
-                <Text style={styles.announcementTitle}>{announcement.title}</Text>
+          {/* Quick Actions */}
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>{t('dashboard.quickActions')}</Text>
+            <View style={styles.quickActionsGrid}>
+              <Pressable style={styles.quickAction} onPress={() => onNavigate?.('ReportFault')}>
+                <Text style={styles.quickActionIcon}>🔧</Text>
+                <Text style={styles.quickActionLabel}>{t('dashboard.reportFault')}</Text>
               </Pressable>
-            ))}
+              <Pressable style={styles.quickAction} onPress={() => onNavigate?.('Documents')}>
+                <Text style={styles.quickActionIcon}>📄</Text>
+                <Text style={styles.quickActionLabel}>{t('dashboard.documents')}</Text>
+              </Pressable>
+              <Pressable style={styles.quickAction} onPress={() => onNavigate?.('MeterReading')}>
+                <Text style={styles.quickActionIcon}>📊</Text>
+                <Text style={styles.quickActionLabel}>{t('dashboard.meterReading')}</Text>
+              </Pressable>
+              <Pressable style={styles.quickAction} onPress={() => onNavigate?.('Payments')}>
+                <Text style={styles.quickActionIcon}>💳</Text>
+                <Text style={styles.quickActionLabel}>{t('dashboard.payments')}</Text>
+              </Pressable>
+            </View>
           </View>
-        </View>
 
-        {/* Quick Actions */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>{t('dashboard.quickActions')}</Text>
-          <View style={styles.quickActionsGrid}>
-            <Pressable style={styles.quickAction} onPress={() => onNavigate?.('ReportFault')}>
-              <Text style={styles.quickActionIcon}>🔧</Text>
-              <Text style={styles.quickActionLabel}>{t('dashboard.reportFault')}</Text>
-            </Pressable>
-            <Pressable style={styles.quickAction} onPress={() => onNavigate?.('Documents')}>
-              <Text style={styles.quickActionIcon}>📄</Text>
-              <Text style={styles.quickActionLabel}>{t('dashboard.documents')}</Text>
-            </Pressable>
-            <Pressable style={styles.quickAction} onPress={() => onNavigate?.('MeterReading')}>
-              <Text style={styles.quickActionIcon}>📊</Text>
-              <Text style={styles.quickActionLabel}>{t('dashboard.meterReading')}</Text>
-            </Pressable>
-            <Pressable style={styles.quickAction} onPress={() => onNavigate?.('Payments')}>
-              <Text style={styles.quickActionIcon}>💳</Text>
-              <Text style={styles.quickActionLabel}>{t('dashboard.payments')}</Text>
-            </Pressable>
-          </View>
-        </View>
-
-        {/* Bottom spacing */}
-        <View style={styles.bottomSpacer} />
-      </ScrollView>
-    </View>
+          {/* Bottom spacing */}
+          <View style={styles.bottomSpacer} />
+        </ScrollView>
+      </View>
+    </NavigateContext.Provider>
   );
 }
 
@@ -335,22 +248,6 @@ const styles = StyleSheet.create({
   logoutButton: { padding: 8 },
   logoutText: { color: 'rgba(255, 255, 255, 0.9)', fontSize: 14 },
   scrollView: { flex: 1 },
-  statsGrid: { flexDirection: 'row', flexWrap: 'wrap', padding: 16, gap: 12 },
-  statCard: {
-    flex: 1,
-    minWidth: '45%',
-    backgroundColor: colors.surface,
-    borderRadius: 12,
-    padding: 16,
-    alignItems: 'center',
-    shadowColor: colors.shadow,
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 2,
-    elevation: 1,
-  },
-  statNumber: { fontSize: 28, fontWeight: 'bold', color: colors.accent },
-  statLabel: { fontSize: 12, color: colors.textMuted, marginTop: 4, textAlign: 'center' },
   section: { padding: 16 },
   sectionHeader: {
     flexDirection: 'row',
@@ -360,24 +257,6 @@ const styles = StyleSheet.create({
   },
   sectionTitle: { fontSize: 18, fontWeight: '600', color: colors.text, marginBottom: 12 },
   seeAllText: { color: colors.accent, fontSize: 14 },
-  actionsList: { gap: 8 },
-  actionCard: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: colors.surface,
-    borderRadius: 12,
-    padding: 16,
-    shadowColor: colors.shadow,
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.05,
-    shadowRadius: 2,
-    elevation: 1,
-  },
-  actionIcon: { fontSize: 24, marginRight: 12 },
-  actionContent: { flex: 1 },
-  actionTitle: { fontSize: 15, fontWeight: '500', color: colors.text },
-  actionDue: { fontSize: 13, color: colors.warning, marginTop: 2 },
-  actionArrow: { fontSize: 24, color: colors.textSubtle },
   announcementsList: { gap: 8 },
   announcementCard: {
     backgroundColor: colors.surface,

--- a/frontend/apps/mobile/src/services/localCacheKeys.ts
+++ b/frontend/apps/mobile/src/services/localCacheKeys.ts
@@ -20,3 +20,8 @@ export const LAST_SYNC_KEY = 'ppt_last_sync';
 // widget layout config (which references building ids, i.e. tenant data).
 export const WIDGET_CONFIG_KEY = '@ppt/widget_configs';
 export const WIDGET_DATA_KEY = '@ppt/widget_data';
+
+// `useDashboardLayout` / layout registry — server-driven resolved screen layout,
+// persisted across restarts so the last-known layout activates at launch before
+// the background fetch completes (next-launch activation pattern).
+export const LAYOUT_CACHE_KEY = (screen: string) => `ppt_layout_${screen.replace(/\//g, '_')}`;

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailContent.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailContent.kt
@@ -42,21 +42,42 @@ internal fun ListingContent(
         )
 
     // Determine whether the agent-contact section is active (visible, non-placeholder).
-    // This controls BottomActionBar visibility outside the LazyColumn.
-    val showActionBar = ListingSectionRegistry.sectionAgentContactIsActive(layout.sections)
+    // StickyAgentBar and BottomActionBar positions are FIXED — agent-contact.v1 controls
+    // visibility only, not render position (position-independent bar placement).
+    val showAgentBars = ListingSectionRegistry.sectionAgentContactIsActive(layout.sections)
+
+    // True when a visible (non-placeholder) gallery section is present in the layout.
+    val hasVisibleGallery = layout.sections.any { it.type == "gallery.v1" && !it.isPlaceholder }
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = if (showActionBar) 110.dp else 16.dp),
+            contentPadding = PaddingValues(bottom = if (showAgentBars) 110.dp else 16.dp),
         ) {
+            // When no visible gallery is present but agent bars are active, StickyAgentBar
+            // renders at the very top of the list (traditional fallback position).
+            if (showAgentBars && !hasVisibleGallery) {
+                item(key = "agent-contact-bar") {
+                    StickyAgentBar(listing = ctx.listing, onCallClick = ctx.onCallClick)
+                }
+            }
+
             for (section in layout.sections) {
                 sectionItems(section = section, ctx = ctx)
+                // After the gallery item, insert StickyAgentBar at its traditional fixed slot.
+                // This is position-independent: agent-contact.v1 controls visibility but NOT
+                // the render position — so the bar always appears right after the gallery
+                // regardless of where agent-contact.v1 lands in the server layout order.
+                if (section.type == "gallery.v1" && !section.isPlaceholder && showAgentBars) {
+                    item(key = "agent-contact-bar") {
+                        StickyAgentBar(listing = ctx.listing, onCallClick = ctx.onCallClick)
+                    }
+                }
             }
             item { Spacer(modifier = Modifier.height(16.dp)) }
         }
 
-        if (showActionBar) {
+        if (showAgentBars) {
             BottomActionBar(
                 modifier = Modifier.align(Alignment.BottomCenter),
                 onMessageClick = onMessageClick,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailContent.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailContent.kt
@@ -3,13 +3,14 @@ package three.two.bit.ppt.reality.ui.listing
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import three.two.bit.ppt.reality.layout.ResolvedLayoutScreen
 import three.two.bit.ppt.reality.listing.*
+import three.two.bit.ppt.reality.ui.listing.ListingSectionRegistry.sectionItems
 
 // ─── Content ────────────────────────────────────────────────────────────────
 
@@ -17,6 +18,7 @@ import three.two.bit.ppt.reality.listing.*
 @Composable
 internal fun ListingContent(
     listing: ListingDetail,
+    layout: ResolvedLayoutScreen,
     isFavorite: Boolean,
     onBackClick: () -> Unit,
     onShareClick: () -> Unit,
@@ -26,42 +28,40 @@ internal fun ListingContent(
     onInquiryClick: () -> Unit,
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
+
+    val ctx =
+        ListingSectionContext(
+            listing = listing,
+            isFavorite = isFavorite,
+            selectedTab = selectedTab,
+            onBackClick = onBackClick,
+            onShareClick = onShareClick,
+            onFavoriteClick = onFavoriteClick,
+            onCallClick = onCallClick,
+            onTabSelect = { selectedTab = it },
+        )
+
+    // Determine whether the agent-contact section is active (visible, non-placeholder).
+    // This controls BottomActionBar visibility outside the LazyColumn.
+    val showActionBar = ListingSectionRegistry.sectionAgentContactIsActive(layout.sections)
+
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 110.dp),
+            contentPadding = PaddingValues(bottom = if (showActionBar) 110.dp else 16.dp),
         ) {
-            item {
-                HeroGallery(
-                    images = listing.images,
-                    isFavorite = isFavorite,
-                    onBackClick = onBackClick,
-                    onShareClick = onShareClick,
-                    onFavoriteClick = onFavoriteClick,
-                )
-            }
-            item { StickyAgentBar(listing = listing, onCallClick = onCallClick) }
-            item { HeaderSection(listing = listing) }
-            item { Spacer(modifier = Modifier.height(18.dp)) }
-            item { QuickStatsStrip(listing = listing) }
-            item { TabStrip(selected = selectedTab, onSelect = { selectedTab = it }) }
-            when (selectedTab) {
-                0 -> {
-                    item { DescriptionBody(description = listing.description) }
-                    if (listing.features.isNotEmpty()) {
-                        item { FeaturesChips(features = listing.features) }
-                    }
-                }
-                1 -> item { BuildingPassportCard(listing = listing) }
-                2 -> item { NearbyPreviewCard() }
-                3 -> item { PriceHistoryCard(listing = listing) }
+            for (section in layout.sections) {
+                sectionItems(section = section, ctx = ctx)
             }
             item { Spacer(modifier = Modifier.height(16.dp)) }
         }
-        BottomActionBar(
-            modifier = Modifier.align(Alignment.BottomCenter),
-            onMessageClick = onMessageClick,
-            onInquiryClick = onInquiryClick,
-        )
+
+        if (showActionBar) {
+            BottomActionBar(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                onMessageClick = onMessageClick,
+                onInquiryClick = onInquiryClick,
+            )
+        }
     }
 }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailScreen.kt
@@ -3,7 +3,6 @@ package three.two.bit.ppt.reality.ui.listing
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
@@ -18,6 +17,9 @@ import three.two.bit.ppt.reality.R
 import three.two.bit.ppt.reality.api.ApiConfig
 import three.two.bit.ppt.reality.auth.AuthState
 import three.two.bit.ppt.reality.auth.SsoService
+import three.two.bit.ppt.reality.layout.DEFAULT_LISTING_DETAIL_LAYOUT
+import three.two.bit.ppt.reality.layout.LayoutRepository
+import three.two.bit.ppt.reality.layout.ResolvedLayoutScreen
 import three.two.bit.ppt.reality.listing.*
 import three.two.bit.ppt.reality.util.isNetworkError
 
@@ -47,6 +49,12 @@ import three.two.bit.ppt.reality.util.isNetworkError
  * as flows (E2 / F2) that live in screens-extension.jsx and aren't fully re-mocked here.
  *
  * Epic 48 - Story 48.2: Portal Mobile Listing View.
+ *
+ * Task 3 (layout dispatch): screen state now starts at [DEFAULT_LISTING_DETAIL_LAYOUT] and fetches
+ * the server-resolved layout once on entry via [LayoutRepository]. Section rendering is delegated
+ * to [ListingSectionRegistry]. The layout fetch is kept in this composable (not in the ViewModel)
+ * because it is screen-level infrastructure orthogonal to listing data / favorites / inquiry state
+ * already owned by [ListingDetailViewModel].
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -95,6 +103,14 @@ fun ListingDetailScreen(
         }
     }
 
+    // Layout state — starts at the compiled default and settles once on entry after the
+    // server responds. LayoutRepository.getListingDetailLayout() never throws (see Task 2).
+    // Keyed on listingId so navigating to a different listing triggers a fresh fetch.
+    var layout by
+        remember(listingId) { mutableStateOf<ResolvedLayoutScreen>(DEFAULT_LISTING_DETAIL_LAYOUT) }
+    val layoutRepository = remember { LayoutRepository() }
+    LaunchedEffect(listingId) { layout = layoutRepository.getListingDetailLayout() }
+
     Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         when {
             state.isLoading ->
@@ -107,6 +123,7 @@ fun ListingDetailScreen(
                 Box(modifier = Modifier.fillMaxSize()) {
                     ListingContent(
                         listing = state.listing!!,
+                        layout = layout,
                         isFavorite = state.isFavorite,
                         onBackClick = onBackClick,
                         onShareClick = viewModel::onShowShareSheet,

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
@@ -43,9 +43,12 @@ data class ListingSectionContext(
  * - listing-header.v1 → [HeaderSection]
  * - key-details.v1 → [QuickStatsStrip]
  * - description.v1 → [TabStrip] + tab-gated description / building / nearby / price-history
- * - agent-contact.v1 → controls [StickyAgentBar] visibility (rendered inline in the list) and
- *   signals [BottomActionBar] visibility (tracked separately by the caller via
- *   [sectionHasAgentContact] / [sectionAgentContactIsActive])
+ * - agent-contact.v1 → POSITION-INDEPENDENT: the VISIBILITY of [StickyAgentBar] and
+ *   [BottomActionBar] is gated on this section being present and active, but the bars are rendered
+ *   at fixed positions by the caller ([ListingContent]) — NOT at the section's list position. This
+ *   ensures pixel-identical output regardless of where agent-contact.v1 appears in the server
+ *   layout (e.g. last in [DEFAULT_LISTING_DETAIL_LAYOUT]). Only the placeholder case emits a card
+ *   in-list.
  * - features.v1 → no-op (features are rendered inside description.v1's tab 0)
  * - additional-info.v1 → no-op
  * - resources.v1 → no-op
@@ -76,13 +79,15 @@ object ListingSectionRegistry {
     /**
      * Emit LazyList items for a single [section].
      *
-     * The [agentContactSection] helpers ([sectionHasAgentContact] / [sectionAgentContactIsActive])
-     * let the caller decide whether to render [BottomActionBar] outside the lazy list without
-     * requiring a separate pass over the sections list.
+     * The [sectionAgentContactIsActive] helper lets the caller decide whether to render
+     * [StickyAgentBar] and [BottomActionBar] at their fixed visual positions (after the gallery and
+     * at screen-bottom respectively) without requiring a separate pass over the sections list.
      *
-     * NOTE: agent-contact.v1 is the only type whose output (StickyAgentBar) is rendered *inside*
-     * the LazyColumn here; the BottomActionBar must be placed by the caller at screen bottom
-     * (outside the LazyColumn) and should only render when [sectionAgentContactIsActive] is true.
+     * NOTE: agent-contact.v1 with a non-placeholder presentation emits NOTHING in the lazy list.
+     * [StickyAgentBar] is placed by the caller immediately after the gallery item;
+     * [BottomActionBar] is placed by the caller outside the LazyColumn at screen-bottom. This makes
+     * bar position independent of where agent-contact.v1 appears in the server-resolved layout
+     * order.
      */
     fun LazyListScope.sectionItems(section: ResolvedLayoutSection, ctx: ListingSectionContext) {
         when (section.type) {
@@ -103,13 +108,14 @@ object ListingSectionRegistry {
             }
 
             "agent-contact.v1" -> {
+                // POSITION-INDEPENDENT: when the section is active (non-placeholder), the bars
+                // are rendered at fixed slots by the caller (StickyAgentBar after gallery,
+                // BottomActionBar at screen-bottom). Nothing is emitted in-list for the active
+                // case so that the bar position does not change with the layout order.
                 if (section.isPlaceholder) {
                     item(key = "placeholder-agent-contact") { PlaceholderSection() }
-                } else {
-                    item(key = "agent-contact") {
-                        StickyAgentBar(listing = ctx.listing, onCallClick = ctx.onCallClick)
-                    }
                 }
+                // else: no-op — StickyAgentBar and BottomActionBar rendered by ListingContent
             }
 
             "listing-header.v1" -> {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
@@ -1,0 +1,212 @@
+package three.two.bit.ppt.reality.ui.listing
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import three.two.bit.ppt.reality.R
+import three.two.bit.ppt.reality.layout.ResolvedLayoutSection
+import three.two.bit.ppt.reality.listing.ListingDetail
+
+/**
+ * Context object that bundles the parameters the individual listing-section composables need.
+ * Passed through [ListingSectionRegistry.sectionItems] so callers do not need to thread each
+ * individual callback down into the registry.
+ */
+data class ListingSectionContext(
+    val listing: ListingDetail,
+    val isFavorite: Boolean,
+    val selectedTab: Int,
+    val onBackClick: () -> Unit,
+    val onShareClick: () -> Unit,
+    val onFavoriteClick: () -> Unit,
+    val onCallClick: () -> Unit,
+    val onTabSelect: (Int) -> Unit,
+)
+
+/**
+ * Dispatches [ResolvedLayoutSection] entries from the server-resolved layout onto the existing
+ * listing-detail composables.
+ *
+ * Supported types:
+ * - gallery.v1 → [HeroGallery]
+ * - listing-header.v1 → [HeaderSection]
+ * - key-details.v1 → [QuickStatsStrip]
+ * - description.v1 → [TabStrip] + tab-gated description / building / nearby / price-history
+ * - agent-contact.v1 → controls [StickyAgentBar] visibility (rendered inline in the list) and
+ *   signals [BottomActionBar] visibility (tracked separately by the caller via
+ *   [sectionHasAgentContact] / [sectionAgentContactIsActive])
+ * - features.v1 → no-op (features are rendered inside description.v1's tab 0)
+ * - additional-info.v1 → no-op
+ * - resources.v1 → no-op
+ * - unknown → no-op (+ log warn)
+ *
+ * Placeholder presentation → [PlaceholderSection] (neutral card, ~96dp) instead of the real
+ * composable. For agent-contact.v1 with placeholder presentation: placeholder card in the list,
+ * neither [StickyAgentBar] nor [BottomActionBar] renders.
+ *
+ * Under [DEFAULT_LISTING_DETAIL_LAYOUT] the output is pixel-identical to the prior fixed item {}
+ * list — this is a pure restructure.
+ */
+object ListingSectionRegistry {
+
+    /** The eight section types the registry knows about. */
+    val supportedTypes: Set<String> =
+        setOf(
+            "gallery.v1",
+            "listing-header.v1",
+            "key-details.v1",
+            "description.v1",
+            "agent-contact.v1",
+            "features.v1",
+            "additional-info.v1",
+            "resources.v1",
+        )
+
+    /**
+     * Emit LazyList items for a single [section].
+     *
+     * The [agentContactSection] helpers ([sectionHasAgentContact] / [sectionAgentContactIsActive])
+     * let the caller decide whether to render [BottomActionBar] outside the lazy list without
+     * requiring a separate pass over the sections list.
+     *
+     * NOTE: agent-contact.v1 is the only type whose output (StickyAgentBar) is rendered *inside*
+     * the LazyColumn here; the BottomActionBar must be placed by the caller at screen bottom
+     * (outside the LazyColumn) and should only render when [sectionAgentContactIsActive] is true.
+     */
+    fun LazyListScope.sectionItems(section: ResolvedLayoutSection, ctx: ListingSectionContext) {
+        when (section.type) {
+            "gallery.v1" -> {
+                if (section.isPlaceholder) {
+                    item(key = "placeholder-gallery") { PlaceholderSection() }
+                } else {
+                    item(key = "gallery") {
+                        HeroGallery(
+                            images = ctx.listing.images,
+                            isFavorite = ctx.isFavorite,
+                            onBackClick = ctx.onBackClick,
+                            onShareClick = ctx.onShareClick,
+                            onFavoriteClick = ctx.onFavoriteClick,
+                        )
+                    }
+                }
+            }
+
+            "agent-contact.v1" -> {
+                if (section.isPlaceholder) {
+                    item(key = "placeholder-agent-contact") { PlaceholderSection() }
+                } else {
+                    item(key = "agent-contact") {
+                        StickyAgentBar(listing = ctx.listing, onCallClick = ctx.onCallClick)
+                    }
+                }
+            }
+
+            "listing-header.v1" -> {
+                if (section.isPlaceholder) {
+                    item(key = "placeholder-listing-header") { PlaceholderSection() }
+                } else {
+                    item(key = "listing-header") { HeaderSection(listing = ctx.listing) }
+                }
+            }
+
+            "key-details.v1" -> {
+                if (section.isPlaceholder) {
+                    item(key = "placeholder-key-details") { PlaceholderSection() }
+                } else {
+                    item(key = "key-details") { QuickStatsStrip(listing = ctx.listing) }
+                }
+            }
+
+            "description.v1" -> {
+                if (section.isPlaceholder) {
+                    item(key = "placeholder-description") { PlaceholderSection() }
+                } else {
+                    item(key = "tab-strip") {
+                        TabStrip(selected = ctx.selectedTab, onSelect = ctx.onTabSelect)
+                    }
+                    when (ctx.selectedTab) {
+                        0 -> {
+                            item(key = "description-body") {
+                                DescriptionBody(description = ctx.listing.description)
+                            }
+                            if (ctx.listing.features.isNotEmpty()) {
+                                item(key = "features-chips") {
+                                    FeaturesChips(features = ctx.listing.features)
+                                }
+                            }
+                        }
+                        1 ->
+                            item(key = "building-passport") {
+                                BuildingPassportCard(listing = ctx.listing)
+                            }
+                        2 -> item(key = "nearby-preview") { NearbyPreviewCard() }
+                        3 -> item(key = "price-history") { PriceHistoryCard(listing = ctx.listing) }
+                    }
+                }
+            }
+
+            // features.v1, additional-info.v1, resources.v1 — folded into other sections
+            "features.v1",
+            "additional-info.v1",
+            "resources.v1" -> {
+                // intentional no-op: content rendered as part of other sections
+            }
+
+            else -> {
+                // Unknown section type — log warn and no-op
+                println(
+                    "WARN ListingSectionRegistry: unknown section type '${section.type}' — skipping"
+                )
+            }
+        }
+    }
+
+    /**
+     * Returns true when the sections list contains an agent-contact.v1 section that is NOT a
+     * placeholder (i.e. the bottom action bar should be rendered).
+     */
+    fun sectionAgentContactIsActive(sections: List<ResolvedLayoutSection>): Boolean = sections.any {
+        it.type == "agent-contact.v1" && !it.isPlaceholder
+    }
+}
+
+// ─── Placeholder ─────────────────────────────────────────────────────────────
+
+/**
+ * Neutral placeholder card shown when a section's presentation is "placeholder". Min height ~96dp,
+ * uses surface-variant background and onSurfaceVariant text to stay neutral. String resource
+ * [R.string.detail_section_unavailable] follows app string-resource conventions.
+ */
+@Composable
+fun PlaceholderSection(modifier: Modifier = Modifier) {
+    Card(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 96.dp)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth().heightIn(min = 96.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(R.string.detail_section_unavailable),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
@@ -1,7 +1,9 @@
 package three.two.bit.ppt.reality.ui.listing
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListScope
@@ -123,6 +125,8 @@ object ListingSectionRegistry {
                     item(key = "placeholder-listing-header") { PlaceholderSection() }
                 } else {
                     item(key = "listing-header") { HeaderSection(listing = ctx.listing) }
+                    // Pre-refactor layout had a dedicated 18dp gap after the header.
+                    item(key = "listing-header-gap") { Spacer(modifier = Modifier.height(18.dp)) }
                 }
             }
 

--- a/mobile-native/androidApp/src/main/res/values/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values/strings.xml
@@ -412,6 +412,7 @@
     <string name="send_feedback">Send Feedback</string>
 
     <!-- Listing Detail Screen -->
+    <string name="detail_section_unavailable">Sekcia nie je dostupná</string>
     <string name="detail_stat_area">Area</string>
     <string name="detail_stat_built">Built</string>
     <string name="detail_stat_energy">Energy</string>

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/DefaultLayout.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/DefaultLayout.kt
@@ -1,0 +1,25 @@
+package three.two.bit.ppt.reality.layout
+
+/**
+ * Compiled default layout for the Reality Portal listing-detail screen.
+ *
+ * Used as a fallback when the server is unreachable, returns a non-2xx status, returns a malformed
+ * body, or echoes back a different screen identifier than expected. The section order mirrors the
+ * web base order defined in the design spec.
+ */
+val DEFAULT_LISTING_DETAIL_LAYOUT =
+    ResolvedLayoutScreen(
+        screen = "reality/listing-detail",
+        version = 0,
+        sections =
+            listOf(
+                ResolvedLayoutSection(type = "gallery.v1"),
+                ResolvedLayoutSection(type = "listing-header.v1"),
+                ResolvedLayoutSection(type = "key-details.v1"),
+                ResolvedLayoutSection(type = "description.v1"),
+                ResolvedLayoutSection(type = "features.v1"),
+                ResolvedLayoutSection(type = "additional-info.v1"),
+                ResolvedLayoutSection(type = "resources.v1"),
+                ResolvedLayoutSection(type = "agent-contact.v1"),
+            ),
+    )

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/DefaultLayout.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/DefaultLayout.kt
@@ -4,8 +4,9 @@ package three.two.bit.ppt.reality.layout
  * Compiled default layout for the Reality Portal listing-detail screen.
  *
  * Used as a fallback when the server is unreachable, returns a non-2xx status, returns a malformed
- * body, or echoes back a different screen identifier than expected. The section order mirrors the
- * web base order defined in the design spec.
+ * body, or echoes back a different screen identifier than expected. The section order mirrors
+ * reality-web's DEFAULT_LISTING_DETAIL_LAYOUT (frontend/apps/reality-web/src/lib/layout.ts);
+ * agent-contact.v1 is last in both.
  */
 val DEFAULT_LISTING_DETAIL_LAYOUT =
     ResolvedLayoutScreen(

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutModels.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutModels.kt
@@ -1,0 +1,41 @@
+package three.two.bit.ppt.reality.layout
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Layout models for Reality Portal mobile app.
+ *
+ * Presentation is a String (not an enum) to guard against the enum-unknown-value hazard: unknown
+ * presentation strings from the server would crash an enum decoder. Instead, defensive helpers
+ * [isPlaceholder] and [isVisible] interpret the value safely — unknown strings map to visible.
+ */
+
+/** A single resolved layout section with type, optional mode/props, and a presentation hint. */
+@Serializable
+data class ResolvedLayoutSection(
+    val type: String,
+    val mode: String? = null,
+    @SerialName("props") val props: JsonObject? = null,
+    val presentation: String = "visible",
+) {
+    /** True when this section is explicitly a placeholder (hidden slot in the layout). */
+    val isPlaceholder: Boolean
+        get() = presentation == "placeholder"
+
+    /**
+     * True when this section should be rendered. Unknown presentation strings are treated as
+     * visible (defensive — future server values must not suppress content silently).
+     */
+    val isVisible: Boolean
+        get() = !isPlaceholder
+}
+
+/** A fully resolved layout screen containing an ordered list of sections. */
+@Serializable
+data class ResolvedLayoutScreen(
+    val screen: String,
+    val version: Int,
+    val sections: List<ResolvedLayoutSection>,
+)

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutRepository.kt
@@ -1,0 +1,56 @@
+package three.two.bit.ppt.reality.layout
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import three.two.bit.ppt.reality.api.ApiConfig
+import three.two.bit.ppt.reality.api.HttpClientProvider
+
+/**
+ * Repository for layout operations.
+ *
+ * Fetches resolved layout configurations from the server. Never throws: any failure (network,
+ * non-2xx, malformed body, screen-echo mismatch) returns [DEFAULT_LISTING_DETAIL_LAYOUT].
+ *
+ * The endpoint path `layout/resolved/reality/listing-detail` is built with literal `/` separators
+ * so that the axum `{*screen}` catch-all route on the server matches correctly. Percent-encoding
+ * the `/` would produce `reality%2Flisting-detail`, which does NOT match the wildcard route.
+ */
+class LayoutRepository(
+    private val baseUrl: String = ApiConfig.baseUrl,
+    private val client: HttpClient = HttpClientProvider.client,
+) {
+
+    /**
+     * Fetch the resolved listing-detail layout for mobile.
+     *
+     * GET `$baseUrl/api/v1/layout/resolved/reality/listing-detail?platform=mobile`
+     *
+     * On any failure (non-2xx, network error, JSON decode error, or server echoes a different
+     * screen identifier) returns [DEFAULT_LISTING_DETAIL_LAYOUT]. An empty sections list from a 200
+     * response is accepted as-is.
+     */
+    suspend fun getListingDetailLayout(): ResolvedLayoutScreen {
+        return try {
+            val response =
+                client.get("$baseUrl/api/v1/layout/resolved/reality/listing-detail") {
+                    parameter("platform", "mobile")
+                }
+
+            if (!response.status.isSuccess()) {
+                return DEFAULT_LISTING_DETAIL_LAYOUT
+            }
+
+            val layout = response.body<ResolvedLayoutScreen>()
+
+            if (layout.screen != DEFAULT_LISTING_DETAIL_LAYOUT.screen) {
+                DEFAULT_LISTING_DETAIL_LAYOUT
+            } else {
+                layout
+            }
+        } catch (_: Exception) {
+            DEFAULT_LISTING_DETAIL_LAYOUT
+        }
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutModelsContractTest.kt
@@ -1,0 +1,215 @@
+package three.two.bit.ppt.reality.layout
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Contract tests for the layout-domain DTOs.
+ *
+ * Pins the wire shape produced/consumed by the reality-server layout endpoint so that any drift in
+ *
+ * @SerialName annotations or model edits is caught at build time. The server's serde output skips
+ *   absent optional fields (mode, props) — verified here via round-trip with encodeDefaults=false.
+ */
+class LayoutModelsContractTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = false
+    }
+
+    // The canonical server-shape fixture. Note: mode and props are absent (null → omitted).
+    private val serverFixture =
+        """
+        {
+          "screen": "reality/listing-detail",
+          "version": 0,
+          "sections": [
+            {"type": "gallery.v1", "presentation": "visible"},
+            {"type": "listing-header.v1", "presentation": "visible"},
+            {"type": "key-details.v1", "presentation": "visible"},
+            {"type": "description.v1", "presentation": "visible"},
+            {"type": "features.v1", "presentation": "visible"},
+            {"type": "additional-info.v1", "presentation": "visible"},
+            {"type": "resources.v1", "presentation": "visible"},
+            {"type": "agent-contact.v1", "presentation": "visible"}
+          ]
+        }
+        """
+            .trimIndent()
+
+    // -------------------------------------------------------------------
+    // Decode from server fixture
+    // -------------------------------------------------------------------
+
+    @Test
+    fun resolvedLayoutScreen_decodes_server_fixture() {
+        val screen: ResolvedLayoutScreen = json.decodeFromString(serverFixture)
+
+        assertEquals("reality/listing-detail", screen.screen)
+        assertEquals(0, screen.version)
+        assertEquals(8, screen.sections.size)
+    }
+
+    @Test
+    fun resolvedLayoutScreen_sections_decode_in_order() {
+        val screen: ResolvedLayoutScreen = json.decodeFromString(serverFixture)
+
+        assertEquals("gallery.v1", screen.sections[0].type)
+        assertEquals("listing-header.v1", screen.sections[1].type)
+        assertEquals("key-details.v1", screen.sections[2].type)
+        assertEquals("description.v1", screen.sections[3].type)
+        assertEquals("features.v1", screen.sections[4].type)
+        assertEquals("additional-info.v1", screen.sections[5].type)
+        assertEquals("resources.v1", screen.sections[6].type)
+        assertEquals("agent-contact.v1", screen.sections[7].type)
+    }
+
+    @Test
+    fun resolvedLayoutSection_visible_presentation_decoded() {
+        val screen: ResolvedLayoutScreen = json.decodeFromString(serverFixture)
+
+        for (section in screen.sections) {
+            assertEquals("visible", section.presentation, "all fixture sections should be visible")
+            assertTrue(section.isVisible)
+            assertFalse(section.isPlaceholder)
+        }
+    }
+
+    @Test
+    fun resolvedLayoutSection_absent_mode_and_props_are_null() {
+        val screen: ResolvedLayoutScreen = json.decodeFromString(serverFixture)
+
+        for (section in screen.sections) {
+            assertNull(section.mode, "mode should be null when absent in JSON")
+            assertNull(section.props, "props should be null when absent in JSON")
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Encode → matches server wire shape (mode/props absent when null)
+    // -------------------------------------------------------------------
+
+    @Test
+    fun resolvedLayoutSection_null_mode_and_props_omitted_in_encode() {
+        val section = ResolvedLayoutSection(type = "gallery.v1", presentation = "visible")
+        val encoded = json.encodeToString(section)
+
+        assertFalse(encoded.contains("\"mode\""), "null mode must be omitted: $encoded")
+        assertFalse(encoded.contains("\"props\""), "null props must be omitted: $encoded")
+        assertTrue(encoded.contains("\"type\":\"gallery.v1\""))
+        // With encodeDefaults=false the presentation default ("visible") is omitted in the
+        // encoded output — the server always sends it explicitly, but the client omits defaults
+        // to keep payloads lean. Decode is the authoritative contract; see round-trip tests.
+        assertFalse(
+            encoded.contains("\"presentation\""),
+            "default presentation omitted with encodeDefaults=false: $encoded",
+        )
+    }
+
+    // -------------------------------------------------------------------
+    // Round-trip
+    // -------------------------------------------------------------------
+
+    @Test
+    fun resolvedLayoutScreen_round_trips_through_json() {
+        val original: ResolvedLayoutScreen = json.decodeFromString(serverFixture)
+        val encoded = json.encodeToString(original)
+        val decoded: ResolvedLayoutScreen = json.decodeFromString(encoded)
+
+        assertEquals(original, decoded)
+    }
+
+    @Test
+    fun resolvedLayoutScreen_with_placeholder_round_trips() {
+        val screen =
+            ResolvedLayoutScreen(
+                screen = "reality/listing-detail",
+                version = 1,
+                sections =
+                    listOf(
+                        ResolvedLayoutSection(type = "gallery.v1", presentation = "visible"),
+                        ResolvedLayoutSection(
+                            type = "key-details.v1",
+                            presentation = "placeholder",
+                        ),
+                    ),
+            )
+
+        val decoded: ResolvedLayoutScreen = json.decodeFromString(json.encodeToString(screen))
+
+        assertEquals(screen, decoded)
+        assertTrue(decoded.sections[1].isPlaceholder)
+        assertFalse(decoded.sections[1].isVisible)
+    }
+
+    // -------------------------------------------------------------------
+    // Placeholder presentation
+    // -------------------------------------------------------------------
+
+    @Test
+    fun resolvedLayoutSection_placeholder_presentation_parsed() {
+        val raw = """{"type":"gallery.v1","presentation":"placeholder"}"""
+        val section: ResolvedLayoutSection = json.decodeFromString(raw)
+
+        assertTrue(section.isPlaceholder)
+        assertFalse(section.isVisible)
+    }
+
+    // -------------------------------------------------------------------
+    // Unknown presentation → visible (defensive)
+    // -------------------------------------------------------------------
+
+    @Test
+    fun resolvedLayoutSection_unknown_presentation_is_visible() {
+        val raw = """{"type":"gallery.v1","presentation":"future-unknown-value"}"""
+        val section: ResolvedLayoutSection = json.decodeFromString(raw)
+
+        assertEquals("future-unknown-value", section.presentation)
+        assertFalse(section.isPlaceholder, "unknown string is not placeholder")
+        assertTrue(section.isVisible, "unknown presentation → treated as visible (defensive)")
+    }
+
+    // -------------------------------------------------------------------
+    // DEFAULT_LISTING_DETAIL_LAYOUT structure
+    // -------------------------------------------------------------------
+
+    @Test
+    fun defaultListingDetailLayout_has_correct_screen_and_version() {
+        assertEquals("reality/listing-detail", DEFAULT_LISTING_DETAIL_LAYOUT.screen)
+        assertEquals(0, DEFAULT_LISTING_DETAIL_LAYOUT.version)
+    }
+
+    @Test
+    fun defaultListingDetailLayout_has_eight_sections_all_visible() {
+        assertEquals(8, DEFAULT_LISTING_DETAIL_LAYOUT.sections.size)
+        for (section in DEFAULT_LISTING_DETAIL_LAYOUT.sections) {
+            assertTrue(section.isVisible, "${section.type} should be visible in default layout")
+            assertFalse(section.isPlaceholder)
+        }
+    }
+
+    @Test
+    fun defaultListingDetailLayout_section_types_in_order() {
+        val types = DEFAULT_LISTING_DETAIL_LAYOUT.sections.map { it.type }
+        assertEquals(
+            listOf(
+                "gallery.v1",
+                "listing-header.v1",
+                "key-details.v1",
+                "description.v1",
+                "features.v1",
+                "additional-info.v1",
+                "resources.v1",
+                "agent-contact.v1",
+            ),
+            types,
+        )
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutRepositoryTest.kt
@@ -1,0 +1,253 @@
+package three.two.bit.ppt.reality.layout
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+
+/**
+ * Repository-level coroutine tests for [LayoutRepository.getListingDetailLayout].
+ *
+ * Mirrors the MockEngine harness from [ListingDetailRepositoryTest]. The repository must NEVER
+ * throw; all failure paths return [DEFAULT_LISTING_DETAIL_LAYOUT].
+ */
+class LayoutRepositoryTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private class Captured {
+        var method: HttpMethod? = null
+        var path: String? = null
+        var query: String? = null
+    }
+
+    private fun repoCapturing(
+        captured: Captured,
+        status: HttpStatusCode,
+        body: String,
+    ): LayoutRepository {
+        val engine = MockEngine { request ->
+            captured.method = request.method
+            captured.path = request.url.encodedPath
+            captured.query = request.url.encodedQuery
+            respond(
+                content = ByteReadChannel(body),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        return LayoutRepository(baseUrl = "https://example.test", client = client)
+    }
+
+    private val validBody =
+        """
+        {
+          "screen": "reality/listing-detail",
+          "version": 1,
+          "sections": [
+            {"type": "gallery.v1", "presentation": "visible"},
+            {"type": "listing-header.v1", "presentation": "visible"},
+            {"type": "key-details.v1", "presentation": "placeholder"},
+            {"type": "description.v1", "presentation": "visible"},
+            {"type": "features.v1", "presentation": "visible"},
+            {"type": "additional-info.v1", "presentation": "visible"},
+            {"type": "resources.v1", "presentation": "visible"},
+            {"type": "agent-contact.v1", "presentation": "visible"}
+          ]
+        }
+        """
+            .trimIndent()
+
+    // -------------------------------------------------------------------
+    // Happy path: 200 decode
+    // -------------------------------------------------------------------
+
+    @Test
+    fun getListingDetailLayout_200_decodes_screen_and_sections_in_order() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.OK, validBody)
+
+        val layout = repo.getListingDetailLayout()
+
+        // Endpoint contract.
+        assertEquals(HttpMethod.Get, cap.method)
+        assertEquals("/api/v1/layout/resolved/reality/listing-detail", cap.path)
+        assertTrue(cap.query?.contains("platform=mobile") == true, "should include platform=mobile")
+
+        // Decode contract.
+        assertEquals("reality/listing-detail", layout.screen)
+        assertEquals(1, layout.version)
+        assertEquals(8, layout.sections.size)
+        assertEquals("gallery.v1", layout.sections[0].type)
+        assertEquals("listing-header.v1", layout.sections[1].type)
+        assertEquals("agent-contact.v1", layout.sections[7].type)
+    }
+
+    @Test
+    fun getListingDetailLayout_200_placeholder_presentation_parsed() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.OK, validBody)
+
+        val layout = repo.getListingDetailLayout()
+
+        val keyDetails = layout.sections[2]
+        assertEquals("key-details.v1", keyDetails.type)
+        assertTrue(keyDetails.isPlaceholder, "presentation=placeholder → isPlaceholder")
+        assertFalse(keyDetails.isVisible, "placeholder → !isVisible")
+    }
+
+    @Test
+    fun getListingDetailLayout_200_visible_sections_are_visible() = runTest {
+        val cap = Captured()
+        val repo = repoCapturing(cap, HttpStatusCode.OK, validBody)
+
+        val layout = repo.getListingDetailLayout()
+
+        assertTrue(layout.sections[0].isVisible, "gallery.v1 should be visible")
+        assertFalse(layout.sections[0].isPlaceholder)
+    }
+
+    @Test
+    fun getListingDetailLayout_200_unknown_extra_json_fields_tolerated() = runTest {
+        val bodyWithExtra =
+            """
+            {
+              "screen": "reality/listing-detail",
+              "version": 2,
+              "future_field": "ignored",
+              "sections": [
+                {"type": "gallery.v1", "presentation": "visible", "unknown_future": true}
+              ]
+            }
+            """
+                .trimIndent()
+        val repo = repoCapturing(Captured(), HttpStatusCode.OK, bodyWithExtra)
+
+        val layout = repo.getListingDetailLayout()
+        assertEquals("reality/listing-detail", layout.screen)
+        assertEquals(1, layout.sections.size)
+    }
+
+    @Test
+    fun getListingDetailLayout_200_empty_sections_accepted_as_is() = runTest {
+        val bodyEmpty =
+            """
+            {
+              "screen": "reality/listing-detail",
+              "version": 0,
+              "sections": []
+            }
+            """
+                .trimIndent()
+        val repo = repoCapturing(Captured(), HttpStatusCode.OK, bodyEmpty)
+
+        val layout = repo.getListingDetailLayout()
+        assertTrue(layout.sections.isEmpty(), "empty sections list is accepted")
+        assertEquals("reality/listing-detail", layout.screen)
+    }
+
+    // -------------------------------------------------------------------
+    // Failure paths: all return DEFAULT_LISTING_DETAIL_LAYOUT
+    // -------------------------------------------------------------------
+
+    @Test
+    fun getListingDetailLayout_non2xx_returns_default() = runTest {
+        val repo =
+            repoCapturing(Captured(), HttpStatusCode.ServiceUnavailable, """{"error":"down"}""")
+
+        val layout = repo.getListingDetailLayout()
+
+        assertEquals(DEFAULT_LISTING_DETAIL_LAYOUT, layout)
+    }
+
+    @Test
+    fun getListingDetailLayout_500_returns_default() = runTest {
+        val repo =
+            repoCapturing(Captured(), HttpStatusCode.InternalServerError, """{"error":"boom"}""")
+
+        val layout = repo.getListingDetailLayout()
+
+        assertEquals(DEFAULT_LISTING_DETAIL_LAYOUT, layout)
+    }
+
+    @Test
+    fun getListingDetailLayout_404_returns_default() = runTest {
+        val repo = repoCapturing(Captured(), HttpStatusCode.NotFound, """{"error":"not found"}""")
+
+        val layout = repo.getListingDetailLayout()
+
+        assertEquals(DEFAULT_LISTING_DETAIL_LAYOUT, layout)
+    }
+
+    @Test
+    fun getListingDetailLayout_malformed_json_returns_default() = runTest {
+        val repo = repoCapturing(Captured(), HttpStatusCode.OK, "not-json-at-all{{{")
+
+        val layout = repo.getListingDetailLayout()
+
+        assertEquals(DEFAULT_LISTING_DETAIL_LAYOUT, layout)
+    }
+
+    @Test
+    fun getListingDetailLayout_wrong_screen_echo_returns_default() = runTest {
+        val wrongScreen =
+            """
+            {
+              "screen": "reality/some-other-screen",
+              "version": 0,
+              "sections": []
+            }
+            """
+                .trimIndent()
+        val repo = repoCapturing(Captured(), HttpStatusCode.OK, wrongScreen)
+
+        val layout = repo.getListingDetailLayout()
+
+        assertEquals(DEFAULT_LISTING_DETAIL_LAYOUT, layout)
+    }
+
+    // -------------------------------------------------------------------
+    // Unknown presentation string → isVisible true (defensive)
+    // -------------------------------------------------------------------
+
+    @Test
+    fun getListingDetailLayout_unknown_presentation_string_is_visible() = runTest {
+        val bodyUnknownPresentation =
+            """
+            {
+              "screen": "reality/listing-detail",
+              "version": 0,
+              "sections": [
+                {"type": "gallery.v1", "presentation": "some-future-value"},
+                {"type": "listing-header.v1", "presentation": "visible"}
+              ]
+            }
+            """
+                .trimIndent()
+        val repo = repoCapturing(Captured(), HttpStatusCode.OK, bodyUnknownPresentation)
+
+        val layout = repo.getListingDetailLayout()
+
+        val section = layout.sections[0]
+        assertEquals("some-future-value", section.presentation)
+        assertFalse(section.isPlaceholder, "unknown string is not placeholder")
+        assertTrue(section.isVisible, "unknown presentation → treated as visible (defensive)")
+    }
+}


### PR DESCRIPTION
## Summary

Eighth slice of the Layout & Content Manager (follows #2424–#2431, all merged). The mobile leg from spec §9 step 6:

- **RN management app** — `features/layout` module: AsyncStorage-backed cache with validated reads, and `useDashboardLayout` implementing spec §4.6's activation semantics strictly: state seeds from the compiled default, activates ONCE from the mount-time cache read, and the background fetch writes the cache only — fresh layouts appear next launch, never mid-session (proven by an activation-cage test where cache and fetch both succeed with different layouts). Dashboard's stats grid and Pending Actions extracted verbatim as `dashboard-stats.v1` / `action-queue.v1` behind an RN `LayoutSections` renderer (order, i18n placeholders in six locales, unknown-skip-warn-once); announcements/quick-actions stay unmanaged for now.
- **KMP shared** — `layout` package: serialization models (presentation-as-String with visible-default helpers — immune to unknown wire values), `DEFAULT_LISTING_DETAIL_LAYOUT`, and a never-throws `LayoutRepository` against reality-server's public resolved endpoint (all failures including wrong-screen echo → compiled default). 23 new commonTests (MockEngine + wire-contract pins).
- **KMP Android** — `ListingSectionRegistry` dispatch over resolved sections: five rendering types mapped to existing composables, three folded no-ops (their content lives in the description tabs), placeholder card, unknown-skip. Agent bars are **position-independent** (visibility gated by `agent-contact.v1`, placement fixed — sticky bar stays after the gallery regardless of server order); pixel-identical under the default layout incl. a review-caught 18dp header gap. Fetch-once-at-entry per spec's "next screen entry" activation.
- **Canonical `mobile-manifest.json`** in the backend `RegistryManifest` map shape, required-flags matching the web manifests (publish-gate safe), consistency-tested against both the RN registry and a KMP drift-guard list.
- **iOS is explicitly out** — no macOS builder in this environment; shared models are iOS-ready (commonMain verified JVM-import-free) and the SwiftUI dispatch is a documented follow-up.

## Verification

- RN: 589 tests green (47 suites); workspace check/typecheck clean.
- KMP: 255 shared tests green (23 new); CI-equivalent gradle gates (`spotlessCheck :shared:allTests :androidApp:assembleDebug`, JDK 17) exit-0 verified. (A local full-`build` R8 minify failure predates this branch and is outside the CI path, which runs assembleDebug.)
- 4-task subagent-driven execution; per-task reviews caught the agent-bar order divergence, a missing 18dp gap, and test-coverage gaps; final opus review's two Important findings (manifest shape vs backend contract, missing KMP drift-guard assertion) fixed in the last commit.

Plan: `docs/superpowers/plans/2026-07-20-layout-mobile-registries.md`. Remaining: iOS SwiftUI dispatch, KMP layout persistence, `layout_editor_*` capability, per-tenant preview, ppt-web frame-protection.