### PR TITLE
gh-issue-2441: org-scope 5 dispute sub-resource handlers (cross-tenant IDOR)

### DIFF
--- a/backend/crates/db/src/repositories/dispute.rs
+++ b/backend/crates/db/src/repositories/dispute.rs
@@ -66,14 +66,25 @@ impl DisputeRepository {
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        // Add complainant as party
-        self.add_party(dispute.id, req.filed_by, party_role::COMPLAINANT)
-            .await?;
+        // Add complainant as party (org derived from the dispute we just
+        // created, so the org-scope guard in `add_party` is satisfied).
+        self.add_party(
+            dispute.id,
+            req.filed_by,
+            party_role::COMPLAINANT,
+            dispute.organization_id,
+        )
+        .await?;
 
         // Add respondents as parties
         for respondent_id in req.respondent_ids {
-            self.add_party(dispute.id, respondent_id, party_role::RESPONDENT)
-                .await?;
+            self.add_party(
+                dispute.id,
+                respondent_id,
+                party_role::RESPONDENT,
+                dispute.organization_id,
+            )
+            .await?;
         }
 
         // Record activity
@@ -492,7 +503,40 @@ impl DisputeRepository {
         Ok(())
     }
 
-    pub async fn list_parties(&self, dispute_id: Uuid) -> Result<Vec<DisputeParty>, AppError> {
+    /// Verify a dispute exists and belongs to `org_id`, returning `NotFound`
+    /// otherwise.
+    ///
+    /// Issue #2441: the dispute sub-resource tables (`dispute_parties`,
+    /// `dispute_evidence`, `dispute_activities`) are not RLS-protected on this
+    /// pool — that is why `get_dispute` derives the org from the JWT and calls
+    /// `find_by_id_with_details_for_org`. The sub-resource read/write methods
+    /// share this guard so a caller in org A cannot reach org B's rows by
+    /// guessing a `dispute_id`. Mapping "no such row in this org" to `NotFound`
+    /// keeps the response from becoming a cross-tenant existence oracle.
+    async fn ensure_dispute_in_org(&self, dispute_id: Uuid, org_id: Uuid) -> Result<(), AppError> {
+        let found: Option<Uuid> =
+            sqlx::query_scalar("SELECT id FROM disputes WHERE id = $1 AND organization_id = $2")
+                .bind(dispute_id)
+                .bind(org_id)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if found.is_none() {
+            return Err(AppError::NotFound("Dispute not found".to_string()));
+        }
+        Ok(())
+    }
+
+    /// List the parties on a dispute, scoped to the caller's organization
+    /// (issue #2441). A foreign-org `dispute_id` yields `NotFound`.
+    pub async fn list_parties(
+        &self,
+        dispute_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Vec<DisputeParty>, AppError> {
+        self.ensure_dispute_in_org(dispute_id, org_id).await?;
+
         let parties = sqlx::query_as::<_, DisputeParty>(
             r#"
             SELECT id, dispute_id, user_id, role, notified_at, responded_at, created_at
@@ -509,31 +553,53 @@ impl DisputeRepository {
         Ok(parties)
     }
 
+    /// Add (or upsert) a party on a dispute, scoped to `org_id` (issue #2441).
+    ///
+    /// The INSERT is gated by an `EXISTS` predicate on the parent dispute's
+    /// organization, so the write is atomic — a caller from another org cannot
+    /// inject or overwrite a party by guessing the `dispute_id`. A foreign-org
+    /// (or unknown) `dispute_id` selects no source row, upserts nothing, and
+    /// surfaces as `NotFound`.
     pub async fn add_party(
         &self,
         dispute_id: Uuid,
         user_id: Uuid,
         role: &str,
+        org_id: Uuid,
     ) -> Result<DisputeParty, AppError> {
         let party = sqlx::query_as::<_, DisputeParty>(
             r#"
             INSERT INTO dispute_parties (dispute_id, user_id, role)
-            VALUES ($1, $2, $3)
-            ON CONFLICT (dispute_id, user_id) DO UPDATE SET role = $3
+            SELECT $1, $2, $3
+            WHERE EXISTS (
+                SELECT 1 FROM disputes WHERE id = $1 AND organization_id = $4
+            )
+            ON CONFLICT (dispute_id, user_id) DO UPDATE SET role = EXCLUDED.role
             RETURNING id, dispute_id, user_id, role, notified_at, responded_at, created_at
             "#,
         )
         .bind(dispute_id)
         .bind(user_id)
         .bind(role)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
         .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Dispute not found".to_string()))?;
 
         Ok(party)
     }
 
-    pub async fn list_evidence(&self, dispute_id: Uuid) -> Result<Vec<DisputeEvidence>, AppError> {
+    /// List the evidence on a dispute, scoped to the caller's organization
+    /// (issue #2441). A foreign-org `dispute_id` yields `NotFound`, so evidence
+    /// metadata (including the S3 `storage_url`) never leaks across tenants.
+    pub async fn list_evidence(
+        &self,
+        dispute_id: Uuid,
+        org_id: Uuid,
+    ) -> Result<Vec<DisputeEvidence>, AppError> {
+        self.ensure_dispute_in_org(dispute_id, org_id).await?;
+
         let evidence = sqlx::query_as::<_, DisputeEvidence>(
             r#"
             SELECT id, dispute_id, uploaded_by, filename, original_filename, content_type,
@@ -585,27 +651,52 @@ impl DisputeRepository {
         Ok(evidence)
     }
 
+    /// Delete an evidence row, scoped to the caller's organization via the
+    /// parent dispute (issue #2441).
+    ///
+    /// The `EXISTS` predicate on `disputes.organization_id` makes the delete
+    /// atomic and tenant-safe — a caller in org A cannot destroy org B's
+    /// evidence by guessing the `dispute_id`/`evidence_id`. Returns `false`
+    /// (→ handler 404) when nothing in the caller's org matched. Mirrors the
+    /// sibling `ViolationRepository::delete_evidence` guard.
     pub async fn delete_evidence(
         &self,
         dispute_id: Uuid,
         evidence_id: Uuid,
+        org_id: Uuid,
     ) -> Result<bool, AppError> {
-        let result = sqlx::query("DELETE FROM dispute_evidence WHERE id = $1 AND dispute_id = $2")
-            .bind(evidence_id)
-            .bind(dispute_id)
-            .execute(&self.pool)
-            .await
-            .map_err(|e| AppError::Database(e.to_string()))?;
+        let result = sqlx::query(
+            r#"
+            DELETE FROM dispute_evidence de
+            WHERE de.id = $1
+              AND de.dispute_id = $2
+              AND EXISTS (
+                  SELECT 1 FROM disputes d
+                  WHERE d.id = de.dispute_id AND d.organization_id = $3
+              )
+            "#,
+        )
+        .bind(evidence_id)
+        .bind(dispute_id)
+        .bind(org_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(result.rows_affected() > 0)
     }
 
+    /// List the activity trail on a dispute, scoped to the caller's
+    /// organization (issue #2441). A foreign-org `dispute_id` yields `NotFound`.
     pub async fn list_activities(
         &self,
         dispute_id: Uuid,
+        org_id: Uuid,
         limit: i32,
         offset: i32,
     ) -> Result<Vec<DisputeActivity>, AppError> {
+        self.ensure_dispute_in_org(dispute_id, org_id).await?;
+
         let activities = sqlx::query_as::<_, DisputeActivity>(
             r#"
             SELECT id, dispute_id, actor_id, activity_type, description, metadata, created_at

--- a/backend/crates/db/tests/dispute_lifecycle_tests.rs
+++ b/backend/crates/db/tests/dispute_lifecycle_tests.rs
@@ -109,10 +109,13 @@ async fn file_then_full_status_lifecycle(pool: PgPool) {
 
     // Filing seeds the complainant + respondent as parties and a
     // `dispute_filed` activity.
-    let parties = repo.list_parties(dispute.id).await.expect("list parties");
+    let parties = repo
+        .list_parties(dispute.id, org)
+        .await
+        .expect("list parties");
     assert_eq!(parties.len(), 2, "complainant + respondent are seeded");
     let activities = repo
-        .list_activities(dispute.id, 50, 0)
+        .list_activities(dispute.id, org, 50, 0)
         .await
         .expect("list activities");
     assert!(
@@ -138,7 +141,7 @@ async fn file_then_full_status_lifecycle(pool: PgPool) {
 
     // Every transition recorded a status_changed activity (4 transitions).
     let activities = repo
-        .list_activities(dispute.id, 50, 0)
+        .list_activities(dispute.id, org, 50, 0)
         .await
         .expect("list activities");
     let status_changes = activities
@@ -349,7 +352,10 @@ async fn add_evidence_persists_and_records_activity(pool: PgPool) {
     assert_eq!(evidence.dispute_id, dispute.id);
     assert_eq!(evidence.uploaded_by, user);
 
-    let listed = repo.list_evidence(dispute.id).await.expect("list evidence");
+    let listed = repo
+        .list_evidence(dispute.id, org)
+        .await
+        .expect("list evidence");
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, evidence.id);
 
@@ -364,7 +370,7 @@ async fn add_evidence_persists_and_records_activity(pool: PgPool) {
     );
 
     let activities = repo
-        .list_activities(dispute.id, 50, 0)
+        .list_activities(dispute.id, org, 50, 0)
         .await
         .expect("list activities");
     assert!(
@@ -380,7 +386,7 @@ async fn add_evidence_persists_and_records_activity(pool: PgPool) {
         .await
         .expect("file second dispute");
     let wrong_scope = repo
-        .delete_evidence(other.id, evidence.id)
+        .delete_evidence(other.id, evidence.id, org)
         .await
         .expect("delete query ok");
     assert!(
@@ -388,7 +394,7 @@ async fn add_evidence_persists_and_records_activity(pool: PgPool) {
         "evidence is not deletable via a foreign dispute id"
     );
     let right_scope = repo
-        .delete_evidence(dispute.id, evidence.id)
+        .delete_evidence(dispute.id, evidence.id, org)
         .await
         .expect("delete query ok");
     assert!(right_scope, "evidence is deletable via its own dispute id");

--- a/backend/servers/api-server/src/routes/disputes.rs
+++ b/backend/servers/api-server/src/routes/disputes.rs
@@ -104,6 +104,45 @@ pub fn router() -> Router<AppState> {
 }
 
 // =============================================================================
+// Shared helpers
+// =============================================================================
+
+/// Derive the caller's organization from the verified JWT, or 403 if absent.
+///
+/// Issue #2441: dispute sub-resource handlers must scope by the JWT tenant
+/// (never a path- or body-supplied org) so they cannot cross tenants.
+fn require_org(user: &AuthUser) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    user.tenant_id.ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new("FORBIDDEN", "No organization context")),
+        )
+    })
+}
+
+/// Map a repository error from an org-scoped sub-resource call to an HTTP
+/// response. `NotFound` (dispute absent or owned by another org) becomes 404 so
+/// the response is not a cross-tenant existence oracle; everything else is 500.
+fn map_dispute_err(
+    err: common::errors::AppError,
+    log_ctx: &str,
+) -> (StatusCode, Json<ErrorResponse>) {
+    match err {
+        common::errors::AppError::NotFound(_) => (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse::new("NOT_FOUND", "Dispute not found")),
+        ),
+        e => {
+            tracing::error!("{}: {:?}", log_ctx, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", log_ctx)),
+            )
+        }
+    }
+}
+
+// =============================================================================
 // Request/Response Types
 // =============================================================================
 
@@ -706,64 +745,58 @@ async fn withdraw_dispute(
 }
 
 /// List parties for a dispute.
+///
+/// Issue #2441: the party roster (`user_id` + `role` PII) is scoped to the
+/// caller's JWT tenant. A `dispute_id` owned by another org returns 404 so a
+/// caller cannot enumerate a foreign dispute's parties.
 async fn list_parties(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<DisputeParty>>, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .dispute_repo
-        .list_parties(id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list parties: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list parties")),
-            )
-        })
+    let organization_id = require_org(&user)?;
+    match state.dispute_repo.list_parties(id, organization_id).await {
+        Ok(parties) => Ok(Json(parties)),
+        Err(e) => Err(map_dispute_err(e, "Failed to list parties")),
+    }
 }
 
 /// Add a party to a dispute.
+///
+/// Issue #2441: the upsert is scoped to the caller's JWT tenant. A `dispute_id`
+/// owned by another org returns 404 and is never mutated, so a caller cannot
+/// inject or overwrite a party (e.g. a MEDIATOR role) on a foreign dispute.
 async fn add_party(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<AddPartyRequest>,
 ) -> Result<(StatusCode, Json<DisputeParty>), (StatusCode, Json<ErrorResponse>)> {
-    state
+    let organization_id = require_org(&user)?;
+    match state
         .dispute_repo
-        .add_party(id, data.user_id, &data.role)
+        .add_party(id, data.user_id, &data.role, organization_id)
         .await
-        .map(|p| (StatusCode::CREATED, Json(p)))
-        .map_err(|e| {
-            tracing::error!("Failed to add party: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to add party")),
-            )
-        })
+    {
+        Ok(party) => Ok((StatusCode::CREATED, Json(party))),
+        Err(e) => Err(map_dispute_err(e, "Failed to add party")),
+    }
 }
 
 /// List evidence for a dispute.
+///
+/// Issue #2441: evidence metadata (including the S3 `storage_url`) is scoped to
+/// the caller's JWT tenant. A `dispute_id` owned by another org returns 404.
 async fn list_evidence(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<DisputeEvidence>>, (StatusCode, Json<ErrorResponse>)> {
-    state
-        .dispute_repo
-        .list_evidence(id)
-        .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list evidence: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list evidence")),
-            )
-        })
+    let organization_id = require_org(&user)?;
+    match state.dispute_repo.list_evidence(id, organization_id).await {
+        Ok(evidence) => Ok(Json(evidence)),
+        Err(e) => Err(map_dispute_err(e, "Failed to list evidence")),
+    }
 }
 
 /// Add evidence to a dispute.
@@ -792,22 +825,21 @@ async fn add_evidence(
 }
 
 /// Delete evidence from a dispute.
+///
+/// Issue #2441: the delete is scoped to the caller's JWT tenant via the parent
+/// dispute. A `dispute_id`/`evidence_id` owned by another org matches nothing
+/// and returns 404, so a caller cannot destroy a foreign org's evidence.
 async fn delete_evidence(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path((id, evidence_id)): Path<(Uuid, Uuid)>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let organization_id = require_org(&user)?;
     let deleted = state
         .dispute_repo
-        .delete_evidence(id, evidence_id)
+        .delete_evidence(id, evidence_id, organization_id)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to delete evidence: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to delete evidence")),
-            )
-        })?;
+        .map_err(|e| map_dispute_err(e, "Failed to delete evidence"))?;
 
     if deleted {
         Ok(StatusCode::NO_CONTENT)
@@ -820,24 +852,29 @@ async fn delete_evidence(
 }
 
 /// List activities for a dispute.
+///
+/// Issue #2441: the activity log is scoped to the caller's JWT tenant. A
+/// `dispute_id` owned by another org returns 404.
 async fn list_activities(
     State(state): State<AppState>,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Query(query): Query<PaginationQuery>,
 ) -> Result<Json<Vec<DisputeActivity>>, (StatusCode, Json<ErrorResponse>)> {
-    state
+    let organization_id = require_org(&user)?;
+    match state
         .dispute_repo
-        .list_activities(id, query.limit.unwrap_or(50), query.offset.unwrap_or(0))
+        .list_activities(
+            id,
+            organization_id,
+            query.limit.unwrap_or(50),
+            query.offset.unwrap_or(0),
+        )
         .await
-        .map(Json)
-        .map_err(|e| {
-            tracing::error!("Failed to list activities: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to list activities")),
-            )
-        })
+    {
+        Ok(activities) => Ok(Json(activities)),
+        Err(e) => Err(map_dispute_err(e, "Failed to list activities")),
+    }
 }
 
 // =============================================================================

--- a/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs
@@ -388,3 +388,183 @@ async fn mediation_notes_present_for_owning_org(pool: PgPool) {
         "org B must not read org A's dispute (and thus never its notes)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Sub-resource cross-org IDOR contract (issue #2441)
+//
+// The five sub-resource repo methods (`list_parties`, `add_party`,
+// `list_evidence`, `delete_evidence`, `list_activities`) previously queried by
+// path-supplied `dispute_id` alone, with no org scoping — a systemic
+// cross-tenant IDOR. Each now takes the caller's `org_id` and rejects a
+// foreign-org `dispute_id` (reads/`add_party` → `NotFound`; `delete_evidence` →
+// `false`, i.e. handler 404), while the owning org still succeeds. These tests
+// pin that contract at the repository layer (the layer that enforces it), so
+// they fail on the pre-fix code and pass after.
+// ---------------------------------------------------------------------------
+
+/// Seed an evidence row on a dispute; returns its id.
+async fn seed_evidence(pool: &PgPool, dispute_id: Uuid, uploaded_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO dispute_evidence (
+            dispute_id, uploaded_by, filename, original_filename,
+            content_type, size_bytes, storage_url, description
+        )
+        VALUES ($1, $2, 'ev.pdf', 'evidence.pdf', 'application/pdf', 1024,
+                's3://ppt-evidence/secret-object.pdf', 'sensitive')
+        RETURNING id
+        "#,
+    )
+    .bind(dispute_id)
+    .bind(uploaded_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed evidence")
+}
+
+// R4 — list_parties: owner reads the roster, foreign org gets NotFound.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_parties_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "sub-parties-a").await;
+    let org_b = seed_org(&pool, "sub-parties-b").await;
+    let user_a = seed_user(&pool, "sub-parties-a@dispute-idor.test").await;
+    let party_user = seed_user(&pool, "sub-parties-p@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+    repo.add_party(dispute_a, party_user, "respondent", org_a)
+        .await
+        .expect("seed party in org A");
+
+    // Owning org reads the roster.
+    let own = repo
+        .list_parties(dispute_a, org_a)
+        .await
+        .expect("org A lists its own parties");
+    assert!(
+        own.iter().any(|p| p.user_id == party_user),
+        "org A must see the party it added"
+    );
+
+    // Foreign org is denied — no PII disclosure.
+    let cross = repo.list_parties(dispute_a, org_b).await;
+    assert!(
+        matches!(cross, Err(::common::errors::AppError::NotFound(_))),
+        "org B must not list org A's parties, got {cross:?}"
+    );
+}
+
+// R5 — add_party: owner upserts, foreign org is NotFound and nothing is written.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_party_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "sub-add-a").await;
+    let org_b = seed_org(&pool, "sub-add-b").await;
+    let user_a = seed_user(&pool, "sub-add-a@dispute-idor.test").await;
+    let injected = seed_user(&pool, "sub-add-injected@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    // Foreign-org write must fail and inject nothing.
+    let cross = repo.add_party(dispute_a, injected, "mediator", org_b).await;
+    assert!(
+        matches!(cross, Err(::common::errors::AppError::NotFound(_))),
+        "org B must not inject a party into org A's dispute, got {cross:?}"
+    );
+    let injected_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM dispute_parties WHERE dispute_id = $1 AND user_id = $2",
+    )
+    .bind(dispute_a)
+    .bind(injected)
+    .fetch_one(&pool)
+    .await
+    .expect("count parties");
+    assert_eq!(injected_count, 0, "cross-org add_party must write no row");
+
+    // Owning org succeeds.
+    let party = repo
+        .add_party(dispute_a, injected, "witness", org_a)
+        .await
+        .expect("org A adds a party to its own dispute");
+    assert_eq!(party.user_id, injected);
+    assert_eq!(party.role, "witness");
+}
+
+// R6 — list_evidence: owner reads, foreign org gets NotFound (no storage_url leak).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_evidence_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "sub-lsev-a").await;
+    let org_b = seed_org(&pool, "sub-lsev-b").await;
+    let user_a = seed_user(&pool, "sub-lsev-a@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+    let _ev = seed_evidence(&pool, dispute_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    let own = repo
+        .list_evidence(dispute_a, org_a)
+        .await
+        .expect("org A lists its own evidence");
+    assert_eq!(own.len(), 1, "org A sees its evidence");
+
+    let cross = repo.list_evidence(dispute_a, org_b).await;
+    assert!(
+        matches!(cross, Err(::common::errors::AppError::NotFound(_))),
+        "org B must not list org A's evidence, got {cross:?}"
+    );
+}
+
+// R7 — delete_evidence: foreign org deletes nothing (row survives); owner deletes.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_evidence_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "sub-delev-a").await;
+    let org_b = seed_org(&pool, "sub-delev-b").await;
+    let user_a = seed_user(&pool, "sub-delev-a@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+    let evidence = seed_evidence(&pool, dispute_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    // Foreign org cannot destroy the evidence — nothing deleted, row survives.
+    let cross = repo
+        .delete_evidence(dispute_a, evidence, org_b)
+        .await
+        .expect("delete query ok");
+    assert!(!cross, "org B must not delete org A's evidence");
+    let survives: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM dispute_evidence WHERE id = $1")
+        .bind(evidence)
+        .fetch_one(&pool)
+        .await
+        .expect("count evidence");
+    assert_eq!(survives, 1, "cross-org delete must leave the row intact");
+
+    // Owning org deletes successfully.
+    let own = repo
+        .delete_evidence(dispute_a, evidence, org_a)
+        .await
+        .expect("delete query ok");
+    assert!(own, "org A deletes its own evidence");
+}
+
+// R8 — list_activities: owner reads the trail, foreign org gets NotFound.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_activities_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "sub-act-a").await;
+    let org_b = seed_org(&pool, "sub-act-b").await;
+    let user_a = seed_user(&pool, "sub-act-a@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    // Owning org reads its (possibly empty) activity trail without error.
+    repo.list_activities(dispute_a, org_a, 50, 0)
+        .await
+        .expect("org A lists its own activities");
+
+    // Foreign org is denied.
+    let cross = repo.list_activities(dispute_a, org_b, 50, 0).await;
+    assert!(
+        matches!(cross, Err(::common::errors::AppError::NotFound(_))),
+        "org B must not list org A's activities, got {cross:?}"
+    );
+}


### PR DESCRIPTION
## Task
Security: cross-tenant IDOR cluster in disputes.rs sub-resource handlers (5 handlers, no org scoping) (Closes #2441)

## Owner
pm-security

## Summary
Five dispute sub-resource handlers in `backend/servers/api-server/src/routes/disputes.rs` extracted `_user: AuthUser` (deliberately unused) and queried the repo using only the path-supplied `dispute_id`, with **no organization scoping** — a systemic cross-tenant IDOR:

| Handler | Route | Impact (pre-fix) |
|---|---|---|
| `list_parties` | `GET /{id}/parties` | disclose party roster (`user_id`, `role` PII) |
| `add_party` | `POST /{id}/parties` | inject/overwrite a party+role (e.g. MEDIATOR) cross-tenant |
| `list_evidence` | `GET /{id}/evidence` | disclose evidence incl. S3 `storage_url` |
| `delete_evidence` | `DELETE /{id}/evidence/{evidence_id}` | destroy another org's evidence |
| `list_activities` | `GET /{id}/activities` | disclose the activity log |

### Fix
Each handler now derives `organization_id` from the verified JWT (`user.tenant_id`, 403 if absent) and passes it to the repo — mirroring the sibling `get_dispute` / `update_dispute_status` guards and the `get_document` org-scope guard added in #2422 (#2438).

Repository enforcement (`backend/crates/db/src/repositories/dispute.rs`):
- **`add_party` / `delete_evidence`** — atomic `EXISTS (SELECT 1 FROM disputes WHERE id = … AND organization_id = $org)` predicate on the write itself, mirroring `ViolationRepository::delete_evidence`. A foreign-org `dispute_id` writes/deletes nothing.
- **`list_parties` / `list_evidence` / `list_activities`** — a shared private `ensure_dispute_in_org` guard runs first; a foreign-org `dispute_id` returns `NotFound`.
- A foreign-org `dispute_id` maps to **404** (delete: nothing deleted → 404) so the response is not a cross-tenant existence oracle. Internal `add_party` callers in `file_dispute` pass the new dispute's own org.

**RLS confirmation:** the fix is application-layer defense that closes a live IDOR — the sub-resource tables (`dispute_parties`, `dispute_evidence`, `dispute_activities`) are not org-scoped by RLS on this pool, which is exactly why `get_dispute` already derives org from the JWT. The issue's premise is confirmed by the sibling handlers, not downgraded to defense-in-depth.

## Tests
Added R4–R8 repo-layer regression tests in `servers/api-server/tests/dispute_cross_org_idor_tests.rs` (alongside the existing R1–R3), pinning the org-scope contract for all five methods: foreign org is rejected (`NotFound` / `false` + row survives), owning org succeeds. Existing `dispute_lifecycle_tests.rs` call sites updated for the new signatures. These are `#[sqlx::test]` tests (run against Postgres in `backend.yml` CI).

## Verification
```
VERIFY-PLAN base=bf644c2 files=4
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p accounting-core --all-targets -- -D warnings
  cd backend && cargo clippy -p accounting-server --all-targets -- -D warnings
  cd backend && cargo clippy -p admin-core --all-targets -- -D warnings
  cd backend && cargo clippy -p api-core --all-targets -- -D warnings
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo clippy -p db --all-targets -- -D warnings
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo clippy -p tenant-ops --all-targets -- -D warnings
  cd backend && cargo test -p {accounting-core,accounting-server,admin-core,api-core,api-server,db,reality-server,tenant-ops}
```

Type gate (the meaningful compile-time verification) run locally, both changed crates, `--all-targets -D warnings`, `SQLX_OFFLINE=true`:
- `cargo clippy -p db --all-targets -- -D warnings` → **EXIT 0** (repo layer + `dispute_lifecycle_tests.rs`)
- `cargo clippy -p api-server --all-targets -- -D warnings` → **EXIT 0** (handlers + `dispute_cross_org_idor_tests.rs`)
- `cargo fmt --all -- --check` → **EXIT 0**

api-server compile used the documented `SWAGGER_UI_DOWNLOAD_URL=file://…` build-asset workaround (the `utoipa-swagger-ui` GitHub download is egress-blocked in the sandbox).

The `cargo test` execution leg requires live Postgres for the `#[sqlx::test]` cases, which this sandbox has no DB for — deferred to `backend.yml` CI (same reason the sibling dispute repo tests are CI-only). No `VERIFY OK` hash is claimed because the full gate's test-run leg did not execute locally.

## CI parity (Band C — hot-path)
This is a hot-path security change. `act`/`gh` are unavailable in the sandbox; CI parity is provided by the required `backend.yml` job on this PR (fmt + clippy + test with a live DB), which must be green before merge.

## Remote-tested
skipped (ppt-bridge MCP not connected)

## Scope drift
`scope-check.sh --owner pm-security` reports drift: the `pm-security` owner-area globs are narrowly auth/MFA-scoped, but this task is a security fix on the **dispute** handlers/repo. Touched paths (all justified, all within the issue's stated fix surface):
- `backend/servers/api-server/src/routes/disputes.rs`
- `backend/crates/db/src/repositories/dispute.rs`
- `backend/crates/db/tests/dispute_lifecycle_tests.rs`
- `backend/servers/api-server/tests/dispute_cross_org_idor_tests.rs`

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. The fix reuses the established sibling pattern (`ViolationRepository::delete_evidence` EXISTS-predicate; `get_dispute`/`get_document` JWT-tenant derivation) rather than introducing new helpers.

## Notes
Closes #2441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Gf6u2ZrR3keF8EqPuhGfv

---
_Generated by [Claude Code](https://claude.ai/code/session_011Gf6u2ZrR3keF8EqPuhGfv)_