### PR TITLE
fix(api-server): bump ammonia to 4.1.4 (RUSTSEC-2026-0213)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -317,9 +317,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",


### PR DESCRIPTION
## Summary

Bumps `ammonia` from `4.1.3` to `4.1.4` to clear the XSS advisory **RUSTSEC-2026-0213**, which was pinning `ammonia v4.1.3` (a transitive dependency of `api-server`) and blocking `cargo-deny` on every backend PR.

`4.1.4` is within the existing `^4` requirement, so this is a **Cargo.lock-only** change — no `Cargo.toml` or source edits, no `.sqlx` regeneration.

## Change

```diff
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
```

## Verification

- `cargo update -p ammonia --precise 4.1.4` — Cargo.lock only (2 lines)
- `cargo tree -i ammonia` -> `ammonia v4.1.4` (transitive dep of `api-server`)
- `cargo deny check advisories` -> **`advisories ok`** (exit 0) — advisory cleared
- Workspace resolves; `cargo check` left to CI to confirm the build.

Closes #2445


---
_Generated by [Claude Code](https://claude.ai/code/session_0158iZ1rpgPSbNscDcPXUoJA)_