### PR TITLE
test(api-server): restore quarantined push-notification tests (BIT-572)

### DIFF
--- a/backend/servers/api-server/tests/suites/push_delivery_receipt_tests.rs
+++ b/backend/servers/api-server/tests/suites/push_delivery_receipt_tests.rs
@@ -152,7 +152,6 @@ fn make_notification(user_id: Uuid) -> Notification {
 /// follow-up). This test verifies the happy path: the wiremock server
 /// asserts one HTTP POST was received and the adapter propagates `Ok(())`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn successful_fcm_delivery_receipt_returns_ok(pool: PgPool) {
     // Start wiremock server and register the FCM v1 success stub.
     let server = MockServer::start().await;
@@ -204,7 +203,6 @@ async fn successful_fcm_delivery_receipt_returns_ok(pool: PgPool) {
 /// The wiremock server has no stubs registered; if the adapter made an
 /// unexpected HTTP call the mock would panic and the test would fail.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn apns_only_path_no_fcm_attempted_returns_ok(pool: PgPool) {
     // No stubs registered — any unexpected HTTP call will cause an assertion
     // failure in wiremock.
@@ -250,7 +248,6 @@ async fn apns_only_path_no_fcm_attempted_returns_ok(pool: PgPool) {
 ///
 /// After `send` completes the token row must be absent from the DB.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn fcm_not_registered_deletes_stale_token(pool: PgPool) {
     let server = MockServer::start().await;
 
@@ -310,7 +307,6 @@ async fn fcm_not_registered_deletes_stale_token(pool: PgPool) {
 /// The APNs token must remain in the DB (it was not stale and no APNs send
 /// is attempted in the current placeholder implementation).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn fcm_failure_with_apns_token_returns_err_not_silent_ok(pool: PgPool) {
     let server = MockServer::start().await;
 
@@ -374,7 +370,6 @@ async fn fcm_failure_with_apns_token_returns_err_not_silent_ok(pool: PgPool) {
 /// which POSTs to `{base_url}/fcm/send`.  A legacy success response
 /// (`{"success":1,"failure":0,…}`) must be decoded as `(success=true, expired=false)`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legacy_fcm_successful_delivery_returns_ok(pool: PgPool) {
     let server = MockServer::start().await;
 
@@ -416,7 +411,6 @@ async fn legacy_fcm_successful_delivery_returns_ok(pool: PgPool) {
 /// The legacy FCM path must also trigger `delete_stale_token` when the
 /// response results contain `"error":"NotRegistered"`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn legacy_fcm_not_registered_deletes_stale_token(pool: PgPool) {
     let server = MockServer::start().await;
 

--- a/backend/servers/api-server/tests/suites/push_fanout_stale_token_isolation_tests.rs
+++ b/backend/servers/api-server/tests/suites/push_fanout_stale_token_isolation_tests.rs
@@ -86,7 +86,6 @@ fn assert_rejected(status: StatusCode, ctx: &str) {
 /// Unauthenticated DELETE on `/api/v1/users/me/push-tokens/{token}` must
 /// be rejected before any DB mutation.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -115,7 +114,6 @@ async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
 /// A request carrying Org B's `X-Tenant-ID` while targeting a token owned by
 /// user A must be rejected by the auth gate (4xx).  The token must survive.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_cross_user_via_http_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -150,7 +148,6 @@ async fn delete_push_token_cross_user_via_http_rejected(pool: PgPool) {
 /// the token is preserved.  This is the exact cross-user IDOR boundary the
 /// `(user_id, token)` scope enforces.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn stale_token_delete_scoped_to_user_id(pool: PgPool) {
     let user_a = seed_user(&pool, "user-a-stale@fanout.test").await;
     let user_b = seed_user(&pool, "user-b-stale@fanout.test").await;

--- a/backend/servers/api-server/tests/suites/push_token_tests.rs
+++ b/backend/servers/api-server/tests/suites/push_token_tests.rs
@@ -142,7 +142,6 @@ async fn token_count(pool: &PgPool, token: &str) -> i64 {
 /// `RlsConnection` validates the JWT before any handler body runs, so
 /// unauthenticated callers can never register a token.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_push_token_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -170,7 +169,6 @@ async fn register_push_token_without_auth_is_rejected(pool: PgPool) {
 /// This test documents the layered defence: invalid tokens can never slip
 /// through regardless of auth state.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_push_token_empty_token_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -193,7 +191,6 @@ async fn register_push_token_empty_token_is_rejected(pool: PgPool) {
 
 /// A whitespace-only token must be rejected (the handler trims before checking).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn register_push_token_whitespace_token_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -215,7 +212,6 @@ async fn register_push_token_whitespace_token_is_rejected(pool: PgPool) {
 /// `DELETE /api/v1/users/me/push-tokens/{token}` with no Bearer token must be
 /// rejected. Verifies the delete endpoint is protected by the same auth gate.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool).await;
 
@@ -245,7 +241,6 @@ async fn delete_push_token_without_auth_is_rejected(pool: PgPool) {
 /// the DB itself and is covered by the migration's `FORCE ROW LEVEL
 /// SECURITY` + `app.current_user_id` policy.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn delete_push_token_cross_user_is_rejected_and_token_survives(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 


### PR DESCRIPTION
## BIT-354 Wave H — restore quarantined push-notification tests

Removes all **14** `BIT-351` quarantine `#[ignore]` markers across the three push-notification suites so they run against the real PR `test` gate:

- `push_delivery_receipt_tests.rs` (6)
- `push_token_tests.rs` (5)
- `push_fanout_stale_token_isolation_tests.rs` (3)

### Why they're safe to restore
- `device_push_tokens` schema (migration `00157_device_push_tokens.sql`) still matches the seed helpers (`user_id`, `token`, `platform`).
- Prod API under test (`FcmConfig` fields, `FcmHttpAdapter::new/send`, `common::notifications`) is unchanged — no seed/assertion drift found.
- The one remaining `#[ignore]` in `push_token_tests.rs` is the pre-existing positive-path test that needs `host_tenant_middleware` (not a BIT-351 quarantine).

### Verification
Verified against the mercury build host + relying on the required backend `test` gate here for the authoritative signal.

Closes BIT-572. Child of BIT-354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)