### PR TITLE
code-review-api-handlers-community-cross-tenant-idor: scope 5 community write handlers to caller org (cross-tenant IDOR)

### DIFF
--- a/backend/crates/db/src/repositories/community.rs
+++ b/backend/crates/db/src/repositories/community.rs
@@ -102,6 +102,31 @@ impl CommunityRepository {
             .await
     }
 
+    /// Tenant-safe group existence check: `true` only when the group belongs
+    /// to `org_id` (resolved via `buildings.organization_id`). `false` when the
+    /// group is absent OR owned by another organization, so handlers can map
+    /// the miss to a 404 without leaking cross-tenant existence (mirrors the
+    /// disputes IDOR fix — enforce the JWT-derived org, never a path-supplied
+    /// id). Uses `EXISTS` (not a row fetch) so the check never has to decode a
+    /// `CommunityGroup`, whose `group_type`/`visibility` are Postgres enum
+    /// columns typed as `String` in the model.
+    pub async fn group_exists_for_org(&self, id: Uuid, org_id: Uuid) -> Result<bool, SqlxError> {
+        sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM community_groups g
+                JOIN buildings b ON b.id = g.building_id
+                WHERE g.id = $1 AND b.organization_id = $2
+            )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await
+    }
+
     /// List groups for a building.
     pub async fn list_groups(
         &self,
@@ -259,6 +284,28 @@ impl CommunityRepository {
         .await
     }
 
+    /// Tenant-safe post existence check: `true` only when the post's group's
+    /// building belongs to `org_id`. `false` when the post is absent OR owned
+    /// by another organization. `EXISTS` avoids decoding `CommunityPost`
+    /// (`post_type` is a Postgres enum typed as `String`).
+    pub async fn post_exists_for_org(&self, id: Uuid, org_id: Uuid) -> Result<bool, SqlxError> {
+        sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM community_posts p
+                JOIN community_groups g ON g.id = p.group_id
+                JOIN buildings b ON b.id = g.building_id
+                WHERE p.id = $1 AND b.organization_id = $2
+            )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await
+    }
+
     /// Add reaction to post.
     pub async fn add_post_reaction(
         &self,
@@ -377,6 +424,27 @@ impl CommunityRepository {
         .await
     }
 
+    /// Tenant-safe event existence check: `true` only when the event's
+    /// building belongs to `org_id`. `false` when the event is absent OR owned
+    /// by another organization. `EXISTS` avoids decoding `CommunityEvent`
+    /// (`event_type` is a Postgres enum typed as `String`).
+    pub async fn event_exists_for_org(&self, id: Uuid, org_id: Uuid) -> Result<bool, SqlxError> {
+        sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM community_events e
+                JOIN buildings b ON b.id = e.building_id
+                WHERE e.id = $1 AND b.organization_id = $2
+            )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await
+    }
+
     /// RSVP to an event.
     pub async fn rsvp_event(
         &self,
@@ -477,6 +545,27 @@ impl CommunityRepository {
             .bind(id)
             .fetch_optional(&self.pool)
             .await
+    }
+
+    /// Tenant-safe marketplace-item existence check: `true` only when the
+    /// item's building belongs to `org_id`. `false` when the item is absent OR
+    /// owned by another organization. `EXISTS` avoids decoding `MarketplaceItem`
+    /// (`category`/`condition` are Postgres enums typed as `String`).
+    pub async fn item_exists_for_org(&self, id: Uuid, org_id: Uuid) -> Result<bool, SqlxError> {
+        sqlx::query_scalar::<_, bool>(
+            r#"
+            SELECT EXISTS(
+                SELECT 1
+                FROM marketplace_items i
+                JOIN buildings b ON b.id = i.building_id
+                WHERE i.id = $1 AND b.organization_id = $2
+            )
+            "#,
+        )
+        .bind(id)
+        .bind(org_id)
+        .fetch_one(&self.pool)
+        .await
     }
 
     /// Create inquiry on item.

--- a/backend/servers/api-server/src/routes/community.rs
+++ b/backend/servers/api-server/src/routes/community.rs
@@ -99,6 +99,137 @@ async fn verify_building_access(
     Ok(building.organization_id)
 }
 
+// SECURITY (cross-tenant IDOR — code-review api-handlers/community): the five
+// write handlers that take a *resource* id from the URL path (`group_id`,
+// `post_id`, `event_id`, `item_id`) — `create_post`, `add_reaction`,
+// `create_comment`, `rsvp_event`, `create_inquiry` — used to bind that id
+// straight into the repository write with no tenant check. Any authenticated
+// user of org A could POST into org B's group/post/event/item by guessing an
+// id. The `verify_*_access` helpers below close that gap the same way the
+// building-id routes use `verify_building_access` and the disputes IDOR fix
+// used `*_for_org`: resolve the resource scoped to the caller's JWT-derived
+// org and reject a miss with **404** (not 403) so the id space cannot be
+// enumerated as an existence oracle.
+
+/// Derive the caller's organization from the verified principal.
+///
+/// The scope MUST come from `RequestPrincipal::effective_org` (JWT + host
+/// resolved, server-side) — never a path- or body-supplied org — so a write
+/// cannot cross tenants. Absent org context (e.g. a platform principal on the
+/// platform host) is a 403, matching the disputes IDOR fix.
+fn require_org(principal: &RequestPrincipal) -> Result<Uuid, (StatusCode, Json<ErrorResponse>)> {
+    principal.effective_org.ok_or_else(|| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new("FORBIDDEN", "No organization context")),
+        )
+    })
+}
+
+/// 500 for a tenant-scoping lookup that errored at the DB.
+fn tenant_lookup_error() -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse::new(
+            "DATABASE_ERROR",
+            "Failed to verify tenant access",
+        )),
+    )
+}
+
+/// 404 for a resource that is absent OR owned by another tenant. Uses the same
+/// opaque body for both cases so the id space is not an existence oracle.
+fn resource_not_found(what: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("NOT_FOUND", what)),
+    )
+}
+
+/// Reject the request unless `group_id` belongs to the caller's org.
+async fn verify_group_access(
+    state: &AppState,
+    principal: &RequestPrincipal,
+    group_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org(principal)?;
+    let exists = state
+        .community_repo
+        .group_exists_for_org(group_id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Group tenant lookup failed");
+            tenant_lookup_error()
+        })?;
+    if !exists {
+        return Err(resource_not_found("Group not found"));
+    }
+    Ok(())
+}
+
+/// Reject the request unless `post_id`'s group belongs to the caller's org.
+async fn verify_post_access(
+    state: &AppState,
+    principal: &RequestPrincipal,
+    post_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org(principal)?;
+    let exists = state
+        .community_repo
+        .post_exists_for_org(post_id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Post tenant lookup failed");
+            tenant_lookup_error()
+        })?;
+    if !exists {
+        return Err(resource_not_found("Post not found"));
+    }
+    Ok(())
+}
+
+/// Reject the request unless `event_id`'s building belongs to the caller's org.
+async fn verify_event_access(
+    state: &AppState,
+    principal: &RequestPrincipal,
+    event_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org(principal)?;
+    let exists = state
+        .community_repo
+        .event_exists_for_org(event_id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Event tenant lookup failed");
+            tenant_lookup_error()
+        })?;
+    if !exists {
+        return Err(resource_not_found("Event not found"));
+    }
+    Ok(())
+}
+
+/// Reject the request unless `item_id`'s building belongs to the caller's org.
+async fn verify_item_access(
+    state: &AppState,
+    principal: &RequestPrincipal,
+    item_id: Uuid,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    let org_id = require_org(principal)?;
+    let exists = state
+        .community_repo
+        .item_exists_for_org(item_id, org_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Marketplace item tenant lookup failed");
+            tenant_lookup_error()
+        })?;
+    if !exists {
+        return Err(resource_not_found("Item not found"));
+    }
+    Ok(())
+}
+
 /// Create community router.
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -429,6 +560,7 @@ pub async fn create_post(
     Path(path): Path<GroupPostsPath>,
     Json(data): Json<CreateCommunityPost>,
 ) -> Result<(StatusCode, Json<CommunityPost>), (StatusCode, Json<ErrorResponse>)> {
+    verify_group_access(&state, &principal, path.group_id).await?;
     let post = state
         .community_repo
         .create_post(path.group_id, principal.user_id, data)
@@ -466,6 +598,7 @@ pub async fn add_reaction(
     Path(path): Path<PostIdPath>,
     Json(data): Json<AddReactionRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    verify_post_access(&state, &principal, path.id).await?;
     state
         .community_repo
         .add_post_reaction(path.id, principal.user_id, &data.reaction_type)
@@ -503,6 +636,7 @@ pub async fn create_comment(
     Path(path): Path<PostIdPath>,
     Json(data): Json<CreateCommunityComment>,
 ) -> Result<(StatusCode, Json<CommunityComment>), (StatusCode, Json<ErrorResponse>)> {
+    verify_post_access(&state, &principal, path.id).await?;
     let comment = state
         .community_repo
         .create_comment(path.id, principal.user_id, data)
@@ -618,6 +752,7 @@ pub async fn rsvp_event(
     Path(id): Path<Uuid>,
     Json(data): Json<EventRsvpRequest>,
 ) -> Result<Json<CommunityEventRsvp>, (StatusCode, Json<ErrorResponse>)> {
+    verify_event_access(&state, &principal, id).await?;
     let rsvp = state
         .community_repo
         .rsvp_event(id, principal.user_id, data)
@@ -765,6 +900,7 @@ pub async fn create_inquiry(
     Path(path): Path<ItemIdPath>,
     Json(data): Json<CreateMarketplaceInquiry>,
 ) -> Result<(StatusCode, Json<MarketplaceInquiry>), (StatusCode, Json<ErrorResponse>)> {
+    verify_item_access(&state, &principal, path.id).await?;
     let inquiry = state
         .community_repo
         .create_inquiry(path.id, principal.user_id, data)

--- a/backend/servers/api-server/tests/suite_3.rs
+++ b/backend/servers/api-server/tests/suite_3.rs
@@ -17,6 +17,8 @@ mod budgets_tests;
 mod building_manager_rbac_tests;
 #[path = "suites/caddy_ask_tests.rs"]
 mod caddy_ask_tests;
+#[path = "suites/community_cross_tenant_idor_tests.rs"]
+mod community_cross_tenant_idor_tests;
 #[path = "suites/community_happy_path_tests.rs"]
 mod community_happy_path_tests;
 #[path = "suites/compliance_wave1b_tests.rs"]

--- a/backend/servers/api-server/tests/suites/community_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/community_cross_tenant_idor_tests.rs
@@ -1,0 +1,362 @@
+//! Cross-tenant IDOR regression coverage for the community `community.rs`
+//! write handlers (code-review: api-handlers/community cross-tenant IDOR).
+//!
+//! Five authenticated write handlers take a *resource* id from the URL path
+//! (`group_id`, `post_id`, `event_id`, `item_id`) and used to bind it straight
+//! into the repository write with no tenant check. Any authenticated user of
+//! org A could POST into org B's group/post/event/item by guessing an id.
+//!
+//! These tests seed org B's resources directly, then drive them as an
+//! authenticated org-A caller and assert **404** (resource absent OR owned by
+//! another tenant — same opaque body, no existence oracle) with no row written.
+//! Same-tenant happy paths are asserted alongside so the guard cannot regress
+//! legitimate writes.
+//!
+//! Setup mirrors `community_happy_path_tests.rs`: the community handlers use
+//! [`RequestPrincipal`], which needs a `ResolvedTenant` request extension
+//! (via `inject_tenant`) and an active `user_memberships` row (via
+//! `seed_user_membership`).
+
+#![allow(dead_code)]
+
+use axum::{body::Body, http::Request};
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::common::{
+    create_authenticated_user_with_org, seed_org, TestApp, TestResponse, TestUser,
+};
+
+async fn seed_user_membership(pool: &PgPool, user_id: Uuid, org_id: Uuid) {
+    sqlx::query(
+        r#"INSERT INTO user_memberships (user_id, organization_id, role)
+           VALUES ($1, $2, 'org_admin')
+           ON CONFLICT DO NOTHING"#,
+    )
+    .bind(user_id)
+    .bind(org_id)
+    .execute(pool)
+    .await
+    .expect("seed user_membership");
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO buildings (organization_id, street, city, postal_code, country)
+           VALUES ($1, 'IDOR St 1', 'Bratislava', '81101', 'Slovakia') RETURNING id"#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+/// Seed a group owned by `building_id`. `owner` only satisfies the `created_by`
+/// FK — tenant ownership flows through `building_id`.
+async fn seed_group(pool: &PgPool, building_id: Uuid, owner: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO community_groups (building_id, name, slug, created_by)
+           VALUES ($1, $2, $3, $4) RETURNING id"#,
+    )
+    .bind(building_id)
+    .bind(format!("Group {slug}"))
+    .bind(slug)
+    .bind(owner)
+    .fetch_one(pool)
+    .await
+    .expect("seed group")
+}
+
+async fn seed_post(pool: &PgPool, group_id: Uuid, author: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO community_posts (group_id, author_id, content)
+           VALUES ($1, $2, 'seeded post') RETURNING id"#,
+    )
+    .bind(group_id)
+    .bind(author)
+    .fetch_one(pool)
+    .await
+    .expect("seed post")
+}
+
+async fn seed_event(pool: &PgPool, building_id: Uuid, organizer: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO community_events
+               (building_id, organizer_id, title, start_time, end_time)
+           VALUES ($1, $2, 'seeded event', NOW() + INTERVAL '7 days',
+                   NOW() + INTERVAL '7 days 2 hours') RETURNING id"#,
+    )
+    .bind(building_id)
+    .bind(organizer)
+    .fetch_one(pool)
+    .await
+    .expect("seed event")
+}
+
+async fn seed_item(pool: &PgPool, building_id: Uuid, seller: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO marketplace_items (building_id, seller_id, title, category)
+           VALUES ($1, $2, 'seeded item', 'furniture') RETURNING id"#,
+    )
+    .bind(building_id)
+    .bind(seller)
+    .fetch_one(pool)
+    .await
+    .expect("seed item")
+}
+
+fn inject_tenant(mut req: Request<Body>, org_id: Uuid) -> Request<Body> {
+    use api_core::middleware::host_tenant::{ResolvedTenant, TenantSource};
+    req.extensions_mut().insert(ResolvedTenant {
+        organization_id: org_id,
+        source: TenantSource::Subdomain,
+    });
+    req
+}
+
+/// The attacker/context: an authenticated org-A caller, plus the victim org B
+/// with fully-seeded community resources that org A must not be able to touch.
+struct Ctx {
+    app: TestApp,
+    pool: PgPool,
+    org_a: Uuid,
+    // org-A resources (legitimate — the caller owns these)
+    group_a: Uuid,
+    post_a: Uuid,
+    token: String,
+    // org-B victim resources
+    group_b: Uuid,
+    post_b: Uuid,
+    event_b: Uuid,
+    item_b: Uuid,
+}
+
+async fn setup(pool: PgPool) -> Ctx {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_a) = create_authenticated_user_with_org(&app, &user, "idor-a").await;
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("resolve user id");
+    seed_user_membership(&pool, user_id, org_a).await;
+
+    // Org A: a real building + group + post the caller legitimately owns.
+    let building_a = seed_building(&pool, org_a).await;
+    let group_a = seed_group(&pool, building_a, user_id, "own-group-a").await;
+    let post_a = seed_post(&pool, group_a, user_id).await;
+
+    // Org B (victim): a separate org with its own building + resources. The
+    // seeded owner FK reuses `user_id` (FK is to users(id), not org-scoped);
+    // tenant ownership is established purely through `building_id -> org B`.
+    let org_b = seed_org(&pool, "idor-b").await;
+    let building_b = seed_building(&pool, org_b).await;
+    let group_b = seed_group(&pool, building_b, user_id, "victim-group-b").await;
+    let post_b = seed_post(&pool, group_b, user_id).await;
+    let event_b = seed_event(&pool, building_b, user_id).await;
+    let item_b = seed_item(&pool, building_b, user_id).await;
+
+    Ctx {
+        app,
+        pool,
+        org_a,
+        group_a,
+        post_a,
+        token,
+        group_b,
+        post_b,
+        event_b,
+        item_b,
+    }
+}
+
+impl Ctx {
+    /// POST as the org-A caller, with the org-A tenant context resolved.
+    async fn post(&self, uri: &str, body: Value) -> TestResponse {
+        let rb = self.app.post(uri).bearer(&self.token).json(body);
+        let req = inject_tenant(rb.build(), self.org_a);
+        self.app.execute(req).await
+    }
+
+    async fn count(&self, sql: &'static str, id: Uuid) -> i64 {
+        sqlx::query_scalar::<_, i64>(sql)
+            .bind(id)
+            .fetch_one(&self.pool)
+            .await
+            .expect("count")
+    }
+}
+
+fn assert_404(resp: &TestResponse, what: &str) {
+    assert_eq!(
+        resp.status,
+        axum::http::StatusCode::NOT_FOUND,
+        "{what} cross-tenant must be 404, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
+// ============================================================================
+// Cross-tenant (must be 404 + no write)
+// ============================================================================
+
+/// IG3 regression: an authenticated org-A caller POSTing into org B's group
+/// must get 404 and insert NO post. Fails on pre-fix `dev` (returns 201 and
+/// the post row lands under org B).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_post_cross_tenant_404(pool: PgPool) {
+    let ctx = setup(pool).await;
+
+    let before = ctx
+        .count(
+            "SELECT COUNT(*) FROM community_posts WHERE group_id = $1",
+            ctx.group_b,
+        )
+        .await;
+
+    let resp = ctx
+        .post(
+            &format!("/api/v1/community/groups/{}/posts", ctx.group_b),
+            json!({ "content": "cross-tenant intrusion" }),
+        )
+        .await;
+    assert_404(&resp, "create_post");
+
+    let after = ctx
+        .count(
+            "SELECT COUNT(*) FROM community_posts WHERE group_id = $1",
+            ctx.group_b,
+        )
+        .await;
+    assert_eq!(
+        before, after,
+        "no post row may be written into org B's group"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_reaction_cross_tenant_404(pool: PgPool) {
+    let ctx = setup(pool).await;
+
+    let resp = ctx
+        .post(
+            &format!("/api/v1/community/posts/{}/reactions", ctx.post_b),
+            json!({ "reaction_type": "like" }),
+        )
+        .await;
+    assert_404(&resp, "add_reaction");
+
+    let reactions = ctx
+        .count(
+            "SELECT COUNT(*) FROM community_post_reactions WHERE post_id = $1",
+            ctx.post_b,
+        )
+        .await;
+    assert_eq!(reactions, 0, "no reaction may land on org B's post");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_comment_cross_tenant_404(pool: PgPool) {
+    let ctx = setup(pool).await;
+
+    let resp = ctx
+        .post(
+            &format!("/api/v1/community/posts/{}/comments", ctx.post_b),
+            json!({ "content": "cross-tenant comment" }),
+        )
+        .await;
+    assert_404(&resp, "create_comment");
+
+    let comments = ctx
+        .count(
+            "SELECT COUNT(*) FROM community_comments WHERE post_id = $1",
+            ctx.post_b,
+        )
+        .await;
+    assert_eq!(comments, 0, "no comment may land on org B's post");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn rsvp_event_cross_tenant_404(pool: PgPool) {
+    let ctx = setup(pool).await;
+
+    let resp = ctx
+        .post(
+            &format!("/api/v1/community/events/{}/rsvp", ctx.event_b),
+            json!({ "status": "going" }),
+        )
+        .await;
+    assert_404(&resp, "rsvp_event");
+
+    let rsvps = ctx
+        .count(
+            "SELECT COUNT(*) FROM community_event_rsvps WHERE event_id = $1",
+            ctx.event_b,
+        )
+        .await;
+    assert_eq!(rsvps, 0, "no RSVP may land on org B's event");
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_inquiry_cross_tenant_404(pool: PgPool) {
+    let ctx = setup(pool).await;
+
+    let resp = ctx
+        .post(
+            &format!("/api/v1/community/marketplace/{}/inquiries", ctx.item_b),
+            json!({ "message": "cross-tenant inquiry" }),
+        )
+        .await;
+    assert_404(&resp, "create_inquiry");
+
+    let inquiries = ctx
+        .count(
+            "SELECT COUNT(*) FROM marketplace_inquiries WHERE item_id = $1",
+            ctx.item_b,
+        )
+        .await;
+    assert_eq!(inquiries, 0, "no inquiry may land on org B's item");
+}
+
+// ============================================================================
+// Same-tenant (must still succeed — guard doesn't block legitimate writes)
+// ============================================================================
+
+/// The tenant guard must not regress the happy path: a caller can still react
+/// to a post its own org owns.
+///
+/// We assert against `add_reaction` (not `create_post`) deliberately —
+/// `add_post_reaction` returns `()` (no struct decode), whereas `create_post`'s
+/// `RETURNING *` decode of `CommunityPost` trips a *pre-existing* enum-vs-String
+/// model bug (the reason `community_happy_path_tests` is quarantined under
+/// BIT-440). Reacting keeps this no-regression check honest and independent of
+/// that unrelated bug: it proves `verify_post_access` lets a same-tenant write
+/// through (200), not 404/403/500.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn add_reaction_same_tenant_200(pool: PgPool) {
+    let ctx = setup(pool).await;
+
+    let resp = ctx
+        .post(
+            &format!("/api/v1/community/posts/{}/reactions", ctx.post_a),
+            json!({ "reaction_type": "like" }),
+        )
+        .await;
+    assert!(
+        resp.status.is_success(),
+        "same-tenant add_reaction should 2xx, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let reactions = ctx
+        .count(
+            "SELECT COUNT(*) FROM community_post_reactions WHERE post_id = $1",
+            ctx.post_a,
+        )
+        .await;
+    assert_eq!(reactions, 1, "the legitimate reaction must be written");
+}


### PR DESCRIPTION
## Task
SECURITY: community.rs 5 write handlers (create_post/add_reaction/create_comment/rsvp_event/create_inquiry) accept cross-tenant IDs

Plan: `.research/plans/code-review-api-handlers-community-cross-tenant-idor.md`

## Owner
pm-security

## What & why
Five authenticated write handlers in `backend/servers/api-server/src/routes/community.rs` took a **resource** id (`group_id`/`post_id`/`event_id`/`item_id`) straight from the URL path and bound it into the repository write with **no tenant check**. Any authenticated user of org A could POST into org B's community group/post/event/marketplace item by guessing an id (cross-tenant IDOR). The sibling `verify_building_access` helper was only applied on the `building_id` routes.

Fix (mirrors `verify_building_access` and the disputes `*_for_org` IDOR fix):
- `backend/crates/db/src/repositories/community.rs` — add `group_exists_for_org`, `post_exists_for_org`, `event_exists_for_org`, `item_exists_for_org`, each scoped through `buildings.organization_id`.
- `backend/servers/api-server/src/routes/community.rs` — add `verify_{group,post,event,item}_access` guards that resolve the resource against `RequestPrincipal::effective_org` (JWT + host resolved, never path/body-supplied) and reject a miss with **404** (not 403) so the id space is not an existence oracle. Each of the 5 write handlers now calls the matching guard before the write.

### Implementation note (deviation from the plan's `*_for_org -> Option<T>`)
The plan suggested `get_*_for_org` returning `Option<CommunityGroup>` etc. The community domain models type their Postgres **enum** columns (`group_type`, `visibility`, `post_type`, `event_type`, `category`, `condition`) as Rust `String`, so `SELECT *`/`RETURNING *` decoding of those structs fails whenever a row is actually returned — a **pre-existing** bug that is exactly why `community_happy_path_tests` is quarantined under BIT-440. Since the guard only needs *existence*, I used `SELECT EXISTS(...) -> bool`, which sidesteps the struct decode entirely and is cheaper. Same tenant semantics, no dependency on the unrelated model bug. (The `create_post`/`rsvp` write-path decode bug is out of scope for this IDOR plan.)

## Verification
Local Postgres 16 (superuser, RLS bypassed as in CI's `sqlx::test`); api-server built with vendored `swagger-ui-dist` 5.17.14 (`SWAGGER_UI_DOWNLOAD_URL=file://…`, GitHub archive host is egress-blocked).

VERIFY-PLAN base=3c9a9b9 files=4 (impact-scoped; full plan below runs in CI)
```
cd backend && cargo fmt --all -- --check            # clean
cd backend && cargo clippy -p db -p api-server --all-targets -- -D warnings   # clean (2m10s)
cd backend && cargo test -p api-server --test suite_3 community_cross_tenant_idor   # 6 passed; 0 failed
```

The dispatcher verify gate escalates a `db`-touching diff to clippy+test across 8 backend crates (db's reverse-dependents: accounting-core/-server, admin-core, api-core, api-server, reality-server, tenant-ops). Those unchanged-crate test suites need seed fixtures unrelated to this diff and are left to CI (`backend.yml`) on this draft PR; the two crates this PR actually changes (`db`, `api-server`) are clippy-clean and the new regression suite is green.

### IG3 — regression fails on pre-fix, passes after fix
New suite `backend/servers/api-server/tests/suites/community_cross_tenant_idor_tests.rs`:

Fixed code (this branch):
```
test result: ok. 6 passed; 0 failed; 0 ignored; ... finished in 46.75s
  create_post_cross_tenant_404 ... ok
  add_reaction_cross_tenant_404 ... ok
  create_comment_cross_tenant_404 ... ok
  rsvp_event_cross_tenant_404 ... ok
  create_inquiry_cross_tenant_404 ... ok
  add_reaction_same_tenant_200 ... ok   # no-regression: same-tenant write still 2xx
```

Pre-fix source (guard reverted, tests kept) — every cross-tenant case FAILs, same-tenant still passes:
```
test result: FAILED. 1 passed; 5 failed; ... finished in 44.52s
  create_post_cross_tenant_404 ... FAILED
  add_reaction_cross_tenant_404 ... FAILED
  create_comment_cross_tenant_404 ... FAILED
  rsvp_event_cross_tenant_404 ... FAILED
  create_inquiry_cross_tenant_404 ... FAILED
  add_reaction_same_tenant_200 ... ok
```

## CI parity (Band C — hot-path security)
Deferred to the draft PR's `backend.yml` run (full clippy+test matrix). Local host cannot seed the 8-crate reverse-dependent test set.

## Scope drift
`scope-check.sh --owner pm-security` flags all 4 changed files as outside pm-security's mapped areas (auth/mfa/extractors/migrations). This is a security fix that lives in `routes/` + `repositories/` (pm-backend territory) — expected for an IDOR fix in community code. Files:
- backend/crates/db/src/repositories/community.rs
- backend/servers/api-server/src/routes/community.rs
- backend/servers/api-server/tests/suites/community_cross_tenant_idor_tests.rs
- backend/servers/api-server/tests/suite_3.rs

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no warnings.

## Notes
- Read-side unauthenticated handlers are explicitly out of scope (tracked in `code-review-api-handlers-community-unauthenticated-reads.md`).
- `require_org` returns 403 when the principal has no org context (e.g. platform principal on the platform host), matching the disputes IDOR fix; platform principals on a tenant host keep their resolved org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQ6A3eb7duxCHD9TVYoXbz)_