### PR TITLE
gh-issue-2466: ignore dtolnay/rust-toolchain dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # dtolnay/rust-toolchain tags track Rust toolchain releases, so Dependabot
+    # keeps proposing a group bump to a nonexistent version (e.g. 1.100.0),
+    # which never resolves. All refs are pinned intentionally (9x @1.94.1 plus
+    # one @stable in deploy-server.yml); bump them by hand alongside the Rust
+    # version. Ignore major/minor auto-bumps here. (See #2466.)
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       actions-minor-patch:
         patterns: ["*"]


### PR DESCRIPTION
## Task
Add a Dependabot ignore rule for dtolnay/rust-toolchain to .github/dependabot.yml so the invalid weekly group bump to 1.100.0 (a nonexistent Rust toolchain release) stops recurring. Add an ignore entry for dtolnay/rust-toolchain (major/minor updates) under the github-actions package-ecosystem. All 9 real workflow refs currently pin dtolnay/rust-toolchain@1.94.1 (valid) plus one @stable in deploy-server.yml — nothing is stale; the bump target itself is invalid. Closes #2466.

## Owner
pm-tech-lead

## Change
Added an `ignore` block to the `github-actions` package-ecosystem entry in `.github/dependabot.yml`:

```yaml
ignore:
  - dependency-name: "dtolnay/rust-toolchain"
    update-types:
      - "version-update:semver-major"
      - "version-update:semver-minor"
```

Patch bumps remain eligible; only the invalid major/minor group bumps (e.g. the recurring 1.100.0 target) are suppressed. The `dtolnay/rust-toolchain` tags track Rust toolchain releases and are pinned intentionally — verified 9 refs at `@1.94.1` (backend.yml x7, backend-dev-push-gate.yml, backend-fmt-clippy-gate.yml) plus one `@stable` in deploy-server.yml. These are bumped by hand alongside the Rust version.

YAML validated with `yaml.safe_load`; the `ignore` block parses as expected.

## Verification
VERIFY-PLAN base=4e9811a2ab9278386bc9bdb8563afcf2c83c9cb9 files=1
VERIFY OK 25df908cb3b61e35e3d74c193453080349050832

(Config-only diff → impact-scoped plan is empty; no build/test commands apply.)

## Scope drift
`scope_drift=true` (deterministic). The `owner_role` hint `pm-tech-lead` maps to `docs/**`, `.research/**`, `_bmad-output/**` in `owner-areas.json`, which does not include `.github/`. The single touched path `.github/dependabot.yml` is the exact file the task targets, so the drift is an owner-hint/area mismatch, not off-scope work. Reviewer to confirm.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- goal-check IG1/IG2/IG8 report structural FAILs (no `.research/plans/` file, dispatcher branch name `auto-impl/...`, no archive move). These are expected for a GitHub-issue-driven config task rather than a research-plan flow; the script exits 0 and IG7 (verify) is green.
- IG3 (regression test) not applicable — Dependabot config has no runnable test harness.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TpFW8EYqYxG4ftnT4WqGpe)_