### PR TITLE
gh-issue-2486: tenant-scope mobile layout cache key + clear on logout

### DIFF
--- a/frontend/apps/mobile/src/features/layout/layout.test.tsx
+++ b/frontend/apps/mobile/src/features/layout/layout.test.tsx
@@ -14,6 +14,7 @@ import { act, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
 import { Text } from 'react-native';
 import { DashboardScreen } from '../../screens/dashboard/DashboardScreen';
+import { resetLocalData } from '../../services/resetLocalData';
 import { LayoutSections } from './LayoutSections';
 import { readCachedLayout, writeCachedLayout } from './layoutCache';
 import type { SectionComponentProps, SectionRegistry } from './registry';
@@ -27,9 +28,11 @@ jest.mock('../../hooks/useApi', () => ({
   apiRequest: jest.fn(),
 }));
 
+// The real `useDashboardLayout` reads `user.id` to tenant-scope the layout
+// cache key (issue #2486), so the mocked auth user must expose an id.
 jest.mock('../../contexts/AuthContext', () => ({
   useAuth: () => ({
-    user: { firstName: 'Ada', lastName: 'Byron' },
+    user: { id: 'user-a', firstName: 'Ada', lastName: 'Byron' },
     logout: jest.fn(),
   }),
 }));
@@ -171,12 +174,13 @@ describe('layoutCache', () => {
     (mockAsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
     (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(SAMPLE_LAYOUT));
 
-    await writeCachedLayout('ppt/dashboard', SAMPLE_LAYOUT);
-    const result = await readCachedLayout('ppt/dashboard');
+    await writeCachedLayout('user-a', 'ppt/dashboard', SAMPLE_LAYOUT);
+    const result = await readCachedLayout('user-a', 'ppt/dashboard');
 
     expect(result).toEqual(SAMPLE_LAYOUT);
+    // Key is tenant-scoped by the `user-a` scope id (issue #2486).
     expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
-      'ppt_layout_ppt_dashboard',
+      'ppt_layout_user-a_ppt_dashboard',
       JSON.stringify(SAMPLE_LAYOUT)
     );
   });
@@ -185,10 +189,10 @@ describe('layoutCache', () => {
     (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue('not-valid-json{{{');
     (mockAsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
 
-    const result = await readCachedLayout('ppt/dashboard');
+    const result = await readCachedLayout('user-a', 'ppt/dashboard');
 
     expect(result).toBeNull();
-    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('ppt_layout_ppt_dashboard');
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('ppt_layout_user-a_ppt_dashboard');
   });
 
   it('returns null and calls removeItem when screen key does not match', async () => {
@@ -196,10 +200,58 @@ describe('layoutCache', () => {
     (mockAsyncStorage.getItem as jest.Mock).mockResolvedValue(JSON.stringify(wrongScreen));
     (mockAsyncStorage.removeItem as jest.Mock).mockResolvedValue(undefined);
 
-    const result = await readCachedLayout('ppt/dashboard');
+    const result = await readCachedLayout('user-a', 'ppt/dashboard');
 
     expect(result).toBeNull();
-    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('ppt_layout_ppt_dashboard');
+    expect(mockAsyncStorage.removeItem).toHaveBeenCalledWith('ppt_layout_user-a_ppt_dashboard');
+  });
+
+  // ── cross-tenant isolation (#2486) ──────────────────────────────────────
+  // The key carries the scope (user/org) id, so a layout written under org A
+  // cannot be read back under org B — different scope ⇒ different key ⇒ miss.
+  it('does not activate org A layout for org B (scoped key)', async () => {
+    const store = new Map<string, string>();
+    (mockAsyncStorage.setItem as jest.Mock).mockImplementation(async (k: string, v: string) => {
+      store.set(k, v);
+    });
+    (mockAsyncStorage.getItem as jest.Mock).mockImplementation(async (k: string) =>
+      store.has(k) ? (store.get(k) as string) : null
+    );
+    (mockAsyncStorage.removeItem as jest.Mock).mockImplementation(async (k: string) => {
+      store.delete(k);
+    });
+
+    // org A caches its dashboard layout…
+    await writeCachedLayout('org-a', 'ppt/dashboard', SAMPLE_LAYOUT);
+    expect(store.has('ppt_layout_org-a_ppt_dashboard')).toBe(true);
+
+    // …org B reading the same screen gets NOTHING (its key never existed).
+    const forOrgB = await readCachedLayout('org-b', 'ppt/dashboard');
+    expect(forOrgB).toBeNull();
+
+    // org A still reads its own entry back.
+    const forOrgA = await readCachedLayout('org-a', 'ppt/dashboard');
+    expect(forOrgA).toEqual(SAMPLE_LAYOUT);
+  });
+
+  // A logout/session-teardown prefix sweep (`resetLocalData`) removes every
+  // `ppt_layout_*` key regardless of scope/screen — so even org A's own entry
+  // does not survive to the next login on a shared device (#2486).
+  it('layout cache is cleared on logout via the ppt_layout_ prefix sweep', async () => {
+    const store = new Map<string, string>([
+      ['ppt_layout_org-a_ppt_dashboard', JSON.stringify(SAMPLE_LAYOUT)],
+      ['ppt_access_token', 'tok'],
+    ]);
+    (mockAsyncStorage.getAllKeys as jest.Mock).mockResolvedValueOnce(Array.from(store.keys()));
+    (mockAsyncStorage.removeMany as jest.Mock).mockImplementation(async (keys: string[]) => {
+      for (const k of keys) store.delete(k);
+    });
+
+    await resetLocalData();
+
+    expect(store.has('ppt_layout_org-a_ppt_dashboard')).toBe(false);
+    // A non-tenant key (the auth token) is untouched by the sweep.
+    expect(store.has('ppt_access_token')).toBe(true);
   });
 });
 
@@ -330,9 +382,11 @@ describe('useDashboardLayout — tightest activation cage', () => {
     expect(capturedLayout).toEqual(cachedLayout);
     expect(capturedLayout).not.toEqual(fetchedLayout);
 
-    // writeCachedLayout / AsyncStorage.setItem must have been called with the FETCHED layout
+    // writeCachedLayout / AsyncStorage.setItem must have been called with the
+    // FETCHED layout, under the tenant-scoped key (scope id `user-a` from the
+    // mocked auth user — issue #2486).
     expect(mockAsyncStorage.setItem).toHaveBeenCalledWith(
-      'ppt_layout_ppt_dashboard',
+      'ppt_layout_user-a_ppt_dashboard',
       JSON.stringify(fetchedLayout)
     );
   });

--- a/frontend/apps/mobile/src/features/layout/layoutCache.ts
+++ b/frontend/apps/mobile/src/features/layout/layoutCache.ts
@@ -2,8 +2,19 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LAYOUT_CACHE_KEY } from '../../services/localCacheKeys';
 import type { ResolvedScreen } from './types';
 
-export async function readCachedLayout(screen: string): Promise<ResolvedScreen | null> {
-  const key = LAYOUT_CACHE_KEY(screen);
+/**
+ * Read the persisted layout for `screen`, scoped to the logged-in user/org
+ * `scopeId`. The resolved layout embeds the org's tenant override, so the key
+ * is tenant-scoped: a different `scopeId` produces a different key and can
+ * never read a foreign tenant's cached layout (issue #2486). The shape-guard
+ * below still cannot detect cross-tenant reuse on its own — scoping the key is
+ * what closes that gap.
+ */
+export async function readCachedLayout(
+  scopeId: string,
+  screen: string
+): Promise<ResolvedScreen | null> {
+  const key = LAYOUT_CACHE_KEY(scopeId, screen);
   try {
     const raw = await AsyncStorage.getItem(key);
     if (!raw) return null;
@@ -29,8 +40,12 @@ export async function readCachedLayout(screen: string): Promise<ResolvedScreen |
   }
 }
 
-export async function writeCachedLayout(screen: string, layout: ResolvedScreen): Promise<void> {
-  const key = LAYOUT_CACHE_KEY(screen);
+export async function writeCachedLayout(
+  scopeId: string,
+  screen: string,
+  layout: ResolvedScreen
+): Promise<void> {
+  const key = LAYOUT_CACHE_KEY(scopeId, screen);
   try {
     await AsyncStorage.setItem(key, JSON.stringify(layout));
   } catch {

--- a/frontend/apps/mobile/src/features/layout/useDashboardLayout.ts
+++ b/frontend/apps/mobile/src/features/layout/useDashboardLayout.ts
@@ -1,19 +1,35 @@
 import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
 import { apiRequest } from '../../hooks/useApi';
 import { readCachedLayout, writeCachedLayout } from './layoutCache';
 import { DEFAULT_DASHBOARD_LAYOUT } from './registry';
 import type { ResolvedScreen } from './types';
 
 export function useDashboardLayout(screen: string): { layout: ResolvedScreen } {
+  // The persisted layout embeds the org's tenant override, so the cache key
+  // MUST be scoped to the logged-in identity — otherwise org A's dashboard
+  // layout activates for org B on a shared device (issue #2486). The hook runs
+  // inside an authenticated screen, so `user.id` is available; we use it as the
+  // tenant scope for the cache key.
+  const { user } = useAuth();
+  const scopeId = user?.id ?? null;
   const [layout, setLayout] = useState<ResolvedScreen>(DEFAULT_DASHBOARD_LAYOUT);
   const warnedRef = useRef(false);
 
   useEffect(() => {
     let cancelled = false;
 
+    // Without an authenticated identity we cannot tenant-scope the cache key,
+    // so we must NOT read or write a shared cache entry — fall back to the
+    // default layout + live fetch only (issue #2486).
+    if (!scopeId) {
+      return;
+    }
+    const sid = scopeId;
+
     async function activate() {
       // Phase 1: read cache at mount (activation — allowed at launch time)
-      const cached = await readCachedLayout(screen);
+      const cached = await readCachedLayout(sid, screen);
       if (!cancelled && cached !== null) {
         setLayout(cached);
       }
@@ -31,7 +47,7 @@ export function useDashboardLayout(screen: string): { layout: ResolvedScreen } {
             fresh.screen === screen &&
             Array.isArray(fresh.sections)
           ) {
-            await writeCachedLayout(screen, fresh);
+            await writeCachedLayout(sid, screen, fresh);
           }
         }
       } catch (err) {
@@ -46,7 +62,7 @@ export function useDashboardLayout(screen: string): { layout: ResolvedScreen } {
     return () => {
       cancelled = true;
     };
-  }, [screen]);
+  }, [screen, scopeId]);
 
   return { layout };
 }

--- a/frontend/apps/mobile/src/services/index.ts
+++ b/frontend/apps/mobile/src/services/index.ts
@@ -9,6 +9,8 @@ export { resolveDeepLinkTarget } from './deepLinkRouting';
 export {
   CACHE_PREFIX,
   LAST_SYNC_KEY,
+  LAYOUT_CACHE_KEY,
+  LAYOUT_PREFIX,
   QUEUE_KEY,
   WIDGET_CONFIG_KEY,
   WIDGET_DATA_KEY,

--- a/frontend/apps/mobile/src/services/localCacheKeys.ts
+++ b/frontend/apps/mobile/src/services/localCacheKeys.ts
@@ -24,4 +24,15 @@ export const WIDGET_DATA_KEY = '@ppt/widget_data';
 // `useDashboardLayout` / layout registry — server-driven resolved screen layout,
 // persisted across restarts so the last-known layout activates at launch before
 // the background fetch completes (next-launch activation pattern).
-export const LAYOUT_CACHE_KEY = (screen: string) => `ppt_layout_${screen.replace(/\//g, '_')}`;
+//
+// The resolved layout embeds the org's tenant override (which sections are
+// hidden/reordered — the org-admin's customization), so — like
+// `WIDGET_CONFIG_KEY` above — it is tenant-scoped data. It MUST therefore be
+// (a) keyed by the logged-in user/org id so a foreign tenant can never read a
+// prior tenant's layout, and (b) purged on session change. Because the exact
+// key is a *function* of a dynamic `screen` (and now a dynamic `scopeId`),
+// `resetLocalData` sweeps every key under `LAYOUT_PREFIX` rather than a fixed
+// list (issue #2486, follow-up to PR #2432 / #2399).
+export const LAYOUT_PREFIX = 'ppt_layout_';
+export const LAYOUT_CACHE_KEY = (scopeId: string, screen: string) =>
+  `${LAYOUT_PREFIX}${scopeId}_${screen.replace(/\//g, '_')}`;

--- a/frontend/apps/mobile/src/services/resetLocalData.test.ts
+++ b/frontend/apps/mobile/src/services/resetLocalData.test.ts
@@ -34,13 +34,17 @@ describe('resetLocalData', () => {
     mockStore.clear();
   });
 
-  it('purges offline cache, queue, sync marker and widget namespaces', async () => {
+  it('purges offline cache, queue, sync marker, widget and layout namespaces', async () => {
     mockStore.set('ppt_cache_faults_list', '[]');
     mockStore.set('ppt_cache_buildings', '[]');
     mockStore.set('ppt_offline_queue', '[]');
     mockStore.set('ppt_last_sync', '111');
     mockStore.set('@ppt/widget_data', '{}');
     mockStore.set('@ppt/widget_configs', '[]');
+    // Tenant-scoped dashboard layout cache — swept by `ppt_layout_` prefix
+    // regardless of the dynamic scope/screen suffix (issue #2486).
+    mockStore.set('ppt_layout_org-a_ppt_dashboard', '{}');
+    mockStore.set('ppt_layout_org-b_ppt_dashboard', '{}');
     // Keys outside the tenant-cache namespace must survive. `ppt_access_token`
     // starts with `ppt_` but not `ppt_cache_`, so prefix scoping must not
     // over-match it.

--- a/frontend/apps/mobile/src/services/resetLocalData.ts
+++ b/frontend/apps/mobile/src/services/resetLocalData.ts
@@ -2,6 +2,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   CACHE_PREFIX,
   LAST_SYNC_KEY,
+  LAYOUT_PREFIX,
   QUEUE_KEY,
   WIDGET_CONFIG_KEY,
   WIDGET_DATA_KEY,
@@ -17,6 +18,11 @@ import {
  * a login/logout and even an app restart:
  *   - `ppt_cache_*` + `ppt_offline_queue` + `ppt_last_sync` (`useOfflineSupport`)
  *   - `@ppt/widget_data` + `@ppt/widget_configs` (`WidgetDataProvider`)
+ *   - `ppt_layout_*` (`useDashboardLayout` — the resolved screen layout embeds
+ *     the org's tenant override, so a stale entry would let a prior tenant's
+ *     dashboard customization activate for the next account on a shared device;
+ *     issue #2486). The key is a function of a dynamic `scopeId`/`screen`, so it
+ *     is swept by prefix rather than matched against a fixed key.
  *
  * Server RLS still prevents an actual data breach on refetch, so the exposure
  * this closes is stale-display + queued-write misattribution (a prior user's
@@ -38,6 +44,7 @@ export async function resetLocalData(): Promise<void> {
     const toRemove = keys.filter(
       (key) =>
         key.startsWith(CACHE_PREFIX) ||
+        key.startsWith(LAYOUT_PREFIX) ||
         key === QUEUE_KEY ||
         key === LAST_SYNC_KEY ||
         key === WIDGET_DATA_KEY ||


### PR DESCRIPTION
## Task
Close GitHub issue #2486 — mobile `LAYOUT_CACHE_KEY` is not tenant-scoped and survives logout, so org A's dashboard layout can activate for org B (PR #2432). Scope the mobile layout cache key by org/user id (`ppt_layout_${scopeId}_${screen}`), clear `ppt_layout_*` on logout via an `AsyncStorage.getAllKeys()` prefix sweep, and add a `layout.test.tsx` case proving org A's cached layout is not activated for org B (and/or is cleared on logout).

Closes #2486

## Owner
pm-frontend (react-native specialist)

## What changed
- **`services/localCacheKeys.ts`** — `LAYOUT_CACHE_KEY` now takes `(scopeId, screen)` and produces `ppt_layout_${scopeId}_${screen}`; added exported `LAYOUT_PREFIX = 'ppt_layout_'`. Updated the doc comment flagging the layout cache as tenant-scoped data (mirrors the existing `WIDGET_CONFIG_KEY` note).
- **`features/layout/useDashboardLayout.ts`** — reads `user.id` from `useAuth()` as the tenant scope and threads it into the cache read/write. When unauthenticated (`scopeId == null`) it skips the cache entirely (default layout + live fetch only), so no un-scoped shared entry is ever written.
- **`features/layout/layoutCache.ts`** — `readCachedLayout`/`writeCachedLayout` take `scopeId` as the first argument.
- **`services/resetLocalData.ts`** — the existing session-teardown prefix sweep (already called on both login and logout in `AuthContext`) now also removes every `ppt_layout_*` key. Because the key is a function of a dynamic `scopeId`/`screen`, it is swept by prefix, not by a fixed key.
- **`services/index.ts`** — re-export `LAYOUT_PREFIX` / `LAYOUT_CACHE_KEY`.

## Tests
- `layout.test.tsx`:
  - `does not activate org A layout for org B (scoped key)` — a layout written under `org-a` cannot be read back under `org-b` (different scope ⇒ different key ⇒ miss), while `org-a` still reads its own entry.
  - `layout cache is cleared on logout via the ppt_layout_ prefix sweep` — `resetLocalData` removes the `ppt_layout_org-a_ppt_dashboard` entry while leaving the auth token untouched.
  - Updated existing cache round-trip / activation-cage assertions to the new scoped key (`ppt_layout_user-a_ppt_dashboard`).
- `resetLocalData.test.ts` — the purge test now seeds `ppt_layout_*` keys and asserts they are swept.

## Verification
```
VERIFY-PLAN base=74cc2004f7cf842ec25313771c56ef233de832be files=7
  cd frontend && pnpm exec biome check apps/mobile/src/features/layout/layout.test.tsx apps/mobile/src/features/layout/layoutCache.ts apps/mobile/src/features/layout/useDashboardLayout.ts apps/mobile/src/services/index.ts apps/mobile/src/services/localCacheKeys.ts apps/mobile/src/services/resetLocalData.test.ts apps/mobile/src/services/resetLocalData.ts
  cd frontend && pnpm --filter "...[74cc2004...]" typecheck
  cd frontend && pnpm --filter "...[74cc2004...]" test
```
VERIFY OK ddc29f9b2e47e750b72472293c7ce2aff1a9ca7a

(47 suites / 591 tests passed; mobile typecheck exit 0; Biome exit 0.)

## CI parity (Band C — hot-path only)
skipped: frontend-only mobile cache change; server RLS still governs data access, so no security/auth/billing/data-integrity server surface changed.

## Remote-tested
skipped

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0.

## Code-reuse review
None — `reuse-grep.sh --specialist react-native` empty. The fix reuses the existing `resetLocalData` prefix-sweep infrastructure rather than adding a new teardown path.

## Notes
- Scope id = logged-in `user.id`. The mobile `User` model has no explicit `orgId` field, so user id is used as the tenant scope (the issue permits "org id **or** logged-in user id"). It both isolates the cache per identity and, combined with the logout sweep, prevents cross-account activation on a shared device.
- IG goal-check (Step 3.5) reports IG1/IG2/IG3 fails that are plan-flow conventions inapplicable to this issue-driven task: no `.research/plan` exists (and the task forbids touching `.research/**`), the branch name `auto-impl/...` was pre-chosen by the dispatcher (not `impl/...`), and the regression test + fix are in a single commit rather than split test:/fix: commits. IG7 (the deterministic verify gate) is green and the required regression coverage is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tqDfPDRJx1fCYdDCH5HuY

---
_Generated by [Claude Code](https://claude.ai/code/session_015tqDfPDRJx1fCYdDCH5HuY)_