### PR TITLE
gh-issue-2484: DB-backed cross-tenant announcement fan-out guard test

### DIFF
--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -1748,6 +1748,219 @@ mod tests {
         assert_eq!(targets, vec![user_1, user_2]);
     }
 
+    // ------------------------------------------------------------------
+    // DB-backed regression (issue #2484, follow-up to PR #2455). IG3.
+    //
+    // The pure-model tests above (`org_scoped_target_users`) reimplement
+    // the `AND b.organization_id = $2` skip in Rust and are therefore
+    // independent of the query they claim to mirror — if someone drops or
+    // weakens that predicate (or the `JOIN buildings b`) in the live SQL,
+    // those tests still pass. The two `#[sqlx::test]`s below exercise the
+    // *real* query in `Scheduler::get_announcement_target_users` against
+    // Postgres, so they fail on the pre-fix SQL and cannot be satisfied by
+    // a drifted re-model. They pin both the `"building"` and `"units"`
+    // legs against the cross-tenant fan-out leak the fix defends against.
+    // ------------------------------------------------------------------
+
+    async fn seed_org(pool: &sqlx::PgPool, slug: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO organizations (name, slug, contact_email, status)
+            VALUES ($1, $2, $3, 'active') RETURNING id
+            "#,
+        )
+        .bind(format!("Fanout Org {slug}"))
+        .bind(format!("fanout-{slug}"))
+        .bind(format!("{slug}@fanout.test"))
+        .fetch_one(pool)
+        .await
+        .expect("seed org")
+    }
+
+    async fn seed_user(pool: &sqlx::PgPool, email: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO users (email, password_hash, name, status, email_verified_at)
+            VALUES ($1, 'test_hash', 'Fanout Resident', 'active', NOW())
+            RETURNING id
+            "#,
+        )
+        .bind(email)
+        .fetch_one(pool)
+        .await
+        .expect("seed user")
+    }
+
+    async fn seed_building(pool: &sqlx::PgPool, org_id: Uuid, slug: &str) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO buildings (organization_id, street, city, postal_code, country)
+            VALUES ($1, $2, 'Bratislava', '81101', 'Slovakia') RETURNING id
+            "#,
+        )
+        .bind(org_id)
+        .bind(format!("{slug} Street 1"))
+        .fetch_one(pool)
+        .await
+        .expect("seed building")
+    }
+
+    async fn seed_unit(pool: &sqlx::PgPool, building_id: Uuid, designation: &str) -> Uuid {
+        // `units` has no `organization_id` column — org is reached only via
+        // the building (migration 00116), which is exactly why the fix must
+        // JOIN buildings to scope the fan-out.
+        sqlx::query_scalar::<_, Uuid>(
+            r#"
+            INSERT INTO units (building_id, designation, floor)
+            VALUES ($1, $2, 1) RETURNING id
+            "#,
+        )
+        .bind(building_id)
+        .bind(designation)
+        .fetch_one(pool)
+        .await
+        .expect("seed unit")
+    }
+
+    async fn seed_resident(pool: &sqlx::PgPool, unit_id: Uuid, user_id: Uuid) {
+        // Open-ended residency (`end_date IS NULL`) — the active-resident
+        // predicate the query filters on.
+        sqlx::query(
+            r#"
+            INSERT INTO unit_residents (unit_id, user_id, resident_type)
+            VALUES ($1, $2, 'tenant')
+            "#,
+        )
+        .bind(unit_id)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("seed resident");
+    }
+
+    /// Build an in-memory published announcement owned by `org_id` and
+    /// targeting `target_type` / `target_ids`. It is deliberately NOT
+    /// inserted: `get_announcement_target_users` only reads the struct's
+    /// fields, so no FK rows are required for the announcement itself —
+    /// which lets us simulate the bypassed-create-validation path where
+    /// `target_ids` carry a foreign org's building/unit.
+    fn make_announcement(
+        org_id: Uuid,
+        target_type: &str,
+        target_ids: Vec<Uuid>,
+    ) -> db::models::Announcement {
+        let now = chrono::Utc::now();
+        db::models::Announcement {
+            id: Uuid::new_v4(),
+            organization_id: org_id,
+            author_id: Uuid::new_v4(),
+            title: "Fanout guard".to_string(),
+            content: "body".to_string(),
+            target_type: target_type.to_string(),
+            target_ids: serde_json::json!(target_ids),
+            status: "published".to_string(),
+            scheduled_at: None,
+            published_at: Some(now),
+            pinned: false,
+            pinned_at: None,
+            pinned_by: None,
+            comments_enabled: true,
+            acknowledgment_required: false,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn test_scheduler(pool: sqlx::PgPool) -> Scheduler {
+        Scheduler::new(
+            pool.clone(),
+            AnnouncementRepository::new(pool),
+            SchedulerConfig::default(),
+        )
+    }
+
+    /// `"building"` leg: an announcement in org A whose `target_ids` include
+    /// org B's building must fan out ONLY to org A's resident. Fails on the
+    /// pre-fix SQL (no `JOIN buildings b` / `AND b.organization_id = $2`),
+    /// which would also return org B's resident.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_announcement_building_fanout_excludes_cross_tenant_sql(pool: sqlx::PgPool) {
+        let org_a = seed_org(&pool, "bld-a").await;
+        let org_b = seed_org(&pool, "bld-b").await;
+        let building_a = seed_building(&pool, org_a, "A").await;
+        let building_b = seed_building(&pool, org_b, "B").await;
+        let unit_a = seed_unit(&pool, building_a, "A-1").await;
+        let unit_b = seed_unit(&pool, building_b, "B-1").await;
+        let resident_a = seed_user(&pool, "bld-a@fanout.test").await;
+        let resident_b = seed_user(&pool, "bld-b@fanout.test").await;
+        seed_resident(&pool, unit_a, resident_a).await;
+        seed_resident(&pool, unit_b, resident_b).await;
+
+        // org A's announcement carries org B's building id in target_ids too.
+        let announcement = make_announcement(org_a, "building", vec![building_a, building_b]);
+
+        let scheduler = test_scheduler(pool.clone());
+        let targets = scheduler
+            .get_announcement_target_users(&announcement)
+            .await
+            .expect("query announcement target users");
+
+        assert!(
+            targets.contains(&resident_a),
+            "org A's own resident must be notified"
+        );
+        assert!(
+            !targets.contains(&resident_b),
+            "cross-org building resident must be excluded — fan-out leaked across \
+             orgs (AND b.organization_id = $2 missing or weakened in the live SQL)"
+        );
+        assert_eq!(
+            targets,
+            vec![resident_a],
+            "only the owning org's resident is targeted"
+        );
+    }
+
+    /// `"units"` leg: same guard, but the foreign id in `target_ids` is a
+    /// unit rather than a building. Chains `unit_residents -> units ->
+    /// buildings` and must exclude org B's resident.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_announcement_units_fanout_excludes_cross_tenant_sql(pool: sqlx::PgPool) {
+        let org_a = seed_org(&pool, "unit-a").await;
+        let org_b = seed_org(&pool, "unit-b").await;
+        let building_a = seed_building(&pool, org_a, "UA").await;
+        let building_b = seed_building(&pool, org_b, "UB").await;
+        let unit_a = seed_unit(&pool, building_a, "UA-1").await;
+        let unit_b = seed_unit(&pool, building_b, "UB-1").await;
+        let resident_a = seed_user(&pool, "unit-a@fanout.test").await;
+        let resident_b = seed_user(&pool, "unit-b@fanout.test").await;
+        seed_resident(&pool, unit_a, resident_a).await;
+        seed_resident(&pool, unit_b, resident_b).await;
+
+        // org A's announcement carries org B's unit id in target_ids too.
+        let announcement = make_announcement(org_a, "units", vec![unit_a, unit_b]);
+
+        let scheduler = test_scheduler(pool.clone());
+        let targets = scheduler
+            .get_announcement_target_users(&announcement)
+            .await
+            .expect("query announcement target users");
+
+        assert!(
+            targets.contains(&resident_a),
+            "org A's own resident must be notified"
+        );
+        assert!(
+            !targets.contains(&resident_b),
+            "cross-org unit resident must be excluded — fan-out leaked across orgs"
+        );
+        assert_eq!(
+            targets,
+            vec![resident_a],
+            "only the owning org's resident is targeted"
+        );
+    }
+
     #[test]
     fn test_scheduler_config_default() {
         let config = SchedulerConfig::default();


### PR DESCRIPTION
## Task

Close #2484 — the announcement cross-tenant fan-out guard added in PR #2455 was tested only via a pure-Rust re-model (`org_scoped_target_users`), never against the real SQL. Add a DB-backed `#[sqlx::test(migrator = "db::MIGRATOR")]` integration test that exercises the real `Scheduler::get_announcement_target_users` SQL (with `AND b.organization_id = $2`), proving a cross-org building/unit target is excluded and the owning org's resident is included. Keep the existing pure-model unit tests.

Closes #2484

## Owner

pm-qa (tester — Rust backend / sqlx integration test)

## What changed

Two new `#[sqlx::test(migrator = "db::MIGRATOR")]` tests in `backend/servers/api-server/src/services/scheduler.rs` (`mod tests`), one per affected leg:

- `test_announcement_building_fanout_excludes_cross_tenant_sql` — `"building"` leg.
- `test_announcement_units_fanout_excludes_cross_tenant_sql` — `"units"` leg.

Each seeds org A + org B, each with a building + unit + resident, builds an announcement in org A whose `target_ids` also carry **org B's** building/unit id (the bypassed-create-validation path the fix defends against), calls the real private `Scheduler::get_announcement_target_users`, and asserts the result **contains** org A's resident and **excludes** org B's resident. These call the live query (they do not re-model it), so they fail on the pre-fix SQL and cannot be satisfied by a drifted re-model.

The existing pure-model unit tests (`org_scoped_target_users`, `test_announcement_fanout_*`) are kept unchanged as fast smoke coverage.

Note: the test is placed in-module (`#[cfg(test)] mod tests`) rather than in `tests/suites/` because `get_announcement_target_users` is private — an out-of-crate integration test could only re-issue the query string, reintroducing exactly the drift risk the issue reports. Seeding helpers mirror the DB-backed style of `tests/suites/dispute_cross_org_idor_tests.rs`.

## Scope drift

`scope-check.sh --owner pm-qa` flags one path outside pm-qa's areas (`backend/**/tests/**`):

- `backend/servers/api-server/src/services/scheduler.rs`

Justified: the method under test is private, so a test that exercises the *real* SQL (the whole point of the issue) must live in the crate's in-module `#[cfg(test)]` block. Only test code (`mod tests`) was added; no production code changed.

## Code-reuse review

`reuse-grep.sh` — none.

## Verification

`verify-impact.sh` selected the api-server band:

```
VERIFY-PLAN base=74cc2004f7cf842ec25313771c56ef233de832be files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

Executed in this sandbox (an ephemeral Postgres 16 cluster was stood up for the `#[sqlx::test]` DB, and the network-blocked `utoipa-swagger-ui` build dep was satisfied from npm's `swagger-ui-dist@5.17.14` repackaged to the expected zip layout — infra only, no code impact):

- `cargo fmt --all -- --check` — OK
- `cargo clippy -p api-server --all-targets -- -D warnings` — OK (full crate + all test targets compiled clean)
- `cargo test -p api-server --lib services::scheduler::tests::test_announcement` — **4 passed; 0 failed** (2 new DB-backed + 2 existing pure-model)

The full `cargo test -p api-server` suite additionally needs Redis/S3/MinIO services not available in this sandbox; CI (`backend.yml`) runs it against the full stack.

## IG3 (fails-on-main proof)

Temporarily neutralizing the guard (`AND b.organization_id = $2` → always-true predicate) on both legs and rerunning the same filter:

```
test result: FAILED. 2 passed; 2 failed; 465 filtered out
```

The 2 failures are exactly the two new DB-backed tests; the 2 pure-model tests still passed — empirically confirming the issue's core finding (the re-model cannot catch a SQL regression) and that the new tests are genuine regression guards. The temporary edit was reverted; the committed tree is clean.

## CI parity (Band C — hot-path only)

skipped: test-only change; the security fix itself already landed in PR #2455. No production code touched here.

## Remote-tested

skipped (ppt-bridge MCP not connected).

## Notes

Pure-additive test change. Reviewer: the in-module placement + scope-drift flag is intentional and explained above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tqDfPDRJx1fCYdDCH5HuY

---
_Generated by [Claude Code](https://claude.ai/code/session_015tqDfPDRJx1fCYdDCH5HuY)_