### PR TITLE
data-signup-funnel-tracking-2026-07-23: instrument onboarding/signup funnel analytics

### DIFF
--- a/frontend/apps/admin-web/src/features/onboarding/analytics.test.ts
+++ b/frontend/apps/admin-web/src/features/onboarding/analytics.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression test for the onboarding/signup funnel instrumentation
+ * (Epic 10B, Story 10B.6). Before this change the tour fired no analytics
+ * events; these assertions lock in that every funnel transition emits its
+ * canonical event with the expected tour context.
+ */
+/// <reference types="vitest/globals" />
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __clearAnalyticsSinks,
+  type AnalyticsEvent,
+  registerAnalyticsSink,
+} from '../../lib/analytics';
+import {
+  ONBOARDING_EVENTS,
+  trackStepCompleted,
+  trackTourCompleted,
+  trackTourReset,
+  trackTourSkipped,
+  trackTourStarted,
+} from './analytics';
+
+const TOUR = { tourId: 'tour-welcome', tourName: 'Welcome tour' };
+
+let captured: AnalyticsEvent[];
+
+beforeEach(() => {
+  captured = [];
+  registerAnalyticsSink((e) => captured.push(e));
+});
+
+afterEach(() => {
+  __clearAnalyticsSinks();
+  vi.restoreAllMocks();
+});
+
+describe('onboarding funnel analytics', () => {
+  it('fires tour_started with tour context', () => {
+    trackTourStarted(TOUR);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe(ONBOARDING_EVENTS.tourStarted);
+    expect(captured[0].properties).toMatchObject({
+      tour_id: 'tour-welcome',
+      tour_name: 'Welcome tour',
+    });
+    expect(captured[0].timestamp).toEqual(expect.any(String));
+  });
+
+  it('fires step_completed with step id and last-step flag', () => {
+    trackStepCompleted(TOUR, 'step-2', false);
+    trackStepCompleted(TOUR, 'step-3', true);
+    expect(captured.map((e) => e.event)).toEqual([
+      ONBOARDING_EVENTS.stepCompleted,
+      ONBOARDING_EVENTS.stepCompleted,
+    ]);
+    expect(captured[0].properties).toMatchObject({ step_id: 'step-2', is_last_step: false });
+    expect(captured[1].properties).toMatchObject({ step_id: 'step-3', is_last_step: true });
+  });
+
+  it('fires tour_completed, tour_skipped and tour_reset', () => {
+    trackTourCompleted(TOUR);
+    trackTourSkipped(TOUR);
+    trackTourReset(TOUR);
+    expect(captured.map((e) => e.event)).toEqual([
+      ONBOARDING_EVENTS.tourCompleted,
+      ONBOARDING_EVENTS.tourSkipped,
+      ONBOARDING_EVENTS.tourReset,
+    ]);
+    for (const e of captured) {
+      expect(e.properties).toMatchObject({ tour_id: 'tour-welcome', tour_name: 'Welcome tour' });
+    }
+  });
+
+  it('mirrors events onto window.dataLayer when present', () => {
+    (globalThis as { dataLayer?: unknown[] }).dataLayer = [];
+    trackTourStarted(TOUR);
+    const dl = (globalThis as { dataLayer?: Array<Record<string, unknown>> }).dataLayer;
+    expect(dl).toHaveLength(1);
+    expect(dl?.[0]).toMatchObject({
+      event: ONBOARDING_EVENTS.tourStarted,
+      tour_id: 'tour-welcome',
+    });
+    (globalThis as { dataLayer?: unknown[] }).dataLayer = undefined;
+  });
+
+  it('never throws when a sink misbehaves', () => {
+    registerAnalyticsSink(() => {
+      throw new Error('boom');
+    });
+    expect(() => trackTourCompleted(TOUR)).not.toThrow();
+    // The well-behaved sink still received the event.
+    expect(captured).toHaveLength(1);
+  });
+});

--- a/frontend/apps/admin-web/src/features/onboarding/analytics.ts
+++ b/frontend/apps/admin-web/src/features/onboarding/analytics.ts
@@ -1,0 +1,57 @@
+/**
+ * Onboarding / signup funnel instrumentation (Epic 10B, Story 10B.6).
+ *
+ * The onboarding tour is the last leg of the signup funnel. Until now the
+ * TourOverlay drove `start` / `complete-step` / `complete` / `skip` / `reset`
+ * mutations but fired no analytics, so the funnel was invisible to the data
+ * team. These helpers emit one canonical event per funnel transition, fired
+ * from `OnboardingToursPage` only after the corresponding server mutation
+ * succeeds (so events count real conversions, not attempts).
+ */
+
+import { trackEvent } from '../../lib/analytics';
+
+/** Canonical funnel event names — keep in sync with the data-team schema. */
+export const ONBOARDING_EVENTS = {
+  tourStarted: 'onboarding.tour_started',
+  stepCompleted: 'onboarding.step_completed',
+  tourCompleted: 'onboarding.tour_completed',
+  tourSkipped: 'onboarding.tour_skipped',
+  tourReset: 'onboarding.tour_reset',
+} as const;
+
+export type OnboardingEventName = (typeof ONBOARDING_EVENTS)[keyof typeof ONBOARDING_EVENTS];
+
+interface TourRef {
+  tourId: string;
+  tourName: string;
+}
+
+export function trackTourStarted({ tourId, tourName }: TourRef): void {
+  trackEvent(ONBOARDING_EVENTS.tourStarted, { tour_id: tourId, tour_name: tourName });
+}
+
+export function trackStepCompleted(
+  { tourId, tourName }: TourRef,
+  stepId: string,
+  isLast: boolean
+): void {
+  trackEvent(ONBOARDING_EVENTS.stepCompleted, {
+    tour_id: tourId,
+    tour_name: tourName,
+    step_id: stepId,
+    is_last_step: isLast,
+  });
+}
+
+export function trackTourCompleted({ tourId, tourName }: TourRef): void {
+  trackEvent(ONBOARDING_EVENTS.tourCompleted, { tour_id: tourId, tour_name: tourName });
+}
+
+export function trackTourSkipped({ tourId, tourName }: TourRef): void {
+  trackEvent(ONBOARDING_EVENTS.tourSkipped, { tour_id: tourId, tour_name: tourName });
+}
+
+export function trackTourReset({ tourId, tourName }: TourRef): void {
+  trackEvent(ONBOARDING_EVENTS.tourReset, { tour_id: tourId, tour_name: tourName });
+}

--- a/frontend/apps/admin-web/src/lib/analytics.ts
+++ b/frontend/apps/admin-web/src/lib/analytics.ts
@@ -1,0 +1,78 @@
+/**
+ * Lightweight, transport-agnostic analytics event bus for admin-web.
+ *
+ * The app has no bundled analytics SDK (PostHog / Segment / GA are injected
+ * at deploy time, if at all). This module gives feature code a single,
+ * dependency-free `trackEvent` entry point that:
+ *
+ *   1. pushes a GTM-style record onto `window.dataLayer` when one is present
+ *      (the deploy-time tag manager consumes it), and
+ *   2. fans the event out to any in-process sinks registered via
+ *      `registerAnalyticsSink` (used by tests and by future in-app dashboards).
+ *
+ * Analytics must never break the UX: every sink call is wrapped so a throwing
+ * sink can't bubble into a React event handler.
+ */
+
+export interface AnalyticsEvent {
+  /** Dot-namespaced event name, e.g. `onboarding.tour_completed`. */
+  event: string;
+  /** Arbitrary, JSON-serialisable event properties. */
+  properties: Record<string, unknown>;
+  /** ISO-8601 capture timestamp. */
+  timestamp: string;
+}
+
+export type AnalyticsSink = (event: AnalyticsEvent) => void;
+
+const sinks = new Set<AnalyticsSink>();
+
+/**
+ * Register an in-process analytics sink. Returns an unsubscribe function.
+ */
+export function registerAnalyticsSink(sink: AnalyticsSink): () => void {
+  sinks.add(sink);
+  return () => {
+    sinks.delete(sink);
+  };
+}
+
+/** Test/reset hook — drops all registered in-process sinks. */
+export function __clearAnalyticsSinks(): void {
+  sinks.clear();
+}
+
+interface DataLayerWindow {
+  dataLayer?: unknown[];
+}
+
+/**
+ * Emit an analytics event. Safe to call from any render/event-handler path —
+ * it never throws.
+ */
+export function trackEvent(event: string, properties: Record<string, unknown> = {}): void {
+  const payload: AnalyticsEvent = {
+    event,
+    properties,
+    timestamp: new Date().toISOString(),
+  };
+
+  // 1. GTM-style dataLayer (deploy-time tag manager), if present.
+  try {
+    const dl = (globalThis as DataLayerWindow).dataLayer;
+    if (Array.isArray(dl)) {
+      dl.push({ event, ...properties, timestamp: payload.timestamp });
+    }
+  } catch {
+    // Never let analytics transport break the caller.
+  }
+
+  // 2. In-process sinks.
+  for (const sink of sinks) {
+    try {
+      sink(payload);
+    } catch {
+      // Swallow — a broken sink must not break the UX.
+    }
+  }
+}

--- a/frontend/apps/admin-web/src/pages/OnboardingToursPage.tsx
+++ b/frontend/apps/admin-web/src/pages/OnboardingToursPage.tsx
@@ -29,6 +29,13 @@ import {
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '../components/Toast';
+import {
+  trackStepCompleted,
+  trackTourCompleted,
+  trackTourReset,
+  trackTourSkipped,
+  trackTourStarted,
+} from '../features/onboarding/analytics';
 import { TourOverlay } from '../features/onboarding/TourOverlay';
 import type {
   OnboardingTour,
@@ -254,6 +261,9 @@ export default function OnboardingToursPage() {
     // Auto-start if not yet started
     if (!progress) {
       startMutation.mutate(tour.tour_id, {
+        onSuccess: () => {
+          trackTourStarted({ tourId: tour.tour_id, tourName: tour.name });
+        },
         onError: (err) => {
           showToast({
             title: t('onboarding.toast.startFailedTitle'),
@@ -273,12 +283,14 @@ export default function OnboardingToursPage() {
       { tourId, stepId },
       {
         onSuccess: () => {
+          trackStepCompleted({ tourId, tourName }, stepId, isLast);
           // Chain `completeOnboardingTour` only after the final step POST
           // has succeeded — keeps the two requests sequenced instead of
           // racing against the backend (issue #702 finding #1).
           if (!isLast) return;
           completeTourMutation.mutate(tourId, {
             onSuccess: () => {
+              trackTourCompleted({ tourId, tourName });
               showToast({
                 title: t('onboarding.toast.completedTitle'),
                 message: t('onboarding.toast.completedMessage', { name: tourName }),
@@ -309,6 +321,7 @@ export default function OnboardingToursPage() {
     if (!activeTour) return;
     skipMutation.mutate(activeTour.tour.tour_id, {
       onSuccess: () => {
+        trackTourSkipped({ tourId: activeTour.tour.tour_id, tourName: activeTour.tour.name });
         showToast({
           title: t('onboarding.toast.skippedTitle'),
           message: t('onboarding.toast.skippedMessage', { name: activeTour.tour.name }),
@@ -330,6 +343,7 @@ export default function OnboardingToursPage() {
     if (!activeTour) return;
     resetMutation.mutate(activeTour.tour.tour_id, {
       onSuccess: () => {
+        trackTourReset({ tourId: activeTour.tour.tour_id, tourName: activeTour.tour.name });
         showToast({
           title: t('onboarding.toast.resetTitle'),
           message: t('onboarding.toast.resetMessage', { name: activeTour.tour.name }),


### PR DESCRIPTION
Auto: Instrument signup / onboarding-tour completion funnel (10b-6) — TourOverlay hook exists, no analytics events fired on complete/skip/reset.

Implementer note (from branch push): funnel events wired via transport-agnostic trackEvent bus + typed funnel helpers, one canonical event per TourOverlay transition emitted from OnboardingToursPage after the server mutation succeeds. Own tests + typecheck + biome green; verify red was limited to pre-existing dev-broken tests (CapabilitiesAdminPage, 4 e2e specs — identical on base). scope_drift=true flagged for reviewer.

---
_Generated by [Claude Code](https://claude.ai/code/session_012niN8m6xzatp6HJVf4ruqG)_