### PR TITLE
gh-issue-2449: correct layout-core Props docstring (key-only gating, values not validated)

### DIFF
--- a/backend/crates/layout-core/src/types.rs
+++ b/backend/crates/layout-core/src/types.rs
@@ -52,3 +52,166 @@ pub struct SectionConfig {
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub overrides: BTreeMap<Platform, SectionPatch>,
 }
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScreenConfig {
+    pub screen: String,
+    pub version: u32,
+    pub sections: Vec<SectionConfig>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Per-component contract published by each frontend (spec §3.3).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ComponentDef {
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub supported_modes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegistryManifest {
+    pub platform: Platform,
+    pub components: BTreeMap<SectionType, ComponentDef>,
+}
+
+/// Sparse per-org delta over a published base config (spec §3.2).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct TenantOverride {
+    /// Full desired order by type. None = keep base order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub order: Option<Vec<SectionType>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub sections: BTreeMap<SectionType, SectionPatch>,
+}
+
+/// What tenant admins may change on a screen (spec §3.4). Authored by superadmin.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct Rails {
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub hideable: BTreeSet<SectionType>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub mode_editable: BTreeSet<SectionType>,
+    #[serde(default)]
+    pub reorderable: bool,
+    /// Per-section set of prop names tenant admins may set.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub prop_whitelist: BTreeMap<SectionType, BTreeSet<String>>,
+}
+
+/// How a resolved section renders (spec §4 rules 2–3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Presentation {
+    Visible,
+    /// Required section that is hidden, killed, or failed validation.
+    Placeholder,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedSection {
+    #[serde(rename = "type")]
+    pub section_type: SectionType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub props: Props,
+    pub presentation: Presentation,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResolvedScreen {
+    pub screen: String,
+    pub version: u32,
+    pub sections: Vec<ResolvedSection>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The illustrative config from spec §3.1 must deserialize and round-trip.
+    #[test]
+    fn screen_config_round_trips_spec_example() {
+        let json = r#"{
+          "screen": "reality/listing-detail",
+          "version": 42,
+          "sections": [
+            { "type": "gallery.v1" },
+            { "type": "agent-contact.v1", "mode": "sticky-sidebar",
+              "overrides": { "mobile": { "mode": "bottom-bar" } } },
+            { "type": "similar-listings.v1", "visible": false },
+            { "type": "mortgage-calc.v1", "props": { "maxYears": 30 } }
+          ]
+        }"#;
+        let cfg: ScreenConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.screen, "reality/listing-detail");
+        assert_eq!(cfg.version, 42);
+        assert_eq!(cfg.sections.len(), 4);
+        // "visible" defaults to true when omitted
+        assert!(cfg.sections[0].visible);
+        assert!(!cfg.sections[2].visible);
+        // platform override parsed under enum key
+        let patch = &cfg.sections[1].overrides[&Platform::Mobile];
+        assert_eq!(patch.mode.as_deref(), Some("bottom-bar"));
+        // props carried as JSON values
+        assert_eq!(cfg.sections[3].props["maxYears"], serde_json::json!(30));
+        // unknown fields are ignored (additive evolution)
+        let with_unknown = r#"{"screen":"s","version":1,"sections":[
+            {"type":"x.v1","futureField":true}]}"#;
+        assert!(serde_json::from_str::<ScreenConfig>(with_unknown).is_ok());
+        // round-trip
+        let back: ScreenConfig =
+            serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
+        assert_eq!(
+            back.sections[1].overrides[&Platform::Mobile]
+                .mode
+                .as_deref(),
+            Some("bottom-bar")
+        );
+    }
+
+    #[test]
+    fn manifest_override_and_rails_deserialize_with_defaults() {
+        let manifest: RegistryManifest = serde_json::from_str(
+            r#"{"platform":"web","components":{
+                "gallery.v1":{"required":true},
+                "listing-grid.v1":{"supported_modes":["list","grid","map"],
+                                    "default_mode":"list"}}}"#,
+        )
+        .unwrap();
+        let gallery = &manifest.components[&SectionType::from("gallery.v1")];
+        assert!(gallery.required);
+        assert!(gallery.supported_modes.is_empty());
+        let grid = &manifest.components[&SectionType::from("listing-grid.v1")];
+        assert!(!grid.required); // required defaults to false
+        assert_eq!(grid.default_mode.as_deref(), Some("list"));
+
+        let ov: TenantOverride = serde_json::from_str(
+            r#"{"order":["b.v1","a.v1"],
+                "sections":{"a.v1":{"visible":false}}}"#,
+        )
+        .unwrap();
+        assert_eq!(ov.order.as_ref().unwrap().len(), 2);
+        assert_eq!(ov.sections[&SectionType::from("a.v1")].visible, Some(false));
+        // empty override is valid (all fields default)
+        assert!(serde_json::from_str::<TenantOverride>("{}").is_ok());
+
+        let rails: Rails = serde_json::from_str(
+            r#"{"hideable":["a.v1"],"reorderable":true,
+                "prop_whitelist":{"a.v1":["title","limit"]}}"#,
+        )
+        .unwrap();
+        assert!(rails.reorderable);
+        assert!(rails.hideable.contains(&SectionType::from("a.v1")));
+        assert!(rails.mode_editable.is_empty()); // defaults empty
+                                                 // empty JSON deserializes to default Rails (all fields have serde defaults)
+        assert!(serde_json::from_str::<Rails>("{}").is_ok());
+    }
+}

--- a/backend/crates/layout-core/src/types.rs
+++ b/backend/crates/layout-core/src/types.rs
@@ -1,7 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Free-form props bag; values validated against component prop schemas at publish time.
+/// Free-form props bag.
+///
+/// Only prop *keys* are gated: tenant overrides are checked against
+/// `rails.prop_whitelist[type]` (see [`crate::validate::validate_tenant_override`]).
+/// Prop *values* are NOT yet validated — any type, range, or length passes
+/// through unchecked at both publish and tenant-override time. Per-prop schema
+/// enforcement (type/min/max/maxLen) is not implemented; see issue #2449.
 pub type Props = BTreeMap<String, serde_json::Value>;
 
 /// Semantic, versioned component type name, e.g. "price-box.v1" (spec §3.1).
@@ -45,167 +51,4 @@ pub struct SectionConfig {
     pub props: Props,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub overrides: BTreeMap<Platform, SectionPatch>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ScreenConfig {
-    pub screen: String,
-    pub version: u32,
-    pub sections: Vec<SectionConfig>,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-/// Per-component contract published by each frontend (spec §3.3).
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct ComponentDef {
-    #[serde(default)]
-    pub required: bool,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub supported_modes: Vec<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub default_mode: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct RegistryManifest {
-    pub platform: Platform,
-    pub components: BTreeMap<SectionType, ComponentDef>,
-}
-
-/// Sparse per-org delta over a published base config (spec §3.2).
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct TenantOverride {
-    /// Full desired order by type. None = keep base order.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub order: Option<Vec<SectionType>>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub sections: BTreeMap<SectionType, SectionPatch>,
-}
-
-/// What tenant admins may change on a screen (spec §3.4). Authored by superadmin.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-pub struct Rails {
-    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub hideable: BTreeSet<SectionType>,
-    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
-    pub mode_editable: BTreeSet<SectionType>,
-    #[serde(default)]
-    pub reorderable: bool,
-    /// Per-section set of prop names tenant admins may set.
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub prop_whitelist: BTreeMap<SectionType, BTreeSet<String>>,
-}
-
-/// How a resolved section renders (spec §4 rules 2–3).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Presentation {
-    Visible,
-    /// Required section that is hidden, killed, or failed validation.
-    Placeholder,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ResolvedSection {
-    #[serde(rename = "type")]
-    pub section_type: SectionType,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub mode: Option<String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub props: Props,
-    pub presentation: Presentation,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ResolvedScreen {
-    pub screen: String,
-    pub version: u32,
-    pub sections: Vec<ResolvedSection>,
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The illustrative config from spec §3.1 must deserialize and round-trip.
-    #[test]
-    fn screen_config_round_trips_spec_example() {
-        let json = r#"{
-          "screen": "reality/listing-detail",
-          "version": 42,
-          "sections": [
-            { "type": "gallery.v1" },
-            { "type": "agent-contact.v1", "mode": "sticky-sidebar",
-              "overrides": { "mobile": { "mode": "bottom-bar" } } },
-            { "type": "similar-listings.v1", "visible": false },
-            { "type": "mortgage-calc.v1", "props": { "maxYears": 30 } }
-          ]
-        }"#;
-        let cfg: ScreenConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(cfg.screen, "reality/listing-detail");
-        assert_eq!(cfg.version, 42);
-        assert_eq!(cfg.sections.len(), 4);
-        // "visible" defaults to true when omitted
-        assert!(cfg.sections[0].visible);
-        assert!(!cfg.sections[2].visible);
-        // platform override parsed under enum key
-        let patch = &cfg.sections[1].overrides[&Platform::Mobile];
-        assert_eq!(patch.mode.as_deref(), Some("bottom-bar"));
-        // props carried as JSON values
-        assert_eq!(cfg.sections[3].props["maxYears"], serde_json::json!(30));
-        // unknown fields are ignored (additive evolution)
-        let with_unknown = r#"{"screen":"s","version":1,"sections":[
-            {"type":"x.v1","futureField":true}]}"#;
-        assert!(serde_json::from_str::<ScreenConfig>(with_unknown).is_ok());
-        // round-trip
-        let back: ScreenConfig =
-            serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
-        assert_eq!(
-            back.sections[1].overrides[&Platform::Mobile]
-                .mode
-                .as_deref(),
-            Some("bottom-bar")
-        );
-    }
-
-    #[test]
-    fn manifest_override_and_rails_deserialize_with_defaults() {
-        let manifest: RegistryManifest = serde_json::from_str(
-            r#"{"platform":"web","components":{
-                "gallery.v1":{"required":true},
-                "listing-grid.v1":{"supported_modes":["list","grid","map"],
-                                    "default_mode":"list"}}}"#,
-        )
-        .unwrap();
-        let gallery = &manifest.components[&SectionType::from("gallery.v1")];
-        assert!(gallery.required);
-        assert!(gallery.supported_modes.is_empty());
-        let grid = &manifest.components[&SectionType::from("listing-grid.v1")];
-        assert!(!grid.required); // required defaults to false
-        assert_eq!(grid.default_mode.as_deref(), Some("list"));
-
-        let ov: TenantOverride = serde_json::from_str(
-            r#"{"order":["b.v1","a.v1"],
-                "sections":{"a.v1":{"visible":false}}}"#,
-        )
-        .unwrap();
-        assert_eq!(ov.order.as_ref().unwrap().len(), 2);
-        assert_eq!(ov.sections[&SectionType::from("a.v1")].visible, Some(false));
-        // empty override is valid (all fields default)
-        assert!(serde_json::from_str::<TenantOverride>("{}").is_ok());
-
-        let rails: Rails = serde_json::from_str(
-            r#"{"hideable":["a.v1"],"reorderable":true,
-                "prop_whitelist":{"a.v1":["title","limit"]}}"#,
-        )
-        .unwrap();
-        assert!(rails.reorderable);
-        assert!(rails.hideable.contains(&SectionType::from("a.v1")));
-        assert!(rails.mode_editable.is_empty()); // defaults empty
-                                                 // empty JSON deserializes to default Rails (all fields have serde defaults)
-        assert!(serde_json::from_str::<Rails>("{}").is_ok());
-    }
 }


### PR DESCRIPTION
## Task
Follow-up: layout tenant/publish validation never checks prop VALUES — only keys; docstring overclaims (PR #2424) (Closes #2449).

Near-term deliverable per issue #2449: fix the misleading `Props` docstring in `backend/crates/layout-core/src/types.rs` so it states only prop KEYS are gated (via `rails.prop_whitelist`) and values are NOT yet validated — removing the "validated against component prop schemas at publish time" claim. This PR lands the docstring-honesty fix only (the accepted minimal landing); the proper per-prop schema enforcement (`ValidationError::PropValueInvalid`) is left tracked under #2449 for when component prop schemas land.

## Change
Single doc-comment edit on `pub type Props`:

- Before: `/// Free-form props bag; values validated against component prop schemas at publish time.`
- After: documents that only prop *keys* are gated (tenant overrides vs `rails.prop_whitelist[type]`, with an intra-doc link to `validate_tenant_override`), that prop *values* are NOT yet validated at publish or tenant-override time, and that per-prop schema enforcement is not implemented — pointing to issue #2449.

No code behavior changes; no public API surface changes.

## Owner
pm-tech-lead (specialist: rust-backend)

## Verification
```
VERIFY-PLAN base=7ae55711285e633c7e38f1d6ee745a94a2fed1e5 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo clippy -p layout-core --all-targets -- -D warnings
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
  cd backend && cargo test -p layout-core
  cd backend && cargo test -p reality-server
```

**Changed crate (`layout-core`) — green locally:**
- `cargo fmt -p layout-core -- --check` → clean (exit 0)
- `cargo clippy -p layout-core --all-targets -- -D warnings` → clean (exit 0)
- `cargo test -p layout-core` → 15 passed; 0 failed (incl. doc-tests: intra-doc link resolves)

**Reverse-dependent crates (`api-server`, `reality-server`) — deferred to CI (environmental sandbox block, NOT this diff):**
The full `just verify` plan pulled in `api-server`/`reality-server` as reverse-dependents of `layout-core`. Their clippy fails in the implementer sandbox because the `utoipa-swagger-ui v9.0.2` build script downloads the Swagger UI zip from GitHub at build time and the sandbox proxy blocks the fetch:
```
error: failed to run custom build command for `utoipa-swagger-ui v9.0.2`
  ... panicked at build.rs:219:51:
  failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
```
This is a build-time network limitation of the isolated worktree, independent of a one-line doc-comment in `layout-core` (which has no swagger-ui dependency). It matches the dispatcher's "checks that can't run in-sandbox defer to CI" contract — CI has network access to complete the download, so `backend.yml` will run the full gate.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs-only comment change; no security/auth/billing/data-integrity code change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` exited 2 (advisory): `backend/crates/layout-core/src/types.rs` is outside the `pm-tech-lead` owner-area map. This is expected — the owner_role is a delivery hint while the work is a backend contract-crate change (specialist rust-backend). Diff is confined to the single intended file. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → empty. The change adds no new symbol/helper (doc comment only).

## Notes
- Scoped to the docstring-honesty fix (issue #2449's accepted minimal landing). Per-prop value schema enforcement (`ComponentDef.prop_schemas` + `ValidationError::PropValueInvalid` in `validate_publish`/`validate_tenant_override`, with numeric-range and string-length accept/reject tests) remains tracked under #2449.
- The branch has intermediate commits from the MCP `push_files` flow (a first push truncated the file; a follow-up push restored the full 218-line file). The final tree was byte-verified against the worktree — net diff vs `dev` is exactly the docstring edit — and squash-merge collapses the intermediate commits.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L731KvaEAG2DxukQQZNFbe)_