### PR TITLE
code-review-ppt-web-ui-savedirty-stale-closure: fix tautological "changed since sent" dirty check in DashboardCustomizePage

### DIFF
--- a/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx
@@ -11,7 +11,7 @@
  */
 import type { TenantLayoutEnvelope } from '@ppt/api-client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -269,6 +269,98 @@ describe('Test 4: 422 errors render verbatim', () => {
       expect(alert).toBeInTheDocument();
       expect(alert?.textContent).toContain('Field X is invalid');
       expect(alert?.textContent).toContain('Field Y missing');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 6: an edit made while a save is in flight must not be discarded.
+//
+// Regression for the tautological "changed since sent" check: the previous
+// implementation compared the closure-captured override against a snapshot
+// taken from the same render (always equal), so it cleared dirty on success
+// even when the user had edited during the in-flight save — silently losing
+// that edit. The fix reads the CURRENT override via a ref and re-marks the
+// form dirty when it diverges from the sent payload.
+// ---------------------------------------------------------------------------
+describe('Test 6: edit during in-flight save is preserved', () => {
+  it('keeps the form dirty when a change lands while the save is pending', async () => {
+    const user = userEvent.setup();
+
+    // Deferred save — stays pending until we resolve it, letting us inject an
+    // edit between save-start and save-success.
+    let resolveSave: (value: unknown) => void = () => {};
+    mockSaveImpl = vi.fn(
+      () =>
+        new Promise((res) => {
+          resolveSave = res;
+        })
+    );
+
+    mockEnvelope = {
+      override: null,
+      rails: {
+        hideable: ['hero', 'stats'],
+        mode_editable: [],
+        reorderable: false,
+        prop_whitelist: {},
+      },
+      published: {
+        sections: [
+          { type: 'hero', visible: true },
+          { type: 'stats', visible: true },
+        ],
+      },
+      manifest: null,
+    };
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('hero')).toBeInTheDocument());
+
+    // Edit #1: toggle hero → form dirty, Save enabled.
+    const firstToggle = screen.getAllByRole('button', {
+      name: /layout\.customize\.(hide|show)/,
+    })[0];
+    await user.click(firstToggle);
+
+    const saveBtn = screen.getByRole('button', { name: 'layout.customize.save' });
+    expect(saveBtn).not.toBeDisabled();
+
+    // Start the save — mutateAsync is now pending.
+    await user.click(saveBtn);
+    await waitFor(() => expect(mockSaveImpl).toHaveBeenCalledOnce());
+
+    // The save captured only the hero patch.
+    const [sentPayload] = mockSaveImpl.mock.calls[0] as [{ sections?: Record<string, unknown> }];
+    expect(sentPayload.sections).toMatchObject({ hero: { visible: false } });
+    expect(sentPayload.sections).not.toHaveProperty('stats');
+
+    // Edit #2 (concurrent): toggle stats WHILE the save is in flight.
+    const statsToggle = screen.getAllByRole('button', {
+      name: /layout\.customize\.(hide|show)/,
+    })[1];
+    await user.click(statsToggle);
+
+    // Now let the in-flight save resolve.
+    await act(async () => {
+      resolveSave({});
+    });
+
+    // The later edit must survive: the form stays dirty (Save re-enabled) so
+    // the newer stats change is not silently discarded.
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'layout.customize.save' })).not.toBeDisabled();
+    });
+
+    // A follow-up save must send BOTH edits, proving the stats toggle was kept.
+    resolveSave = () => {};
+    mockSaveImpl.mockResolvedValueOnce({});
+    await user.click(screen.getByRole('button', { name: 'layout.customize.save' }));
+    await waitFor(() => expect(mockSaveImpl).toHaveBeenCalledTimes(2));
+    const [secondPayload] = mockSaveImpl.mock.calls[1] as [{ sections?: Record<string, unknown> }];
+    expect(secondPayload.sections).toMatchObject({
+      hero: { visible: false },
+      stats: { visible: false },
     });
   });
 });

--- a/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
@@ -35,8 +35,12 @@ export function DashboardCustomizePage() {
   // Validation errors from a 422 response — cleared on next change
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
 
-  // Track the JSON we last sent so we can conditionally clear dirty
-  const sentJsonRef = useRef<string | null>(null);
+  // Mirror the latest committed override in a ref so an async save-success
+  // callback can read the CURRENT state (not the stale value captured by the
+  // closure that started the save). Updated every render, so an edit made
+  // while a save is in flight is visible here by the time the save resolves.
+  const localOverrideRef = useRef<TenantOverride | null>(localOverride);
+  localOverrideRef.current = localOverride;
 
   const mutation = useSaveTenantLayoutOverride(SCREEN);
 
@@ -55,17 +59,23 @@ export function DashboardCustomizePage() {
 
   const handleSave = async () => {
     if (localOverride === null) return;
-    const json = JSON.stringify(localOverride);
-    sentJsonRef.current = json;
+    // Snapshot the payload we're about to send. Comparing the CURRENT state
+    // against this snapshot on success tells us whether the user edited while
+    // the save was in flight.
+    const sentJson = JSON.stringify(localOverride);
     try {
       await mutation.mutateAsync(localOverride);
       showToast({
         type: 'success',
         title: t('layout.customize.saveSuccess'),
       });
-      // Only clear dirty if the override hasn't changed since we sent
-      if (JSON.stringify(localOverride) === json) {
+      // Compare the CURRENT override (via the ref) against what we sent. If the
+      // user edited during the in-flight save the two diverge, so we keep the
+      // form dirty instead of silently discarding the newer edit.
+      if (JSON.stringify(localOverrideRef.current) === sentJson) {
         setIsDirty(false);
+      } else {
+        setIsDirty(true);
       }
     } catch (err) {
       if (err instanceof TenantLayoutError && err.status === 422) {


### PR DESCRIPTION
## Task
DashboardCustomizePage 'changed since sent' check is tautological — concurrent edits during an in-flight save are silently discarded. Fix the dirty-tracking so edits made while a save is in flight are not lost: snapshot the payload sent at save-start and compare the CURRENT state against that snapshot on save-success (not against itself), re-marking dirty if they diverge. Add a test simulating an edit during an in-flight save and asserting the later edit is preserved.

## Owner
pm-backend (hint) — actual work is a `ppt-web` frontend fix; specialist: **react-web**.

## Root cause
`handleSave` compared the closure-captured `localOverride` against `json = JSON.stringify(localOverride)` taken from the *same* render — always equal, so the "only clear dirty if unchanged since we sent" guard was tautological. An edit made while the save was in flight produces a new `localOverride` in a *new* closure; the in-flight save's success handler never sees it, so it cleared `isDirty` and silently discarded the later edit.

## Fix
- Snapshot the sent payload at save-start (`sentJson`).
- Mirror the latest committed `localOverride` in a ref (`localOverrideRef`, updated every render) so the async success callback reads the CURRENT state.
- On success, compare `localOverrideRef.current` against `sentJson`; clear dirty only when they match, otherwise re-mark dirty so the newer edit survives.

## Test (IG3 — fails on `dev`, passes with fix)
`Test 6: edit during in-flight save is preserved` — toggles a section, starts a deferred save, toggles a second section while the save is pending, resolves the save, then asserts the form stays dirty and a follow-up save sends BOTH edits. Verified this test fails on `origin/dev` (dirty cleared, Save disabled) and passes with the fix. Committed test-first (`test:`) then the `fix:`.

## Verification
```
VERIFY-PLAN base=e149a67f38088e85e7e05a71a5f60ad215d6966d files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx
  cd frontend && pnpm --filter "...[<base>]" typecheck
  cd frontend && pnpm --filter "...[<base>]" test
```
`VERIFY OK 92354840547eac9f1726c4ac9422a14afc6b7bab` (re-run on the rebased tree via goal-check IG7). Full frontend impact band green: biome + typecheck + 1575 tests passed.

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 because the two changed files live under `frontend/apps/ppt-web/` — outside the `pm-backend` area. This is an owner-hint/area mismatch, not real drift: the task is explicitly a ppt-web UI fix and the diff is exactly the `DashboardCustomizePage` the finding named. Diff (2 files):
- `frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.tsx`
- `frontend/apps/ppt-web/src/features/layout/DashboardCustomizePage.test.tsx`

## Code-reuse review
`reuse-grep.sh --specialist react-web --base origin/dev` → empty (exit 0). The change adds no new helper; it reuses the existing `useRef`.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- goal-check IG1/IG8 fail structurally because this is a dispatcher code-review-finding task with no `.research/plans/<slug>.md` file and no archive-move commit — not applicable to this flow. IG3 (TDD evidence) and IG7 (verify) pass.
- Checks that can't run in-sandbox defer to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFG4dJNeDhY3CEBNMxPZuF

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFG4dJNeDhY3CEBNMxPZuF)_