### PR TITLE
data-privacy-retention-policy-2026-07-23: support_tooling_events retention policy (730-day TTL)

### DIFF
--- a/backend/crates/db/migrations/00222_support_tooling_events_retention.sql
+++ b/backend/crates/db/migrations/00222_support_tooling_events_retention.sql
@@ -1,0 +1,88 @@
+-- Migration 00222: Support Tooling Events — Retention Policy (data-privacy)
+--
+-- Publishes a data-retention (TTL) policy for the append-only
+-- support_tooling_events audit trail created in migration 00163 and hardened
+-- in 00165. Until now the table had NO automated retention: rows persisted
+-- indefinitely, which conflicts with GDPR storage-limitation (Art. 5(1)(e)).
+-- See docs/data/support-data-retention-privacy.md for the full policy write-up.
+--
+-- Retention period: 730 days (24 months). This is the sanctioned lifetime for
+-- admin support-tooling audit events — long enough to satisfy security /
+-- accountability investigations, bounded enough to honour storage limitation.
+-- The period is a function parameter (DEFAULT 730) so operators can override
+-- per-invocation without a schema change, mirroring cleanup_old_traces
+-- (migration 00079) and cleanup_old_health_check_results (migration 00074).
+--
+-- Mechanism: a DB-native `cleanup_old_support_tooling_events(retention_days)`
+-- function, invoked from db::PlatformAdminRepository::cleanup_old_support_tooling_events
+-- (the same repository-method + `SELECT cleanup_old_*()` pattern the tracing and
+-- health-monitoring retention jobs already use). Wiring the call into the
+-- api-server background scheduler is a separate, out-of-scope follow-up (owner
+-- pm-backend) — this migration + repository method establish the retention
+-- definition itself.
+--
+-- Immutability interaction: support_tooling_events carries triggers (migration
+-- 00163) that reject ALL UPDATE/DELETE so the log is tamper-evident. A retention
+-- prune must, by definition, DELETE aged rows. We therefore relax the trigger to
+-- permit DELETE **only** inside the sanctioned retention path, which sets the
+-- session-local `app.retention_prune` GUC (same `app.*` namespace as
+-- app.org_id / app.is_super_admin). Every other UPDATE/DELETE — i.e. any
+-- tampering attempt — is still rejected. UPDATE remains unconditionally
+-- forbidden.
+
+-- 1. Relax the immutability trigger: UPDATE always rejected; DELETE rejected
+--    unless the caller is inside the sanctioned retention path.
+CREATE OR REPLACE FUNCTION support_tooling_events_immutable()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'support_tooling_events rows are immutable';
+    END IF;
+
+    -- TG_OP = 'DELETE': allow only when the retention-prune GUC is set to 'on'
+    -- (set transaction-locally by cleanup_old_support_tooling_events). Any other
+    -- DELETE is tampering and is rejected, preserving append-only semantics.
+    IF current_setting('app.retention_prune', true) IS DISTINCT FROM 'on' THEN
+        RAISE EXCEPTION 'support_tooling_events rows are immutable';
+    END IF;
+
+    RETURN OLD;
+END;
+$$;
+
+-- 2. DB-native retention prune. Mirrors cleanup_old_traces (00079) /
+--    cleanup_old_health_check_results (00074): DELETE aged rows by timestamp,
+--    return the deleted count. Wrapped so it (a) opens the sanctioned
+--    retention path for the immutability trigger and (b) asserts the
+--    super-admin RLS context so the FORCE-RLS policy (migration 00165) permits
+--    the delete when run by the api-server (bound by FORCE RLS, no BYPASSRLS).
+--    Both GUCs are set transaction-locally (is_local = true) and reset before
+--    return, so context never bleeds onto the pooled connection.
+CREATE OR REPLACE FUNCTION cleanup_old_support_tooling_events(retention_days INTEGER DEFAULT 730)
+RETURNS BIGINT AS $$
+DECLARE
+    deleted_count BIGINT;
+BEGIN
+    PERFORM set_config('app.retention_prune', 'on', true);
+    PERFORM set_config('app.is_super_admin', 'true', true);
+
+    DELETE FROM support_tooling_events
+    WHERE occurred_at < NOW() - (retention_days || ' days')::INTERVAL;
+
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+    -- Close the sanctioned path immediately after the prune so no subsequent
+    -- statement in the same transaction inherits delete rights.
+    PERFORM set_config('app.retention_prune', 'off', true);
+    PERFORM set_config('app.is_super_admin', 'false', true);
+
+    RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_old_support_tooling_events IS
+    'Retention prune for support_tooling_events: deletes admin support-tooling '
+    'audit events older than the retention period (default 730 days / 24 months, '
+    'GDPR Art. 5(1)(e) storage limitation). Deletes are gated by the '
+    'app.retention_prune GUC so the append-only immutability trigger still blocks '
+    'every other UPDATE/DELETE.';

--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -800,12 +800,10 @@ impl PlatformAdminRepository {
         &self,
         retention_days: i32,
     ) -> Result<i64, SqlxError> {
-        let deleted = sqlx::query_scalar::<_, i64>(
-            "SELECT cleanup_old_support_tooling_events($1)",
-        )
-        .bind(retention_days)
-        .fetch_one(&self.pool)
-        .await?;
+        let deleted = sqlx::query_scalar::<_, i64>("SELECT cleanup_old_support_tooling_events($1)")
+            .bind(retention_days)
+            .fetch_one(&self.pool)
+            .await?;
 
         Ok(deleted)
     }

--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -781,6 +781,34 @@ impl PlatformAdminRepository {
         .fetch_one(&self.pool)
         .await
     }
+
+    /// Prune `support_tooling_events` older than the retention period, returning
+    /// the number of rows deleted.
+    ///
+    /// This is the retention (TTL) entry point for the append-only admin audit
+    /// trail (migration `00222_support_tooling_events_retention.sql`). It calls
+    /// the DB-native `cleanup_old_support_tooling_events(retention_days)`
+    /// function, mirroring the tracing / health-monitoring retention jobs
+    /// (`cleanup_old_traces`, `cleanup_old_health_check_results`). The function
+    /// opens the sanctioned retention path so the immutability trigger permits
+    /// these — and only these — deletes; every other `UPDATE`/`DELETE` on the
+    /// table remains rejected.
+    ///
+    /// `retention_days` defaults to 730 (24 months) at the SQL layer; callers
+    /// pass an explicit value here so the policy is visible at the call site.
+    pub async fn cleanup_old_support_tooling_events(
+        &self,
+        retention_days: i32,
+    ) -> Result<i64, SqlxError> {
+        let deleted = sqlx::query_scalar::<_, i64>(
+            "SELECT cleanup_old_support_tooling_events($1)",
+        )
+        .bind(retention_days)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(deleted)
+    }
 }
 
 #[cfg(test)]

--- a/backend/crates/db/tests/suite_4.rs
+++ b/backend/crates/db/tests/suite_4.rs
@@ -30,6 +30,8 @@ mod sentiment_rls_repo_tests;
 mod subscription_rls_repo_tests;
 #[path = "suites/support_data_session_columns_tests.rs"]
 mod support_data_session_columns_tests;
+#[path = "suites/support_tooling_events_retention_tests.rs"]
+mod support_tooling_events_retention_tests;
 #[path = "suites/thread_participant_state_tests.rs"]
 mod thread_participant_state_tests;
 #[path = "suites/unified_portal_user_tests.rs"]

--- a/backend/crates/db/tests/suites/support_tooling_events_retention_tests.rs
+++ b/backend/crates/db/tests/suites/support_tooling_events_retention_tests.rs
@@ -1,0 +1,133 @@
+//! DB-backed regression tests for the support_tooling_events retention policy
+//! (migration `00222_support_tooling_events_retention.sql`).
+//!
+//! Background
+//! ----------
+//! `support_tooling_events` (migration 00163) is an append-only admin audit
+//! trail: triggers reject every UPDATE/DELETE so it is tamper-evident. It had
+//! NO retention until migration 00222, which added
+//! `cleanup_old_support_tooling_events(retention_days)` — a DB-native prune that
+//! deletes aged rows via the sanctioned `app.retention_prune` GUC path while
+//! leaving the immutability guarantee intact for every other mutation.
+//!
+//! These tests pin three properties:
+//!   1. The retention prune deletes rows older than the retention window and
+//!      keeps newer ones (returning the deleted count).
+//!   2. An ordinary DELETE (outside the sanctioned path) is still rejected —
+//!      the append-only guarantee is preserved.
+//!   3. An ordinary UPDATE is still rejected.
+//!
+//! `#[sqlx::test]` connects as the Postgres superuser (bypasses RLS), so these
+//! exercise the trigger + retention function directly, independent of the
+//! FORCE-RLS policy added in migration 00165.
+
+use db::repositories::PlatformAdminRepository;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_admin_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'test_hash', 'Retention Admin', 'active', NOW(), 'public')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed admin user")
+}
+
+/// Insert a support_tooling_events row with an explicit `occurred_at`.
+///
+/// `occurred_at` must be set at INSERT time because the immutability trigger
+/// forbids UPDATE — a test cannot backdate a row after the fact.
+async fn insert_event_at(pool: &PgPool, admin_user_id: Uuid, days_ago: i64) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO support_tooling_events (event_kind, admin_user_id, props, occurred_at)
+        VALUES ('support_data_viewed', $1, '{}'::jsonb, NOW() - ($2 || ' days')::INTERVAL)
+        RETURNING id
+        "#,
+    )
+    .bind(admin_user_id)
+    .bind(days_ago.to_string())
+    .fetch_one(pool)
+    .await
+    .expect("insert support_tooling_events row")
+}
+
+async fn count_events(pool: &PgPool) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM support_tooling_events")
+        .fetch_one(pool)
+        .await
+        .expect("count events")
+}
+
+#[sqlx::test]
+async fn retention_prune_deletes_aged_rows_and_keeps_recent(pool: PgPool) {
+    let admin = seed_admin_user(&pool, "retention-admin@test.local").await;
+
+    // One row well past the 730-day window, one comfortably inside it.
+    let old_id = insert_event_at(&pool, admin, 800).await;
+    let recent_id = insert_event_at(&pool, admin, 10).await;
+    assert_eq!(count_events(&pool).await, 2);
+
+    let repo = PlatformAdminRepository::new(pool.clone());
+    let deleted = repo
+        .cleanup_old_support_tooling_events(730)
+        .await
+        .expect("retention prune should succeed");
+
+    assert_eq!(deleted, 1, "exactly the aged row should be pruned");
+
+    // The recent row survives; the aged row is gone.
+    let surviving: Vec<Uuid> =
+        sqlx::query_scalar::<_, Uuid>("SELECT id FROM support_tooling_events")
+            .fetch_all(&pool)
+            .await
+            .expect("select surviving ids");
+    assert_eq!(surviving, vec![recent_id]);
+    assert!(
+        !surviving.contains(&old_id),
+        "aged row must have been pruned"
+    );
+}
+
+#[sqlx::test]
+async fn ordinary_delete_is_still_rejected(pool: PgPool) {
+    let admin = seed_admin_user(&pool, "no-delete-admin@test.local").await;
+    let id = insert_event_at(&pool, admin, 5).await;
+
+    // A DELETE outside the sanctioned retention path (no app.retention_prune
+    // GUC) must be rejected by the immutability trigger.
+    let err = sqlx::query("DELETE FROM support_tooling_events WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect_err("ordinary DELETE must be rejected");
+    assert!(
+        err.to_string().contains("immutable"),
+        "unexpected error: {err}"
+    );
+
+    // Row is still present.
+    assert_eq!(count_events(&pool).await, 1);
+}
+
+#[sqlx::test]
+async fn update_is_still_rejected(pool: PgPool) {
+    let admin = seed_admin_user(&pool, "no-update-admin@test.local").await;
+    let id = insert_event_at(&pool, admin, 5).await;
+
+    let err = sqlx::query("UPDATE support_tooling_events SET event_kind = 'support_data_viewed' WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect_err("UPDATE must always be rejected");
+    assert!(
+        err.to_string().contains("immutable"),
+        "unexpected error: {err}"
+    );
+}

--- a/backend/crates/db/tests/suites/support_tooling_events_retention_tests.rs
+++ b/backend/crates/db/tests/suites/support_tooling_events_retention_tests.rs
@@ -121,11 +121,13 @@ async fn update_is_still_rejected(pool: PgPool) {
     let admin = seed_admin_user(&pool, "no-update-admin@test.local").await;
     let id = insert_event_at(&pool, admin, 5).await;
 
-    let err = sqlx::query("UPDATE support_tooling_events SET event_kind = 'support_data_viewed' WHERE id = $1")
-        .bind(id)
-        .execute(&pool)
-        .await
-        .expect_err("UPDATE must always be rejected");
+    let err = sqlx::query(
+        "UPDATE support_tooling_events SET event_kind = 'support_data_viewed' WHERE id = $1",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .expect_err("UPDATE must always be rejected");
     assert!(
         err.to_string().contains("immutable"),
         "unexpected error: {err}"

--- a/docs/data/support-data-retention-privacy.md
+++ b/docs/data/support-data-retention-privacy.md
@@ -99,8 +99,44 @@ resistant record of *who looked at what, when*.
 |----------|-------|---------------------|
 | Sessions | `refresh_tokens` | Token lifetime is **7 days** (`refresh_token_lifetime`, `services/jwt.rs`); access tokens are 15 min. A scheduled cleanup deletes rows where `expires_at < NOW() OR revoked_at < NOW() - INTERVAL '7 days'` — `SessionRepository::cleanup_expired_tokens`, invoked by the background scheduler `cleanup_sessions` (default tick every 60s, `services/scheduler.rs`). So expired/revoked sessions are purged within ~7 days. |
 | Activity log | `audit_logs` | **Append-only, no automated retention/expiry found.** Rows persist indefinitely; `user_id` is `ON DELETE SET NULL` so the entry survives user deletion (anonymised). Used for compliance (Epic 9 / Story 9.6). |
-| Support-tooling events | `support_tooling_events` | **Append-only, immutable, no automated retention found.** `admin_user_id` is `ON DELETE RESTRICT` (migration `00165`) so the audit trail cannot be lost via admin-account deletion; RLS restricts the table to super-admins. |
+| Support-tooling events | `support_tooling_events` | **Append-only, immutable; 730-day (24-month) retention (migration `00222`).** Aged events are pruned by the DB-native `cleanup_old_support_tooling_events(retention_days DEFAULT 730)` function via a sanctioned, GUC-gated delete path — every other UPDATE/DELETE stays rejected. `admin_user_id` is `ON DELETE RESTRICT` (migration `00165`) so the trail cannot be lost via admin-account deletion; RLS restricts the table to super-admins. See [Retention policy](#retention-policy-support_tooling_events) below. |
 | Aggregate counts | n/a (computed) | Not stored; recomputed per request. |
+
+## Retention policy (`support_tooling_events`)
+
+Published to satisfy GDPR storage limitation (Art. 5(1)(e)) for the admin
+support-tooling audit trail. Defined in migration
+`00222_support_tooling_events_retention.sql`.
+
+- **Retention period:** **730 days (24 months).** Long enough to support
+  security / accountability investigations into who accessed support data;
+  bounded so events are not retained indefinitely. The period is a function
+  parameter (`retention_days`, default 730) so operations can override it
+  per-invocation without a schema migration — mirroring `cleanup_old_traces`
+  (migration `00079`) and `cleanup_old_health_check_results` (migration `00074`).
+- **Legal basis for retention:** legitimate interest in a tamper-evident record
+  of privileged support access (security & accountability); the 24-month bound
+  is the storage-limitation control.
+- **Mechanism:** DB-native `cleanup_old_support_tooling_events(retention_days)`
+  deletes rows whose `occurred_at` is older than the window and returns the
+  deleted count. It is exposed to Rust via
+  `PlatformAdminRepository::cleanup_old_support_tooling_events`, following the
+  same repository-method + `SELECT cleanup_old_*()` pattern the tracing and
+  health-monitoring retention jobs already use.
+- **Immutability preserved:** the table's append-only triggers (migration
+  `00163`) reject all UPDATE, and reject DELETE **except** inside the sanctioned
+  retention path. The retention function opens that path by setting the
+  transaction-local `app.retention_prune` GUC (same `app.*` namespace as
+  `app.org_id` / `app.is_super_admin`); it also asserts the super-admin RLS
+  context so the FORCE-RLS policy (migration `00165`) permits the delete when the
+  api-server runs it. Both GUCs are reset before the function returns, so context
+  never bleeds onto the pooled connection. Any DELETE outside this path is still
+  rejected — the tamper-evidence guarantee for recent events is intact.
+- **Scheduling (follow-up, out of scope for pm-data):** invoking the prune on a
+  cadence belongs in the api-server background scheduler
+  (`services/scheduler.rs`, alongside `cleanup_sessions`) or an external
+  scheduler such as pg_cron. That wiring is a separate pm-backend task; this
+  change establishes the retention *definition* and its call surface.
 
 ## PII / GDPR considerations
 
@@ -124,10 +160,13 @@ Mitigations already in place:
 
 Recommendations / gaps:
 
-1. **No documented retention limit for `audit_logs` or `support_tooling_events`.**
-   GDPR storage-limitation (Art. 5(1)(e)) expects a defined retention period.
-   Recommend defining and enforcing one (e.g. a scheduled prune) and documenting
-   the legal basis for indefinite audit retention if that is intentional.
+1. **`support_tooling_events` retention — ADDRESSED (migration `00222`).** A
+   730-day retention policy with a DB-native prune is now defined and documented
+   (see [Retention policy](#retention-policy-support_tooling_events)). **`audit_logs`
+   still has no documented retention limit** — GDPR storage-limitation
+   (Art. 5(1)(e)) expects a defined retention period; recommend defining and
+   enforcing one (e.g. the same scheduled-prune pattern) and documenting the
+   legal basis for indefinite audit retention if that is intentional.
 2. **IP / user-agent in `details` JSONB** of `audit_logs` is unstructured — a
    data-subject erasure (Art. 17) would need to account for PII that may be
    embedded there, not just the `user_id` SET NULL.
@@ -148,9 +187,10 @@ Recommendations / gaps:
    request time. The queries now use `revoked_at IS NULL` / `SET revoked_at = NOW()`
    to match the schema, covered by
    `crates/db/tests/support_data_session_columns_tests.rs`.
-2. **`audit_logs` / `support_tooling_events` retention** — is indefinite
-   retention an intentional compliance decision, or a missing cleanup job? (See
-   recommendation 1.)
+2. **`audit_logs` retention** — is indefinite retention an intentional
+   compliance decision, or a missing cleanup job? (`support_tooling_events` now
+   has a defined 730-day policy via migration `00222`; `audit_logs` does not.
+   See recommendation 1.)
 3. **`details` JSONB contents** — what PII actually lands in `audit_logs.details`
    in practice was not exhaustively traced; the audit producers should be
    reviewed before treating it as PII-free.


### PR DESCRIPTION
## Task
Publish a data-retention policy for support-data / analytics events / audit trail. The append-only support_tooling_events table has no TTL yet. Document the retention policy (docs), and if the codebase has an established migration/retention mechanism, add the TTL/retention definition for support_tooling_events consistent with existing patterns. Prefer a documentation + minimal-migration change; keep scope tight to owner_role pm-data.

## Owner
pm-data

## What changed
- **Docs (primary):** `docs/data/support-data-retention-privacy.md` now publishes the retention policy for `support_tooling_events` — 730-day (24-month) period, legal basis (GDPR Art. 5(1)(e) storage limitation), mechanism, immutability interaction, and the scheduling follow-up. Resolves the doc's prior "no retention found" gap for this table (audit_logs gap left open, out of scope).
- **Migration `00222_support_tooling_events_retention.sql`:** DB-native `cleanup_old_support_tooling_events(retention_days INTEGER DEFAULT 730)` returning the deleted count — same pattern as `cleanup_old_traces` (00079) and `cleanup_old_health_check_results` (00074). Relaxes the append-only immutability trigger (00163) to permit DELETE **only** inside a sanctioned, GUC-gated retention path (`app.retention_prune`); UPDATE and every other DELETE stay rejected, so the trail remains tamper-evident. Also asserts super-admin RLS context (transaction-locally) so the FORCE-RLS policy (00165) permits the prune when the api-server runs it; both GUCs reset before return.
- **`PlatformAdminRepository::cleanup_old_support_tooling_events`:** the Rust call surface, mirroring `InfrastructureRepository::cleanup_old_traces` (runtime `SELECT cleanup_old_*()`, no sqlx offline data needed).
- **Regression tests (`db` suite_4, `#[sqlx::test]`):** prune deletes aged rows / keeps recent (returns count); ordinary DELETE and UPDATE still rejected as immutable.

Scheduling the prune on a cadence (api-server `services/scheduler.rs` next to `cleanup_sessions`, or pg_cron) is a separate pm-backend follow-up — this PR establishes the retention definition + call surface only, keeping scope inside pm-data (`backend/crates/db/**`, `docs/data/**`).

## Scope drift
None — `scope-check.sh --owner pm-data` exit 0 (all paths in `backend/crates/db/**` + `docs/data/**`).

## Code-reuse review
None — `reuse-grep.sh --specialist db-migration` clean. The new function deliberately mirrors the existing `cleanup_old_traces` / `cleanup_old_health_check_results` retention pattern.

## Verification
```
VERIFY-PLAN base=cc14c0415e97516169c5da65cb4179d11ed484a3 files=5
  # WARN: migrations touched — SQL truth needs a live DB (localhost:5433); runtime sqlx compiles without one, so run DB-backed tests before merge
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```
Runnable, DB-free portions were executed green in this environment:
- `cargo fmt --all -- --check` → OK
- `cargo clippy -p db --lib -- -D warnings` → OK (validates the new repository method)
- `cargo test -p db --test suite_4 --no-run` → OK (new `#[sqlx::test]` module compiles + links)

Environment-blocked (NOT code issues — CI must run these with a DB):
- `cargo clippy --workspace` — the `utoipa-swagger-ui` build script (server crates only, not `db`) fails downloading the Swagger UI zip through the sandbox proxy.
- `cargo test --workspace` — the `#[sqlx::test]` retention tests need a live Postgres on localhost:5433 (the migration WARN flags exactly this). They compile clean here; execution is deferred to CI / pre-merge.

## CI parity (Band C — hot-path only)
Skipped: touches an audit table but no auth/billing/session-integrity code path; not flagged hot-path.

## Remote-tested
Skipped (no ppt-bridge MCP in this session).

## Notes
- The immutability-trigger relaxation is the security-sensitive part: reviewer should confirm the `app.retention_prune` GUC gate is acceptable as the sanctioned delete path. Recent-event tamper-evidence is preserved; only time-based retention pruning can delete.
- CI (`backend.yml`) runs the DB-backed `db` suite — that is where the three new retention tests execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbQ28JDq9gmm88so3P7zLo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VbQ28JDq9gmm88so3P7zLo)_