### PR TITLE
refactor-churn-hotspot-backend-cargo-toml-2026-07-20: alphabetize [workspace.dependencies] groups

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -50,43 +50,45 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 validator = { version = "0.20", features = ["derive"] }
 
 # Database
-sqlx = { version = "0.9", features = ["runtime-tokio", "postgres", "uuid", "chrono", "migrate", "rust_decimal"] }
+# Entries within each group are kept alphabetically sorted so that Dependabot
+# and manual edits land in a deterministic spot (minimizes merge conflicts).
 rust_decimal = { version = "1.34", features = ["serde", "serde-str"] }
 rust_decimal_macros = "1.34"
+sqlx = { version = "0.9", features = ["runtime-tokio", "postgres", "uuid", "chrono", "migrate", "rust_decimal"] }
 
 # Auth
+argon2 = "=0.6.0-rc.8"
 # jsonwebtoken 10 split its crypto backend into a cargo feature; without one it
 # panics at runtime ("Could not determine the CryptoProvider"). `rust_crypto` is
 # the pure-Rust backend (matches the provider jsonwebtoken 9 had built in).
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
-argon2 = "=0.6.0-rc.8"
 
 # Utilities
-uuid = { version = "1.6", features = ["v4", "serde"] }
+anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
-thiserror = "2.0"
-anyhow = "1.0"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 config = "0.15"
 dotenvy = "0.15"
-rand = "0.10"
 hex = "0.4"
+rand = "0.10"
+thiserror = "2.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+uuid = { version = "1.6", features = ["v4", "serde"] }
 
 # Crypto
-sha2 = "0.11"
-sha1 = "0.11"
-hmac = "0.13"
 base64 = "0.22"
 # base32 for RFC-6238 TOTP secrets (authenticator-app compatible)
 data-encoding = "2"
+hmac = "0.13"
+sha1 = "0.11"
+sha2 = "0.11"
 # provably-constant-time equality (timing-safe secret compares)
 subtle = "2"
 
 # URL encoding
-urlencoding = "2.1"
 url = "2.5"
+urlencoding = "2.1"
 
 # HTTP client (for integrations)
 reqwest = { version = "0.13", features = ["json", "form", "query", "http2"] }
@@ -121,20 +123,20 @@ reqwest = { version = "0.13", features = ["json", "form", "query", "http2"] }
 quick-xml = { version = "=0.41.0", features = ["serialize"] }
 
 # Observability (Epic 95)
-opentelemetry = { version = "0.32", features = ["metrics", "trace"] }
-opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
-tracing-opentelemetry = "0.33"
 metrics = "0.24"
 metrics-exporter-prometheus = "0.12"
+opentelemetry = { version = "0.32", features = ["metrics", "trace"] }
+opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"] }
+tracing-opentelemetry = "0.33"
 
 # Error tracking (Epic 95)
 sentry = { version = "0.48", features = ["tracing", "tower", "tower-http"] }
 
 # AWS SDK for S3 (Epic 103)
 aws-config = { version = "1.1", features = ["behavior-version-latest"] }
-aws-sdk-s3 = "1.17"
 aws-credential-types = "1.1"
+aws-sdk-s3 = "1.17"
 
 # Redis (Epic 103)
 redis = { version = "1.2", features = ["tokio-comp", "connection-manager"] }
@@ -149,26 +151,26 @@ rust_xlsxwriter = "0.96"
 fluent = "0.16"
 fluent-bundle = "0.16"
 fluent-syntax = "0.11"
-unic-langid = "0.9"
 intl-memoizer = "0.5"
+unic-langid = "0.9"
 
 # Internal crates
-common = { path = "crates/common" }
-api-core = { path = "crates/api-core" }
+accounting-core = { path = "crates/accounting-core" }
 admin-core = { path = "crates/admin-core" }
+api-core = { path = "crates/api-core" }
+common = { path = "crates/common" }
 db = { path = "crates/db" }
 integrations = { path = "crates/integrations" }
-tenant-ops = { path = "crates/tenant-ops" }
-accounting-core = { path = "crates/accounting-core" }
 layout-core = { path = "crates/layout-core" }
+tenant-ops = { path = "crates/tenant-ops" }
 
 # Phase 1: deploy-server
-bollard = "0.16"
-listenfd = "1.0"
-tokio-util = { version = "0.7", features = ["io"] }
-futures-util = "0.3"
 async-trait = "0.1"
+bollard = "0.16"
+futures-util = "0.3"
+listenfd = "1.0"
 tempfile = "3.10"
+tokio-util = { version = "0.7", features = ["io"] }
 which = "8.0"
 
 [profile.release]


### PR DESCRIPTION
## Task
Churn hotspot: backend/Cargo.toml — 3 touches this window (dependabot minor-patch cascade + layout-core crate). Behaviour-preserving maintainability refactor of the workspace manifest (e.g. group/alphabetize [workspace.dependencies], de-duplicate, tidy feature lists) WITHOUT changing resolved versions or build behaviour.

## Owner
pm-tech-lead

## What changed
Order-only tidy of `backend/Cargo.toml`. Each existing semantic group in `[workspace.dependencies]` (Database, Auth, Utilities, Crypto, URL encoding, Observability, AWS SDK, i18n, Internal crates, deploy-server) is now alphabetically sorted, so future Dependabot bumps and manual edits land in a deterministic spot and stop colliding — the reason this manifest is a churn hotspot. The out-of-position `layout-core` path-dep (the cited layout-core churn source) is now in sorted position. Group headers and all explanatory comments are preserved and moved with their entry (e.g. the jsonwebtoken crypto-backend note, the data-encoding/subtle notes, the quick-xml SECURITY PIN block — untouched). One short comment added to the Database group documenting the sort convention.

No changes to: `[workspace] members` ordering (intentional dependency layering, left as-is), `workspace.package`, profiles, the deploy-server exclude, or any version/feature string.

## Behaviour preservation (proofs)
- **Identical dependency-entry set** vs `origin/dev` — `diff` of the sorted entry lines is empty (order-only change; no version/feature edited).
- **`Cargo.lock` untouched** — `git status` clean for the lockfile before and after.
- **`cargo metadata --locked` succeeds** — the manifest resolves against the existing lock with no lock mutation, i.e. the resolution graph is byte-identical.
- No duplicate keys existed, so reordering cannot change any "last-wins" resolution.

## Verification
```
VERIFY-PLAN base=8b92803f1b65f38766c1c685b021332523f1d063 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```
Ran locally to the extent this sandbox permits:
- `cargo fmt --all -- --check` → **OK**
- `cargo clippy -p common -p layout-core -p api-core -p admin-core -p db -p integrations -p tenant-ops -p accounting-core --all-targets -- -D warnings` → **OK (exit 0)** — all 8 library crates.

The three server binaries (`api-server`, `reality-server`, `accounting-server`) transitively pull `utoipa-swagger-ui`, whose build script downloads `swagger-ui/archive/refs/tags/v5.17.14.zip` from github.com at build time. In this sandbox that host returns **HTTP 403 (org egress policy: "GitHub access to this repository is not enabled for this session")**, so the full-workspace `clippy`/`test` cannot complete locally. This failure is environmental, reproduces identically on untouched `dev`, and is causally unrelated to a Cargo.toml key reorder. The authoritative full-workspace gate runs in GitHub Actions `backend.yml` (which has repo access) — **this PR is left as a draft pending that green CI run.** Do not merge until CI is green.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — pure manifest ordering).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` flagged `backend/Cargo.toml` (exit 2) — the manifest is not inside the pm-tech-lead owner glob. This is expected: the task itself is a deliberate workspace-manifest edit assigned to pm-tech-lead. Single file, order-only.

## Code-reuse review
none — no new helpers/symbols added (manifest ordering only).

## Notes
Low-priority, behaviour-preserving. Diff is 26 insertions / 24 deletions, one file. Reviewer should confirm CI `backend.yml` is green (it exercises the server crates that the local sandbox could not) before un-drafting/merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNw59SBeXFBk1Zz3dWSnUx

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNw59SBeXFBk1Zz3dWSnUx)_