### PR TITLE
fix(dev-stack): repair bitrotted docker-compose dev flow

### DIFF
--- a/backend/servers/api-server/Cargo.toml
+++ b/backend/servers/api-server/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 publish = false
+# `cargo run -p api-server` broke when the ppt-features/ppt-seed bins were
+# added (docker-compose.dev.yml and backend/CLAUDE.md both rely on it).
+default-run = "api-server"
 
 [lib]
 name = "api_server"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -108,6 +108,9 @@ services:
       REDIS_URL: redis://redis:6379
       JWT_SECRET: dev-jwt-secret-minimum-32-characters-long
       RUST_LOG: debug
+      # Servers refuse to boot without ESIGN_* secrets unless RUST_ENV signals
+      # a dev environment (found 2026-07-22 live-testing the dev compose flow).
+      RUST_ENV: development
       S3_ENDPOINT: http://minio:9000
       S3_ACCESS_KEY: minioadmin
       S3_SECRET_KEY: minioadmin123
@@ -150,6 +153,9 @@ services:
       REDIS_URL: redis://redis:6379
       JWT_SECRET: dev-jwt-secret-minimum-32-characters-long
       RUST_LOG: debug
+      # Servers refuse to boot without ESIGN_* secrets unless RUST_ENV signals
+      # a dev environment (found 2026-07-22 live-testing the dev compose flow).
+      RUST_ENV: development
       S3_ENDPOINT: http://minio:9000
       S3_ACCESS_KEY: minioadmin
       S3_SECRET_KEY: minioadmin123

--- a/docker/backend/Dockerfile.dev
+++ b/docker/backend/Dockerfile.dev
@@ -1,13 +1,22 @@
 # Development Dockerfile for Rust backend with hot-reload
 # Uses cargo-watch for automatic recompilation
 
-FROM rust:1.75-slim-bookworm
+# Keep in sync with backend/rust-toolchain.toml (channel 1.94.1). The old
+# rust:1.75 base could no longer parse the v4 Cargo.lock (bitrot found
+# 2026-07-22 while live-testing the build-experience roadmap).
+FROM rust:1.94-slim-bookworm
 
-# Install development dependencies
+# Install development dependencies. clang + lld are required because the
+# bind-mounted backend/.cargo/config.toml sets them as the linker for
+# x86_64-linux — without them every runtime `cargo run` fails with
+# "linker `clang` not found" (image-time builds worked only because the
+# COPY below does not include .cargo/).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     curl \
+    clang \
+    lld \
     && rm -rf /var/lib/apt/lists/*
 
 # Install cargo-watch for hot-reloading
@@ -19,6 +28,13 @@ WORKDIR /app
 COPY backend/Cargo.toml backend/Cargo.lock ./
 COPY backend/crates ./crates
 COPY backend/servers ./servers
+
+# crates/common embeds the frontend sitemap JSON via a relative include that
+# resolves one level above the backend workspace root (/app → /frontend/...).
+# Without it the workspace cannot compile inside the image. The runtime
+# bind-mount only covers /app, so rebuilds keep using this image-baked copy —
+# rebuild the image if the sitemap JSON changes.
+COPY frontend/packages/sitemap/src/json/sitemap.json /frontend/packages/sitemap/src/json/sitemap.json
 
 # Build dependencies (cached)
 RUN cargo build


### PR DESCRIPTION
## Summary

Found while live-testing the merged build-experience roadmap (#2444): the docker-compose dev stack could not build or boot at all. Five independent bitrot findings, all fixed:

1. **`Dockerfile.dev` pinned `rust:1.75`** — cannot parse the v4 `Cargo.lock` → `rust:1.94-slim-bookworm` (matches `rust-toolchain.toml` 1.94.1)
2. **Missing sitemap JSON in image** — `crates/common` `include!`s `frontend/packages/sitemap/src/json/sitemap.json` one level above the backend workspace root; the image never copied it, so the workspace could not compile in-image → `COPY` to `/frontend/...`
3. **Missing clang/lld in image** — the bind-mounted `backend/.cargo/config.toml` sets clang+lld as linker; runtime `cargo run` failed with "linker \`clang\` not found" → apt-install both
4. **`cargo run -p api-server` broken** — compose command + `backend/CLAUDE.md` rely on it, but it broke when the `ppt-features`/`ppt-seed` bins were added → `default-run = "api-server"`
5. **Missing `RUST_ENV`** — servers fail closed on absent `ESIGN_*` secrets unless `RUST_ENV` signals dev → `RUST_ENV: development` in both server env blocks

## Verification (live, on merged dev tip 7e982cf91)

- Full workspace compiled in-image (14m41s) and natively
- Both servers boot: `/health` green on 8080/8081, 300+ sqlx migrations applied
- Real API flow: register (DB write) → email-verification policy → login (argon2+JWT) → authenticated `/api/v1/auth/me`; public `/api/v1/listings`; OpenAPI served
- `just verify-plan` on this diff correctly scopes to `clippy -p api-server`; fmt + clippy green