### PR TITLE
code-review-ppt-web-ui-actionqueue-mock-shipped: gate dashboard action-queue mock behind dev-only flag

### DIFF
--- a/frontend/apps/ppt-web/src/features/dashboard/hooks/useActionQueue.test.tsx
+++ b/frontend/apps/ppt-web/src/features/dashboard/hooks/useActionQueue.test.tsx
@@ -1,0 +1,164 @@
+/// <reference types="vitest/globals" />
+/**
+ * useActionQueue tests.
+ *
+ * The action-queue backend endpoint does not exist yet, so the hook must:
+ *  - return an EMPTY queue (never fabricated data) unless the dev-only mock
+ *    gate is active (DEV + dev-panel `mock` mode);
+ *  - fail loudly on approve/reject/dismiss instead of a silent fake success;
+ *  - serve mock data + simulated mutations only under the mock gate.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import {
+  type ActionQueueData,
+  applyActionQueueFilters,
+  isActionQueueMockEnabled,
+  useActionQueue,
+} from './useActionQueue';
+
+const MODE_KEY = 'ppt-dev-panel-mode';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function enableMock() {
+  localStorage.setItem(MODE_KEY, 'mock');
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('applyActionQueueFilters', () => {
+  const data: ActionQueueData = {
+    items: [
+      {
+        id: 'a',
+        type: 'fault_pending',
+        title: 'Water leak',
+        description: 'ceiling',
+        priority: 'urgent',
+        createdAt: '2026-01-01T00:00:00Z',
+        entityId: 'f-1',
+        entityType: 'fault',
+        actions: [],
+      },
+      {
+        id: 'b',
+        type: 'vote_active',
+        title: 'Garden vote',
+        description: 'renovation',
+        priority: 'low',
+        createdAt: '2026-01-01T00:00:00Z',
+        entityId: 'v-1',
+        entityType: 'vote',
+        actions: [],
+      },
+    ],
+    total: 2,
+    counts: { urgent: 1, high: 0, medium: 0, low: 1 },
+  };
+
+  it('filters by type', () => {
+    const out = applyActionQueueFilters(data, { types: ['vote_active'] });
+    expect(out.items.map((i) => i.id)).toEqual(['b']);
+    expect(out.total).toBe(1);
+  });
+
+  it('filters by priority', () => {
+    const out = applyActionQueueFilters(data, { priorities: ['urgent'] });
+    expect(out.items.map((i) => i.id)).toEqual(['a']);
+  });
+
+  it('filters by case-insensitive search over title and description', () => {
+    expect(applyActionQueueFilters(data, { search: 'GARDEN' }).items.map((i) => i.id)).toEqual([
+      'b',
+    ]);
+    expect(applyActionQueueFilters(data, { search: 'ceiling' }).items.map((i) => i.id)).toEqual([
+      'a',
+    ]);
+  });
+
+  it('returns all items when no filters supplied', () => {
+    expect(applyActionQueueFilters(data).items).toHaveLength(2);
+  });
+});
+
+describe('isActionQueueMockEnabled', () => {
+  it('is disabled by default (no dev-panel mock mode set)', () => {
+    expect(isActionQueueMockEnabled()).toBe(false);
+  });
+
+  it('is enabled under DEV when dev-panel mode is mock', () => {
+    enableMock();
+    // Tests run under Vite DEV (import.meta.env.DEV === true).
+    expect(isActionQueueMockEnabled()).toBe(true);
+  });
+});
+
+describe('useActionQueue — no backend / mock disabled', () => {
+  it('resolves an empty queue instead of fabricated data', async () => {
+    const { result } = renderHook(() => useActionQueue('manager'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.items).toEqual([]);
+    expect(result.current.total).toBe(0);
+    expect(result.current.stats).toEqual({ total: 0, urgent: 0, high: 0, medium: 0, low: 0 });
+  });
+
+  it('fails loudly on an action instead of a silent no-op', async () => {
+    const { result } = renderHook(() => useActionQueue('manager'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    result.current.handleAction('some-item', 'approve');
+
+    await waitFor(() => expect(result.current.isExecuteError).toBe(true));
+    expect((result.current.executeError as Error).message).toMatch(/not implemented/i);
+  });
+});
+
+describe('useActionQueue — mock enabled (DEV)', () => {
+  it('serves mock manager items and computes stats', async () => {
+    enableMock();
+    const { result } = renderHook(() => useActionQueue('manager'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.items.length).toBeGreaterThan(0));
+    expect(result.current.total).toBe(result.current.items.length);
+    expect(result.current.stats.total).toBe(result.current.items.length);
+  });
+
+  it('applies filters to the mock data', async () => {
+    enableMock();
+    const { result } = renderHook(
+      () => useActionQueue('manager', { types: ['approval_pending'] }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.items.length).toBeGreaterThan(0));
+    expect(result.current.items.every((i) => i.type === 'approval_pending')).toBe(true);
+  });
+
+  it('executes an action without error under the mock', async () => {
+    enableMock();
+    const { result } = renderHook(() => useActionQueue('manager'), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.items.length).toBeGreaterThan(0));
+
+    result.current.handleAction(result.current.items[0].id, 'dismiss');
+
+    await waitFor(() => expect(result.current.isExecuting).toBe(false));
+    expect(result.current.isExecuteError).toBe(false);
+  });
+});

--- a/frontend/apps/ppt-web/src/features/dashboard/hooks/useActionQueue.ts
+++ b/frontend/apps/ppt-web/src/features/dashboard/hooks/useActionQueue.ts
@@ -5,6 +5,7 @@
  * @module features/dashboard/hooks/useActionQueue
  */
 
+import { getMode, parseMode } from '@ppt/dev-panel';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo } from 'react';
 
@@ -48,7 +49,7 @@ export interface ActionQueueFilters {
   search?: string;
 }
 
-interface ActionQueueData {
+export interface ActionQueueData {
   items: ActionItem[];
   total: number;
   counts: {
@@ -59,7 +60,60 @@ interface ActionQueueData {
   };
 }
 
-// Mock data generator for development
+/**
+ * Dev-only mock gate.
+ *
+ * There is no backend action-queue endpoint yet (no `/api/v1/action-queue`
+ * route in api-server, no TypeSpec contract). To avoid shipping fabricated
+ * action items to production users — and silent no-op approve/reject/dismiss
+ * mutations — the mock data + simulated mutations are served ONLY when the app
+ * runs in DEV under the dev-panel `mock` API mode. In every other case (prod
+ * builds, `local`/`worktree` modes) the queue resolves empty and mutations
+ * fail loudly rather than pretending to succeed.
+ *
+ * Track the backend gap: see PR body "API gap" section.
+ */
+export function isActionQueueMockEnabled(): boolean {
+  return import.meta.env.DEV && getMode(parseMode(import.meta.env.VITE_API_DEFAULT)) === 'mock';
+}
+
+/** Empty queue returned when the mock is disabled and no real backend exists. */
+function emptyQueue(): ActionQueueData {
+  return { items: [], total: 0, counts: { urgent: 0, high: 0, medium: 0, low: 0 } };
+}
+
+/** Apply client-side filters to an action-queue payload. Exported for testing. */
+export function applyActionQueueFilters(
+  data: ActionQueueData,
+  filters?: ActionQueueFilters
+): ActionQueueData {
+  let filteredItems = data.items;
+
+  if (filters?.types?.length) {
+    filteredItems = filteredItems.filter((item) => filters.types!.includes(item.type));
+  }
+
+  if (filters?.priorities?.length) {
+    filteredItems = filteredItems.filter((item) => filters.priorities!.includes(item.priority));
+  }
+
+  if (filters?.search) {
+    const searchLower = filters.search.toLowerCase();
+    filteredItems = filteredItems.filter(
+      (item) =>
+        item.title.toLowerCase().includes(searchLower) ||
+        item.description.toLowerCase().includes(searchLower)
+    );
+  }
+
+  return {
+    items: filteredItems,
+    total: filteredItems.length,
+    counts: data.counts,
+  };
+}
+
+// Mock data generator — DEV-only (see isActionQueueMockEnabled).
 function generateMockData(role: 'manager' | 'resident'): ActionQueueData {
   const now = new Date();
   const items: ActionItem[] = [];
@@ -240,39 +294,20 @@ export function useActionQueue(role: 'manager' | 'resident', filters?: ActionQue
   const query = useQuery({
     queryKey: ['actionQueue', role, filters],
     queryFn: async (): Promise<ActionQueueData> => {
-      // TODO: Replace with actual API call when backend is ready
-      // const response = await fetch(`/api/v1/action-queue?role=${role}`);
-      // return response.json();
+      // No real backend endpoint exists yet (see isActionQueueMockEnabled).
+      // Outside DEV mock mode we return an empty queue so production users
+      // never see fabricated action items — the ActionQueue component then
+      // renders its "all caught up" empty state.
+      if (!isActionQueueMockEnabled()) {
+        return emptyQueue();
+      }
 
-      // For now, return mock data
+      // TODO(backend): replace with real call once `/api/v1/action-queue`
+      // (and the TypeSpec contract + generated client hook) exist:
+      //   const response = await client.actionQueue.list({ role });
+      //   return response.data;
       await new Promise((resolve) => setTimeout(resolve, 300)); // Simulate network delay
-      const data = generateMockData(role);
-
-      // Apply filters
-      let filteredItems = data.items;
-
-      if (filters?.types?.length) {
-        filteredItems = filteredItems.filter((item) => filters.types!.includes(item.type));
-      }
-
-      if (filters?.priorities?.length) {
-        filteredItems = filteredItems.filter((item) => filters.priorities!.includes(item.priority));
-      }
-
-      if (filters?.search) {
-        const searchLower = filters.search.toLowerCase();
-        filteredItems = filteredItems.filter(
-          (item) =>
-            item.title.toLowerCase().includes(searchLower) ||
-            item.description.toLowerCase().includes(searchLower)
-        );
-      }
-
-      return {
-        items: filteredItems,
-        total: filteredItems.length,
-        counts: data.counts,
-      };
+      return applyActionQueueFilters(generateMockData(role), filters);
     },
     staleTime: 30000, // 30 seconds
     refetchInterval: 60000, // 1 minute
@@ -281,12 +316,16 @@ export function useActionQueue(role: 'manager' | 'resident', filters?: ActionQue
   // Mutation for executing an action
   const executeAction = useMutation({
     mutationFn: async ({ itemId, action }: { itemId: string; action: ActionButton['action'] }) => {
-      // TODO: Replace with actual API call
-      // await fetch(`/api/v1/action-queue/${itemId}/execute`, {
-      //   method: 'POST',
-      //   body: JSON.stringify({ action }),
-      // });
+      // Fail loudly outside DEV mock mode instead of returning a fake success:
+      // approve/reject/dismiss must not be silent no-ops in production while the
+      // backend endpoint is missing. The surfaced error drives the caller's
+      // error handling (mutation `isError`) rather than a lie.
+      if (!isActionQueueMockEnabled()) {
+        throw new Error('Action queue backend is not implemented yet (no /api/v1/action-queue).');
+      }
 
+      // TODO(backend): replace with real call once the endpoint exists:
+      //   await client.actionQueue.execute({ itemId, action });
       await new Promise((resolve) => setTimeout(resolve, 500)); // Simulate network delay
       return { success: true, itemId, action };
     },
@@ -334,5 +373,7 @@ export function useActionQueue(role: 'manager' | 'resident', filters?: ActionQue
     dismissItem,
     handleAction,
     isExecuting: executeAction.isPending,
+    isExecuteError: executeAction.isError,
+    executeError: executeAction.error,
   };
 }


### PR DESCRIPTION
## Task
Wire useActionQueue (ppt-web) to the real action-queue API instead of generateMockData, and make approve/reject/dismiss call the real mutations. If the backend endpoint does not exist yet, at minimum stop shipping fabricated data (empty/loading/disabled state) and clearly gate the mock behind a dev-only flag — surface the API gap in the PR body. Add/adjust tests.

## Owner
pm-backend (hint) — see Scope drift below; this is inherently a ppt-web frontend change.

## API gap (backend endpoint does not exist)
There is **no backend action-queue endpoint** and **no contract** for one:
- No route in `backend/` (searched `action.queue` / `action_queue` — zero hits in api-server / reality-server).
- No TypeSpec under `docs/api/typespec/` and therefore no generated `@ppt/api-client` hook.

So the task's fallback branch applies: **stop shipping fabricated data and gate the mock behind a dev-only flag**, and surface the gap here. What a follow-up backend task needs to build:
- `GET /api/v1/action-queue?role={manager|resident}` → aggregated `{ items, total, counts }`.
- `POST /api/v1/action-queue/{itemId}/execute` (or per-action routes) for approve / reject / dismiss / complete / escalate.
- TypeSpec contract + regenerated Rust + TS clients, then swap the two `TODO(backend)` sites in `useActionQueue.ts` and drop the mock gate.

## What changed (`frontend/apps/ppt-web/src/features/dashboard/hooks/useActionQueue.ts`)
- **No more fabricated data in production.** `queryFn` now returns an **empty queue** unless the dev-only mock gate is active; the existing `ActionQueue` component then renders its "all caught up" empty state. Previously it returned `generateMockData(role)` unconditionally.
- **Dev-only mock gate** `isActionQueueMockEnabled()` = `import.meta.env.DEV && dev-panel mode === 'mock'`. Reuses the existing `@ppt/dev-panel` `getMode`/`parseMode` mode system (same gate that already guards MSW in `main.tsx`) — no new flag mechanism introduced.
- **Mutations are no longer silent no-ops.** Outside mock mode, `executeAction` throws a clear `Error('Action queue backend is not implemented yet …')` instead of returning fake `{ success: true }`. The hook now also returns `isExecuteError` / `executeError` so callers can surface failures. (In production the queue is empty, so no action buttons render — but the mutation path is now honest either way.)
- Extracted `applyActionQueueFilters` as a pure, exported, unit-tested helper.

## Tests (`useActionQueue.test.tsx`, new — 11 cases)
- `applyActionQueueFilters`: type / priority / case-insensitive search / no-filter.
- `isActionQueueMockEnabled`: disabled by default, enabled under DEV + `mock`.
- Hook, mock disabled: resolves an **empty** queue (not fabricated data); an action **fails loudly** (`isExecuteError`).
- Hook, mock enabled: serves mock items + stats, applies filters, executes without error.
TDD: red `test:` commit precedes the `fix:` commit (test fails on `dev` — the new exports don't exist and the queue is non-empty there).

## Verification
The deterministic `just verify` / `scripts/verify-impact.sh` gate is **not present in this base branch** (`origin/dev` @ 66618e4 — no `verify` recipe in the justfile, no `verify-impact.sh`). Ran the equivalent impact-scoped frontend checks manually:

```
pnpm -F @ppt/web test:run   → Test Files 93 passed (93) | Tests 1483 passed (1483)   exit 0
pnpm -F @ppt/web typecheck  → exit 0  (tsc --noEmit + tsc -p tsconfig.e2e.json)
biome check <changed files> → Checked 2 files. exit 0
```
Note: the package `lint` script (`eslint …`) is broken repo-wide (no eslint.config.js — pre-existing, unrelated to this diff); Biome is the actual CI formatter/linter gate and is clean. Full-workspace impact suite defers to CI (`frontend.yml`).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
`owner_role=pm-backend` maps to `backend/`, but the fix is entirely under `frontend/apps/ppt-web/` (the task is intrinsically a ppt-web frontend change — the "pm-backend" owner reflects the missing backend endpoint, which is deliberately left as a follow-up, not built here). Files:
- `frontend/apps/ppt-web/src/features/dashboard/hooks/useActionQueue.ts`
- `frontend/apps/ppt-web/src/features/dashboard/hooks/useActionQueue.test.tsx`

## Code-reuse review
None. Reuses the existing `@ppt/dev-panel` mode system rather than adding a new flag.

## Notes
- Draft PR. No public API/route added — purely a client-side safety fix + follow-up backend gap documented above.
- IG goal-check IG1/IG2/IG4–6 are `.research/plans` flow-specific (plan file + `impl/<slug>` branch) and don't apply to this dispatcher action-list task (pre-assigned `auto-impl/…` branch, no plan file). IG3 (TDD split) is satisfied.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFG4dJNeDhY3CEBNMxPZuF)_