### PR TITLE
test(api-server): Wave E de-quarantine — report-execution/notification tests (BIT-569)

### DIFF
--- a/backend/servers/api-server/tests/suites/notification_pipeline_dispatch_tests.rs
+++ b/backend/servers/api-server/tests/suites/notification_pipeline_dispatch_tests.rs
@@ -79,7 +79,6 @@ fn status_of(
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn dispatch_respects_channel_preferences(pool: PgPool) {
     let user = seed_user(&pool).await;
     set_channel_pref(&pool, user, "email", false).await;
@@ -114,7 +113,6 @@ async fn dispatch_respects_channel_preferences(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn urgent_notification_bypasses_preferences(pool: PgPool) {
     let user = seed_user(&pool).await;
     // Disable EVERY channel — an urgent alert must still go out.
@@ -166,7 +164,6 @@ async fn urgent_notification_bypasses_preferences(pool: PgPool) {
 // ===========================================================================
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn dispatch_writes_in_app_delivery_record(pool: PgPool) {
     let user = seed_user(&pool).await;
     let entity_id = Uuid::new_v4();

--- a/backend/servers/api-server/tests/suites/notification_preference_realtime_sync_tests.rs
+++ b/backend/servers/api-server/tests/suites/notification_preference_realtime_sync_tests.rs
@@ -101,7 +101,6 @@ use sqlx::PgPool;
 /// coupled to the realtime sync leg. This is the core #480–#487 concern: a
 /// missing/broken pubsub must never break preference updates.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn preference_update_succeeds_without_redis(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -131,7 +130,6 @@ async fn preference_update_succeeds_without_redis(pool: PgPool) {
 /// the realtime event went out. We re-read via the public GET endpoint to prove
 /// the write landed (the sync leg is fire-and-forget and never gates this).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn preference_update_persists_independently_of_sync(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -179,7 +177,6 @@ async fn preference_update_persists_independently_of_sync(pool: PgPool) {
 /// spurious `preference.updated` being emitted for a change that never landed —
 /// a realtime-sync correctness concern from the #480–#487 cluster.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn disable_all_guard_blocks_before_publish(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -241,7 +238,6 @@ async fn disable_all_guard_blocks_before_publish(pool: PgPool) {
 /// same persisted state rather than erroring. push + in_app stay enabled, so the
 /// disable-all guard never enters the picture for either apply.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn repeated_disable_is_idempotent(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -298,7 +294,6 @@ async fn repeated_disable_is_idempotent(pool: PgPool) {
 /// return 200 both times and leave the channel enabled — the enable path has no
 /// state-dependent rejection, making it unconditionally idempotent.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn repeated_enable_is_idempotent_and_never_conflicts(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -356,7 +351,6 @@ async fn repeated_enable_is_idempotent_and_never_conflicts(pool: PgPool) {
 /// must still return 200 — a replayed disable of an off channel is a pure no-op
 /// and must not be mistaken for "disabling the last channel". in_app stays on.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn redisable_of_off_channel_never_conflicts(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -417,7 +411,6 @@ async fn redisable_of_off_channel_never_conflicts(pool: PgPool) {
 /// test pins the baseline — GET on an untouched user returns exactly the three
 /// channels (push, email, in_app), each enabled, with no all-disabled warning.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn fresh_user_has_all_channels_enabled_by_default(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -480,7 +473,6 @@ async fn fresh_user_has_all_channels_enabled_by_default(pool: PgPool) {
 /// publish leg can never emit an event for a channel the system doesn't model,
 /// and leaves the user's real preferences untouched.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unknown_channel_is_rejected_without_mutation(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -524,7 +516,6 @@ async fn unknown_channel_is_rejected_without_mutation(pool: PgPool) {
 /// and the persisted state must converge to enabled — proving the update leg
 /// the publish leg rides is a genuine state machine, not a one-way latch.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn disable_then_enable_restores_channel(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -590,7 +581,6 @@ async fn disable_then_enable_restores_channel(pool: PgPool) {
 /// response so a connected client can render the "you may miss updates" notice.
 /// This is the update-leg warning the publish leg notifies clients about.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn confirmed_disable_all_succeeds_with_warning(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::new();
@@ -661,7 +651,6 @@ async fn confirmed_disable_all_succeeds_with_warning(pool: PgPool) {
 /// payload shape. A regression that drops the publish or changes the channel
 /// name / payload would now fail in CI rather than silently passing.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn patch_publishes_preference_updated_event(pool: PgPool) {
     let (app, recorder) = TestApp::with_recording_pubsub(pool.clone()).await;
     let user = TestUser::new();
@@ -723,7 +712,6 @@ async fn patch_publishes_preference_updated_event(pool: PgPool) {
 /// change can never emit a spurious realtime event — assertable in CI without
 /// Redis.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn rejected_disable_all_records_no_event(pool: PgPool) {
     let (app, recorder) = TestApp::with_recording_pubsub(pool.clone()).await;
     let user = TestUser::new();
@@ -789,7 +777,6 @@ async fn rejected_disable_all_records_no_event(pool: PgPool) {
 /// test will fail and force an explicit decision rather than a silent behaviour
 /// shift.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn replayed_disable_republishes_identical_event(pool: PgPool) {
     let (app, recorder) = TestApp::with_recording_pubsub(pool.clone()).await;
     let user = TestUser::new();
@@ -1000,7 +987,6 @@ async fn preference_update_publishes_realtime_event(pool: PgPool) {
 /// broker instead of a real Redis. Proves the event is published to the
 /// correct channel with the correct payload (Story 1376).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn preference_update_publishes_realtime_event_in_memory(pool: PgPool) {
     use integrations::{InMemoryBroker, PubSubService};
     use std::sync::Arc;

--- a/backend/servers/api-server/tests/suites/report_execution_download_retry_e2e_tests.rs
+++ b/backend/servers/api-server/tests/suites/report_execution_download_retry_e2e_tests.rs
@@ -154,7 +154,6 @@ async fn authed_member(app: &TestApp, pool: &PgPool, org_id: Uuid, role: &str) -
 /// completed, file-bearing execution must receive a populated `download_url`
 /// pointing at that execution's download endpoint.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_populates_download_url_for_completed(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -215,7 +214,6 @@ async fn list_executions_populates_download_url_for_completed(pool: PgPool) {
 /// completed, file-bearing execution must receive a 200 with a non-empty URL,
 /// the stored file name, and a content type derived from the file extension.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_returns_presigned_payload(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -299,7 +297,6 @@ async fn get_execution_download_url_returns_presigned_payload(pool: PgPool) {
 /// A dedicated integration test against a live S3 stub would be required to
 /// verify the downstream presigning step; that is out of scope here.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn download_url_can_be_repeatedly_represigned_after_expiry(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -400,7 +397,6 @@ async fn download_url_can_be_repeatedly_represigned_after_expiry(pool: PgPool) {
 /// download URL — the endpoint returns 422 `NO_FILE_YET` rather than leaking a
 /// bogus link. Pins the "file not ready" branch of the handler.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_without_file_returns_422(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -457,7 +453,6 @@ async fn get_execution_download_url_without_file_returns_422(pool: PgPool) {
 /// persisted row must reflect the reset (status `pending`, error fields
 /// cleared). This is the core of the retry contract.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_failed_execution_resets_to_pending(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -513,7 +508,6 @@ async fn retry_failed_execution_resets_to_pending(pool: PgPool) {
 /// be rejected with 400 `INVALID_STATE` and must not mutate the row. Pins the
 /// "only failed executions may be retried" guard end-to-end.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_non_failed_execution_returns_400(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -571,7 +565,6 @@ async fn retry_non_failed_execution_returns_400(pool: PgPool) {
 /// and the failed execution stays failed. Proves the retry endpoint's
 /// manager-tier gate end-to-end (complements the cross-tenant IDOR tests).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_as_resident_returns_403(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/report_schedule_cron_roundtrip_tests.rs
+++ b/backend/servers/api-server/tests/suites/report_schedule_cron_roundtrip_tests.rs
@@ -117,7 +117,6 @@ fn put_schedule_req(
 /// land in the dedicated `cron_expression` column, be returned in the response
 /// body, and leave the legacy `time` HH:MM value untouched.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_cron_expression_roundtrips_through_dedicated_column(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -191,7 +190,6 @@ async fn update_cron_expression_roundtrips_through_dedicated_column(pool: PgPool
 /// guards the `COALESCE($cron, cron_expression)` partial-update in
 /// `update_schedule()` from regressing into an unconditional overwrite.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn recipients_only_update_preserves_cron_and_time(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -263,7 +261,6 @@ async fn recipients_only_update_preserves_cron_and_time(pool: PgPool) {
 /// - the validator rejects an expression it previously accepted (PUT → 400), or
 /// - the SELECT projection drops / transforms `cron_expression` (read ≠ write).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn cron_validator_round_trip_stable(pool: PgPool) {
     // Canonical set taken from the validate_cron_expression unit tests in
     // reports.rs.  If the validator is tightened so that any of these become


### PR DESCRIPTION
## Summary

Restores 27 BIT-351-quarantined tests across 4 suites for Wave E of BIT-354.

**Context:** post-#2461 (206 binaries → 8 `suite_N` harnesses), the files now live under `tests/suites/` and compile via `suite_6` (notification_*) and `suite_7` (report_*).

**Changes:**
- `suites/notification_preference_realtime_sync_tests.rs` — removed 14 BIT-351 `#[ignore]` markers (keeps 1 Redis-gated ignore)
- `suites/report_execution_download_retry_e2e_tests.rs` — removed 7 markers
- `suites/report_schedule_cron_roundtrip_tests.rs` — removed 3 markers
- `suites/notification_pipeline_dispatch_tests.rs` — removed 3 markers

**Pre-flight:** all referenced schema/routes/services verified present on dev — `report_schedules.cron_expression` (00166), `report_executions` columns (00162), `notification_preferences` + default-prefs trigger (00021/00023), `grouped_notifications` (00061); all 4 report handlers in `routes/reports.rs`; `NotificationPipeline`/`EmailService::development()` + common notification types in services/common crate.

## Test plan

- [ ] CI `test` gate for `suite_6` + `suite_7` passes green

Closes BIT-569. Child of BIT-354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)