### PR TITLE
gh-issue-2483: org-scope dispute add_evidence write (cross-tenant IDOR follow-up to #2450)

### DIFF
--- a/backend/crates/db/src/repositories/dispute.rs
+++ b/backend/crates/db/src/repositories/dispute.rs
@@ -617,12 +617,29 @@ impl DisputeRepository {
         Ok(evidence)
     }
 
-    pub async fn add_evidence(&self, req: AddEvidence) -> Result<DisputeEvidence, AppError> {
+    /// Attach evidence to a dispute, scoped to the caller's organization
+    /// (issue #2483 — follow-up to #2441/PR #2450, which org-scoped the sibling
+    /// sub-resource methods but missed this write).
+    ///
+    /// The INSERT is gated by an `EXISTS` predicate on the parent dispute's
+    /// organization, so the write is atomic — a caller from another org cannot
+    /// attach evidence by guessing the `dispute_id`. A foreign-org (or unknown)
+    /// `dispute_id` selects no source row, inserts nothing, and surfaces as
+    /// `NotFound`. The follow-up `record_activity` is gated on the same success,
+    /// so no phantom activity row is written for a rejected attempt.
+    pub async fn add_evidence(
+        &self,
+        req: AddEvidence,
+        org_id: Uuid,
+    ) -> Result<DisputeEvidence, AppError> {
         let evidence = sqlx::query_as::<_, DisputeEvidence>(
             r#"
             INSERT INTO dispute_evidence (dispute_id, uploaded_by, filename, original_filename,
                                           content_type, size_bytes, storage_url, description)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            SELECT $1, $2, $3, $4, $5, $6, $7, $8
+            WHERE EXISTS (
+                SELECT 1 FROM disputes WHERE id = $1 AND organization_id = $9
+            )
             RETURNING id, dispute_id, uploaded_by, filename, original_filename, content_type,
                       size_bytes, storage_url, description, created_at
             "#,
@@ -635,9 +652,11 @@ impl DisputeRepository {
         .bind(req.size_bytes)
         .bind(&req.storage_url)
         .bind(&req.description)
-        .fetch_one(&self.pool)
+        .bind(org_id)
+        .fetch_optional(&self.pool)
         .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Dispute not found".to_string()))?;
 
         self.record_activity(
             req.dispute_id,

--- a/backend/crates/db/tests/suites/dispute_lifecycle_tests.rs
+++ b/backend/crates/db/tests/suites/dispute_lifecycle_tests.rs
@@ -337,16 +337,19 @@ async fn add_evidence_persists_and_records_activity(pool: PgPool) {
         .expect("file dispute");
 
     let evidence = repo
-        .add_evidence(AddEvidence {
-            dispute_id: dispute.id,
-            uploaded_by: user,
-            filename: "noise-recording.mp3".into(),
-            original_filename: "recording (1).mp3".into(),
-            content_type: "audio/mpeg".into(),
-            size_bytes: 1024,
-            storage_url: "s3://evidence/noise-recording.mp3".into(),
-            description: Some("Recording of the noise".into()),
-        })
+        .add_evidence(
+            AddEvidence {
+                dispute_id: dispute.id,
+                uploaded_by: user,
+                filename: "noise-recording.mp3".into(),
+                original_filename: "recording (1).mp3".into(),
+                content_type: "audio/mpeg".into(),
+                size_bytes: 1024,
+                storage_url: "s3://evidence/noise-recording.mp3".into(),
+                description: Some("Recording of the noise".into()),
+            },
+            org,
+        )
         .await
         .expect("add evidence");
     assert_eq!(evidence.dispute_id, dispute.id);

--- a/backend/servers/api-server/src/routes/disputes.rs
+++ b/backend/servers/api-server/src/routes/disputes.rs
@@ -800,28 +800,29 @@ async fn list_evidence(
 }
 
 /// Add evidence to a dispute.
+///
+/// Issue #2483 (follow-up to #2441 / PR #2450, which org-scoped the other five
+/// dispute sub-resource handlers but missed this one): the INSERT is scoped to
+/// the caller's JWT tenant. A `dispute_id` owned by another org returns 404 and
+/// is never mutated, so a caller cannot attach evidence to a foreign dispute by
+/// guessing the `dispute_id`.
 async fn add_evidence(
     State(state): State<AppState>,
     user: AuthUser,
     Path(id): Path<Uuid>,
     Json(data): Json<AddEvidenceRequest>,
 ) -> Result<(StatusCode, Json<DisputeEvidence>), (StatusCode, Json<ErrorResponse>)> {
+    let organization_id = require_org(&user)?;
     let mut evidence = data.data;
     evidence.dispute_id = id;
     evidence.uploaded_by = user.user_id;
 
     state
         .dispute_repo
-        .add_evidence(evidence)
+        .add_evidence(evidence, organization_id)
         .await
         .map(|e| (StatusCode::CREATED, Json(e)))
-        .map_err(|e| {
-            tracing::error!("Failed to add evidence: {:?}", e);
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse::new("DB_ERROR", "Failed to add evidence")),
-            )
-        })
+        .map_err(|e| map_dispute_err(e, "Failed to add evidence"))
 }
 
 /// Delete evidence from a dispute.

--- a/backend/servers/api-server/tests/suites/dispute_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/dispute_cross_org_idor_tests.rs
@@ -544,6 +544,64 @@ async fn delete_evidence_is_scoped_to_owning_org(pool: PgPool) {
     assert!(own, "org A deletes its own evidence");
 }
 
+// R9 — add_evidence: foreign org writes nothing (NotFound); owner attaches.
+//
+// Issue #2483 — follow-up to #2441/PR #2450, which org-scoped the five sibling
+// sub-resource methods but missed this WRITE. Before the fix, `add_evidence`
+// INSERTed on the path-supplied `dispute_id` alone, so any authenticated user
+// could attach evidence to any dispute in any org. The INSERT is now gated by an
+// `EXISTS` on the parent dispute's org: a foreign-org `dispute_id` inserts no
+// row and surfaces `NotFound`, while the owning org still succeeds. This is the
+// IG3 regression test — it fails on pre-fix `dev` and passes after.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_evidence_is_scoped_to_owning_org(pool: PgPool) {
+    let org_a = seed_org(&pool, "sub-addev-a").await;
+    let org_b = seed_org(&pool, "sub-addev-b").await;
+    let user_a = seed_user(&pool, "sub-addev-a@dispute-idor.test").await;
+    let attacker = seed_user(&pool, "sub-addev-attacker@dispute-idor.test").await;
+    let dispute_a = seed_dispute(&pool, org_a, user_a).await;
+
+    let repo = DisputeRepository::new(pool.clone());
+
+    let new_evidence = |uploaded_by: Uuid| db::models::AddEvidence {
+        dispute_id: dispute_a,
+        uploaded_by,
+        filename: "ev.pdf".into(),
+        original_filename: "evidence.pdf".into(),
+        content_type: "application/pdf".into(),
+        size_bytes: 2048,
+        storage_url: "s3://ppt-evidence/injected-object.pdf".into(),
+        description: Some("injected".into()),
+    };
+
+    // Foreign-org write must fail with NotFound and attach nothing.
+    let cross = repo.add_evidence(new_evidence(attacker), org_b).await;
+    assert!(
+        matches!(cross, Err(::common::errors::AppError::NotFound(_))),
+        "org B must not attach evidence to org A's dispute, got {cross:?}"
+    );
+    let injected_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM dispute_evidence WHERE dispute_id = $1 AND uploaded_by = $2",
+    )
+    .bind(dispute_a)
+    .bind(attacker)
+    .fetch_one(&pool)
+    .await
+    .expect("count evidence");
+    assert_eq!(
+        injected_count, 0,
+        "cross-org add_evidence must write no row"
+    );
+
+    // Owning org attaches successfully.
+    let ev = repo
+        .add_evidence(new_evidence(user_a), org_a)
+        .await
+        .expect("org A attaches evidence to its own dispute");
+    assert_eq!(ev.dispute_id, dispute_a);
+    assert_eq!(ev.uploaded_by, user_a);
+}
+
 // R8 — list_activities: owner reads the trail, foreign org gets NotFound.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_activities_is_scoped_to_owning_org(pool: PgPool) {


### PR DESCRIPTION
## Task

Follow-up: `add_evidence` dispute sub-resource is still cross-tenant-writable (missed by #2441 / PR #2450).

PR #2450 org-scoped five dispute sub-resource handlers but missed the sixth: `add_evidence`. It was a cross-tenant **WRITE** IDOR — any authenticated user could attach evidence to any dispute in any org by guessing a `dispute_id`. This mirrors the #2450 pattern for the missed handler.

Closes #2483

## Owner

`pm-security` (issue recommendation). Concrete specialist: `rust-backend`.

## What changed

1. **Handler** `backend/servers/api-server/src/routes/disputes.rs::add_evidence` — threads `let organization_id = require_org(&user)?;` and passes it to the repo; errors now route through `map_dispute_err`, so a foreign/unknown `dispute_id` surfaces **404** (was 500) instead of silently succeeding.
2. **Repo** `backend/crates/db/src/repositories/dispute.rs::add_evidence` — the INSERT is now atomic + org-gated:
   `INSERT ... SELECT ... WHERE EXISTS (SELECT 1 FROM disputes WHERE id = $1 AND organization_id = $9) RETURNING ...`, with `fetch_optional` + `ok_or(NotFound)`, so a foreign `dispute_id` writes **no row** and returns `NotFound`. The follow-up `record_activity` is gated on the same success (no phantom activity row on a rejected attempt).
3. **Regression test (IG3)** `backend/servers/api-server/tests/suites/dispute_cross_org_idor_tests.rs` — new R9 `add_evidence_is_scoped_to_owning_org` (sibling to #2450's R4–R8): org B `add_evidence` on org A's dispute → `NotFound` and `SELECT COUNT(*)` proves no row written; owning org still succeeds. Fails on pre-fix `dev` (2-arg signature + ungated INSERT). Also bumped the quarantined `dispute_lifecycle_tests` `add_evidence` call to the new signature so the crate keeps compiling.

## Verification

```
VERIFY-PLAN base=c92c86e3c04751db53b8c060bdb2e687d33489d8 files=4
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p {accounting-core,accounting-server,admin-core,api-core,api-server,db,reality-server,tenant-ops} --all-targets -- -D warnings
  cd backend && cargo test -p {accounting-core,accounting-server,admin-core,api-core,api-server,db,reality-server,tenant-ops}
```

Results in this sandbox:
- `cargo fmt --check` — **OK**
- All 8 `cargo clippy` steps — **OK** (0 warnings)
- `cargo test` — accounting-core / accounting-server / admin-core / api-core — **OK**
- `cargo test -p api-server` — **all green except one pre-existing, unrelated, environment-determined failure**: `airbnb_oauth_routes_tests::token_exchange_returns_503_when_not_configured` (asserts 503 "when `AIRBNB_CLIENT_ID` is unset"; this sandbox resolves Airbnb as configured, returning 400). That test file is **not in this diff** (`git diff --name-only origin/dev...HEAD` = the 4 dispute files only), is byte-identical to `dev`, and cannot be influenced by a dispute-evidence change. CI (`backend.yml`) runs in the properly-configured env.

Direct confirmation of the touched surface (run standalone, capped threads):
```
cargo test -p api-server --test suite_3 -- dispute_cross_org_idor_tests
running 14 tests ... test result: ok. 14 passed; 0 failed; 0 ignored
  incl. dispute_cross_org_idor_tests::add_evidence_is_scoped_to_owning_org ... ok   (R9)
```

> Environment note: `utoipa-swagger-ui`'s build script downloads the swagger-ui GitHub archive, which the sandbox proxy blocks. To run the gate locally I vendored `swagger-ui-dist@5.17.14` from npm into the expected `swagger-ui-<ver>/dist/` zip layout and set `SWAGGER_UI_DOWNLOAD_URL=file://…`. No shipped code changed for this; CI downloads the asset normally.

## CI parity (Band C — hot-path)

This is a security / cross-tenant data-integrity change. The relevant CI job is `backend.yml` (`cargo fmt`, `clippy`, `cargo test`), which this PR's diff triggers. Locally replicated as the verify gate above (all green except the unrelated pre-existing Airbnb env test). Recommend confirming `backend.yml` is green on CI before un-drafting.

## Scope drift

`scope_drift=true`. The `pm-security` owner area (`scripts/owner-areas.json`) is scoped to auth/mfa paths; this fix legitimately lives in the disputes domain (`routes/disputes.rs`, `repositories/dispute.rs`) as directed by issue #2483. Drifting paths: the 4 dispute files. Reviewer to confirm the domain placement is expected for this security follow-up.

## Code-reuse review

`code_reuse_warn=none` — reuse-grep found no duplicated helpers. The fix reuses the existing `require_org`, `map_dispute_err`, and the exact `EXISTS`-gated INSERT pattern established by #2450's `add_party`.

## Notes

- Behavior change: a foreign/unknown `dispute_id` on `POST …/evidence` now returns **404** (previously 500 on foreign dispute due to FK, or a silent cross-tenant write). Matches the #2450 siblings.
- IG3 satisfied via the `test:` + `fix:` commit pair on this branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LbvHtEDsvso1CZT8yjVuF2)_