### PR TITLE
refactor-churn-hotspot-ppt-dashboard-md-2026-07-21: tidy ppt/dashboard screen-map (fix error-banner drift)

### DIFF
--- a/docs/screens/ppt/dashboard.md
+++ b/docs/screens/ppt/dashboard.md
@@ -86,7 +86,7 @@ UC-15 + UC-02 + UC-03 + UC-04 hub for residents on mobile (RN). The home screen 
 
 ### Specific (recent)
 
-- Load errors surface via a retryable inline banner above the stats grid (`hasError` across all four dashboard queries; #2282/#2304). The banner is now the shared `components/QueryErrorBanner.tsx` (extracted #2323) so sibling screens can reuse the same contract — it renders a caller-provided, already-localized message and never a raw `error.message`. The whole mobile screens tree was swept in #2323 to drop raw `error.message`/`combinedError.message` renders (backend-internals leak).
+- Load errors surface via a retryable inline banner above the My-home card (`hasError` across the dashboard queries; #2282/#2304). The banner is now the shared `components/QueryErrorBanner.tsx` (extracted #2323) so sibling screens can reuse the same contract — it renders a caller-provided, already-localized message and never a raw `error.message`. The whole mobile screens tree was swept in #2323 to drop raw `error.message`/`combinedError.message` renders (backend-internals leak).
 - Dashboard dates now localize to `i18n.language` (was hardcoded `en-US`); the announcement category badge is translated via `dashboard.category.*` (was rendering the raw enum).
 - Mobile tokens defined as a JS object (`MOB_TOKENS`) inline in screens.jsx — production must replace with imports from a shared RN theme file consumed from `@ppt/ui-kit` or equivalent. Don't ship inline-token objects.
 - 📌 emoji in pinned-announcement card violates SKILL.md non-negotiable — replace with Lucide `pin` SVG. Same for any other emoji glyph elsewhere.
@@ -103,6 +103,7 @@ UC-15 + UC-02 + UC-03 + UC-04 hub for residents on mobile (RN). The home screen 
 
 <!-- newest entries on top -->
 
+- 2026-07-23 — agent: doc tidy (behaviour-preserving) — fixed error-banner drift in Notes ("above the stats grid / four dashboard queries" → "above the My-home card / dashboard queries") to match the States section and this mobile-only screen; frontmatter and sitemap IDs unchanged
 - 2026-07-20 — agent: RN mobile dashboard renders via cached resolved layout (next-launch activation).
 - 2026-07-20 — agent: layout preview mode (postMessage bridge) added.
 - 2026-07-20 — agent: org-admin customize entry point added (/dashboard/customize, layout tenant editor)


### PR DESCRIPTION
## Task
Churn hotspot: docs/screens/ppt/dashboard.md — 3 touches this run (Layout & Content Manager pilot integration). Behaviour-preserving documentation tidy of the screen-map file (consistent section ordering, dedupe stale notes, fix any drift) WITHOUT changing frontmatter semantics (buildStatus/apiStatus/redesignStatus IDs) or sitemap IDs. Run /screens validate after editing.

## Owner
pm-tech-lead

## What changed
Behaviour-preserving tidy of the mobile-only `ppt/dashboard` screen-map:

- **Section ordering** — already canonical (`Functionality Checklist → States → Notes → Agent Log`; Notes `Broader context → Specific (recent)`); no reordering needed. Verified against sibling maps (faults-list, report-fault, announcements).
- **Drift fix** — the "Specific (recent)" error-banner note anchored the retryable `QueryErrorBanner` *"above the stats grid (across all four dashboard queries)"*. This mobile home screen has no stats grid (checklist = Top bar / Address strip / Pinned announcement / My-home / Recent-activity / Tab bar), and the States section already places the banner *"above the My-home card"*. Re-anchored the note to match the screen and dropped the drifted web-manager specifics ("stats grid", "four"). All behavioral facts preserved (`hasError` trigger, shared `QueryErrorBanner`, no raw `error.message`, refs #2282/#2304/#2323).
- **Agent Log** — added the required `2026-07-23` entry.

No frontmatter semantics (buildStatus/apiStatus/redesignStatus) or sitemap IDs changed.

## Tested (Band A — fast check)
`pnpm --filter @ppt/screen-map cli validate --root <repo>` → exit 0

```
ok  docs/screens/ppt/dashboard.md
Validated 167 screen-maps: 0 errors, 0 warnings.
```

## Built (Band B — full build)
skipped: docs-only change (<50 LOC, no public API/config/build-output touch).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs-only; no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Scope-drift check: clean (`pm-tech-lead` owns `docs/**`) — `scope_drift=false`.
- Code-reuse pre-flight: N/A (docs-only, no new code symbols) — `code_reuse_warn=none`.
- Draft PR per implementer contract.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KdtTXRJqZFMURBtsaHv5Nh)_