### PR TITLE
fix(ppt-web): rename ARReportEntry.unit_number → designation (BIT-495)

### DIFF
--- a/frontend/apps/ppt-web/src/features/financial/components/ARAgingTable.tsx
+++ b/frontend/apps/ppt-web/src/features/financial/components/ARAgingTable.tsx
@@ -97,10 +97,10 @@ export function ARAgingTable({ entries, totals, isLoading, onRowClick }: ARAging
                 }}
                 tabIndex={onRowClick ? 0 : undefined}
                 role={onRowClick ? 'button' : undefined}
-                aria-label={onRowClick ? `View details for unit ${entry.unit_number}` : undefined}
+                aria-label={onRowClick ? `View details for unit ${entry.designation}` : undefined}
               >
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                  {entry.unit_number}
+                  {entry.designation}
                 </td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-500">
                   {formatCurrency(entry.current)}

--- a/frontend/packages/api-client/src/financial/types.ts
+++ b/frontend/packages/api-client/src/financial/types.ts
@@ -343,7 +343,7 @@ export interface PaymentResponse {
 
 export interface ARReportEntry {
   unit_id: string;
-  unit_number: string;
+  designation: string;
   current: number;
   days_30: number;
   days_60: number;


### PR DESCRIPTION
## Summary

Follow-up to **BIT-479** (Rust `ARReportEntry.unit_number` → `designation`, commit `e41155b59`), which changed the ar-aging report JSON response key from `unit_number` to `designation` for `GET /api/v1/financial/reports/ar-aging`.

The frontend was still reading `unit_number`, so the AR aging table in ppt-web rendered blank unit labels.

## Changes

- `frontend/packages/api-client/src/financial/types.ts` — `ARReportEntry.unit_number` → `designation`.
- `frontend/apps/ppt-web/src/features/financial/components/ARAgingTable.tsx` — `entry.unit_number` → `entry.designation` (cell text + `aria-label`).

No OpenAPI-generated file references `ARReportEntry` (the type is hand-maintained under `packages/api-client/src`); the `unit_number` fields in `InvoiceForm`/`PaymentForm` are unrelated local unit-dropdown interfaces and are left untouched.

## Verification

- `tsc --noEmit` on `@ppt/web` — clean (exit 0).
- `biome check` on both changed files — clean.

Resolves Paperclip **BIT-495**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)