### PR TITLE
fix(api-server): signature-request list/create unreachable — mount as document sub-resource (BIT-313)

### DIFF
--- a/backend/servers/api-server/src/routes/documents/mod.rs
+++ b/backend/servers/api-server/src/routes/documents/mod.rs
@@ -26,6 +26,12 @@ pub fn router() -> Router<AppState> {
         .merge(folders::router())
         .merge(shares::authenticated_router())
         .merge(intelligence::router())
+        // Signature requests are a document sub-resource; see BIT-313 —
+        // the handlers extract `Path(document_id)`, so they are mounted here
+        // as `/api/v1/documents/{id}/signature-requests` rather than under the
+        // bare `/api/v1/signature-requests` root where extraction had no
+        // segment to bind.
+        .merge(crate::routes::signatures::document_signature_router())
 }
 
 /// Public (no-auth) document routes — shared document access.

--- a/backend/servers/api-server/src/routes/signatures.rs
+++ b/backend/servers/api-server/src/routes/signatures.rs
@@ -50,14 +50,27 @@ static ESIGN_PROVIDER: LazyLock<LightweightProvider> = LazyLock::new(|| {
 /// Create router for signature endpoints.
 pub fn router() -> Router<AppState> {
     Router::new()
-        .route(
-            "/",
-            get(list_signature_requests).post(create_signature_request),
-        )
         .route("/{id}", get(get_signature_request))
         .route("/{id}/remind", post(send_reminder))
         .route("/{id}/cancel", post(cancel_signature_request))
         .route("/webhook/{provider}", post(handle_webhook))
+}
+
+/// Document-nested signature-request routes.
+///
+/// Mounted by `routes::documents` under `/api/v1/documents`, yielding
+/// `/api/v1/documents/{id}/signature-requests`. The `list`/`create` handlers
+/// extract `Path(document_id)`, so they must live under a route that actually
+/// carries that path segment — the previous bare `/` mount under
+/// `/api/v1/signature-requests` left `Path<Uuid>` extraction with nothing to
+/// bind, making both endpoints unreachable (BIT-313). The document param is
+/// named `{id}` to match the sibling document sub-routes and keep axum's
+/// path-parameter names consistent across the shared prefix.
+pub fn document_signature_router() -> Router<AppState> {
+    Router::new().route(
+        "/{id}/signature-requests",
+        get(list_signature_requests).post(create_signature_request),
+    )
 }
 
 /// Create a new signature request for a document.

--- a/backend/servers/api-server/tests/signature_request_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/signature_request_happy_path_tests.rs
@@ -1,0 +1,177 @@
+//! BIT-313: happy-path coverage for the document-nested signature-request
+//! endpoints (Story 7B.3 / Epic 84.2).
+//!
+//! These were deferred from BIT-312 because, as originally wired, the list and
+//! create handlers were **unreachable**: `router()` mounted them at the bare
+//! `/` under `/api/v1/signature-requests`, but both handlers extract
+//! `Path(document_id): Path<Uuid>` — with no `{document_id}` segment in the
+//! matched route, axum's `Path<Uuid>` extraction had nothing to bind. BIT-313
+//! re-mounts them as a document sub-resource:
+//!
+//! - POST /api/v1/documents/{id}/signature-requests  (create_signature_request) 201
+//! - GET  /api/v1/documents/{id}/signature-requests  (list_signature_requests)  200
+//!
+//! Setup is API-first (drive the real document handler to seed) so these tests
+//! stay resilient to schema drift in the seed layer. `TestApp::new` sets
+//! `RUST_ENV=development`, so the `LightweightProvider` used on the create path
+//! falls back to its dev HMAC secret and signing-link generation succeeds; the
+//! signer invitation email is best-effort (warn-and-continue) so it does not
+//! affect the `201`.
+
+#![allow(dead_code)]
+
+mod common;
+
+use axum::http::StatusCode;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use common::{create_authenticated_user_with_org, TestApp, TestUser};
+
+/// Create a document via the API and return its id. The org creator is an
+/// `org_admin`, which clears the manager gate on document creation.
+async fn create_document(app: &TestApp, token: &str, org_id: Uuid, key: &str) -> Uuid {
+    let res = app
+        .execute(
+            app.session(token.to_string(), org_id)
+                .post("/api/v1/documents")
+                .json(json!({
+                    "title": "Lease to sign",
+                    "category": "contracts",
+                    "file_key": format!("org/contracts/{key}.pdf"),
+                    "file_name": format!("{key}.pdf"),
+                    "mime_type": "application/pdf",
+                    "size_bytes": 4096
+                }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(res.status, StatusCode::CREATED, "body: {}", res.text());
+    res.json_value()["id"]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .expect("created document id")
+}
+
+// ---------------------------------------------------------------------------
+// signatures.rs — POST /api/v1/documents/{id}/signature-requests
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_signature_request_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "sig-create-ok").await;
+    let doc_id = create_document(&app, &token, org_id, "sig-create").await;
+
+    let res = app
+        .execute(
+            app.session(token, org_id)
+                .post(&format!("/api/v1/documents/{doc_id}/signature-requests"))
+                .json(json!({
+                    "signers": [
+                        { "email": "signer@example.com", "name": "Sam Signer" }
+                    ],
+                    "subject": "Please sign the lease"
+                }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(res.status, StatusCode::CREATED, "body: {}", res.text());
+    let body = res.json_value();
+    assert!(
+        body["signature_request"]["id"].is_string(),
+        "response must include the created signature_request id, body: {body}"
+    );
+    assert_eq!(
+        body["signature_request"]["document_id"].as_str(),
+        Some(doc_id.to_string().as_str()),
+        "signature request must be bound to the seeded document"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// signatures.rs — GET /api/v1/documents/{id}/signature-requests
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_signature_requests_empty_succeeds(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "sig-list-empty").await;
+    let doc_id = create_document(&app, &token, org_id, "sig-list-empty").await;
+
+    let res = app
+        .execute(
+            app.session(token, org_id)
+                .get(&format!("/api/v1/documents/{doc_id}/signature-requests"))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(res.status, StatusCode::OK, "body: {}", res.text());
+    let body = res.json_value();
+    assert_eq!(
+        body["total"].as_i64(),
+        Some(0),
+        "a document with no signature requests must report total 0, body: {body}"
+    );
+    assert!(
+        body["signature_requests"]
+            .as_array()
+            .is_some_and(|a| a.is_empty()),
+        "signature_requests must be an empty array, body: {body}"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_signature_requests_returns_created(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "sig-list-one").await;
+    let doc_id = create_document(&app, &token, org_id, "sig-list-one").await;
+
+    // Create one signature request through the API, then list it back.
+    let created = app
+        .execute(
+            app.session(token.clone(), org_id)
+                .post(&format!("/api/v1/documents/{doc_id}/signature-requests"))
+                .json(json!({
+                    "signers": [
+                        { "email": "signer@example.com", "name": "Sam Signer" }
+                    ]
+                }))
+                .build(),
+        )
+        .await;
+    assert_eq!(
+        created.status,
+        StatusCode::CREATED,
+        "body: {}",
+        created.text()
+    );
+
+    let res = app
+        .execute(
+            app.session(token, org_id)
+                .get(&format!("/api/v1/documents/{doc_id}/signature-requests"))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(res.status, StatusCode::OK, "body: {}", res.text());
+    let body = res.json_value();
+    assert_eq!(
+        body["total"].as_i64(),
+        Some(1),
+        "list must report the one created request, body: {body}"
+    );
+    assert_eq!(
+        body["signature_requests"][0]["document_id"].as_str(),
+        Some(doc_id.to_string().as_str()),
+        "listed request must belong to the seeded document, body: {body}"
+    );
+}

--- a/backend/servers/api-server/tests/signature_request_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/signature_request_happy_path_tests.rs
@@ -31,6 +31,10 @@ use common::{create_authenticated_user_with_org, TestApp, TestUser};
 
 /// Create a document via the API and return its id. The org creator is an
 /// `org_admin`, which clears the manager gate on document creation.
+///
+/// `file_key` must start with the caller's own `{org_id}/` prefix — the
+/// org-scope guard added in GH #2320 (`validate_file_key_org_scope`) rejects
+/// anything else with 400 `INVALID_FILE_KEY`.
 async fn create_document(app: &TestApp, token: &str, org_id: Uuid, key: &str) -> Uuid {
     let res = app
         .execute(
@@ -39,7 +43,7 @@ async fn create_document(app: &TestApp, token: &str, org_id: Uuid, key: &str) ->
                 .json(json!({
                     "title": "Lease to sign",
                     "category": "contracts",
-                    "file_key": format!("org/contracts/{key}.pdf"),
+                    "file_key": format!("{org_id}/contracts/{key}.pdf"),
                     "file_name": format!("{key}.pdf"),
                     "mime_type": "application/pdf",
                     "size_bytes": 4096

--- a/docs/endpoint-checklist/groups/documents-forms.md
+++ b/docs/endpoint-checklist/groups/documents-forms.md
@@ -65,11 +65,11 @@ _Server: api-server. Modules: signatures.rs, templates.rs, legal.rs, lease_abstr
 | DELETE | /api/v1/templates/{id} | delete_template | done | documents_intelligence_templates_tests.rs | NO_CONTENT + follow-up GET returns 404 |
 | POST | /api/v1/templates/{id}/generate | generate_document | done | documents_intelligence_templates_tests.rs | CREATED happy path asserting document_id |
 
-## signatures.rs  (mount: /api/v1/signature-requests router; /api/v1/signatures public_sign_router)
+## signatures.rs  (mount: /api/v1/signature-requests router; /api/v1/documents/{id}/signature-requests document_signature_router; /api/v1/signatures public_sign_router)
 | Method | Path | Handler | Status | Tests | Notes |
 |---|---|---|---|---|---|
-| GET | /api/v1/signature-requests | list_signature_requests | partial | — | BLOCKED: handler extracts Path(document_id) but router registers it at "/" with no path param — unreachable as wired (see BIT-312 follow-up) |
-| POST | /api/v1/signature-requests | create_signature_request | partial | — | BLOCKED: same Path(document_id)-vs-"/" wiring mismatch; requests currently seeded via SQL, not the API (see BIT-312 follow-up) |
+| GET | /api/v1/documents/{id}/signature-requests | list_signature_requests | done | signature_request_happy_path_tests.rs | BIT-313: re-mounted as a document sub-resource (was unreachable at bare "/"); OK happy path asserts total + document_id |
+| POST | /api/v1/documents/{id}/signature-requests | create_signature_request | done | signature_request_happy_path_tests.rs | BIT-313: re-mounted as a document sub-resource (was unreachable at bare "/"); CREATED happy path asserts signature_request.id + document_id |
 | GET | /api/v1/signature-requests/{id} | get_signature_request | done | esignature_email_status_tracking_tests.rs | OK happy path asserting signer_counts |
 | POST | /api/v1/signature-requests/{id}/remind | send_reminder | partial | — | no test |
 | POST | /api/v1/signature-requests/{id}/cancel | cancel_signature_request | partial | — | no test |


### PR DESCRIPTION
## BIT-313 — signature-request list/create endpoints unreachable

### Problem
`list_signature_requests` and `create_signature_request` both extract
`Path(document_id): Path<Uuid>`, but `router()` registered them at the bare `/`
under `/api/v1/signature-requests`. With no `{document_id}` segment in the
matched route, axum's `Path<Uuid>` extraction had nothing to bind, so neither
endpoint could return a success response. (The existing suite seeded signature
requests via raw SQL, which corroborated the bug.)

### Fix
Re-mount them as a **document sub-resource** via a new
`document_signature_router()` merged into `routes::documents`:

- `GET  /api/v1/documents/{id}/signature-requests` (list)
- `POST /api/v1/documents/{id}/signature-requests` (create)

The document param is named `{id}` to match the sibling document sub-routes
(versions / shares / intelligence) so axum's path-parameter names stay
consistent across the shared `/{param}` prefix.

**Why not option 2** (`.route("/{document_id}")` under the existing mount):
it would collide with the existing `/{id}` GET route (`get_signature_request`).
axum path params are positional, so two `/{param}` GET routes on the same mount
panic at router build.

### Tests
New `signature_request_happy_path_tests.rs` (deferred from BIT-312), API-first
setup driving the real document handler to seed:
- `create_signature_request_succeeds` → **201**, asserts `signature_request.id` + `document_id`
- `list_signature_requests_empty_succeeds` → **200**, `total == 0`
- `list_signature_requests_returns_created` → **200**, `total == 1`, correct `document_id`

Flips the `documents-forms.md` checklist rows for both handlers partial→done.

### Verification
- `cargo test -p api-server --test signature_request_happy_path_tests --no-run` compiles clean (mercury builder).
- `rustfmt --check` clean.
- Full compile + test run authoritatively gated by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)