### PR TITLE
gap-84-1-wire-ppt-web-direct-to-s3-upload-2026-07-23: pin direct-upload building_id boundary (#2366)

### DIFF
--- a/docs/screens/ppt/upload-document.md
+++ b/docs/screens/ppt/upload-document.md
@@ -122,9 +122,19 @@ UC-08 document upload — single-step form. Multi-file with per-file progress an
   → presigned `PUT` straight to S3 → `POST /api/v1/documents` to register. Bytes
   no longer proxy through the api-server multipart `/upload` route. Per-file
   progress is driven by the S3 PUT phase. The legacy multipart `useUploadDocument`
-  hook is still exported for callers that need the byte-proxy path. NB: a backend
-  PR (#2339) is hardening the presigned endpoint (org-scoped `file_key` +
-  signed Content-Length) — the client already sends the signed `Content-Type`.
+  hook is still exported for callers that need the byte-proxy path. The backend
+  presigned endpoint shipped in **#2309** (org-scoped `file_key` + size cap); the
+  client already sends the signed `Content-Type` on the PUT.
+- **Known limitation — building association not persisted (#2366):** the
+  direct-upload registration (`POST /api/v1/documents`) does **not** record a
+  `building_id`, and neither did the legacy multipart `/upload` path — the
+  `documents` table has no such column and the Rust `CreateDocumentRequest`
+  has no such field. `DocumentUpload` still accepts a `buildingId` prop, but it
+  is intentionally NOT forwarded to the register call (see the `#2366` note in
+  `api-client` `uploadDocumentDirect` + its regression test). Building scope is
+  carried today by `folder_id` (folders are building-scoped) or by
+  `access_scope='building'` + `access_target_ids`. A real `building_id` needs a
+  backend migration/struct/repo change first — tracked in **#2366**.
 - The bundle uses **single-screen layout** (dropzone + metadata + submit on one page) instead of a multi-step wizard. This is intentional for the common case (1–4 files, single batch). For 10+ files or split-batch needs, document a future "advanced upload" flow.
 - File-icon block uses 3-letter colored tags matching `forms/file-upload.html`: PDF red, XLS green, DOC blue, JPG amber, PNG cyan, ZIP gray, generic gray for unknown types.
 - "HLAVNÝ" pill is auto-assigned to the first successful upload — the design states "Premenujte ho v zozname, ak chcete iný" (rename in list to swap). Production must allow per-file context menu to manually set "Make primary".
@@ -142,6 +152,7 @@ UC-08 document upload — single-step form. Multi-file with per-file progress an
 
 <!-- newest entries on top -->
 
+- 2026-07-23 — agent: gap-84-1 verified already wired in dev (api-client binding + `DocumentUpload` integration + tests all present); documented the deliberate `building_id` omission on the direct-upload register path (#2366 — no backend column/field, forwarding would be a false-green) with an anchor comment in `uploadDocumentDirect` + a regression test; reconciled backend ref to #2309. #2366 remains blocked on a backend migration/product decision.
 - 2026-07-15 — agent: wired direct-to-S3 upload (gap-84-1) — added `createUploadUrl` + `uploadDocumentDirect` bindings and `useUploadDocumentDirect` hook to @ppt/api-client; switched `DocumentUpload` to the direct hook (upload-url → presigned PUT → register). Frontend-only; backend endpoint landed in #2309.
 - 2026-05-09 — agent: design analyzed (pages/ppt-upload-document.html — 3 artboards: loaded-4-files-mixed / empty-drag-over / success-toast); flipped ppt-web redesignStatus → in-progress; attached designSource; populated functionality checklist (10 sections), 6 states, design-specific notes (HLAVNÝ auto-detect + per-file error specificity + audience-driven notification count + draft-bypass-upload-completion); declared 8 sharedComponents; added 1 relatedScreen (document-detail sibling)
 - 2026-05-08 — init: created from scan (source: sitemap)

--- a/frontend/packages/api-client/src/documents/api.test.ts
+++ b/frontend/packages/api-client/src/documents/api.test.ts
@@ -155,4 +155,62 @@ describe('documents api client', () => {
 
     vi.unstubAllGlobals();
   });
+
+  it('uploadDocumentDirect forwards folder_id but NOT building_id (#2366)', async () => {
+    // Guards the deliberate omission documented in `uploadDocumentDirect`:
+    // the backend registration contract has no `building_id` (no column, no
+    // struct field, no `deny_unknown_fields`), so forwarding it would be a
+    // silent no-op — a false-green. `folder_id` DOES carry building scope and
+    // must survive. When #2366's backend support lands, this test should be
+    // updated deliberately alongside the forwarding change.
+    const listeners: Record<string, () => void> = {};
+    const xhrMock = {
+      upload: { addEventListener: vi.fn() },
+      addEventListener: (evt: string, cb: () => void) => {
+        listeners[evt] = cb;
+      },
+      open: vi.fn(),
+      setRequestHeader: vi.fn(),
+      send: vi.fn(() => {
+        queueMicrotask(() => {
+          xhrMock.status = 200;
+          listeners.load?.();
+        });
+      }),
+      status: 0,
+    };
+    vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestMock() {
+      return xhrMock;
+    });
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockOkResponse({
+          url: 'https://s3.example/bucket/key?sig=abc',
+          file_key: 'org/2026/07/uuid_report.pdf',
+          content_type: 'application/pdf',
+          method: 'PUT',
+          expires_at: '2026-07-15T00:05:00Z',
+        })
+      )
+      .mockResolvedValueOnce(mockOkResponse({ id: 'doc-99', message: 'created' }));
+
+    const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+    await uploadDocumentDirect({
+      file,
+      title: 'Report',
+      category: 'report',
+      organizationId: 'org-1',
+      buildingId: 'building-7',
+      folderId: 'folder-3',
+    });
+
+    const registerBody = JSON.parse(
+      (vi.mocked(fetch).mock.calls[1][1] as RequestInit).body as string
+    );
+    expect(registerBody.folder_id).toBe('folder-3');
+    expect(registerBody).not.toHaveProperty('building_id');
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -401,6 +401,19 @@ export async function uploadDocumentDirect(
     params.onProgress
   );
 
+  // NOTE (#2366): `params.buildingId` is deliberately NOT forwarded here.
+  // There is no `building_id` on the registration contract — the backend
+  // `documents` table has no such column, `CreateDocumentRequest` (Rust) has no
+  // such field, and it lacks `#[serde(deny_unknown_fields)]`, so a forwarded
+  // `building_id` would be *silently* dropped server-side (a false-green: the
+  // client would compile and pass CI while persisting nothing). The legacy
+  // multipart `uploadDocument` path drops it the same way (drained + ignored in
+  // the handler). Building association today is carried by `folder_id`
+  // (folders are building-scoped) or by `access_scope='building'` +
+  // `access_target_ids`. Adding a real `building_id` needs a backend
+  // migration + struct + repo change first — tracked in #2366. Do not add
+  // `building_id` here until that lands, or association loss just moves one
+  // layer deeper.
   const registration: CreateDocumentRequest = {
     title: params.title,
     description: params.description,


### PR DESCRIPTION
## Task

Wire ppt-web direct-to-S3 upload. The upload wiring (api-client binding + DocumentUpload integration + screen-map note) already landed in `dev`; this branch closes out the re-dispatched task by pinning the one remaining backend-blocked boundary (#2366) as a deliberate limitation rather than shipping a false-green forward.

## What changed

- `uploadDocumentDirect`: anchor comment explaining why `building_id` is NOT forwarded (no `documents.building_id` column / `CreateDocumentRequest` field; no `deny_unknown_fields` ⇒ silent server-side drop).
- `api.test.ts`: regression test asserting `folder_id` survives but `building_id` is absent from the register body — a future forward fails loudly until backend support (migration + struct + repo) lands.
- `upload-document.md`: record the #2366 limitation, reconcile backend ref to #2309, Agent Log entry per screen-map protocol.

Auto-opened by the dispatcher (branch pushed with commits, no PR yet).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACT69Di48rYMvy22GLnwSt)_