### PR TITLE
docs-screen-map-frontmatter-epics-2026-07-23: backfill screen-map epics frontmatter for ppt screens

### DIFF
--- a/docs/screens/ppt/announcement-edit.md
+++ b/docs/screens/ppt/announcement-edit.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-6
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/announcement-new.md
+++ b/docs/screens/ppt/announcement-new.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-6
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/community-events.md
+++ b/docs/screens/ppt/community-events.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-27
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/community-group-detail.md
+++ b/docs/screens/ppt/community-group-detail.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-27
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/community-groups-new.md
+++ b/docs/screens/ppt/community-groups-new.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-27
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/community-groups.md
+++ b/docs/screens/ppt/community-groups.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-27
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/community-marketplace.md
+++ b/docs/screens/ppt/community-marketplace.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-27
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/community.md
+++ b/docs/screens/ppt/community.md
@@ -15,7 +15,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-27
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/dashboard-manager.md
+++ b/docs/screens/ppt/dashboard-manager.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-3
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/dashboard-resident.md
+++ b/docs/screens/ppt/dashboard-resident.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-3
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/dashboard.md
+++ b/docs/screens/ppt/dashboard.md
@@ -32,7 +32,8 @@ designSources:
   - adapter: claude-design
     file: guest-registration-v2-design-system/project/ui_kits/mobile/screens.jsx
     frame: MobHomeScreen
-epics: []
+epics:
+  - Epic-3
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/fault-detail.md
+++ b/docs/screens/ppt/fault-detail.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-4
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/fault-edit.md
+++ b/docs/screens/ppt/fault-edit.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-4
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/fault-new.md
+++ b/docs/screens/ppt/fault-new.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-4
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/fault-reports.md
+++ b/docs/screens/ppt/fault-reports.md
@@ -24,7 +24,8 @@ sharedComponents:
   - bar-chart
   - date-range-filter
   - building-selector
-epics: []
+epics:
+  - Epic-4
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/faults-list.md
+++ b/docs/screens/ppt/faults-list.md
@@ -37,7 +37,8 @@ designSources:
     frame: mobile-faults-list
 useCases:
   - UC-03
-epics: []
+epics:
+  - Epic-4
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/financial-budgets.md
+++ b/docs/screens/ppt/financial-budgets.md
@@ -18,7 +18,8 @@ sharedComponents: []
 diagrams: []
 useCases:
   - UC-40
-epics: []
+epics:
+  - Epic-11
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/financial-invoices.md
+++ b/docs/screens/ppt/financial-invoices.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-11
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/financial-payments.md
+++ b/docs/screens/ppt/financial-payments.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-11
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/financial.md
+++ b/docs/screens/ppt/financial.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-11
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/forgot-password.md
+++ b/docs/screens/ppt/forgot-password.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-1
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/home.md
+++ b/docs/screens/ppt/home.md
@@ -39,7 +39,8 @@ useCases:
   - UC-04
   - UC-17
 endpoints: []
-epics: []
+epics:
+  - Epic-3
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-application-detail.md
+++ b/docs/screens/ppt/lease-application-detail.md
@@ -15,7 +15,8 @@ sharedComponents: []
 diagrams: []
 useCases:
   - UC-33
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-applications.md
+++ b/docs/screens/ppt/lease-applications.md
@@ -15,7 +15,8 @@ sharedComponents: []
 diagrams: []
 useCases:
   - UC-33
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-create.md
+++ b/docs/screens/ppt/lease-create.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-detail.md
+++ b/docs/screens/ppt/lease-detail.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-templates.md
+++ b/docs/screens/ppt/lease-templates.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-violation-create.md
+++ b/docs/screens/ppt/lease-violation-create.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-violation-detail.md
+++ b/docs/screens/ppt/lease-violation-detail.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/lease-violations.md
+++ b/docs/screens/ppt/lease-violations.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/leases-dashboard.md
+++ b/docs/screens/ppt/leases-dashboard.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/leases-list.md
+++ b/docs/screens/ppt/leases-list.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-19
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/login.md
+++ b/docs/screens/ppt/login.md
@@ -34,7 +34,8 @@ designSources:
     frame: row1-loaded+magic / row2-totp+sms / row3-loading+empty / row4-errors-3up
 useCases:
   - UC-14
-epics: []
+epics:
+  - Epic-1
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/meter-comparison.md
+++ b/docs/screens/ppt/meter-comparison.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-12
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/meter-detail.md
+++ b/docs/screens/ppt/meter-detail.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-12
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/meter-edit-reading.md
+++ b/docs/screens/ppt/meter-edit-reading.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-12
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/meter-submit-reading.md
+++ b/docs/screens/ppt/meter-submit-reading.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-12
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/meter-validations.md
+++ b/docs/screens/ppt/meter-validations.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-12
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/meters.md
+++ b/docs/screens/ppt/meters.md
@@ -14,7 +14,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-12
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/neighbors.md
+++ b/docs/screens/ppt/neighbors.md
@@ -19,7 +19,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-27
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/register.md
+++ b/docs/screens/ppt/register.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-1
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/report-fault.md
+++ b/docs/screens/ppt/report-fault.md
@@ -33,7 +33,8 @@ designSources:
     frame: MobReportFaultScreen
 useCases:
   - UC-03
-epics: []
+epics:
+  - Epic-4
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/reset-password.md
+++ b/docs/screens/ppt/reset-password.md
@@ -17,7 +17,8 @@ relatedScreens:
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-1
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/settings-password.md
+++ b/docs/screens/ppt/settings-password.md
@@ -15,7 +15,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-1
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/settings-profile.md
+++ b/docs/screens/ppt/settings-profile.md
@@ -15,7 +15,8 @@ relatedScreens: []
 sharedComponents: []
 diagrams: []
 useCases: []
-epics: []
+epics:
+  - Epic-1
 designSources: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/vote-create.md
+++ b/docs/screens/ppt/vote-create.md
@@ -34,7 +34,8 @@ designSources:
 useCases:
   - UC-04
 endpoints: []
-epics: []
+epics:
+  - Epic-5
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/vote-detail.md
+++ b/docs/screens/ppt/vote-detail.md
@@ -39,7 +39,8 @@ designSources:
 useCases:
   - UC-04
 endpoints: []
-epics: []
+epics:
+  - Epic-5
 diagrams: []
 owner: pm-frontend
 ---

--- a/docs/screens/ppt/voting.md
+++ b/docs/screens/ppt/voting.md
@@ -42,7 +42,8 @@ designSources:
     frame: MobVotingScreen
 useCases:
   - UC-04
-epics: []
+epics:
+  - Epic-5
 diagrams: []
 owner: pm-frontend
 ---


### PR DESCRIPTION
## Task
Backfill screen-map frontmatter `epics:` field so epic->screen linkage stops manufacturing orphans in coverage scan (systemic finding from 2026-06-23 deep scan; still present).

## Owner
pm-frontend (specialist: react-web)

## What changed
48 `ppt/*` screen-maps that had `epics: []` now link to their canonical epic. Assignments are drawn from `_bmad-output/epics.md` (authoritative BMAD catalog) and corroborated by already-populated sibling screens:

| Epic | Domain | Screens |
|------|--------|---------|
| Epic-1  | User Authentication & Sessions | login, register, forgot-password, reset-password, settings-password, settings-profile |
| Epic-3  | Property & Building Management | dashboard, dashboard-manager, dashboard-resident, home |
| Epic-4  | Fault Reporting & Resolution | fault-detail, fault-edit, fault-new, fault-reports, faults-list, report-fault |
| Epic-5  | Building Voting & Decisions | vote-create, vote-detail, voting |
| Epic-6  | Announcements & Communication | announcement-edit, announcement-new |
| Epic-11 | Financial Management & Payments | financial, financial-budgets, financial-invoices, financial-payments |
| Epic-12 | Meter Readings & Utilities | meter-comparison, meter-detail, meter-edit-reading, meter-submit-reading, meter-validations, meters |
| Epic-19 | Lease Management & Tenant Screening | lease-application-detail, lease-applications, lease-create, lease-detail, lease-templates, lease-violation-create, lease-violation-detail, lease-violations, leases-dashboard, leases-list |
| Epic-27 | Community, Marketplace & News | community, community-events, community-group-detail, community-groups, community-groups-new, community-marketplace, neighbors |

All IDs are canonical `Epic-N` form, matching the 62 already-populated screens.

## Intentionally left empty (documented, not oversight)
- **reality-web screens** — the reality portal uses a *separate* epic namespace. The only populated reality-web ground-truth (`reality/agency-dashboard => Epic-32`) contradicts the canonical Epic-15/16/17 reality epics, so mapping reality-web core screens has no reliable source. Deferred to a follow-up once the reality epic catalog is available.
- **ppt infra/error pages** (forbidden, server-error, session-expired, error-handling-toasts) — legitimately have no product epic; `epics: []` is the correct state.
- **ppt ambiguous screens** (outages/outage-*, notification-analytics, notification-triggers) — no single unambiguous epic; left rather than guessing.

Only unambiguous single-domain screens were backfilled to avoid fabricating wrong epic linkage.

## Verification
```
VERIFY-PLAN base=e49de5a60fce30b05b80cb29815fbf91bd073b0b files=48
VERIFY OK 6d40da9ee633320876e82dfee0c34bb7517b776e
```
- `screen-map cli validate` — **167 screen-maps: 0 errors, 0 warnings** (mandated check, stays green).
- `@ppt/screen-map` unit tests — 82 passed / 1 skipped.
- Docs-only diff → verify-impact produces an empty plan (VERIFY OK).

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0.

## Code-reuse review
None — `reuse-grep.sh` empty.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs-only; no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- The `screen-map cli update` (drift) command reports `unknown-epic` for every epic ref because `extractEpics()` reads `docs/epics/EPIC-*.md`, which does not exist in this repo — so `knownEpics` is empty and all epic refs (including the 62 pre-existing ones) are unresolved. That is a **pre-existing, separate root cause** in the extractor, not introduced here; the mandated `validate` check does not consult epics and is green. A follow-up could point `extractEpics()` at the real catalog (`_bmad-output/epics.md`) so the drift command can actually resolve epic IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGfhZvZXTLwc41ccruGBrW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGfhZvZXTLwc41ccruGBrW)_