### PR TITLE
refactor-churn-hotspot-layouteditorpage-tsx-2026-07-21: extract LayoutEditorPage styles module

### DIFF
--- a/frontend/apps/admin-web/src/features/layout-editor/LayoutEditorPage.styles.ts
+++ b/frontend/apps/admin-web/src/features/layout-editor/LayoutEditorPage.styles.ts
@@ -1,0 +1,124 @@
+/**
+ * Presentational style constants for LayoutEditorPage.
+ *
+ * Extracted from the page component so the wiring logic (queries, mutations,
+ * seeding effect, handlers) reads without ~115 lines of inline CSSProperties
+ * noise. These are plain module constants — no behaviour, no state.
+ */
+
+import type React from 'react';
+
+export const PAGE_STYLE: React.CSSProperties = {
+  padding: '24px',
+  maxWidth: 960,
+  margin: '0 auto',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+};
+
+export const CARD_STYLE: React.CSSProperties = {
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 'var(--ppt-radius-lg, 10px)',
+  padding: '20px 24px',
+  background: 'var(--ppt-bg-surface, #fff)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+};
+
+export const CARD_TITLE_STYLE: React.CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+  color: 'var(--ppt-fg-primary, #111827)',
+  margin: 0,
+};
+
+export const ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  gap: 8,
+  alignItems: 'center',
+  flexWrap: 'wrap',
+};
+
+export const SELECT_STYLE: React.CSSProperties = {
+  padding: '6px 10px',
+  fontSize: 14,
+  borderRadius: 6,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  minWidth: 200,
+};
+
+export const INPUT_STYLE: React.CSSProperties = {
+  padding: '6px 10px',
+  fontSize: 14,
+  borderRadius: 6,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  minWidth: 240,
+};
+
+export const BTN_BASE: React.CSSProperties = {
+  padding: '6px 14px',
+  fontSize: 14,
+  borderRadius: 6,
+  cursor: 'pointer',
+  border: '1px solid transparent',
+  fontWeight: 500,
+};
+
+export const BTN_PRIMARY: React.CSSProperties = {
+  ...BTN_BASE,
+  background: 'var(--ppt-primary-600, #2563eb)',
+  color: '#fff',
+  borderColor: 'var(--ppt-primary-600, #2563eb)',
+};
+
+export const BTN_SECONDARY: React.CSSProperties = {
+  ...BTN_BASE,
+  background: 'var(--ppt-bg-surface, #fff)',
+  color: 'var(--ppt-fg-primary, #111827)',
+  borderColor: 'var(--ppt-border-default, #e5e7eb)',
+};
+
+export const BTN_DANGER: React.CSSProperties = {
+  ...BTN_BASE,
+  background: 'var(--ppt-danger-600, #dc2626)',
+  color: '#fff',
+  borderColor: 'var(--ppt-danger-600, #dc2626)',
+};
+
+export const ALERT_STYLE: React.CSSProperties = {
+  background: 'var(--ppt-danger-50, #fef2f2)',
+  border: '1px solid var(--ppt-danger-200, #fecaca)',
+  borderRadius: 8,
+  padding: '12px 16px',
+  color: 'var(--ppt-danger-800, #991b1b)',
+};
+
+export const TABLE_STYLE: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 13,
+};
+
+export const TH_STYLE: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '6px 10px',
+  fontWeight: 600,
+  color: 'var(--ppt-fg-secondary, #6b7280)',
+  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+};
+
+export const TD_STYLE: React.CSSProperties = {
+  padding: '6px 10px',
+  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+  verticalAlign: 'middle',
+};
+
+export const TOGGLE_STYLE: React.CSSProperties = {
+  display: 'flex',
+  gap: 4,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 6,
+  overflow: 'hidden',
+};

--- a/frontend/apps/admin-web/src/features/layout-editor/LayoutEditorPage.tsx
+++ b/frontend/apps/admin-web/src/features/layout-editor/LayoutEditorPage.tsx
@@ -27,6 +27,23 @@ import {
   type ScreenConfig,
   unkill,
 } from './api';
+import {
+  ALERT_STYLE,
+  BTN_BASE,
+  BTN_DANGER,
+  BTN_PRIMARY,
+  BTN_SECONDARY,
+  CARD_STYLE,
+  CARD_TITLE_STYLE,
+  INPUT_STYLE,
+  PAGE_STYLE,
+  ROW_STYLE,
+  SELECT_STYLE,
+  TABLE_STYLE,
+  TD_STYLE,
+  TH_STYLE,
+  TOGGLE_STYLE,
+} from './LayoutEditorPage.styles';
 import { PreviewPanel } from './PreviewPanel';
 import { RailsEditor } from './RailsEditor';
 import { SectionTreeEditor } from './SectionTreeEditor';
@@ -42,125 +59,6 @@ const EMPTY_RAILS: Rails = {
   mode_editable: [],
   reorderable: false,
   prop_whitelist: {},
-};
-
-// ---------------------------------------------------------------------------
-// Styles
-// ---------------------------------------------------------------------------
-
-const PAGE_STYLE: React.CSSProperties = {
-  padding: '24px',
-  maxWidth: 960,
-  margin: '0 auto',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 24,
-};
-
-const CARD_STYLE: React.CSSProperties = {
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 'var(--ppt-radius-lg, 10px)',
-  padding: '20px 24px',
-  background: 'var(--ppt-bg-surface, #fff)',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 16,
-};
-
-const CARD_TITLE_STYLE: React.CSSProperties = {
-  fontSize: 16,
-  fontWeight: 600,
-  color: 'var(--ppt-fg-primary, #111827)',
-  margin: 0,
-};
-
-const ROW_STYLE: React.CSSProperties = {
-  display: 'flex',
-  gap: 8,
-  alignItems: 'center',
-  flexWrap: 'wrap',
-};
-
-const SELECT_STYLE: React.CSSProperties = {
-  padding: '6px 10px',
-  fontSize: 14,
-  borderRadius: 6,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  minWidth: 200,
-};
-
-const INPUT_STYLE: React.CSSProperties = {
-  padding: '6px 10px',
-  fontSize: 14,
-  borderRadius: 6,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  minWidth: 240,
-};
-
-const BTN_BASE: React.CSSProperties = {
-  padding: '6px 14px',
-  fontSize: 14,
-  borderRadius: 6,
-  cursor: 'pointer',
-  border: '1px solid transparent',
-  fontWeight: 500,
-};
-
-const BTN_PRIMARY: React.CSSProperties = {
-  ...BTN_BASE,
-  background: 'var(--ppt-primary-600, #2563eb)',
-  color: '#fff',
-  borderColor: 'var(--ppt-primary-600, #2563eb)',
-};
-
-const BTN_SECONDARY: React.CSSProperties = {
-  ...BTN_BASE,
-  background: 'var(--ppt-bg-surface, #fff)',
-  color: 'var(--ppt-fg-primary, #111827)',
-  borderColor: 'var(--ppt-border-default, #e5e7eb)',
-};
-
-const BTN_DANGER: React.CSSProperties = {
-  ...BTN_BASE,
-  background: 'var(--ppt-danger-600, #dc2626)',
-  color: '#fff',
-  borderColor: 'var(--ppt-danger-600, #dc2626)',
-};
-
-const ALERT_STYLE: React.CSSProperties = {
-  background: 'var(--ppt-danger-50, #fef2f2)',
-  border: '1px solid var(--ppt-danger-200, #fecaca)',
-  borderRadius: 8,
-  padding: '12px 16px',
-  color: 'var(--ppt-danger-800, #991b1b)',
-};
-
-const TABLE_STYLE: React.CSSProperties = {
-  width: '100%',
-  borderCollapse: 'collapse',
-  fontSize: 13,
-};
-
-const TH_STYLE: React.CSSProperties = {
-  textAlign: 'left',
-  padding: '6px 10px',
-  fontWeight: 600,
-  color: 'var(--ppt-fg-secondary, #6b7280)',
-  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
-};
-
-const TD_STYLE: React.CSSProperties = {
-  padding: '6px 10px',
-  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
-  verticalAlign: 'middle',
-};
-
-const TOGGLE_STYLE: React.CSSProperties = {
-  display: 'flex',
-  gap: 4,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 6,
-  overflow: 'hidden',
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Task
Churn hotspot: `frontend/apps/admin-web/src/features/layout-editor/LayoutEditorPage.tsx` — 2 touches, 900 lines this run. Behaviour-preserving refactor that reduces complexity / improves maintainability (extract sub-components, hooks, or helpers; tighten types) WITHOUT changing behaviour.

## What changed
Extracted the ~115 lines of module-private `React.CSSProperties` style constants (`PAGE_STYLE`, `CARD_STYLE`, all `BTN_*`, `TABLE_STYLE`, etc.) out of `LayoutEditorPage.tsx` into a co-located `LayoutEditorPage.styles.ts` and re-imported them into the page.

- **Pure presentational extraction — zero behaviour change.** Every constant keeps the same name and the exact same value; the page imports and uses them identically.
- The page drops from 900 → 799 lines, so the query / mutation / seeding-effect / handler logic reads without the inline styling wall.
- The style constants were module-private (never exported, no other consumer), so nothing outside this file is affected. Tests import only the default `LayoutEditorPage` export and mock `./api`, so they are unaffected.

No hooks/components/logic were touched — deliberately the lowest-risk valuable refactor for a low-priority churn-hotspot task.

## Owner
pm-tech-lead

## Verification
```
VERIFY-PLAN base=67660c6dc453d42ae344ec0258f4226998e02a8c files=2
  cd frontend && pnpm exec biome check apps/admin-web/src/features/layout-editor/LayoutEditorPage.styles.ts apps/admin-web/src/features/layout-editor/LayoutEditorPage.tsx
  cd frontend && pnpm --filter "...[67660c6...]" typecheck
  cd frontend && pnpm --filter "...[67660c6...]" test
```

Per-command results:
- `biome check` (2 changed files) — **PASS** (Checked 2 files, no errors).
- `pnpm --filter @ppt/admin-web typecheck` (`tsc --noEmit`) — **PASS**.
- Layout-editor test suite (`vitest run src/features/layout-editor`) — **PASS**: 6 files, 52/52 tests green.

### Pre-existing baseline failures (NOT caused by this PR)
The package-scoped `pnpm test` band is red, but **only** on files this PR does not touch and which fail identically on a pristine `origin/dev` checkout:
- `src/pages/CapabilitiesAdminPage.test.tsx` — asserts `CAPABILITIES.length === 17` while the registry now has 18 entries. Reproduced on clean `origin/dev` (1 failed | 6 passed).
- `e2e/specs/{flows,login,platform-health,smoke}.spec.ts` — Playwright specs picked up by vitest (environment/config issue), pre-existing.

None of these import or relate to `layout-editor`. This PR's own scope (biome + typecheck + all 52 layout-editor tests) is fully green.

## Scope drift
`scope-check.sh --owner pm-tech-lead` returned exit 2: the admin-web frontend path is not in `pm-tech-lead`'s mapped owner area. Drifting paths:
- `frontend/apps/admin-web/src/features/layout-editor/LayoutEditorPage.styles.ts`
- `frontend/apps/admin-web/src/features/layout-editor/LayoutEditorPage.tsx`

These are exactly the task's target file and its extracted sibling — the drift is the owner-map not covering admin-web frontend for a tech-lead-owned churn task, not an out-of-task edit. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist react-web` — no warnings (no new security/auth/crypto/http helpers introduced; this is a style-constant move only).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
Skipped (ppt-bridge MCP not used).

## Notes
Behaviour-preserving refactor only. The verify gate's red is entirely pre-existing `admin-web` baseline breakage unrelated to the diff (proven against clean `origin/dev`); the refactor's own scope is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mhptmv73si95ZpeCgpkAVS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhptmv73si95ZpeCgpkAVS)_