### PR TITLE
gh-issue-2485: layout publish webhook — add timestamp + replay protection

### DIFF
--- a/backend/servers/api-server/src/routes/layout/webhook.rs
+++ b/backend/servers/api-server/src/routes/layout/webhook.rs
@@ -7,15 +7,26 @@
 //!
 //! ## Signature format
 //!
-//! The outbound signature is placed in the `X-Webhook-Signature` header as:
+//! Each delivery carries an `X-Webhook-Timestamp` header (unix seconds) and an
+//! `X-Webhook-Signature` header computed over the **timestamped** payload:
 //!
 //! ```text
-//! sha256=<base64(HMAC-SHA256(LAYOUT_WEBHOOK_SECRET, body))>
+//! X-Webhook-Timestamp: <unix-seconds>
+//! X-Webhook-Signature: sha256=<base64(HMAC-SHA256(LAYOUT_WEBHOOK_SECRET, "{timestamp}.{body}"))>
 //! ```
 //!
-//! This matches the exact format used by the inbound portal-webhook receivers
-//! (`routes/portal_webhooks.rs`), enabling the same `verify_webhook_signature`
-//! helper to verify outbound deliveries on the receiving end.
+//! This mirrors the timestamped portal-webhook convention
+//! (`routes/portal_webhooks.rs::verify_timestamped_portal_webhook` and the
+//! Stripe receiver): folding the timestamp into the signed payload binds it to
+//! the signature so it cannot be swapped independently, and the receiver
+//! (`reality-web /api/layout-revalidate`) enforces a ±300s freshness window.
+//!
+//! ## Replay protection (issue #2485)
+//!
+//! Previously the signature was computed over the raw body ALONE with no
+//! timestamp, so a captured POST could be replayed against the reality-web
+//! revalidation endpoint indefinitely. Signing `"{timestamp}.{body}"` and
+//! shipping the timestamp lets the receiver reject stale/replayed deliveries.
 //!
 //! ## Fire-and-forget
 //!
@@ -35,15 +46,16 @@ type HmacSha256 = Hmac<Sha256>;
 /// receiving end can reuse the same verification logic.
 const SIGNATURE_HEADER: &str = "X-Webhook-Signature";
 
-/// Sign `body` with `secret` using HMAC-SHA256 and return the header value.
+/// The header name carrying the signed unix-seconds timestamp used for replay
+/// protection (issue #2485). Matches the portal-webhook convention
+/// (`portal_webhooks.rs::TIMESTAMP_HEADER`).
+const TIMESTAMP_HEADER: &str = "X-Webhook-Timestamp";
+
+/// Sign `bytes` with `secret` using HMAC-SHA256 and return the header value.
 ///
-/// The returned string has the form `sha256=<base64-digest>`, matching the
-/// format the inbound `verify_webhook_signature` helper in
-/// `routes/portal_webhooks.rs` expects:
-///
-/// ```text
-/// sha256=<base64(HMAC-SHA256(secret, body))>
-/// ```
+/// The returned string has the form `sha256=<base64-digest>`. This is the
+/// low-level primitive; outbound layout deliveries sign the *timestamped*
+/// payload via [`sign_timestamped_payload`].
 ///
 /// This is a pure function with no I/O; it is unit-tested with a hardcoded
 /// known vector below.
@@ -52,6 +64,23 @@ pub fn sign_payload(secret: &str, body: &[u8]) -> String {
         HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts keys of any length");
     mac.update(body);
     format!("sha256={}", BASE64.encode(mac.finalize().into_bytes()))
+}
+
+/// Sign the timestamped payload `"{timestamp}.{body}"` with `secret`.
+///
+/// This is the format the reality-web receiver reconstructs and verifies: the
+/// unix-seconds `timestamp` (also shipped in the `X-Webhook-Timestamp` header)
+/// is folded into the signed bytes so it cannot be swapped independently of the
+/// signature, defeating replay of a captured delivery outside the freshness
+/// window (issue #2485). Mirrors
+/// `portal_webhooks.rs::verify_timestamped_portal_webhook`'s
+/// `"{timestamp}.{raw_body}"` construction.
+pub fn sign_timestamped_payload(secret: &str, timestamp: i64, body: &[u8]) -> String {
+    let mut signed = Vec::with_capacity(body.len() + 20);
+    signed.extend_from_slice(timestamp.to_string().as_bytes());
+    signed.push(b'.');
+    signed.extend_from_slice(body);
+    sign_payload(secret, &signed)
 }
 
 /// Notify an external webhook endpoint that a layout change occurred.
@@ -105,7 +134,11 @@ pub fn notify_layout_change(screen: &str, event: &'static str) {
         .to_string()
         .into_bytes();
 
-    let signature = sign_payload(&secret, &body);
+    // Replay protection (issue #2485): ship a signed unix-seconds timestamp and
+    // sign over "{timestamp}.{body}" so the reality-web receiver can reject any
+    // captured delivery replayed outside its ±300s freshness window.
+    let timestamp = chrono::Utc::now().timestamp();
+    let signature = sign_timestamped_payload(&secret, timestamp, &body);
 
     tokio::spawn(async move {
         let client = reqwest::Client::builder()
@@ -126,6 +159,7 @@ pub fn notify_layout_change(screen: &str, event: &'static str) {
         match client
             .post(&url)
             .header("Content-Type", "application/json")
+            .header(TIMESTAMP_HEADER, timestamp.to_string())
             .header(SIGNATURE_HEADER, &signature)
             .body(body)
             .send()
@@ -230,6 +264,66 @@ mod tests {
         assert!(
             BASE64.decode(b64_part).is_ok(),
             "the portion after 'sha256=' must be valid standard base64, got: {b64_part}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Timestamped signing (issue #2485): the outbound delivery must sign
+    // "{timestamp}.{body}" so the reality-web receiver can enforce a
+    // freshness window and reject replayed captures.
+    // ------------------------------------------------------------------
+
+    const TS: i64 = 1_700_000_000;
+
+    #[test]
+    fn sign_timestamped_payload_matches_prefixed_body() {
+        // The timestamped signer must equal signing the composed
+        // "{ts}.{body}" bytes through the low-level primitive — this is the
+        // exact string the receiver reconstructs.
+        let mut composed = Vec::new();
+        composed.extend_from_slice(format!("{TS}.").as_bytes());
+        composed.extend_from_slice(KNOWN_BODY);
+
+        assert_eq!(
+            sign_timestamped_payload(KNOWN_SECRET, TS, KNOWN_BODY),
+            sign_payload(KNOWN_SECRET, &composed),
+            "timestamped signature must cover exactly \"{{timestamp}}.{{body}}\""
+        );
+    }
+
+    #[test]
+    fn sign_timestamped_payload_known_vector() {
+        // Independently verified:
+        //   printf '1700000000.{"screen":"home","event":"published"}' \
+        //     | openssl dgst -sha256 -hmac "test-secret" -binary | base64
+        let sig = sign_timestamped_payload(KNOWN_SECRET, TS, KNOWN_BODY);
+        assert_eq!(
+            sig, "sha256=JUbVDRhJ5cUMQCjGQZ3EM3xJbMOGT/D7UqU/TXmAvEg=",
+            "timestamped signer must produce the pinned known-vector output"
+        );
+    }
+
+    #[test]
+    fn sign_timestamped_payload_differs_per_timestamp() {
+        // A different timestamp must yield a different signature — this is what
+        // makes a captured (timestamp, signature) pair non-replayable with a
+        // swapped-in fresh timestamp.
+        assert_ne!(
+            sign_timestamped_payload(KNOWN_SECRET, TS, KNOWN_BODY),
+            sign_timestamped_payload(KNOWN_SECRET, TS + 1, KNOWN_BODY),
+            "the timestamp must be bound into the signature"
+        );
+    }
+
+    #[test]
+    fn sign_timestamped_payload_differs_from_body_only() {
+        // Regression guard for #2485: the timestamped signature must NOT equal
+        // the old body-only signature, or a legacy replayable delivery would
+        // still validate.
+        assert_ne!(
+            sign_timestamped_payload(KNOWN_SECRET, TS, KNOWN_BODY),
+            sign_payload(KNOWN_SECRET, KNOWN_BODY),
+            "timestamped and body-only signatures must diverge"
         );
     }
 }

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
@@ -7,14 +7,15 @@ vi.mock('next/cache', () => ({
 }));
 
 import { revalidateTag } from 'next/cache';
-import { layoutTagsFor, POST } from './route';
+import { isTimestampFresh, layoutTagsFor, POST, parseWebhookTimestamp } from './route';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeSignature(secret: string, body: string): string {
-  return 'sha256=' + createHmac('sha256', secret).update(body).digest('base64');
+/** Sign the timestamped payload "{timestamp}.{body}" (issue #2485). */
+function makeSignature(secret: string, timestamp: number, body: string): string {
+  return 'sha256=' + createHmac('sha256', secret).update(`${timestamp}.${body}`).digest('base64');
 }
 
 function makeRequest(body: string, headers: Record<string, string> = {}): Request {
@@ -22,6 +23,29 @@ function makeRequest(body: string, headers: Record<string, string> = {}): Reques
     method: 'POST',
     body,
     headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+/** A fresh unix-seconds timestamp for the current wall clock. */
+function nowTs(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Build a fully-signed request: fresh (or supplied) timestamp header plus a
+ * signature over "{timestamp}.{body}". This is the happy-path shape every
+ * non-timestamp test reuses so those tests exercise the check they name.
+ */
+function signedRequest(
+  secret: string,
+  body: string,
+  opts: { timestamp?: number; extraHeaders?: Record<string, string> } = {}
+): Request {
+  const ts = opts.timestamp ?? nowTs();
+  return makeRequest(body, {
+    'X-Webhook-Timestamp': String(ts),
+    'X-Webhook-Signature': makeSignature(secret, ts, body),
+    ...opts.extraHeaders,
   });
 }
 
@@ -46,6 +70,49 @@ describe('layoutTagsFor', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Replay-protection helpers (issue #2485)
+// ---------------------------------------------------------------------------
+
+describe('parseWebhookTimestamp', () => {
+  it('parses a plain unix-seconds integer', () => {
+    expect(parseWebhookTimestamp('1700000000')).toBe(1_700_000_000);
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseWebhookTimestamp('  1700000000  ')).toBe(1_700_000_000);
+  });
+
+  it('returns null for a missing header', () => {
+    expect(parseWebhookTimestamp(null)).toBeNull();
+  });
+
+  it.each(['', 'abc', '123abc', '1.5', '0x10', '1e3', 'NaN'])(
+    'returns null for malformed value %j',
+    (raw) => {
+      expect(parseWebhookTimestamp(raw)).toBeNull();
+    }
+  );
+});
+
+describe('isTimestampFresh', () => {
+  const NOW = 1_700_000_000;
+
+  it('accepts a timestamp equal to now', () => {
+    expect(isTimestampFresh(NOW, NOW)).toBe(true);
+  });
+
+  it('accepts the exact ±300s boundary (inclusive)', () => {
+    expect(isTimestampFresh(NOW - 300, NOW)).toBe(true);
+    expect(isTimestampFresh(NOW + 300, NOW)).toBe(true);
+  });
+
+  it('rejects just outside the window in the past and future', () => {
+    expect(isTimestampFresh(NOW - 301, NOW)).toBe(false);
+    expect(isTimestampFresh(NOW + 301, NOW)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // POST handler
 // ---------------------------------------------------------------------------
 
@@ -61,7 +128,7 @@ describe('POST /api/layout-revalidate', () => {
   it('returns 503 when LAYOUT_WEBHOOK_SECRET is not set', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', '');
     const body = JSON.stringify({ screen: 'reality/listing-detail' });
-    const req = makeRequest(body, { 'X-Webhook-Signature': makeSignature(SECRET, body) });
+    const req = signedRequest(SECRET, body);
     const res = await POST(req);
     expect(res.status).toBe(503);
     const json = await res.json();
@@ -72,7 +139,8 @@ describe('POST /api/layout-revalidate', () => {
   it('returns 401 when X-Webhook-Signature header is missing', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = JSON.stringify({ screen: 'reality/listing-detail' });
-    const req = makeRequest(body);
+    // Fresh timestamp present, but no signature header.
+    const req = makeRequest(body, { 'X-Webhook-Timestamp': String(nowTs()) });
     const res = await POST(req);
     expect(res.status).toBe(401);
     const json = await res.json();
@@ -83,7 +151,10 @@ describe('POST /api/layout-revalidate', () => {
   it('returns 401 when X-Webhook-Signature is wrong', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = JSON.stringify({ screen: 'reality/listing-detail' });
-    const req = makeRequest(body, { 'X-Webhook-Signature': 'sha256=invalidsignature==' });
+    const req = makeRequest(body, {
+      'X-Webhook-Timestamp': String(nowTs()),
+      'X-Webhook-Signature': 'sha256=invalidsignature==',
+    });
     const res = await POST(req);
     expect(res.status).toBe(401);
     const json = await res.json();
@@ -91,11 +162,68 @@ describe('POST /api/layout-revalidate', () => {
     expect(revalidateTag).not.toHaveBeenCalled();
   });
 
-  it('returns 200 and revalidates layout:listing-detail on valid request', async () => {
+  // --- Replay protection (issue #2485) ---
+
+  it('returns 401 when X-Webhook-Timestamp header is missing', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    // Signature is valid for a fresh ts, but no timestamp header is sent.
+    const req = makeRequest(body, {
+      'X-Webhook-Signature': makeSignature(SECRET, nowTs(), body),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'missing timestamp' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when X-Webhook-Timestamp is malformed', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    const req = makeRequest(body, {
+      'X-Webhook-Timestamp': 'not-a-number',
+      'X-Webhook-Signature': makeSignature(SECRET, nowTs(), body),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'missing timestamp' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for a stale timestamp (replay outside the freshness window)', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = JSON.stringify({ screen: 'reality/listing-detail', event: 'published' });
-    const sig = makeSignature(SECRET, body);
-    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    // Correctly signed, but 301s in the past — just outside the ±300s window.
+    const staleTs = nowTs() - 301;
+    const req = signedRequest(SECRET, body, { timestamp: staleTs });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'stale timestamp' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when a fresh timestamp is swapped onto an old signature', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail', event: 'published' });
+    // Attacker captured (oldTs, sigOverOldTs) and presents a fresh timestamp to
+    // beat the window while reusing the old signature. Because the timestamp is
+    // folded into the HMAC, the swap fails the signature check.
+    const oldTs = nowTs() - 10_000;
+    const staleSig = makeSignature(SECRET, oldTs, body);
+    const req = makeRequest(body, {
+      'X-Webhook-Timestamp': String(nowTs()),
+      'X-Webhook-Signature': staleSig,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'invalid signature' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 and revalidates layout:listing-detail on a fresh signed request', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail', event: 'published' });
+    const req = signedRequest(SECRET, body);
     const res = await POST(req);
     expect(res.status).toBe(200);
     const json = await res.json();
@@ -104,11 +232,19 @@ describe('POST /api/layout-revalidate', () => {
     expect(revalidateTag).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts a timestamp at the exact ±300s boundary', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail', event: 'published' });
+    const req = signedRequest(SECRET, body, { timestamp: nowTs() - 300 });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(revalidateTag).toHaveBeenCalledTimes(1);
+  });
+
   it('returns 422 when screen has no slash', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = JSON.stringify({ screen: 'listing-detail' });
-    const sig = makeSignature(SECRET, body);
-    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const req = signedRequest(SECRET, body);
     const res = await POST(req);
     expect(res.status).toBe(422);
     expect(revalidateTag).not.toHaveBeenCalled();
@@ -117,8 +253,7 @@ describe('POST /api/layout-revalidate', () => {
   it('returns 422 when second segment is empty (e.g., "foo/")', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = JSON.stringify({ screen: 'foo/' });
-    const sig = makeSignature(SECRET, body);
-    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const req = signedRequest(SECRET, body);
     const res = await POST(req);
     expect(res.status).toBe(422);
     expect(revalidateTag).not.toHaveBeenCalled();
@@ -127,8 +262,7 @@ describe('POST /api/layout-revalidate', () => {
   it('returns 422 when body is not valid JSON', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = 'not-json';
-    const sig = makeSignature(SECRET, body);
-    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const req = signedRequest(SECRET, body);
     const res = await POST(req);
     expect(res.status).toBe(422);
     expect(revalidateTag).not.toHaveBeenCalled();
@@ -137,8 +271,7 @@ describe('POST /api/layout-revalidate', () => {
   it('returns 422 when body is JSON but has no screen string', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     const body = JSON.stringify({ event: 'published' });
-    const sig = makeSignature(SECRET, body);
-    const req = makeRequest(body, { 'X-Webhook-Signature': sig });
+    const req = signedRequest(SECRET, body);
     const res = await POST(req);
     expect(res.status).toBe(422);
     expect(revalidateTag).not.toHaveBeenCalled();

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
@@ -16,6 +16,41 @@ export function layoutTagsFor(screen: string): string[] | null {
 }
 
 // ---------------------------------------------------------------------------
+// Replay protection (issue #2485).
+//
+// The delivery must carry an `X-Webhook-Timestamp` (unix seconds), and the
+// signature is computed over the timestamped payload `"{timestamp}.{body}"`
+// (matching api-server `routes/layout/webhook.rs::sign_timestamped_payload`
+// and the portal-webhook convention). A captured POST is only valid within
+// TOLERANCE_SECS of the receiver's clock, so it cannot be replayed
+// indefinitely, and because the timestamp is folded into the HMAC it cannot be
+// swapped for a fresh one without invalidating the signature.
+// ---------------------------------------------------------------------------
+
+/** Max accepted clock skew (seconds) between the signed timestamp and now. */
+const TOLERANCE_SECS = 300;
+
+/** Parse a strict base-10 integer unix-seconds timestamp, or null if malformed. */
+export function parseWebhookTimestamp(raw: string | null): number | null {
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  // Reject empty, non-integer, or anything Number.parseInt would silently
+  // truncate (e.g. "123abc", "1.5", "0x10").
+  if (!/^-?\d+$/.test(trimmed)) return null;
+  const ts = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(ts) ? ts : null;
+}
+
+/** Whether `timestamp` is within `tolerance` seconds of `nowSecs` (inclusive). */
+export function isTimestampFresh(
+  timestamp: number,
+  nowSecs: number,
+  tolerance: number = TOLERANCE_SECS
+): boolean {
+  return Math.abs(nowSecs - timestamp) <= tolerance;
+}
+
+// ---------------------------------------------------------------------------
 // POST /api/layout-revalidate
 // ---------------------------------------------------------------------------
 
@@ -29,9 +64,23 @@ export async function POST(request: Request): Promise<NextResponse> {
   // 2. Read raw body FIRST — signature is over the raw bytes
   const rawBody = await request.text();
 
-  // 3. Verify HMAC signature
+  // 3. Replay protection (issue #2485): require a fresh signed timestamp.
+  // Reject a missing/malformed timestamp, or one outside the ±TOLERANCE_SECS
+  // window, BEFORE the HMAC check — a captured delivery is only valid briefly.
+  const timestamp = parseWebhookTimestamp(request.headers.get('X-Webhook-Timestamp'));
+  if (timestamp === null) {
+    return NextResponse.json({ error: 'missing timestamp' }, { status: 401 });
+  }
+  const nowSecs = Math.floor(Date.now() / 1000);
+  if (!isTimestampFresh(timestamp, nowSecs)) {
+    return NextResponse.json({ error: 'stale timestamp' }, { status: 401 });
+  }
+
+  // 4. Verify HMAC signature over the timestamped payload "{timestamp}.{body}"
+  // so the timestamp is bound to the signature and cannot be swapped.
   const header = request.headers.get('X-Webhook-Signature') ?? '';
-  const expected = 'sha256=' + createHmac('sha256', secret).update(rawBody).digest('base64');
+  const signedPayload = `${timestamp}.${rawBody}`;
+  const expected = 'sha256=' + createHmac('sha256', secret).update(signedPayload).digest('base64');
 
   const headerBuf = Buffer.from(header);
   const expectedBuf = Buffer.from(expected);
@@ -41,7 +90,7 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json({ error: 'invalid signature' }, { status: 401 });
   }
 
-  // 4. Parse body and validate shape
+  // 5. Parse body and validate shape
   let body: unknown;
   try {
     body = JSON.parse(rawBody);
@@ -59,12 +108,12 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   const screen = (body as { screen: string }).screen;
 
-  // 5. Validate screen contains a slash and has non-empty second segment
+  // 6. Validate screen contains a slash and has non-empty second segment
   if (!screen.includes('/')) {
     return NextResponse.json({ error: 'invalid screen' }, { status: 422 });
   }
 
-  // 6. Revalidate tags
+  // 7. Revalidate tags
   const tags = layoutTagsFor(screen);
   if (!tags) {
     return NextResponse.json({ error: 'invalid screen' }, { status: 422 });


### PR DESCRIPTION
## Task
Follow-up: layout publish webhook has no timestamp/replay protection (PR #2431) (Closes #2485)

The layout publish webhook signed HMAC-SHA256 over the body ALONE with no `X-Webhook-Timestamp` and no freshness window, so a captured POST to reality-web `/api/layout-revalidate` could be replayed indefinitely. This aligns it with the repo's existing timestamped portal-webhook convention.

- **api-server** `routes/layout/webhook.rs`: sends `X-Webhook-Timestamp` (unix seconds) and signs over `"{timestamp}.{body}"` via new `sign_timestamped_payload()` (mirrors `portal_webhooks.rs::verify_timestamped_portal_webhook` and the Stripe receiver).
- **reality-web** `app/api/layout-revalidate/route.ts`: requires the header and rejects **401** on a missing/malformed timestamp or one outside a **±300s** window (checked before the HMAC), and now verifies the signature over `"{timestamp}.{body}"` so the timestamp is bound to the signature and cannot be swapped.

## Owner
pm-tech-lead

## Verification

Changed-code checks all green:
```
VERIFY-PLAN base=723391af33b40a23144ec2e165da5b7df0b927a6 files=3
  cd backend && cargo fmt --all -- --check                                  # PASS (FMT_ALL_OK)
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings     # PASS (clean)
  cd backend && cargo test -p api-server                                    # 471 passed, 2 failed*
  cd frontend && pnpm exec biome check .../layout-revalidate/route*.ts      # PASS (exit 0)
  cd frontend && pnpm --filter "...[base]" typecheck                        # PASS
  cd frontend && pnpm --filter "...[base]" test                             # 197 passed, 4 failed**
```
- Backend webhook module: `cargo test -p api-server --lib routes::layout::webhook` → **9 passed** (incl. new timestamped known-vector, per-timestamp divergence, body-only divergence).
- Frontend route file: `vitest run .../layout-revalidate/route.test.ts` → **30 passed** (helper + stale/fresh/missing/malformed/timestamp-swap route cases).

### Environment-blocked gate steps (NOT caused by this diff — 3 files touched, none of these)
- `*` The 2 backend failures are `#[sqlx::test]` tests in `services::scheduler` (`test_announcement_{building,units}_fanout_excludes_cross_tenant_sql`) that require a live Postgres (`sqlx_core::testing::run_test_*`). No `DATABASE_URL` in this sandbox. Unrelated file — not in the diff.
- `**` The 4 frontend failures are pre-existing in `components/agency/RealtorManagement.test.tsx` (a `getByLabelText(/email \*/i)` query) — unrelated file, not in the diff; fails on `origin/dev` independently.
- Also note: the api-server build requires the network-gated `swagger-ui` archive (github archive host is policy-blocked in this sandbox). Clippy/tests above were run by supplying a locally-reconstructed `swagger-ui-dist@5.17.14` zip via `SWAGGER_UI_DOWNLOAD_URL=file://…`. **CI (`backend.yml` with a Postgres service + real swagger download, `frontend.yml`) will run the untainted gate.**

## CI parity (Band C — hot-path)
This is a security / replay-protection change. Backend clippy + the webhook unit tests were replicated locally as above; full `backend.yml` (needs live Postgres) and `frontend.yml` will run on the PR. Please confirm both are green before un-drafting.

## Remote-tested
skipped

## Scope drift
None — `scope-check.sh --owner pm-tech-lead` exit 0. Diff is 3 files: `backend/servers/api-server/src/routes/layout/webhook.rs`, `frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts` (+ its `route.test.ts`).

## Code-reuse review
`reuse-grep.sh` empty — no duplicated helpers. `sign_timestamped_payload` reuses the existing `sign_payload` primitive; the `"{timestamp}.{body}"` construction matches the portal-webhook receiver byte-for-byte.

## Notes
- Unlike the per-portal receivers (which kept a legacy body-only accept-both branch for un-migrated external senders), this webhook is an **internal** api-server → reality-web link, so both ends move to the timestamped scheme at once — no legacy fallback, replay protection is mandatory immediately.
- Freshness window is ±300s, matching `PORTAL_WEBHOOK_TOLERANCE_SECS` and the Stripe receiver.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BH4ugLuu2aSMgrGaSn9AHn)_