### PR TITLE
chore(claude): version shared agent config (settings, guard hooks, commands)

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -1,0 +1,101 @@
+# Generate Changelog
+
+Generate a changelog from git commits.
+
+## Instructions
+
+### Step 1: Determine Range
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+```
+
+If $ARGUMENTS provided, use as range:
+- `/changelog v0.1.0..v0.2.0` - Between two tags
+- `/changelog v0.1.0` - From tag to HEAD
+- `/changelog 10` - Last 10 commits
+
+### Step 2: Get Commits
+```bash
+if [[ -n "$LAST_TAG" ]]; then
+  COMMITS=$(git log --oneline "$LAST_TAG"..HEAD)
+else
+  COMMITS=$(git log --oneline -50)
+fi
+```
+
+### Step 3: Categorize Commits
+Parse commit messages by conventional commit type:
+
+**Features** (`feat`):
+```bash
+echo "$COMMITS" | grep -E "^[a-f0-9]+ feat"
+```
+
+**Bug Fixes** (`fix`):
+```bash
+echo "$COMMITS" | grep -E "^[a-f0-9]+ fix"
+```
+
+**Documentation** (`docs`):
+```bash
+echo "$COMMITS" | grep -E "^[a-f0-9]+ docs"
+```
+
+**Refactoring** (`refactor`):
+```bash
+echo "$COMMITS" | grep -E "^[a-f0-9]+ refactor"
+```
+
+**Tests** (`test`):
+```bash
+echo "$COMMITS" | grep -E "^[a-f0-9]+ test"
+```
+
+**Chores** (`chore`):
+```bash
+echo "$COMMITS" | grep -E "^[a-f0-9]+ chore"
+```
+
+**Other** (remaining):
+```bash
+echo "$COMMITS" | grep -vE "^[a-f0-9]+ (feat|fix|docs|refactor|test|chore)"
+```
+
+### Step 4: Format Output
+Generate markdown:
+
+```markdown
+# Changelog
+
+## [Unreleased] - YYYY-MM-DD
+
+### Features
+- {feat commits with scope and description}
+
+### Bug Fixes
+- {fix commits}
+
+### Documentation
+- {docs commits}
+
+### Other Changes
+- {remaining commits}
+
+### Contributors
+{unique commit authors}
+```
+
+### Step 5: Output Options
+Based on context:
+- Display in terminal (default)
+- If `/changelog > CHANGELOG.md` requested, append to file
+
+### Step 6: Announce
+```bash
+.claude/hooks/play-tts.sh "Changelog generated with X commits"
+```
+
+## Usage
+- `/changelog` - Generate from last tag to HEAD
+- `/changelog v0.1.0` - Generate from specific tag
+- `/changelog 20` - Last 20 commits only

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,98 @@
+# Create a Release
+
+Automate version bumping, changelog generation, and release creation.
+
+## Instructions
+
+### Step 1: Validate State
+```bash
+git status --short
+git branch --show-current
+```
+
+Verify:
+- On main branch (or create release branch)
+- No uncommitted changes
+- All CI checks passing: `gh pr checks` or `gh run list --limit 1`
+
+### Step 2: Determine Version Bump
+Parse $ARGUMENTS:
+- `patch` (default) - Bug fixes: 0.1.0 -> 0.1.1
+- `minor` - New features: 0.1.0 -> 0.2.0
+- `major` - Breaking changes: 0.1.0 -> 1.0.0
+
+### Step 3: Get Current Version
+```bash
+cat VERSION
+```
+
+### Step 4: Generate Changelog
+Get commits since last tag:
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+if [[ -n "$LAST_TAG" ]]; then
+  git log --oneline "$LAST_TAG"..HEAD
+else
+  git log --oneline -20
+fi
+```
+
+Group by type:
+- **Features**: `feat(...)` commits
+- **Fixes**: `fix(...)` commits
+- **Other**: remaining commits
+
+### Step 5: Bump Version
+```bash
+./scripts/bump-version.sh $TYPE
+```
+
+This updates:
+- `VERSION` file
+- All `package.json` files
+- `mobile-native/gradle.properties`
+
+### Step 6: Create Release Commit
+```bash
+NEW_VERSION=$(cat VERSION)
+git add -A
+git commit -m "chore(release): v$NEW_VERSION"
+```
+
+### Step 7: Create Tag
+```bash
+git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+```
+
+### Step 8: Push & Create GitHub Release
+```bash
+git push origin main --tags
+
+gh release create "v$NEW_VERSION" \
+  --title "v$NEW_VERSION" \
+  --notes "$(cat <<EOF
+## What's Changed
+
+### Features
+{list feat commits}
+
+### Bug Fixes
+{list fix commits}
+
+### Other Changes
+{list other commits}
+
+**Full Changelog**: https://github.com/OWNER/REPO/compare/$LAST_TAG...v$NEW_VERSION
+EOF
+)"
+```
+
+### Step 9: Announce
+```bash
+.claude/hooks/play-tts.sh "Release v$NEW_VERSION created successfully"
+```
+
+## Usage
+- `/release` - Create patch release
+- `/release minor` - Create minor release
+- `/release major` - Create major release

--- a/.claude/hooks/branch-guard.sh
+++ b/.claude/hooks/branch-guard.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+#
+# branch-guard.sh - PreToolUse hook to prevent dangerous git operations
+#
+# Blocks force pushes to main/master and warns about direct commits.
+#
+# Hook Event: PreToolUse (matcher: Bash)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TTS_SCRIPT="$SCRIPT_DIR/play-tts.sh"
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Parse tool name and command
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
+TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only process Bash tool calls
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    exit 0
+fi
+
+# Get current branch
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+
+# Check for dangerous operations
+
+# 1. Block force push to main/master
+if [[ "$TOOL_INPUT" =~ git\ push.*--force ]] || [[ "$TOOL_INPUT" =~ git\ push.*-f ]]; then
+    if [[ "$TOOL_INPUT" =~ (main|master) ]] || [[ "$BRANCH" == "main" ]] || [[ "$BRANCH" == "master" ]]; then
+        if [[ -x "$TTS_SCRIPT" ]]; then
+            "$TTS_SCRIPT" "Blocked! Force push to main is not allowed."
+        fi
+        cat << EOF
+{
+    "decision": "block",
+    "reason": "Force push to main/master branch is blocked for safety. Use a feature branch and PR instead."
+}
+EOF
+        exit 0
+    fi
+fi
+
+# 2. Block hard reset on main/master
+if [[ "$TOOL_INPUT" =~ git\ reset\ --hard ]]; then
+    if [[ "$BRANCH" == "main" ]] || [[ "$BRANCH" == "master" ]]; then
+        if [[ -x "$TTS_SCRIPT" ]]; then
+            "$TTS_SCRIPT" "Blocked! Hard reset on main is dangerous."
+        fi
+        cat << EOF
+{
+    "decision": "block",
+    "reason": "Hard reset on main/master branch is blocked. This operation is destructive and irreversible."
+}
+EOF
+        exit 0
+    fi
+fi
+
+# 3. Warn about direct commits to main (but allow)
+if [[ "$TOOL_INPUT" =~ git\ commit ]] && [[ ! "$TOOL_INPUT" =~ --amend ]]; then
+    if [[ "$BRANCH" == "main" ]] || [[ "$BRANCH" == "master" ]]; then
+        if [[ -x "$TTS_SCRIPT" ]]; then
+            "$TTS_SCRIPT" "Warning: Committing directly to main. Consider using a feature branch."
+        fi
+        # Allow but warn
+        cat << EOF
+{
+    "warning": "Direct commit to main branch. Consider using feature branches for better collaboration."
+}
+EOF
+    fi
+fi
+
+# 4. Block rebase of main
+if [[ "$TOOL_INPUT" =~ git\ rebase ]]; then
+    if [[ "$BRANCH" == "main" ]] || [[ "$BRANCH" == "master" ]]; then
+        if [[ -x "$TTS_SCRIPT" ]]; then
+            "$TTS_SCRIPT" "Blocked! Rebasing main is not allowed."
+        fi
+        cat << EOF
+{
+    "decision": "block",
+    "reason": "Rebasing main/master branch is blocked. This can cause issues for other contributors."
+}
+EOF
+        exit 0
+    fi
+fi
+
+# Allow operation
+exit 0

--- a/.claude/hooks/gh-ci-checker.sh
+++ b/.claude/hooks/gh-ci-checker.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# gh-ci-checker.sh - PostToolUse hook for GitHub CI status
+#
+# Triggered after Bash commands, checks if it was a gh/git command
+# and announces CI status via TTS.
+#
+# Hook Event: PostToolUse (matcher: Bash)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TTS_SCRIPT="$SCRIPT_DIR/play-tts.sh"
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Parse tool name and command
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
+TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only process Bash tool calls
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    exit 0
+fi
+
+# Check if this is a relevant GitHub/git command
+if [[ ! "$TOOL_INPUT" =~ ^(gh\ pr|gh\ run|git\ push) ]]; then
+    exit 0
+fi
+
+# Wait a moment for GitHub to register the action
+sleep 2
+
+# Get current PR checks (suppress errors if no PR)
+CHECKS=$(gh pr checks 2>/dev/null || echo "")
+
+if [[ -z "$CHECKS" ]]; then
+    # No PR associated with current branch
+    exit 0
+fi
+
+# Count check statuses
+PASS=$(echo "$CHECKS" | grep -c "pass" || echo "0")
+FAIL=$(echo "$CHECKS" | grep -c "fail" || echo "0")
+PENDING=$(echo "$CHECKS" | grep -c -E "(pending|queued|in_progress)" || echo "0")
+
+# Announce via TTS if the script exists
+if [[ -x "$TTS_SCRIPT" ]]; then
+    if [[ "$PENDING" -gt 0 ]]; then
+        "$TTS_SCRIPT" "CI running, $PENDING checks pending"
+    elif [[ "$FAIL" -gt 0 ]]; then
+        "$TTS_SCRIPT" "CI has $FAIL failures"
+    elif [[ "$PASS" -gt 0 ]]; then
+        "$TTS_SCRIPT" "All $PASS CI checks passed"
+    fi
+fi
+
+# Output JSON for Claude (optional context)
+cat << EOF
+{
+    "ci_status": {
+        "passed": $PASS,
+        "failed": $FAIL,
+        "pending": $PENDING
+    }
+}
+EOF
+
+exit 0

--- a/.claude/hooks/pr-auto-fill.sh
+++ b/.claude/hooks/pr-auto-fill.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+#
+# pr-auto-fill.sh - PostToolUse hook to auto-fill PR descriptions
+#
+# Triggered after `gh pr create` commands
+# Extracts epic/story/UC context from documentation
+#
+# Hook Event: PostToolUse (matcher: Bash)
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+TTS_SCRIPT="$SCRIPT_DIR/play-tts.sh"
+EPICS_FILE="$PROJECT_DIR/_bmad-output/epics.md"
+USE_CASES_FILE="$PROJECT_DIR/docs/use-cases.md"
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Parse tool name and command
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
+TOOL_INPUT=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+
+# Only process Bash tool calls with gh pr create
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+    exit 0
+fi
+
+if [[ ! "$TOOL_INPUT" =~ gh\ pr\ create ]]; then
+    exit 0
+fi
+
+# Get current branch and extract epic number
+BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+EPIC_NUM=""
+
+# Try to extract epic number from branch name
+# Patterns: feature/epic-5-voting, feature/EPIC-5, feature/epic-2a-orgs
+if [[ "$BRANCH" =~ [Ee]pic[-_]?([0-9]+[AaBb]?) ]]; then
+    EPIC_NUM="${BASH_REMATCH[1]}"
+fi
+
+if [[ -z "$EPIC_NUM" ]]; then
+    # Announce that we couldn't detect epic
+    if [[ -x "$TTS_SCRIPT" ]]; then
+        "$TTS_SCRIPT" "PR created. No epic detected from branch name."
+    fi
+    exit 0
+fi
+
+# Normalize epic number (uppercase for letters)
+EPIC_NUM=$(echo "$EPIC_NUM" | tr '[:lower:]' '[:upper:]')
+
+# Wait for PR to be created
+sleep 2
+
+# Get PR number
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+
+if [[ -z "$PR_NUM" ]]; then
+    exit 0
+fi
+
+# Check if epics file exists
+if [[ ! -f "$EPICS_FILE" ]]; then
+    if [[ -x "$TTS_SCRIPT" ]]; then
+        "$TTS_SCRIPT" "PR $PR_NUM created. Epics file not found."
+    fi
+    exit 0
+fi
+
+# Extract epic section from epics.md
+# Look for ## Epic N: or ## Epic NA:
+EPIC_SECTION=$(awk "/^## Epic $EPIC_NUM:/,/^## Epic [0-9]/" "$EPICS_FILE" | head -n -1)
+
+if [[ -z "$EPIC_SECTION" ]]; then
+    # Try with different formats
+    EPIC_SECTION=$(awk "/^## Epic ${EPIC_NUM}[^0-9]/,/^## Epic [0-9]/" "$EPICS_FILE" | head -n -1)
+fi
+
+if [[ -z "$EPIC_SECTION" ]]; then
+    if [[ -x "$TTS_SCRIPT" ]]; then
+        "$TTS_SCRIPT" "PR $PR_NUM created. Epic $EPIC_NUM not found in documentation."
+    fi
+    exit 0
+fi
+
+# Extract key information
+EPIC_TITLE=$(echo "$EPIC_SECTION" | grep -m1 "^## Epic" | sed 's/^## //')
+EPIC_GOAL=$(echo "$EPIC_SECTION" | grep -A1 "^\*\*Goal:\*\*" | tail -1 | sed 's/^[[:space:]]*//')
+FRS_COVERED=$(echo "$EPIC_SECTION" | grep -A1 "^\*\*FRs covered:\*\*" | tail -1 | sed 's/^[[:space:]]*//')
+
+# Extract stories (look for ### Story patterns)
+STORIES=$(echo "$EPIC_SECTION" | grep "^### Story" | sed 's/^### /- /')
+
+# Count stories
+STORY_COUNT=$(echo "$STORIES" | grep -c "^-" || echo "0")
+
+# Get current PR body
+CURRENT_BODY=$(gh pr view "$PR_NUM" --json body -q '.body' 2>/dev/null || echo "")
+
+# Generate new PR body
+NEW_BODY="## Summary
+${EPIC_GOAL:-Implementation of $EPIC_TITLE}
+
+## $EPIC_TITLE
+
+**Goal:** ${EPIC_GOAL:-See epic documentation}
+
+**FRs Covered:** ${FRS_COVERED:-See documentation}
+
+## Stories Implemented ($STORY_COUNT stories)
+$STORIES
+
+## Changes
+$(git diff main...HEAD --stat 2>/dev/null | tail -5)
+
+---
+*Auto-generated from \`_bmad-output/epics.md\`*"
+
+# Update PR body
+gh pr edit "$PR_NUM" --body "$NEW_BODY" 2>/dev/null
+
+# Announce via TTS
+if [[ -x "$TTS_SCRIPT" ]]; then
+    "$TTS_SCRIPT" "PR $PR_NUM filled with Epic $EPIC_NUM context. $STORY_COUNT stories documented."
+fi
+
+# Output result
+cat << EOF
+{
+    "pr_filled": true,
+    "pr_number": $PR_NUM,
+    "epic": "$EPIC_NUM",
+    "stories_count": $STORY_COUNT
+}
+EOF
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/branch-guard.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gh-ci-checker.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pr-auto-fill.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "bmad-system@hanibalsk-marketplace": true,
+    "claude-auto-agents@hanibalsk-marketplace": true,
+    "prettier-plugin@cli-lsp-client-plugins": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,13 @@ Thumbs.db
 .claude-threads/
 .bmad/
 _bmad/
-.claude/
+# .claude: ignore everything except the shared agent config subset
+.claude/*
+!.claude/settings.json
+!.claude/commands/
+!.claude/agents/
+!.claude/skills/
+!.claude/hooks/
 .cursor/
 .mcp.json
 


### PR DESCRIPTION
Second wave of the AI-DX initiative (follows #2448): version the shared agent config.

- **Committed the untracked `.claude/` subset**: `settings.json` (post-cleanup: TTS session-start hook removed; branch-guard PreToolUse + gh-ci-checker/pr-auto-fill PostToolUse kept), the three functional hooks, `commands/changelog.md` + `commands/release.md`.
- **.gitignore**: `.claude/` → `.claude/*` with explicit whitelist (`settings.json`, `commands/`, `agents/`, `skills/`, `hooks/`); `settings.local.json`, `worktrees/`, `audio/`, caches stay ignored.
- Secrets scan on everything committed: clean (no credentials; only token-discipline prose).
- Note: most `.claude/` skills/agents were already tracked on dev (newer than local copies) — this PR adds only what was genuinely missing. Separately, the local checkout's `.claude/` was purged of ~606 MB AgentVibes/TTS cruft (38 hook scripts + audio) — local-only, not part of this diff.
