### PR TITLE
test(api-server): re-add import + cert-document authz sweep cases after SSRF review (BIT-559)

### DIFF
--- a/backend/servers/api-server/tests/org_property_authz_backfill_tests.rs
+++ b/backend/servers/api-server/tests/org_property_authz_backfill_tests.rs
@@ -203,9 +203,17 @@ fn agencies_cases() -> Vec<(Method, String, Option<&'static str>)> {
             format!("{base}/{UUID}/listings/{UUID2}/history"),
             None,
         ),
-        // NOTE: POST {base}/{UUID}/import (source_url) is intentionally omitted —
-        // the handler performs an outbound fetch of the source URL, which hangs the
-        // synchronous authz sweep in CI. The import read endpoints are covered below.
+        // POST .../import re-added after BIT-559 verification: the handler
+        // (`create_import_job`) performs NO outbound fetch — it calls
+        // `verify_agency_admin` (403 for a non-admin) BEFORE persisting the
+        // `source` string, and `TenantExtractor` runs before the JSON body is
+        // even parsed, so an unauthorized caller is rejected pre-storage. The
+        // earlier CI hang was the ~50-min cold workspace compile, not SSRF.
+        (
+            Method::POST,
+            format!("{base}/{UUID}/import"),
+            Some(r#"{"source":"https://example.com/import.csv"}"#),
+        ),
         (Method::GET, format!("{base}/{UUID}/import/{UUID2}"), None),
         (Method::GET, format!("{base}/{UUID}/import"), None),
     ]
@@ -242,8 +250,18 @@ fn building_certifications_cases() -> Vec<(Method, String, Option<&'static str>)
         (Method::PUT, credit.clone(), Some(r#"{"points":6}"#)),
         (Method::DELETE, credit.clone(), None),
         (Method::GET, format!("{cert}/documents"), None),
-        // NOTE: POST {cert}/documents (url) omitted — handler fetches the document
-        // URL, which hangs the synchronous authz sweep in CI.
+        // POST {cert}/documents re-added after BIT-559 verification: the handler
+        // (`create_document`) performs NO outbound fetch — it only stores the
+        // `file_url` string. The `RlsConnection` extractor validates tenant
+        // membership before the handler body (and before the JSON body is
+        // parsed), so a non-member is rejected pre-storage.
+        (
+            Method::POST,
+            format!("{cert}/documents"),
+            Some(
+                r#"{"document_type":"certificate","title":"cert.pdf","file_url":"https://example.com/cert.pdf"}"#,
+            ),
+        ),
         (Method::DELETE, doc.clone(), None),
         (Method::GET, format!("{cert}/milestones"), None),
         (


### PR DESCRIPTION
## BIT-559 — SSRF / authz-ordering investigation (spun out of BIT-328 / PR #2447)

### Finding: no SSRF, no authz-ordering bug

Two endpoints were flagged after the BIT-328 authz sweep appeared to hang CI, on the hypothesis that they perform a **synchronous outbound fetch of a caller-supplied URL before authz**:

- `POST /api/v1/agencies/{id}/import` — body `{"source": "..."}`
- `POST /api/v1/building-certifications/{id}/documents` — body `{"file_url": "..."}`

I verified both against the handler source:

| Handler | File | Outbound fetch? | Authz before storage? |
|---------|------|-----------------|-----------------------|
| `create_import_job` | `routes/agencies.rs:561` | **None** (plain DB `INSERT` of `source`) | Yes — `verify_agency_admin` at `agencies.rs:570` returns 403 for non-admins **before** the store; `TenantExtractor` also runs before the JSON body is parsed |
| `create_document` | `routes/building_certifications.rs:419` | **None** (plain DB `INSERT` of `file_url`) | Yes — `RlsConnection` extractor validates tenant membership **before** the handler body; non-members rejected pre-storage |

Neither handler calls `reqwest` or any HTTP client on the supplied URL — the URL is only ever stored as a string. In Axum, `TenantExtractor` / `RlsConnection` run **before** the `Json` body extractor, so an anonymous or unprivileged caller is rejected before the body is even deserialized.

**The BIT-328 "hang >50m" was the ~50-minute cold full-workspace compile that the required `test` gate performs before any test runs** — not an outbound fetch. The SSRF/DoS premise was inferred from that hang, not from the code.

### Ask #2 (reorder + timeout + SSRF guard): N/A
There is no fetch to reorder or guard. No code change to the handlers is warranted.

### Ask #3 (re-add authz coverage): done
PR #2447 dropped both POST cases from the sweep with a NOTE claiming *"the handler performs an outbound fetch … which hangs the synchronous authz sweep"*. That NOTE is factually incorrect. This PR re-adds both cases (with corrected comments) so the sweep proves both endpoints reject unauthorized callers **4xx before any storage**:

- `org_property_endpoints_require_auth` (anon → 4xx)
- `agencies_endpoints_reject_unprivileged_user` (authed non-admin → 4xx)
- `building_certifications_reject_non_member` (authed non-member → 4xx)

### Verification
- `cargo fmt` (CI toolchain 1.94.1) — clean.
- Change is purely additive `(Method, String, Option<&'static str>)` tuples into existing case tables; CI `test` gate compiles + runs the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)