### PR TITLE
refactor-churn-hotspot-mobile-package-json-2026-07-20: tidy mobile package.json field order

### DIFF
--- a/frontend/apps/mobile/package.json
+++ b/frontend/apps/mobile/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@ppt/mobile",
+  "version": "0.3.218",
   "private": true,
   "description": "Property Management Mobile App (React Native)",
   "scripts": {
@@ -64,6 +65,5 @@
     "jest-expo": "^56.0.5",
     "react-test-renderer": "19.2.7",
     "typescript": "^5.3.0"
-  },
-  "version": "0.3.218"
+  }
 }


### PR DESCRIPTION
## Task
Churn hotspot: `frontend/apps/mobile/package.json` — 5 touches this window (Expo/expo-notifications/expo-config-plugins dependabot cascade). Behaviour-preserving maintainability refactor of the package manifest (group/alphabetize dependencies + devDependencies, tidy) WITHOUT changing any resolved version, script, or config value. Do NOT touch the lockfile.

## Owner
pm-tech-lead

## What changed
Single behaviour-preserving tidy: relocated the top-level `"version": "0.3.218"` field from **last position** (after `devDependencies`) to its conventional npm slot right after `"name"`. `dependencies` and `devDependencies` were already fully alphabetized, so no reordering there was needed. No resolved version, script, or config value changed.

The stray-trailing-`version` placement is exactly what the dependabot / `npm version` cascade churns; putting it in the conventional metadata block makes future diffs to this hotspot cleaner.

Diff is 2 lines added / 2 removed — `version` moved up, removed from the bottom.

## Tested (Band A — fast check)
For a pure manifest field-reorder (no TS, no runtime code, no dependency/script/config value change), the meaningful gate is manifest validity + lockfile consistency:

- `node -e 'JSON.parse(...)'` → **package.json parses OK** (exit 0)
- Order-insensitive deep-equality of before/after → **semantically identical (true)** (exit 0) — proves no value changed, only field order
- `git diff --name-only HEAD~1 HEAD` → only `frontend/apps/mobile/package.json` (lockfile untouched)
- `pnpm -C frontend install --frozen-lockfile --offline` → **"Lockfile is up to date, resolution step is skipped"** — frozen-lockfile consistency check passed against the modified manifest. The command then exits 1 only on `ERR_PNPM_NO_OFFLINE_TARBALL` (empty offline store in sandbox), which is a store/network limitation, not a manifest/lockfile mismatch.

`pnpm -F mobile typecheck` / `test` were not run: they require a full `pnpm install` (blocked by the offline store) and their outcomes are provably unaffected by a field reorder that changes no dependency, script, or config value.

## Built (Band B — full build)
skipped: change <50 LOC, no public API/config touch (metadata field reorder only).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` returned exit 2: `frontend/apps/mobile/package.json` is not in pm-tech-lead's mapped owner areas. This is expected — the task is a cross-cutting tech-lead churn-hotspot maintainability task on a frontend manifest. Reviewer to adjudicate; the single touched file matches the task text exactly.

## Notes
- `reuse-grep.sh --specialist react-native` → clean (no duplicated helpers).
- `goal-check.sh` reports IG1/IG2/IG8 FAIL — these are artifacts of the research-**plan** flow (they expect a `.research/plans/<slug>.md`, an `impl/<slug>` branch, and an archive-move). This is a dispatcher-issued churn task with a pre-assigned `auto-impl/...` branch and no plan file, so those checks are inapplicable by design. IG3 (TDD test commit) legitimately skipped for a pure refactor. The Step 3 verify gate above is the applicable gate and passed.
- Lockfile intentionally untouched per task instruction.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KdtTXRJqZFMURBtsaHv5Nh)_