### PR TITLE
gh-issue-2460: retry-remint skips stems marked done/ghost in action-list-archive

### DIFF
--- a/.research/retry-remint.sh
+++ b/.research/retry-remint.sh
@@ -38,6 +38,14 @@
 #       an anchored "<id>:" prefix that stems to the candidate stem (same
 #       join convention as dev-reconcile.sh). Both degrade gracefully when
 #       their input is missing (no exclusion).
+#     - archive-marker guard (issue #2460 — out-of-band ghost blind spot):
+#       the stem's LATEST action-list-archive row carries NO done/ghost marker
+#       (`[RECONCILED-DONE`, `[DROPPED`, `[already-satisfied`, `[CASCADED-DROP`,
+#       `[GHOST-DROP`, `[GHOST-RETRY-DROP`, `[BAD-RETRY-REMINT-DROP`). Those are
+#       written by gc1-reconcile/dev-reconcile/cascade EXACTLY when the work
+#       landed under a different id, was already satisfied, or is non-completable
+#       — the signal the coverage/dev-log guards (which key on the task's OWN id)
+#       structurally miss. Degrades gracefully when the archive is absent.
 #
 #   Minted rows carry `retry_of` (the original failed task_id) and
 #   `retry_round`. `retry_of` is the field Phase 3 and backlog-refill.sh use
@@ -165,6 +173,23 @@ CANDIDATES=$(jq -n \
   # same join convention as dev-reconcile.sh (prefix must contain no spaces,
   # so a chore commit merely MENTIONING an id never matches).
   | ([ $devlog_f[0][] | capture("^(?<p>[^:\\s]+):") | .p | stem ] | unique) as $dev_landed_stems
+  # Archive-marker guard (issue #2460): stems whose LATEST action-list-archive
+  # row carries a done/ghost marker written by reconcile/cascade. These prove
+  # the work landed under a DIFFERENT id, was already satisfied, or is
+  # non-completable — the blind spot the coverage/dev-log guards (which key on
+  # the failed task id itself) structurally miss. Latest = max last_updated (falls back
+  # to first_open_at). Missing archive => empty array => no exclusion.
+  | ([ $arch_items[]
+       | select(.id != null)
+       | { stem: (.id | stem),
+           ts: (.last_updated // .first_open_at // "1970-01-01T00:00:00Z"),
+           marked: (((.action // "")
+             | test("\\[(RECONCILED-DONE|DROPPED|already-satisfied|CASCADED-DROP|GHOST-DROP|GHOST-RETRY-DROP|BAD-RETRY-REMINT-DROP)"))) }
+     ]
+     | group_by(.stem)
+     | map(sort_by(.ts) | last)              # newest archive row per stem
+     | map(select(.marked) | .stem)
+     | unique) as $ghost_marked_stems
 
   | ([ $assign[] | select(.status=="failed") ]
      | group_by(.task_id | stem)
@@ -187,6 +212,7 @@ CANDIDATES=$(jq -n \
          and ((.stem | IN($al_live_stems[])) | not)
          and ((.stem | IN($cov_done_stems[])) | not)
          and ((.stem | IN($dev_landed_stems[])) | not)
+         and ((.stem | IN($ghost_marked_stems[])) | not)
          and (($now_e - (.newest_failure | epoch)) >= $cooldown_s)
        ))
      | map(. + { mint_id: (.stem + "-retry" + ((.rounds_used + 1) | tostring)) })

--- a/.research/test-retry-remint.sh
+++ b/.research/test-retry-remint.sh
@@ -3,9 +3,12 @@
 # Exercises: retryable classification (pr_number=null only), cool-down gate,
 # retry-round cap, landed-stem exclusion, active-stem exclusion, live
 # action-list stem exclusion (T24), minted-id idempotency, retry_of/round
-# stamping, per-run cap + ceil headroom, append-only count guard, and the
+# stamping, per-run cap + ceil headroom, append-only count guard, the
 # issue #2153 dev-truth guards (coverage-done exclusion + anchored dev-log
-# subject exclusion, both degrading gracefully when their input is missing).
+# subject exclusion, both degrading gracefully when their input is missing),
+# and the issue #2460 archive-marker guard (skip a stem whose LATEST
+# action-list-archive row carries a done/ghost marker — latest-row semantics
+# and graceful degradation when the archive is absent).
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -34,7 +37,8 @@ seed() {
 EOF
   cat > "$ALA" <<'EOF'
 { "version": 1, "items": [
-  { "id": "bug-retryable", "action": "Fix the retryable bug", "owner_role": "pm-backend", "priority": "high", "status": "dropped" }
+  { "id": "bug-retryable", "action": "Fix the retryable bug", "owner_role": "pm-backend", "priority": "high", "status": "dropped" },
+  { "id": "bug-ghost-marked", "action": "[RECONCILED-DONE: fix landed on dev under a DIFFERENT story id] Fix the ghost-marked bug", "owner_role": "pm-backend", "priority": "high", "status": "done", "last_updated": "2026-06-20T00:00:00Z" }
 ] }
 EOF
   cat > "$ASG" <<'EOF'
@@ -72,6 +76,8 @@ EOF
   { "task_id": "bug-cov-done",        "status": "failed", "pr_number": null,
     "last_updated": "2026-06-20T00:00:00Z" },
   { "task_id": "bug-on-dev",          "status": "failed", "pr_number": null,
+    "last_updated": "2026-06-20T00:00:00Z" },
+  { "task_id": "bug-ghost-marked",    "status": "failed", "pr_number": null,
     "last_updated": "2026-06-20T00:00:00Z" }
 ] }
 EOF
@@ -109,6 +115,7 @@ grep -q "active-stem-task" <<<"$OUT" && bad "active assignment stem must block" 
 grep -q "live-stem-task"   <<<"$OUT" && bad "live action-list stem must block (T24)" || ok "live action-list stem excluded"
 grep -q "bug-cov-done"     <<<"$OUT" && bad "coverage-done story must not re-mint (#2153)" || ok "coverage-done stem excluded"
 grep -q "bug-on-dev"       <<<"$OUT" && bad "anchored dev-log subject must block (#2153)" || ok "dev-log subject-prefix excluded"
+grep -q "bug-ghost-marked" <<<"$OUT" && bad "archive-marker stem must not re-mint (#2460)" || ok "archive-marker stem excluded"
 grep -q "bug-second-round-retry2" <<<"$OUT" && ok "loose (non-anchored) dev-log mention does NOT exclude" || bad "non-anchored mention wrongly excluded bug-second-round"
 grep -q "bug-retryable-retry1"    <<<"$OUT" && ok "coverage status=partial does NOT exclude" || bad "coverage partial wrongly excluded bug-retryable"
 [ "$(jq '.items | length' "$AL")" = "2" ] && ok "dry-run leaves file untouched" || bad "dry-run mutated action-list"
@@ -159,6 +166,38 @@ OUT=$(ACTION_LIST="$AL" ACTION_ARCHIVE="$ALA" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASG
 grep -q "bug-retryable-retry1" <<<"$OUT" && ok "still mints without guard inputs" || bad "no-guard-input run minted nothing: $OUT"
 grep -q "bug-cov-done-retry1"  <<<"$OUT" && ok "coverage guard inert when file missing" || bad "coverage guard fired without file"
 grep -q "bug-on-dev-retry1"    <<<"$OUT" && ok "dev-log guard inert when file missing" || bad "dev-log guard fired without file"
+
+echo "T8 archive-marker guard: latest-row semantics + graceful degradation (#2460)"
+seed
+# (b) an OLDER marked archive row superseded by a NEWER unmarked row in the
+#     same stem must NOT exclude — the guard keys on the LATEST row only.
+A8="$TMP/al8.json"; ALA8="$TMP/ala8.json"; ASG8="$TMP/asg8.json"; ASGA8="$TMP/asga8.json"
+cat > "$A8" <<'EOF'
+{ "version": 1, "items": [] }
+EOF
+cat > "$ALA8" <<'EOF'
+{ "version": 1, "items": [
+  { "id": "bug-superseded",     "action": "[DROPPED: stale] first attempt", "status": "dropped", "last_updated": "2026-05-01T00:00:00Z" },
+  { "id": "bug-superseded-fix", "action": "genuine reopen, no marker",        "status": "open",    "last_updated": "2026-06-25T00:00:00Z" }
+] }
+EOF
+cat > "$ASG8" <<'EOF'
+{ "assignments": [] }
+EOF
+cat > "$ASGA8" <<'EOF'
+{ "assignments": [
+  { "task_id": "bug-superseded", "status": "failed", "pr_number": null, "last_updated": "2026-06-20T00:00:00Z" }
+] }
+EOF
+OUT=$(ACTION_LIST="$A8" ACTION_ARCHIVE="$ALA8" ASSIGN="$ASG8" ASSIGN_ARCHIVE="$ASGA8" \
+      RETRY_NOW="$NOW" bash "$SCRIPT")
+grep -q "bug-superseded-retry1" <<<"$OUT" && ok "newer unmarked archive row supersedes older marker -> mints" || bad "latest-row semantics wrong: $OUT"
+# (c) guard inert when the action-list-archive file is absent: bug-ghost-marked
+#     (blocked only by the marker in T1) becomes eligible and mints.
+OUT=$(ACTION_LIST="$AL" ACTION_ARCHIVE="$TMP/no-ala.json" ASSIGN="$ASG" ASSIGN_ARCHIVE="$ASGA" \
+      COVERAGE_FILE="$COV" DEV_LOG_FILE="$DEVLOG" RETRY_NOW="$NOW" bash "$SCRIPT"); RC=$?
+[ "$RC" -eq 0 ] && ok "missing archive exits 0" || bad "missing archive errored (rc=$RC): $OUT"
+grep -q "bug-ghost-marked-retry1" <<<"$OUT" && ok "archive-marker guard inert when archive missing" || bad "marker guard fired without archive file: $OUT"
 
 echo
 [ "$FAIL" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
## Task
retry-remint.sh re-mints ghost retries for work already landed out-of-band (dev-truth guard blind spot). Add a third exclusion to `.research/retry-remint.sh`: skip any stem whose latest `.research/management/action-list-archive.json` row carries a done/ghost marker (`[RECONCILED-DONE`, `[DROPPED`, `[already-satisfied`, `[CASCADED-DROP`, `[GHOST-DROP`, `[GHOST-RETRY-DROP`, `[BAD-RETRY-REMINT-DROP`). Extend the smoke test. Closes #2460.

## Owner
pm-tech-lead

## Root cause
`retry-remint.sh`'s two existing dev-truth guards (#2153) both key on the **failed task's own id** — its coverage story id (`status=done`), and an anchored `<id>:` commit-subject prefix on `origin/dev`. When a fix lands on `dev` under a **different** id (e.g. the SearchScreen race fix landed under story `82-3`, not `code-review-...kmp-search...`), neither guard sees it. The archive row stays `failed, pr=null`, so retry-remint re-mints a `-retryN` ghost every run (4 ghosts minted + 3 pre-existing observed in run 2026-07-22).

## Fix
Third dev-truth exclusion in the jq candidate filter: build `$ghost_marked_stems` from `action-list-archive.json` — group items by `stem`, take the **latest** row per stem (`max last_updated`, falling back to `first_open_at`), and exclude the stem if that latest row's `action` text matches any of the seven done/ghost markers. Those markers are written by `gc1-reconcile`/`dev-reconcile`/cascade precisely when work landed or the task is non-completable — the exact signal the id-keyed guards lack.

- **Latest-row semantics**: a genuine reopen (newer unmarked archive row) supersedes a stale marker, so a legitimately-retryable stem is not permanently blocked.
- **Fail-open**: missing/empty archive → empty stem set → no exclusion, same contract as the #2153 guards.
- Computed inline from the already-slurped `$arch_items`; no new work file, no new external input.

## TDD evidence (IG3)
- `5b4508e` `test(dispatcher): …` — adds fixtures + assertions; **fails** against the unpatched script (`re-minting 1 of 3 eligible` — the ghost stem becomes a 3rd candidate).
- `17668ea` `fix(dispatcher): …` — adds the guard; turns the test green.

## Test plan
`bash .research/test-retry-remint.sh` — **ALL PASS** (8 groups). New coverage:
- T1: archive-marker stem excluded (alongside existing #2153 coverage-done / dev-log-subject guards, which continue to pass — no regression).
- T8: latest-row semantics (newer unmarked row supersedes older marker → still mints) + graceful degradation when the archive file is absent.

## Verification
```
VERIFY-PLAN base=e89d08e149a3d523cf8444a1b42a3342a4b57b1a files=2
VERIFY OK 52b849857a2d71bb21b0338bedf207ea3206092a
```
Note: the impact gate maps `.research/*.sh` to no build/test band (empty plan), so correctness rests on the deterministic offline smoke test above (ALL PASS), which is the script's own regression harness.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (dispatcher tooling; no security/auth/billing/data-integrity change).

## Scope drift
`scope-check.sh --owner pm-tech-lead` exit 0 — diff (`.research/retry-remint.sh`, `.research/test-retry-remint.sh`) stays in-area. No `.research/management/**` state touched.

## Code-reuse review
`reuse-grep.sh --specialist generic` — no warnings.

## Remote-tested
skipped.

## Notes
- Goal-check IG1 (plan file) and IG2 (`impl/<slug>` branch name) are N/A to this dispatcher gh-issue flow: there is no `.research/plans/<slug>.md`, and the branch name `auto-impl/gh-issue-2460-ebb29f20` is dispatcher-mandated. IG3 (TDD) and IG7 (verify) pass.
- Specialist: `generic` (shell/tooling under `.research/`; no roster stack matched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mhptmv73si95ZpeCgpkAVS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhptmv73si95ZpeCgpkAVS)_