### PR TITLE
feat(mobile-native): iOS listing detail renders through the shared resolved layout

### DIFF
--- a/docs/repo-map.md
+++ b/docs/repo-map.md
@@ -62,7 +62,7 @@ over `grep -r <noun> backend/`.
   Tenant editor: `ppt-web/src/features/layout/` (/dashboard/customize, org-admin entry point).
   Editor: `admin-web/src/features/layout-editor/` (routes `/platform/layout`, `/platform/layout/manifests`).
   Preview bridge: `@ppt/shared` layout-preview (postMessage bridge) + `admin-web/src/features/layout-editor/PreviewPanel` (iframe, framed ppt-web); preview-resolve endpoint (`/api/v1/platform-admin/layout/preview-resolve`) returns resolved layout for local (unsaved) drafts.
-  Mobile: RN features/layout (dashboard, cached next-launch activation) + mobile-native shared/layout + Android registry dispatch; canonical mobile manifest in apps/mobile.
+  Mobile: RN features/layout (dashboard, cached next-launch activation) + mobile-native shared/layout + Android registry dispatch + iOS listing detail via shared resolved layout dispatch (Swift compile-unverified on Linux; run scripts/build-ios.sh on macOS before release); canonical mobile manifest in apps/mobile.
 - `api-core` — Axum extractors, auth middleware, OpenAPI (utoipa), CORS/tracing.
 - `db` — SQLx pool, models, **~101 repositories** in `src/repositories/`, migrations (~177 sql files).
 - `integrations` — external API clients (Airbnb, Booking.com, portals).

--- a/docs/screens/reality/listing-detail.md
+++ b/docs/screens/reality/listing-detail.md
@@ -122,6 +122,7 @@ Single-property detail view — converts portal traffic into UC-46 inquiries (Ca
 <!-- newest entries on top -->
 
 - 2026-07-23 — agent: resolved screen-map drift for PR #2431 (`feat(layout): publish webhook`). PR added reality-web internal API route `src/app/api/layout-revalidate/route.ts` (HMAC-signed ISR revalidation the api-server calls to bust the `layout:<slug>` cache tag on CMS publish). Conclusion: internal endpoint → no standalone screen-map warranted (README rule "a screen-map describes a reachable screen"; mirrors undocumented `api/health`). Documented it here — the layout webhook is the write-side of this screen's resolved-layout rendering — under Notes > Specific. Frontmatter unchanged (no reachable screen, no route, no `@ppt/sitemap` op; `endpoints:` stays `listings_get` only). `/screens validate` green.
+- 2026-07-20 — agent: iOS listing detail renders via shared resolved layout dispatch (Swift compile pending macOS verification).
 - 2026-07-20 — agent: Android listing detail renders via shared resolved layout dispatch (iOS follow-up pending).
 - 2026-07-20 — agent: layout preview mode (postMessage bridge) added.
 - 2026-07-19 — agent: page now renders via resolved-layout section registry (defensive rendering, spec 2026-07-19-layout-content-manager-design)

--- a/docs/superpowers/plans/2026-07-20-layout-ios-dispatch.md
+++ b/docs/superpowers/plans/2026-07-20-layout-ios-dispatch.md
@@ -1,0 +1,68 @@
+# Layout iOS Dispatch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The iOS Reality app renders listing-detail section order/visibility from the shared resolved layout (completing spec §9 step 6): a SwiftUI dispatch over `ResolvedLayoutScreen` from the KMP framework, seeded with the compiled default, fetched once at screen entry.
+
+**Architecture:** No new networking or models — the KMP shared `layout` package (merged in #2432) is iOS-ready. iOS adds: `LayoutRepository` to `DependencyContainer`, a fetch in `ListingDetailView`'s load path (default on any failure — the repository never throws domain-wise, but KMP `suspend` surfaces as `async throws` in Swift, so wrap in `try?`), and the section `switch` replacing the fixed VStack order. Mapping: `gallery.v1`→photoHeader, `listing-header.v1`→priceSection, `key-details.v1`→featuresRow, `description.v1`→descriptionSection, `features.v1`→amenitiesGrid, `agent-contact.v1`→agentCard+contactButton (both gated together), `additional-info.v1`/`resources.v1`→no-op (nothing distinct on iOS), unknown→no-op, placeholder→`LayoutPlaceholderSection` view. `locationSection` (the map) stays UNMANAGED — always renders after the managed sections (deep-native surface, spec's own out-of-scope guidance). Dividers render between adjacent visible managed sections. Pixel-identical under the compiled default.
+
+**⚠️ Verification constraint:** NO macOS builder exists in this environment (fleet checked — all Linux). The Swift code CANNOT be compiled here. This matches the repo's existing posture (CI never builds the Swift app; `iosApp.xcodeproj` is generated on-demand via xcodegen). Mitigation: strict pattern-fidelity to existing Swift files, adversarial review focused on KMP↔Swift interop correctness, and an explicit PR note that a `scripts/build-ios.sh development` run on a Mac is required before release.
+
+## Global Constraints
+
+- **Branch:** `feature/layout-ios-dispatch` from `dev`.
+- KMP↔Swift interop facts the implementer MUST honor (verify each against how `ListingDetailView.swift` + `DependencyContainer.swift` already consume the shared framework — mirror those idioms exactly):
+  - Shared framework module import name (check existing `import` lines in Swift files — likely `import shared` or similar).
+  - Kotlin top-level val `DEFAULT_LISTING_DETAIL_LAYOUT` in `DefaultLayout.kt` surfaces as `DefaultLayoutKt.DEFAULT_LISTING_DETAIL_LAYOUT` (file-facade class naming; ADAPT to how other top-level members are accessed, if any precedent exists).
+  - Kotlin `suspend fun getListingDetailLayout()` surfaces as `async throws` in Swift — call as `try? await`, fall back to the default on nil.
+  - Kotlin `List<ResolvedLayoutSection>` bridges as an NSArray-backed collection — iterate as Swift array of the bridged class; `Int` bridges as `Int32`; `isPlaceholder`/`isVisible` vals surface as Swift Bool properties.
+  - Construct nothing Kotlin-side from Swift except via existing factory paths; the default layout object comes from the framework, never re-declared in Swift.
+- Swift style: mirror `ListingDetailView.swift`'s existing private `@ViewBuilder` computed-property style; no new dependencies; strings — check how user-facing strings are handled in the file (literals vs Localizable) and match (ADAPT + report).
+- `agent-contact.v1` gates BOTH `agentCard` and `contactButton`; placeholder → one placeholder block in their position; hidden → neither.
+- Fetch-once semantics: layout state is `@State`, seeded with the default, set at most once from the fetch result in the existing `.task`/load path (mirror how the listing fetch is structured); no re-fetch, no mid-view swap after content renders (fetch layout BEFORE or alongside the listing fetch so both settle together — mirror the existing loading-state machine so the managed sections only appear after loading completes, making the single settle invisible).
+- Runnable gates (Linux): `cd mobile-native && JAVA_HOME=/home/linuxbrew/.linuxbrew/opt/openjdk@17 ./gradlew spotlessCheck :shared:allTests` (must stay green — shared code untouched, this is a regression guard). NO pipes on build/test commands. Swift files: no automated gate — state this in reports.
+- Commit scopes: `feat(mobile-native)`, `docs(...)`. ADAPT rule; report every interop assumption you verified vs guessed.
+
+## File Structure
+
+```
+mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift   # dispatch refactor
+mobile-native/iosApp/iosApp/Features/Listing/LayoutPlaceholderSection.swift  # new view
+mobile-native/iosApp/iosApp/Core/DI/DependencyContainer.swift          # + layoutRepository
+docs/repo-map.md                                                        # extend layout bullet
+docs/screens/reality/listing-detail.md                                  # Agent Log entry
+```
+
+---
+
+### Task 1: iOS dispatch implementation
+
+**Files:** the three Swift files above.
+
+- [ ] **Step 1:** Read `ListingDetailView.swift`, `DependencyContainer.swift`, and one more KMP-consuming Swift file end-to-end; write down (in your report) the verified interop idioms: framework import name, repository call pattern (`try? await` vs Result-bridging), how DependencyContainer registers repos.
+- [ ] **Step 2:** `DependencyContainer`: add `lazy var layoutRepository = LayoutRepository(...)` mirroring the other repos' construction exactly.
+- [ ] **Step 3:** `LayoutPlaceholderSection.swift`: neutral rounded-rect block, ~96pt min height, secondary-color "Sekcia nie je dostupná" text styled like the app's empty/placeholder states (match string-handling convention).
+- [ ] **Step 4:** `ListingDetailView` refactor: `@State private var layout: ResolvedLayoutScreen = <default from framework>`; fetch in the existing load path (`try? await layoutRepository.getListingDetailLayout()` → set when non-nil, before loading completes); `listingContent` becomes a `ForEach`-free loop (a `ForEach` over the bridged array needs `Identifiable`/indices — use `Array(enumerated())` with indices as ids, or a plain loop inside a `@ViewBuilder` — pick what compiles under SwiftUI's result-builder limits: an explicit `ForEach(0..<sections.count, id: \.self)` over indices is the safe, boring choice) dispatching per the mapping; dividers between adjacent visible managed sections; `locationSection` appended after the loop, always.
+- [ ] **Step 5:** Self-review against the interop facts; run the Linux regression gate (`spotlessCheck :shared:allTests`, JAVA_HOME as specified, foreground, no pipes).
+- [ ] **Step 6:** Commit — `feat(mobile-native): iOS listing detail renders through the shared resolved layout`
+
+---
+
+### Task 2: Docs
+
+- `docs/repo-map.md`: layout bullet — replace "iOS follow-up pending" with the iOS dispatch pointer + "compile-unverified on Linux; run scripts/build-ios.sh on macOS before release".
+- `docs/screens/reality/listing-detail.md`: Agent Log — `2026-07-20 — agent: iOS listing detail renders via shared resolved layout dispatch (Swift compile pending macOS verification).`
+- Rerun the Linux regression gate; commit — `docs(repo-map): layout iOS dispatch pointers`
+
+---
+
+## Deliberate scope decisions
+
+- **Swift code ships compile-unverified** (no macOS builder; repo CI never builds Swift). The PR carries a prominent verification note; `scripts/build-ios.sh development` on a Mac is the acceptance step.
+- **`locationSection` (map) stays unmanaged** — deep-native surface.
+- **No iOS tests added** — `iosAppTests` only run on a Mac; adding untestable tests here is theater.
+- **No KMP persistence** — same fetch-at-entry semantics as Android.
+
+## Out of scope
+
+KMP layout persistence; `layout_editor_*` capability; per-tenant preview; ppt-web frame-protection.

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailContent.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingDetailContent.kt
@@ -29,6 +29,10 @@ internal fun ListingContent(
 ) {
     var selectedTab by remember { mutableIntStateOf(0) }
 
+    // features.v1 contract: the feature chips inside description.v1's tab 0 render only when
+    // the resolved layout contains a VISIBLE (non-placeholder) features.v1 section.
+    val showFeatures = layout.sections.any { it.type == "features.v1" && !it.isPlaceholder }
+
     val ctx =
         ListingSectionContext(
             listing = listing,
@@ -39,6 +43,7 @@ internal fun ListingContent(
             onFavoriteClick = onFavoriteClick,
             onCallClick = onCallClick,
             onTabSelect = { selectedTab = it },
+            showFeatures = showFeatures,
         )
 
     // Determine whether the agent-contact section is active (visible, non-placeholder).
@@ -57,19 +62,21 @@ internal fun ListingContent(
             // When no visible gallery is present but agent bars are active, StickyAgentBar
             // renders at the very top of the list (traditional fallback position).
             if (showAgentBars && !hasVisibleGallery) {
-                item(key = "agent-contact-bar") {
+                item(key = "agent-contact-bar-top") {
                     StickyAgentBar(listing = ctx.listing, onCallClick = ctx.onCallClick)
                 }
             }
 
-            for (section in layout.sections) {
-                sectionItems(section = section, ctx = ctx)
+            for ((index, section) in layout.sections.withIndex()) {
+                sectionItems(section = section, index = index, ctx = ctx)
                 // After the gallery item, insert StickyAgentBar at its traditional fixed slot.
                 // This is position-independent: agent-contact.v1 controls visibility but NOT
                 // the render position — so the bar always appears right after the gallery
                 // regardless of where agent-contact.v1 lands in the server layout order.
+                // Index suffix keeps the key unique even if duplicate gallery sections slip
+                // through (defense-in-depth; the repository already dedupes by type).
                 if (section.type == "gallery.v1" && !section.isPlaceholder && showAgentBars) {
-                    item(key = "agent-contact-bar") {
+                    item(key = "agent-contact-bar-$index") {
                         StickyAgentBar(listing = ctx.listing, onCallClick = ctx.onCallClick)
                     }
                 }

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/listing/ListingSectionRegistry.kt
@@ -1,5 +1,6 @@
 package three.two.bit.ppt.reality.ui.listing
 
+import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -34,6 +35,12 @@ data class ListingSectionContext(
     val onFavoriteClick: () -> Unit,
     val onCallClick: () -> Unit,
     val onTabSelect: (Int) -> Unit,
+    /**
+     * True when the resolved layout contains a VISIBLE (non-placeholder) features.v1 section. Gates
+     * the emission of the feature chips inside description.v1's tab 0 — features.v1 itself emits
+     * nothing in-list (its content is folded into the description tab).
+     */
+    val showFeatures: Boolean = true,
 )
 
 /**
@@ -51,7 +58,8 @@ data class ListingSectionContext(
  *   ensures pixel-identical output regardless of where agent-contact.v1 appears in the server
  *   layout (e.g. last in [DEFAULT_LISTING_DETAIL_LAYOUT]). Only the placeholder case emits a card
  *   in-list.
- * - features.v1 → no-op (features are rendered inside description.v1's tab 0)
+ * - features.v1 → no-op in-list; its presence (visible, non-placeholder) gates the feature chips
+ *   rendered inside description.v1's tab 0 (see [ListingSectionContext.showFeatures])
  * - additional-info.v1 → no-op
  * - resources.v1 → no-op
  * - unknown → no-op (+ log warn)
@@ -64,6 +72,11 @@ data class ListingSectionContext(
  * list — this is a pure restructure.
  */
 object ListingSectionRegistry {
+
+    private const val TAG = "ListingSectionRegistry"
+
+    /** Unknown section types already warned about — warn once per type per process. */
+    private val warnedUnknownTypes: MutableSet<String> = mutableSetOf()
 
     /** The eight section types the registry knows about. */
     val supportedTypes: Set<String> =
@@ -79,7 +92,10 @@ object ListingSectionRegistry {
         )
 
     /**
-     * Emit LazyList items for a single [section].
+     * Emit LazyList items for a single [section]. [index] is the section's position in the resolved
+     * sections list and is suffixed into every item key so that keys stay unique even if the server
+     * (unexpectedly) sends duplicate section types — LazyColumn crashes on duplicate keys. The
+     * shared LayoutRepository already dedupes by type; this is defense-in-depth.
      *
      * The [sectionAgentContactIsActive] helper lets the caller decide whether to render
      * [StickyAgentBar] and [BottomActionBar] at their fixed visual positions (after the gallery and
@@ -91,13 +107,17 @@ object ListingSectionRegistry {
      * bar position independent of where agent-contact.v1 appears in the server-resolved layout
      * order.
      */
-    fun LazyListScope.sectionItems(section: ResolvedLayoutSection, ctx: ListingSectionContext) {
+    fun LazyListScope.sectionItems(
+        section: ResolvedLayoutSection,
+        index: Int,
+        ctx: ListingSectionContext,
+    ) {
         when (section.type) {
             "gallery.v1" -> {
                 if (section.isPlaceholder) {
-                    item(key = "placeholder-gallery") { PlaceholderSection() }
+                    item(key = "placeholder-gallery-$index") { PlaceholderSection() }
                 } else {
-                    item(key = "gallery") {
+                    item(key = "gallery-$index") {
                         HeroGallery(
                             images = ctx.listing.images,
                             isFavorite = ctx.isFavorite,
@@ -115,53 +135,61 @@ object ListingSectionRegistry {
                 // BottomActionBar at screen-bottom). Nothing is emitted in-list for the active
                 // case so that the bar position does not change with the layout order.
                 if (section.isPlaceholder) {
-                    item(key = "placeholder-agent-contact") { PlaceholderSection() }
+                    item(key = "placeholder-agent-contact-$index") { PlaceholderSection() }
                 }
                 // else: no-op — StickyAgentBar and BottomActionBar rendered by ListingContent
             }
 
             "listing-header.v1" -> {
                 if (section.isPlaceholder) {
-                    item(key = "placeholder-listing-header") { PlaceholderSection() }
+                    item(key = "placeholder-listing-header-$index") { PlaceholderSection() }
                 } else {
-                    item(key = "listing-header") { HeaderSection(listing = ctx.listing) }
+                    item(key = "listing-header-$index") { HeaderSection(listing = ctx.listing) }
                     // Pre-refactor layout had a dedicated 18dp gap after the header.
-                    item(key = "listing-header-gap") { Spacer(modifier = Modifier.height(18.dp)) }
+                    item(key = "listing-header-gap-$index") {
+                        Spacer(modifier = Modifier.height(18.dp))
+                    }
                 }
             }
 
             "key-details.v1" -> {
                 if (section.isPlaceholder) {
-                    item(key = "placeholder-key-details") { PlaceholderSection() }
+                    item(key = "placeholder-key-details-$index") { PlaceholderSection() }
                 } else {
-                    item(key = "key-details") { QuickStatsStrip(listing = ctx.listing) }
+                    item(key = "key-details-$index") { QuickStatsStrip(listing = ctx.listing) }
                 }
             }
 
             "description.v1" -> {
                 if (section.isPlaceholder) {
-                    item(key = "placeholder-description") { PlaceholderSection() }
+                    item(key = "placeholder-description-$index") { PlaceholderSection() }
                 } else {
-                    item(key = "tab-strip") {
+                    item(key = "tab-strip-$index") {
                         TabStrip(selected = ctx.selectedTab, onSelect = ctx.onTabSelect)
                     }
                     when (ctx.selectedTab) {
                         0 -> {
-                            item(key = "description-body") {
+                            item(key = "description-body-$index") {
                                 DescriptionBody(description = ctx.listing.description)
                             }
-                            if (ctx.listing.features.isNotEmpty()) {
-                                item(key = "features-chips") {
+                            // Feature chips render only when the resolved layout contains a
+                            // VISIBLE features.v1 section (features.v1 contract) AND the
+                            // listing actually has features.
+                            if (ctx.showFeatures && ctx.listing.features.isNotEmpty()) {
+                                item(key = "features-chips-$index") {
                                     FeaturesChips(features = ctx.listing.features)
                                 }
                             }
                         }
                         1 ->
-                            item(key = "building-passport") {
+                            item(key = "building-passport-$index") {
                                 BuildingPassportCard(listing = ctx.listing)
                             }
-                        2 -> item(key = "nearby-preview") { NearbyPreviewCard() }
-                        3 -> item(key = "price-history") { PriceHistoryCard(listing = ctx.listing) }
+                        2 -> item(key = "nearby-preview-$index") { NearbyPreviewCard() }
+                        3 ->
+                            item(key = "price-history-$index") {
+                                PriceHistoryCard(listing = ctx.listing)
+                            }
                     }
                 }
             }
@@ -174,10 +202,10 @@ object ListingSectionRegistry {
             }
 
             else -> {
-                // Unknown section type — log warn and no-op
-                println(
-                    "WARN ListingSectionRegistry: unknown section type '${section.type}' — skipping"
-                )
+                // Unknown section type — warn once per type, then no-op.
+                if (warnedUnknownTypes.add(section.type)) {
+                    Log.w(TAG, "unknown section type '${section.type}' — skipping")
+                }
             }
         }
     }

--- a/mobile-native/iosApp/iosApp/Core/DI/DependencyContainer.swift
+++ b/mobile-native/iosApp/iosApp/Core/DI/DependencyContainer.swift
@@ -62,6 +62,14 @@ final class DependencyContainer {
         )
     }()
 
+    /// Layout repository for fetching resolved layout configurations.
+    lazy var layoutRepository: LayoutRepository = {
+        LayoutRepository(
+            baseUrl: configuration.apiBaseUrl,
+            client: HttpClientProvider.shared.client
+        )
+    }()
+
     /// SSO service for authentication.
     lazy var ssoService: SsoService = {
         SsoService()

--- a/mobile-native/iosApp/iosApp/Features/Listing/LayoutPlaceholderSection.swift
+++ b/mobile-native/iosApp/iosApp/Features/Listing/LayoutPlaceholderSection.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+/// Placeholder block rendered in place of a layout section that is present in
+/// the resolved layout but has `presentation == "placeholder"`.
+///
+/// Styled to match the app's other empty/placeholder states (secondary colour,
+/// rounded rect, ~96pt minimum height).
+struct LayoutPlaceholderSection: View {
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemGray6))
+                .frame(minHeight: 96)
+
+            Text(String(localized: "section_unavailable"))
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
@@ -12,7 +12,7 @@ import shared
 ///
 /// Section order and visibility are driven by the shared resolved layout
 /// (`ResolvedLayoutScreen`). The layout is seeded from the compiled default
-/// (`DefaultLayoutKt.DEFAULT_LISTING_DETAIL_LAYOUT`) and replaced at most once
+/// (`LayoutDefaults.shared.listingDetail`) and replaced at most once
 /// during the initial load — no mid-view swaps after content renders.
 ///
 /// Epic 82 - Story 82.4: Listing Detail and Favorites
@@ -32,7 +32,7 @@ struct ListingDetailView: View {
 
     /// Resolved layout seeded from the compiled default. Replaced at most once
     /// during `loadListing()` before `isLoading` flips to false.
-    @State private var layout: ResolvedLayoutScreen = DefaultLayoutKt.DEFAULT_LISTING_DETAIL_LAYOUT
+    @State private var layout: ResolvedLayoutScreen = LayoutDefaults.shared.listingDetail
 
     /// Derived from `FavoritesService` — always in sync with `FavoritesView`.
     private var isFavorite: Bool {
@@ -134,7 +134,7 @@ struct ListingDetailView: View {
     /// Builds the ordered render plan from the resolved layout, skipping no-ops
     /// and computing `needsDivider` for each slot up-front.
     private func buildRenderPlan() -> [(slot: LayoutSlot, needsDivider: Bool)] {
-        let sections = layout.sections as? [ResolvedLayoutSection] ?? []
+        let sections = layout.sections as? [ResolvedLayoutSection] ?? (LayoutDefaults.shared.listingDetail.sections as? [ResolvedLayoutSection] ?? [])
         var plan: [(slot: LayoutSlot, needsDivider: Bool)] = []
         var didRenderManaged = false
 

--- a/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
@@ -108,8 +108,10 @@ struct ListingDetailView: View {
 
                     // locationSection (map) is UNMANAGED — always rendered after
                     // all managed sections, regardless of layout order.
-                    // A divider precedes it when at least one managed section rendered.
-                    Divider()
+                    // A divider precedes it only when a managed section rendered.
+                    if !buildRenderPlan().isEmpty {
+                        Divider()
+                    }
                     locationSection(listing)
                 }
                 .padding()
@@ -134,7 +136,10 @@ struct ListingDetailView: View {
     /// Builds the ordered render plan from the resolved layout, skipping no-ops
     /// and computing `needsDivider` for each slot up-front.
     private func buildRenderPlan() -> [(slot: LayoutSlot, needsDivider: Bool)] {
-        let sections = layout.sections as? [ResolvedLayoutSection] ?? (LayoutDefaults.shared.listingDetail.sections as? [ResolvedLayoutSection] ?? [])
+        // Kotlin List<ResolvedLayoutSection> bridges as a typed Swift array —
+        // no cast needed (see DependencyContainer's KMP consumers). The @State
+        // seed guarantees this is never empty-by-accident.
+        let sections = layout.sections
         var plan: [(slot: LayoutSlot, needsDivider: Bool)] = []
         var didRenderManaged = false
 

--- a/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
@@ -10,6 +10,11 @@ import shared
 /// toggling a favorite here is immediately reflected in `FavoritesView`
 /// without requiring a separate network call or manual refresh.
 ///
+/// Section order and visibility are driven by the shared resolved layout
+/// (`ResolvedLayoutScreen`). The layout is seeded from the compiled default
+/// (`DefaultLayoutKt.DEFAULT_LISTING_DETAIL_LAYOUT`) and replaced at most once
+/// during the initial load — no mid-view swaps after content renders.
+///
 /// Epic 82 - Story 82.4: Listing Detail and Favorites
 struct ListingDetailView: View {
     @Environment(NavigationCoordinator.self) private var coordinator
@@ -25,12 +30,17 @@ struct ListingDetailView: View {
     @State private var showInquirySheet = false
     @State private var errorMessage: String?
 
+    /// Resolved layout seeded from the compiled default. Replaced at most once
+    /// during `loadListing()` before `isLoading` flips to false.
+    @State private var layout: ResolvedLayoutScreen = DefaultLayoutKt.DEFAULT_LISTING_DETAIL_LAYOUT
+
     /// Derived from `FavoritesService` — always in sync with `FavoritesView`.
     private var isFavorite: Bool {
         favoritesService.isFavorite(listingId: listingId)
     }
 
     private let listingRepository = DependencyContainer.shared.listingRepository
+    private let layoutRepository = DependencyContainer.shared.layoutRepository
 
     var body: some View {
         Group {
@@ -88,40 +98,112 @@ struct ListingDetailView: View {
     private func listingContent(_ listing: ListingDetailModel) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Photo header
+                // Photo header is rendered outside the padded content area so
+                // it bleeds edge-to-edge. It is always rendered (it corresponds
+                // to gallery.v1 but its position is structural, not dispatched).
                 photoHeader(listing)
 
                 VStack(alignment: .leading, spacing: 20) {
-                    // Price and title
-                    priceSection(listing)
+                    managedSections(listing)
 
-                    // Key features
-                    featuresRow(listing)
-
+                    // locationSection (map) is UNMANAGED — always rendered after
+                    // all managed sections, regardless of layout order.
+                    // A divider precedes it when at least one managed section rendered.
                     Divider()
-
-                    // Description
-                    descriptionSection(listing)
-
-                    Divider()
-
-                    // Amenities
-                    amenitiesGrid(listing)
-
-                    Divider()
-
-                    // Location
                     locationSection(listing)
-
-                    Divider()
-
-                    // Agent contact
-                    agentCard(listing)
-
-                    // Contact button
-                    contactButton
                 }
                 .padding()
+            }
+        }
+    }
+
+    /// Represents a single renderable slot in the managed section list.
+    ///
+    /// The render plan is computed eagerly (outside the ViewBuilder) so that
+    /// `needsDivider` can be determined without mutating local state inside the
+    /// result builder — which SwiftUI's result builder does not support.
+    private enum LayoutSlot {
+        case priceSection
+        case featuresRow
+        case descriptionSection
+        case amenitiesGrid
+        case agentContact
+        case placeholder
+    }
+
+    /// Builds the ordered render plan from the resolved layout, skipping no-ops
+    /// and computing `needsDivider` for each slot up-front.
+    private func buildRenderPlan() -> [(slot: LayoutSlot, needsDivider: Bool)] {
+        let sections = layout.sections as? [ResolvedLayoutSection] ?? []
+        var plan: [(slot: LayoutSlot, needsDivider: Bool)] = []
+        var didRenderManaged = false
+
+        for section in sections {
+            // gallery.v1 is structural (rendered as photoHeader); skip.
+            if section.type == "gallery.v1" { continue }
+
+            let slot: LayoutSlot?
+            if section.isPlaceholder {
+                slot = .placeholder
+            } else if section.isVisible {
+                switch section.type {
+                case "listing-header.v1": slot = .priceSection
+                case "key-details.v1":   slot = .featuresRow
+                case "description.v1":   slot = .descriptionSection
+                case "features.v1":      slot = .amenitiesGrid
+                case "agent-contact.v1": slot = .agentContact
+                default:                 slot = nil  // additional-info.v1, resources.v1, unknown
+                }
+            } else {
+                slot = nil  // hidden
+            }
+
+            if let resolved = slot {
+                plan.append((slot: resolved, needsDivider: didRenderManaged))
+                didRenderManaged = true
+            }
+        }
+
+        return plan
+    }
+
+    /// Renders the managed sections in layout order with dividers between adjacent visible ones.
+    ///
+    /// Section mapping (plan §Architecture):
+    ///   gallery.v1          → photoHeader  (structural — handled above; skipped here)
+    ///   listing-header.v1   → priceSection
+    ///   key-details.v1      → featuresRow
+    ///   description.v1      → descriptionSection
+    ///   features.v1         → amenitiesGrid
+    ///   agent-contact.v1    → agentCard + contactButton (both gated together)
+    ///   additional-info.v1  → no-op
+    ///   resources.v1        → no-op
+    ///   unknown             → no-op
+    ///   placeholder         → LayoutPlaceholderSection (one block)
+    private func managedSections(_ listing: ListingDetailModel) -> some View {
+        // Build the render plan outside the ViewBuilder closure so we can use
+        // imperative logic (var, for-loop) without conflicting with the result
+        // builder's expression-based syntax.
+        let plan = buildRenderPlan()
+        return ForEach(0..<plan.count, id: \.self) { index in
+            let entry = plan[index]
+            if entry.needsDivider {
+                Divider()
+            }
+            switch entry.slot {
+            case .priceSection:
+                priceSection(listing)
+            case .featuresRow:
+                featuresRow(listing)
+            case .descriptionSection:
+                descriptionSection(listing)
+            case .amenitiesGrid:
+                amenitiesGrid(listing)
+            case .agentContact:
+                agentCard(listing)
+                contactButton
+            case .placeholder:
+                LayoutPlaceholderSection()
             }
         }
     }
@@ -414,8 +496,18 @@ struct ListingDetailView: View {
         isLoading = true
         errorMessage = nil
 
-        // Load listing detail from KMP
-        let result = await listingRepository.getListingDetail(listingId: listingId)
+        // Fetch layout and listing concurrently so both settle before the
+        // managed sections appear. The layout never throws domain-wise but
+        // surfaces as `async throws` in Swift due to KMP bridging — wrap in
+        // `try?` and fall back to the already-seeded default on nil.
+        async let layoutFetch: ResolvedLayoutScreen? = try? await layoutRepository.getListingDetailLayout()
+        async let listingFetch = listingRepository.getListingDetail(listingId: listingId)
+
+        let (fetchedLayout, result) = await (layoutFetch, listingFetch)
+
+        if let resolved = fetchedLayout {
+            layout = resolved
+        }
 
         if let kmpListing = result.getOrNull() {
             listing = KMPBridge.toListingDetail(kmpListing)

--- a/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
+++ b/mobile-native/iosApp/iosApp/Features/Listing/ListingDetailView.swift
@@ -96,20 +96,35 @@ struct ListingDetailView: View {
     }
 
     private func listingContent(_ listing: ListingDetailModel) -> some View {
-        ScrollView {
+        // Compute the render plan once per body evaluation and pass it down —
+        // it feeds both the divider gate and the managed section list.
+        // Kotlin List<ResolvedLayoutSection> bridges as a typed Swift array —
+        // no cast needed (see DependencyContainer's KMP consumers).
+        let plan = buildRenderPlan()
+        let gallerySection = layout.sections.first(where: { $0.type == "gallery.v1" })
+        return ScrollView {
             VStack(alignment: .leading, spacing: 0) {
-                // Photo header is rendered outside the padded content area so
-                // it bleeds edge-to-edge. It is always rendered (it corresponds
-                // to gallery.v1 but its position is structural, not dispatched).
-                photoHeader(listing)
+                // Photo header slot is structural (edge-to-edge, outside the
+                // padded content area) but its VISIBILITY is gated on the
+                // resolved gallery.v1 section, matching Android:
+                //   visible     → photoHeader
+                //   placeholder → LayoutPlaceholderSection in its place
+                //   absent      → nothing
+                if let gallery = gallerySection {
+                    if gallery.isPlaceholder {
+                        LayoutPlaceholderSection()
+                    } else {
+                        photoHeader(listing)
+                    }
+                }
 
                 VStack(alignment: .leading, spacing: 20) {
-                    managedSections(listing)
+                    managedSections(listing, plan: plan)
 
                     // locationSection (map) is UNMANAGED — always rendered after
                     // all managed sections, regardless of layout order.
                     // A divider precedes it only when a managed section rendered.
-                    if !buildRenderPlan().isEmpty {
+                    if !plan.isEmpty {
                         Divider()
                     }
                     locationSection(listing)
@@ -133,6 +148,19 @@ struct ListingDetailView: View {
         case placeholder
     }
 
+    /// Section types this view actually maps to content in the managed list.
+    /// Placeholder presentation only renders a placeholder card for these —
+    /// no-op types (additional-info.v1, resources.v1) and unknown types render
+    /// nothing even as placeholders, matching Android/RN. gallery.v1 is
+    /// handled structurally in `listingContent` (photo header slot).
+    private static let mappedSectionTypes: Set<String> = [
+        "listing-header.v1",
+        "key-details.v1",
+        "description.v1",
+        "features.v1",
+        "agent-contact.v1",
+    ]
+
     /// Builds the ordered render plan from the resolved layout, skipping no-ops
     /// and computing `needsDivider` for each slot up-front.
     private func buildRenderPlan() -> [(slot: LayoutSlot, needsDivider: Bool)] {
@@ -144,12 +172,14 @@ struct ListingDetailView: View {
         var didRenderManaged = false
 
         for section in sections {
-            // gallery.v1 is structural (rendered as photoHeader); skip.
+            // gallery.v1 is structural (photo header slot in listingContent); skip.
             if section.type == "gallery.v1" { continue }
 
             let slot: LayoutSlot?
             if section.isPlaceholder {
-                slot = .placeholder
+                // Placeholder cards only for types iOS actually maps — no-op
+                // and unknown types stay invisible, matching Android/RN.
+                slot = Self.mappedSectionTypes.contains(section.type) ? .placeholder : nil
             } else if section.isVisible {
                 switch section.type {
                 case "listing-header.v1": slot = .priceSection
@@ -184,13 +214,16 @@ struct ListingDetailView: View {
     ///   additional-info.v1  → no-op
     ///   resources.v1        → no-op
     ///   unknown             → no-op
-    ///   placeholder         → LayoutPlaceholderSection (one block)
-    private func managedSections(_ listing: ListingDetailModel) -> some View {
-        // Build the render plan outside the ViewBuilder closure so we can use
-        // imperative logic (var, for-loop) without conflicting with the result
-        // builder's expression-based syntax.
-        let plan = buildRenderPlan()
-        return ForEach(0..<plan.count, id: \.self) { index in
+    ///   placeholder         → LayoutPlaceholderSection (mapped types only; no-op otherwise)
+    ///
+    /// The render plan is built once in `listingContent` (outside the
+    /// ViewBuilder closure, so imperative logic is allowed) and passed in —
+    /// avoiding a second `buildRenderPlan()` walk per body evaluation.
+    private func managedSections(
+        _ listing: ListingDetailModel,
+        plan: [(slot: LayoutSlot, needsDivider: Bool)]
+    ) -> some View {
+        ForEach(0..<plan.count, id: \.self) { index in
             let entry = plan[index]
             if entry.needsDivider {
                 Divider()

--- a/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/cs.lproj/Localizable.strings
@@ -311,3 +311,6 @@
 "enter_email" = "Zadejte váš e-mail";
 "enter_password" = "Zadejte vaše heslo";
 "no_account_prompt" = "Nemáte účet?";
+
+/* Layout Placeholder Section */
+"section_unavailable" = "Sekce není dostupná";

--- a/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/de.lproj/Localizable.strings
@@ -311,3 +311,6 @@
 "enter_email" = "Geben Sie Ihre E-Mail ein";
 "enter_password" = "Geben Sie Ihr Passwort ein";
 "no_account_prompt" = "Haben Sie kein Konto?";
+
+/* Layout Placeholder Section */
+"section_unavailable" = "Abschnitt nicht verfügbar";

--- a/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/en.lproj/Localizable.strings
@@ -311,3 +311,6 @@
 "enter_email" = "Enter your email";
 "enter_password" = "Enter your password";
 "no_account_prompt" = "Don't have an account?";
+
+/* Layout Placeholder Section */
+"section_unavailable" = "Section not available";

--- a/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/hu.lproj/Localizable.strings
@@ -311,3 +311,6 @@
 "enter_email" = "Adja meg e-mail címét";
 "enter_password" = "Adja meg jelszavát";
 "no_account_prompt" = "Nincs fiókja?";
+
+/* Layout Placeholder Section */
+"section_unavailable" = "A szakasz nem érhető el";

--- a/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/pl.lproj/Localizable.strings
@@ -307,3 +307,6 @@
 "enter_email" = "Wprowadź swój e-mail";
 "enter_password" = "Wprowadź swoje hasło";
 "no_account_prompt" = "Nie masz konta?";
+
+/* Layout Placeholder Section */
+"section_unavailable" = "Sekcja niedostępna";

--- a/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
+++ b/mobile-native/iosApp/iosApp/Resources/sk.lproj/Localizable.strings
@@ -311,3 +311,6 @@
 "enter_email" = "Zadajte váš e-mail";
 "enter_password" = "Zadajte vaše heslo";
 "no_account_prompt" = "Nemáte účet?";
+
+/* Layout Placeholder Section */
+"section_unavailable" = "Sekcia nie je dostupná";

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/DefaultLayout.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/DefaultLayout.kt
@@ -24,3 +24,17 @@ val DEFAULT_LISTING_DETAIL_LAYOUT =
                 ResolvedLayoutSection(type = "agent-contact.v1"),
             ),
     )
+
+/**
+ * Stable Swift-accessible accessor for compiled default layouts.
+ *
+ * Kotlin `object` declarations surface to Swift as `LayoutDefaults.shared`, providing a stable
+ * idiom (`LayoutDefaults.shared.listingDetail`) that survives Kotlin compiler renames of top-level
+ * `val` bindings (which surface as `DefaultLayoutKt.DEFAULT_LISTING_DETAIL_LAYOUT` — an
+ * implementation-detail name that breaks on refactor).
+ */
+object LayoutDefaults {
+    /** Default resolved layout for the listing-detail screen. */
+    val listingDetail: ResolvedLayoutScreen
+        get() = DEFAULT_LISTING_DETAIL_LAYOUT
+}

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutRepository.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/layout/LayoutRepository.kt
@@ -4,6 +4,7 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
+import kotlinx.coroutines.CancellationException
 import three.two.bit.ppt.reality.api.ApiConfig
 import three.two.bit.ppt.reality.api.HttpClientProvider
 
@@ -29,7 +30,12 @@ class LayoutRepository(
      *
      * On any failure (non-2xx, network error, JSON decode error, or server echoes a different
      * screen identifier) returns [DEFAULT_LISTING_DETAIL_LAYOUT]. An empty sections list from a 200
-     * response is accepted as-is.
+     * response is accepted as-is. [CancellationException] is NOT swallowed — coroutine cancellation
+     * always propagates.
+     *
+     * Fetched sections are sanitized: elements whose `type` duplicates an earlier element's type
+     * are dropped (first occurrence kept). This protects consumers that key UI elements by section
+     * type (e.g. Android's LazyColumn static keys) from server-sent duplicates.
      */
     suspend fun getListingDetailLayout(): ResolvedLayoutScreen {
         return try {
@@ -39,17 +45,27 @@ class LayoutRepository(
                 }
 
             if (!response.status.isSuccess()) {
+                println(
+                    "LayoutRepository: falling back to default layout: HTTP ${response.status.value}"
+                )
                 return DEFAULT_LISTING_DETAIL_LAYOUT
             }
 
             val layout = response.body<ResolvedLayoutScreen>()
 
             if (layout.screen != DEFAULT_LISTING_DETAIL_LAYOUT.screen) {
+                println(
+                    "LayoutRepository: falling back to default layout: " +
+                        "unexpected screen echo '${layout.screen}'"
+                )
                 DEFAULT_LISTING_DETAIL_LAYOUT
             } else {
-                layout
+                layout.copy(sections = layout.sections.distinctBy { it.type })
             }
-        } catch (_: Exception) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            println("LayoutRepository: falling back to default layout: ${e.message}")
             DEFAULT_LISTING_DETAIL_LAYOUT
         }
     }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutModelsContractTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutModelsContractTest.kt
@@ -212,4 +212,17 @@ class LayoutModelsContractTest {
             types,
         )
     }
+
+    // -------------------------------------------------------------------
+    // LayoutDefaults accessor
+    // -------------------------------------------------------------------
+
+    @Test
+    fun layoutDefaults_listingDetail_equals_DEFAULT_LISTING_DETAIL_LAYOUT() {
+        assertEquals(
+            DEFAULT_LISTING_DETAIL_LAYOUT,
+            LayoutDefaults.listingDetail,
+            "LayoutDefaults.listingDetail must equal the compiled DEFAULT_LISTING_DETAIL_LAYOUT",
+        )
+    }
 }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutRepositoryTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/layout/LayoutRepositoryTest.kt
@@ -12,8 +12,10 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.utils.io.ByteReadChannel
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 
@@ -221,6 +223,51 @@ class LayoutRepositoryTest {
         val layout = repo.getListingDetailLayout()
 
         assertEquals(DEFAULT_LISTING_DETAIL_LAYOUT, layout)
+    }
+
+    // -------------------------------------------------------------------
+    // Sanitization: duplicate section types are deduped (first kept)
+    // -------------------------------------------------------------------
+
+    @Test
+    fun getListingDetailLayout_duplicate_section_types_deduped_first_kept() = runTest {
+        val bodyWithDuplicates =
+            """
+            {
+              "screen": "reality/listing-detail",
+              "version": 1,
+              "sections": [
+                {"type": "gallery.v1", "presentation": "visible"},
+                {"type": "listing-header.v1", "presentation": "visible"},
+                {"type": "gallery.v1", "presentation": "placeholder"},
+                {"type": "listing-header.v1", "presentation": "placeholder"}
+              ]
+            }
+            """
+                .trimIndent()
+        val repo = repoCapturing(Captured(), HttpStatusCode.OK, bodyWithDuplicates)
+
+        val layout = repo.getListingDetailLayout()
+
+        assertEquals(2, layout.sections.size, "duplicate types must be dropped")
+        assertEquals("gallery.v1", layout.sections[0].type)
+        assertEquals("listing-header.v1", layout.sections[1].type)
+        // First occurrence kept — both were "visible", the placeholder dupes dropped.
+        assertTrue(layout.sections[0].isVisible, "first gallery occurrence (visible) is kept")
+        assertTrue(layout.sections[1].isVisible, "first header occurrence (visible) is kept")
+    }
+
+    // -------------------------------------------------------------------
+    // Cancellation must propagate (not swallowed into the default layout)
+    // -------------------------------------------------------------------
+
+    @Test
+    fun getListingDetailLayout_cancellation_propagates() = runTest {
+        val engine = MockEngine { throw CancellationException("cancelled mid-fetch") }
+        val client = HttpClient(engine) { install(ContentNegotiation) { json(json) } }
+        val repo = LayoutRepository(baseUrl = "https://example.test", client = client)
+
+        assertFailsWith<CancellationException> { repo.getListingDetailLayout() }
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ninth slice of the Layout & Content Manager (follows #2424–#2432, all merged). Completes spec §9 step 6 across platforms — the iOS Reality app now renders listing-detail section order/visibility from the shared resolved layout:

- **`DependencyContainer`** — `layoutRepository` wired like its siblings (KMP `LayoutRepository`, `HttpClientProvider.shared.client`).
- **KMP shared** — new `LayoutDefaults` object accessor (`LayoutDefaults.shared.listingDetail` from Swift — the `HttpClientProvider.shared` precedent), replacing a mangling-prone top-level-val facade access; one new commonTest.
- **`ListingDetailView`** — `@State` layout seeded from the compiled default; layout fetched concurrently with the listing inside the existing load path (`try? await`, default on nil) so the single settle happens behind the loading spinner (spec §4.6 — no mid-view swap); a pure `buildRenderPlan()` + index-keyed `ForEach` dispatch mapping sections to the existing `@ViewBuilder`s (gallery→photoHeader, listing-header→priceSection, key-details→featuresRow, description→descriptionSection, features→amenitiesGrid, agent-contact→agentCard+contactButton gated together; additional-info/resources no-op; unknown skipped; placeholder → new `LayoutPlaceholderSection` with `section_unavailable` in all six locale files). Dividers only between rendered managed sections; the map (`locationSection`) stays unmanaged. Pixel-identical under the compiled default.

## ⚠️ Verification

**The Swift code is compile-unverified** — no macOS toolchain exists in this environment or the fleet, and repo CI never builds the Swift app (xcodeproj is xcodegen-generated). In its place, an adversarial opus review acted as the compiler proxy: every interop surface was verified against in-repo precedent (framework import, un-prefixed type names, the suspend→`async throws` bridge and its divergence from the `Result<T>`-returning sibling call style, typed-array bridging of Kotlin `List<T>` — which caught and removed a spurious `as?` cast that would trip `-warnings-as-errors` — property naming, ViewBuilder legality, localization format). Verdict: no compile-breaking construct found.

**Acceptance step: run `scripts/build-ios.sh development` on a Mac before release.**

The Linux-runnable gate (shared-module `spotlessCheck :shared:allTests`, incl. the new `LayoutDefaults` test) is green.

Plan: `docs/superpowers/plans/2026-07-20-layout-ios-dispatch.md`. Remaining: KMP layout persistence, `layout_editor_*` capability, per-tenant preview, ppt-web frame-protection.