### PR TITLE
test(api-server): restore 8 quarantined cross-org IDOR suites (BIT-563)

### DIFF
--- a/backend/servers/api-server/tests/suites/owner_analytics_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/owner_analytics_cross_org_idor_tests.rs
@@ -150,7 +150,6 @@ fn mint_token(user_id: Uuid, email: &str, org_id: Uuid) -> String {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unit_valuation_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "valuation-a").await;
@@ -180,7 +179,6 @@ async fn unit_valuation_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn value_history_from_other_org_is_empty(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "hist-a").await;
@@ -221,7 +219,6 @@ async fn value_history_from_other_org_is_empty(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unit_valuation_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "legit-a").await;
@@ -254,7 +251,6 @@ async fn unit_valuation_same_org_succeeds(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn unit_valuation_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let uri = format!("/api/v1/owner-analytics/units/{}/valuation", Uuid::new_v4());

--- a/backend/servers/api-server/tests/suites/predictive_maintenance_photos_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/predictive_maintenance_photos_idor_tests.rs
@@ -174,7 +174,6 @@ fn photos_uri(log_id: Uuid) -> String {
 
 /// A user whose JWT `tenant_id` matches the log's org can read its photos.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_photos_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -212,7 +211,6 @@ async fn list_photos_same_org_succeeds(pool: PgPool) {
 /// A user from Org B cannot read Org A's maintenance photos by log id — the
 /// org-scoped log lookup finds no row and the handler returns 404 (#848 IDOR).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_photos_cross_org_is_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -252,7 +250,6 @@ async fn list_photos_cross_org_is_not_found(pool: PgPool) {
 
 /// A cross-org POST must not attach a photo to another org's log.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_photo_cross_org_does_not_insert(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/reserve_funds_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/reserve_funds_cross_org_idor_tests.rs
@@ -129,7 +129,6 @@ async fn seed_fund(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
 
 /// A user whose JWT `tenant_id` matches the fund's organization can read it.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_fund_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -162,7 +161,6 @@ async fn get_fund_same_org_succeeds(pool: PgPool) {
 /// A user from Org B cannot read Org A's fund by id — the org-scoped query
 /// finds no row and the handler returns 404 (the core #810 IDOR).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_fund_cross_org_is_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -199,7 +197,6 @@ async fn get_fund_cross_org_is_not_found(pool: PgPool) {
 
 /// A cross-org `PUT` must not rename another org's fund.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_fund_cross_org_does_not_mutate(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/service_history_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/service_history_cross_org_idor_tests.rs
@@ -110,7 +110,6 @@ async fn user_id_for(pool: &PgPool, email: &str) -> Uuid {
 /// Org B user requests service history for Org A equipment. Must be rejected
 /// with 403; Org A's work-order data must not be disclosed.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -161,7 +160,6 @@ async fn get_equipment_service_history_cross_org_is_rejected(pool: PgPool) {
 /// Org B user requests service history for Org A building. Must be rejected
 /// with 403; Org A's work-order data must not be disclosed.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_building_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -212,7 +210,6 @@ async fn get_building_service_history_cross_org_is_rejected(pool: PgPool) {
 /// A member of Org A reads service history for Org A equipment. Should succeed
 /// with 200 — the fix must not over-block legitimate callers.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_service_history_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -263,7 +260,6 @@ async fn get_equipment_service_history_same_org_succeeds(pool: PgPool) {
 /// A member of Org A reads service history for Org A building. Should succeed
 /// with 200.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_building_service_history_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -315,7 +311,6 @@ async fn get_building_service_history_same_org_succeeds(pool: PgPool) {
 /// so callers cannot distinguish "exists but forbidden" from "does not exist"
 /// via timing or error codes.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_equipment_service_history_unknown_id_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/vendor_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/vendor_cross_org_idor_tests.rs
@@ -102,7 +102,6 @@ fn assert_rejected(status: StatusCode, ctx: &str) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vendor_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "noauth-a").await;
@@ -119,7 +118,6 @@ async fn get_vendor_without_auth_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_vendors_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "lst-a").await;
@@ -153,7 +151,6 @@ async fn list_vendors_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vendor_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "get-a").await;
@@ -189,7 +186,6 @@ async fn get_vendor_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_vendor_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "del-a").await;
@@ -230,7 +226,6 @@ async fn delete_vendor_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_vendor_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "upd-a").await;
@@ -271,7 +266,6 @@ async fn update_vendor_from_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_vendor_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "crt-a").await;
@@ -316,7 +310,6 @@ async fn create_vendor_for_other_org_is_rejected(pool: PgPool) {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_vendor_for_own_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "own-a").await;

--- a/backend/servers/api-server/tests/suites/violations_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/violations_cross_org_idor_tests.rs
@@ -126,7 +126,6 @@ async fn seed_violation(pool: &PgPool, org_id: Uuid, number: &str) -> Uuid {
 /// A user whose JWT `tenant_id` matches the violation's organization can read
 /// it.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_violation_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -157,7 +156,6 @@ async fn get_violation_same_org_succeeds(pool: PgPool) {
 /// A user from Org B cannot read Org A's violation by id — the org-scoped
 /// query finds no row and the handler returns 404 (the core #850 IDOR).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_violation_cross_org_is_not_found(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/work_order_cross_org_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/work_order_cross_org_idor_tests.rs
@@ -133,7 +133,6 @@ async fn work_order_title(pool: &PgPool, id: Uuid) -> String {
 /// handler reads the row, sees it belongs to Org A, and rejects the caller
 /// (403) because they are not a member of Org A.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_work_order_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -180,7 +179,6 @@ async fn get_work_order_from_other_org_is_rejected(pool: PgPool) {
 /// A member of Org B attempts to update an Org A work order. The request is
 /// rejected (403) and the Org A row's title is unchanged.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_work_order_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -240,7 +238,6 @@ async fn update_work_order_from_other_org_is_rejected(pool: PgPool) {
 /// A member of Org B attempts to delete an Org A work order. Rejected (403)
 /// and the row still exists.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_work_order_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -296,7 +293,6 @@ async fn delete_work_order_from_other_org_is_rejected(pool: PgPool) {
 /// owner. `verify_org_access` rejects it (403) and no work order is inserted
 /// into Org A.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn create_work_order_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -357,7 +353,6 @@ async fn create_work_order_for_other_org_is_rejected(pool: PgPool) {
 /// passes and the handler returns 200 with the row — proving the fix does not
 /// over-block legitimate same-org access.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_work_order_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -452,7 +447,6 @@ async fn seed_completed_work_order(
 /// retained `verify_org_access` defense-in-depth gate rejects with 403. The
 /// test therefore asserts 403 — the floor guaranteed even if RLS were disabled.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn equipment_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -499,7 +493,6 @@ async fn equipment_service_history_cross_org_is_rejected(pool: PgPool) {
 /// lookup; this superuser test pool bypasses RLS, so `verify_org_access` is the
 /// gate that fires and the assertion is 403.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn building_service_history_cross_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -541,7 +534,6 @@ async fn building_service_history_cross_org_is_rejected(pool: PgPool) {
 /// A member of Org A reading Org A equipment service history succeeds — proves
 /// the fix does not over-block legitimate same-org access.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn equipment_service_history_same_org_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/workflow_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/workflow_cross_tenant_idor_tests.rs
@@ -154,7 +154,6 @@ fn assert_rejected(status: StatusCode, ctx: &str) {
 /// can only assert "rejected" (4xx) because `host_tenant_middleware`
 /// isn't wired.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn trigger_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -217,7 +216,6 @@ async fn trigger_workflow_from_owning_org_does_not_404(pool: PgPool) {
 
 /// GET /workflows/{id} from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "get-a").await;
@@ -234,7 +232,6 @@ async fn get_workflow_from_other_org_returns_404(pool: PgPool) {
 
 /// PUT /workflows/{id} from another org → rejected and no row mutation.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "upd-a").await;
@@ -262,7 +259,6 @@ async fn update_workflow_from_other_org_returns_404(pool: PgPool) {
 
 /// DELETE /workflows/{id} from another org → rejected and the row survives.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_workflow_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "del-a").await;
@@ -289,7 +285,6 @@ async fn delete_workflow_from_other_org_returns_404(pool: PgPool) {
 
 /// GET /workflows/{id}/actions from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_actions_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "la-a").await;
@@ -306,7 +301,6 @@ async fn list_actions_from_other_org_returns_404(pool: PgPool) {
 
 /// POST /workflows/{id}/actions from another org → rejected and no row inserted.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn add_action_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "aa-a").await;
@@ -343,7 +337,6 @@ async fn add_action_from_other_org_returns_404(pool: PgPool) {
 /// DELETE /workflows/actions/{action_id} from another org → rejected and
 /// the action survives.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_action_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "da-a").await;
@@ -380,7 +373,6 @@ async fn delete_action_from_other_org_returns_404(pool: PgPool) {
 
 /// GET /workflows/executions/{id} from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "ge-a").await;
@@ -409,7 +401,6 @@ async fn get_execution_from_other_org_returns_404(pool: PgPool) {
 
 /// GET /workflows/executions/{id}/steps from another org → rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_execution_steps_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org_a = seed_org(&pool, "les-a").await;


### PR DESCRIPTION
## Summary

Removes all 41 \`#[ignore = "BIT-351 quarantine"]\` markers from 8 cross-org IDOR test suites (tenant-isolation regression tests). Child of BIT-354 repair wave.

These tests assert that Org B cannot read/mutate Org A's records by id (the core cross-org IDOR pattern). They were quarantined in PR #1948 as "blind CI failures" — restoring them re-activates the isolation guardrails.

## Files (all under backend/servers/api-server/tests/suites/)

| File | Tests restored |
|------|----------------|
| workflow_cross_tenant_idor_tests.rs | 9 |
| work_order_cross_org_idor_tests.rs | 8 |
| vendor_cross_org_idor_tests.rs | 7 |
| service_history_cross_org_idor_tests.rs | 5 |
| owner_analytics_cross_org_idor_tests.rs | 4 |
| reserve_funds_cross_org_idor_tests.rs | 3 |
| predictive_maintenance_photos_idor_tests.rs | 3 |
| violations_cross_org_idor_tests.rs | 2 |

Total: 41 tests restored.

## Test plan

- Static seed-vs-migration audit: all 8 files schema-compatible
- Mercury nohup verify running in parallel (PID 992329)
- CI check + test gate (canonical)

🤖 Generated with Claude Code