### PR TITLE
code-review-ppt-web-ui-propinput-json-coerce: keep string-typed layout props as strings in PropInput

### DIFF
--- a/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx
@@ -1,5 +1,5 @@
 import type { BaseSection, LayoutManifest, LayoutRails, TenantOverride } from '@ppt/api-client';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { TenantSectionEditor } from './TenantSectionEditor';
@@ -281,6 +281,44 @@ describe('Scenario 5: whitelisted prop input', () => {
     // props pruned → sections.hero has no props → sections pruned entirely
     expect(next.sections?.hero?.props).toBeUndefined();
     expect(next.sections?.hero).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 5a: string-typed prop is NOT JSON-coerced on commit
+// ---------------------------------------------------------------------------
+
+describe('Scenario 5a: string-typed prop keeps string values', () => {
+  // Whitelist a prop whose base (declared) value is a string. The declared
+  // type must gate coercion so JSON-looking input stays a string instead of
+  // being silently parsed into a boolean / array / number.
+  const stringPropRails: LayoutRails = {
+    ...noRails,
+    prop_whitelist: { hero: ['label'] },
+  };
+  const stringBase: BaseSection[] = [{ type: 'hero', props: { label: 'Welcome' } }];
+
+  // fireEvent.change is used instead of userEvent.type because the JSON-ish
+  // inputs ('[]') contain characters userEvent parses as keyboard descriptors.
+  it.each([['true'], ['[]'], ['123']])('input %j round-trips as the string %j', async (typed) => {
+    const onChange = vi.fn();
+    render(
+      <TenantSectionEditor
+        baseSections={stringBase}
+        rails={stringPropRails}
+        manifest={null}
+        override={emptyOverride}
+        onChange={onChange}
+      />
+    );
+    const input = screen.getByRole('textbox', { name: 'label' });
+    fireEvent.change(input, { target: { value: typed } });
+    fireEvent.blur(input); // commit
+    expect(onChange).toHaveBeenCalledOnce();
+    const next = onChange.mock.calls[0][0] as TenantOverride;
+    const committed = next.sections?.hero?.props?.label;
+    expect(committed).toBe(typed);
+    expect(typeof committed).toBe('string');
   });
 });
 

--- a/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
+++ b/frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
@@ -47,15 +47,46 @@ function pruneSectionPatch(
   return next;
 }
 
+/**
+ * Coerce a blur-committed input string to the value stored in the override.
+ *
+ * A string-typed prop must stay a string: `"true"`, `"[]"` and `"123"` are
+ * legitimate string content, not a signal to coerce them into a boolean /
+ * array / number. We therefore only run JSON coercion when the prop's
+ * *declared* type (the base section's value for this prop) is non-string —
+ * or unknown/untyped, which preserves the ability to enter numbers, booleans
+ * and arrays for whitelisted props that have no string default. JSON that
+ * fails to parse always falls back to the raw string, so user intent for the
+ * whitelisted prop's value is never lost.
+ */
+function coercePropValue(raw: string, declaredValue: unknown): unknown {
+  if (typeof declaredValue === 'string') {
+    return raw;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
 interface PropInputProps {
   type: string;
   propName: string;
   currentValue: unknown;
+  declaredValue: unknown;
   override: TenantOverride;
   onChange(next: TenantOverride): void;
 }
 
-function PropInput({ type, propName, currentValue, override, onChange }: PropInputProps) {
+function PropInput({
+  type,
+  propName,
+  currentValue,
+  declaredValue,
+  override,
+  onChange,
+}: PropInputProps) {
   const display =
     currentValue === undefined || currentValue === null
       ? ''
@@ -73,14 +104,7 @@ function PropInput({ type, propName, currentValue, override, onChange }: PropInp
     if (val === '') {
       delete existingProps[propName];
     } else {
-      // Try JSON parse; fall back to string
-      let parsed: unknown = val;
-      try {
-        parsed = JSON.parse(val);
-      } catch {
-        parsed = val;
-      }
-      existingProps[propName] = parsed;
+      existingProps[propName] = coercePropValue(val, declaredValue);
     }
 
     const newPatch: Record<string, unknown> = { ...existingPatch };
@@ -241,12 +265,16 @@ export function TenantSectionEditor({
                   const currentValue = (override.sections?.[type]?.props ?? base.props ?? {})[
                     propName
                   ];
+                  // Declared type signal: the base section's value for this
+                  // prop. Drives whether a blur-committed string is coerced.
+                  const declaredValue = base.props?.[propName];
                   return (
                     <PropInput
                       key={`${type}:${propName}:${JSON.stringify(currentValue) ?? ''}`}
                       type={type}
                       propName={propName}
                       currentValue={currentValue}
+                      declaredValue={declaredValue}
                       override={override}
                       onChange={onChange}
                     />


### PR DESCRIPTION
## Task

TenantSectionEditor PropInput silently JSON.parse-coerces every string prop on blur — override payload corrupted ("true" -> boolean, "[]" -> array). Fix PropInput.commit so a string-typed prop stays a string; only coerce when the prop's declared type is non-string (or the user explicitly enters JSON). Preserve user intent for the whitelisted prop's value. Add a test asserting "true"/"[]"/"123" round-trip as strings for a string prop.

## Owner

pm-backend (hint) — actual change is `frontend/apps/ppt-web` (react-web specialist). See Scope drift below.

## What changed

`PropInput.commit` blindly ran `JSON.parse(val)` on every blur-committed value, so a string-typed whitelisted prop edited to `true`, `[]` or `123` was silently coerced into a boolean / array / number in the tenant override payload.

The fix gates coercion on the prop's **declared type** — the base section's value for that prop (`base.props?.[propName]`), now threaded into `PropInput` as `declaredValue`:

- `typeof declaredValue === 'string'` → keep the user's text verbatim (string-typed props are never coerced).
- otherwise (number / boolean / object, or untyped/absent) → JSON-coerce, falling back to the raw string on parse failure.

This is the minimal signal available: the layout manifest carries no per-prop type schema (props are `Record<string, unknown>`), so the base value's runtime type is the declared-type source of truth. The change preserves the pre-existing Scenario 5 behavior (an untyped prop still coerces `'5'` → `5`), and only closes the string-corruption hole.

## Tests

`test:` commit adds Scenario 5a asserting `"true"` / `"[]"` / `"123"` round-trip as strings (value **and** `typeof === 'string'`) for a string-typed prop. Verified failing on the unfixed component (all 3 cases coerce to boolean/array/number) and passing after the fix — a genuine regression test (IG3).

## Verification

```
VERIFY-PLAN base=e149a67f38088e85e7e05a71a5f60ad215d6966d files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx apps/ppt-web/src/features/layout/TenantSectionEditor.tsx
  cd frontend && pnpm --filter "...[e149a67f38088e85e7e05a71a5f60ad215d6966d]" typecheck
  cd frontend && pnpm --filter "...[e149a67f38088e85e7e05a71a5f60ad215d6966d]" test
```
```
VERIFY OK d8e0128b3ef8e051e70720b4e97183c5eacba0cf
```
Full impact-scoped gate green: biome clean, frontend typecheck clean, 1577 ppt-web tests pass (incl. the 3 new Scenario 5a cases). Anything not runnable in-sandbox defers to CI.

## Scope drift

`owner_role=pm-backend` but the change is entirely frontend (`ppt-web`):
- `frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.tsx`
- `frontend/apps/ppt-web/src/features/layout/TenantSectionEditor.test.tsx`

`scope-check.sh --owner pm-backend` exits 2 solely because of this owner_role/area mismatch — the task text explicitly names these files (TenantSectionEditor / PropInput), so the drift is a mislabeled owner_role, not scope creep. Reviewer to confirm.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested

skipped (no ppt-bridge MCP in session).

## Notes

- The `TenantSectionEditor` feature landed on `dev` only on 2026-07-20 (PR #2429); the implementer's initial `origin/dev` checkout was stale (2026-07-16) and required a fetch before the target file was present.
- Two-commit history (`test:` then `fix:`) pushed via the GitHub MCP (git push is proxy-blocked in this environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFG4dJNeDhY3CEBNMxPZuF)_