### PR TITLE
test(api-server): re-enable resident-add happy-path (BIT-585)

### DIFF
--- a/backend/servers/api-server/tests/suites/org_property_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/suites/org_property_happy_path_tests.rs
@@ -105,13 +105,12 @@ fn id_of(resp: &common::TestResponse) -> Uuid {
 // Buildings / units / owners / residents — tenant-scoped (X-Tenant-ID).
 // ---------------------------------------------------------------------------
 
-// BIT-575 Wave J2: building/unit/owner steps pass, but POST
-// /units/{uid}/residents returns 500 DB_ERROR ("Failed to add resident") while
-// the parallel owner-add path (assign_owner_rls) succeeds. Root cause not yet
-// isolated (all static paths — enum cast, FK created_by, NOT NULL, RETURNING
-// decode — check out); quarantined so the rest of Wave J2 can land. Tracked as
-// a follow-up; do NOT delete — this is a real un-quarantine target.
-#[ignore = "BIT-575 follow-up: resident-add 500 DB_ERROR, root cause pending"]
+// BIT-585 (BIT-575 Wave J2 follow-up): the resident-add POST used to 500 because
+// `UnitResidentRepository::create` bound the `resident_type` String straight into
+// the Postgres `resident_type` ENUM column with no cast — Postgres sent it as
+// `text` (OID 25) and there is no implicit text→enum coercion (SQLSTATE 42804).
+// Fixed by casting `$3::resident_type` (and `$2::resident_type` in `update`), so
+// the test is re-enabled.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn buildings_units_owners_residents_happy_path(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;


### PR DESCRIPTION
## BIT-585 — Root-cause + re-enable resident-add happy-path (BIT-575 Wave J2 follow-up)

`buildings_units_owners_residents_happy_path` (`tests/suites/org_property_happy_path_tests.rs`) was quarantined with `#[ignore]` in BIT-575 Wave J2 (#2503) because `POST /buildings/{bid}/units/{uid}/residents` returned `500 {"code":"DB_ERROR"}`.

### Root cause
`UnitResidentRepository::create` (and `update`) bound the `resident_type` Rust `String` straight into the Postgres `resident_type` **ENUM** column with no cast. sqlx sends `String` as `text` (OID 25), and Postgres has no implicit `text → resident_type` coercion → **SQLSTATE 42804** → the generic 500 `DB_ERROR`. The owner-add step passed because `unit_owners` has no enum column.

### Fix
`#2503` **already** added the casts `$3::resident_type` (create) and `$2::resident_type` (update) in the same PR, but left the test `#[ignore]`d because the local verify host was congested and the fix went in unverified. This PR removes the `#[ignore]` and refreshes the explanatory comment.

### Verification (real Postgres, via rbuild host)
- The exact repo INSERT with real fixtures (org→building→unit→user) → **succeeds**, returns the row.
- sqlx-equivalent path — a `text` parameter bound through the extended protocol into `$1::resident_type` → **succeeds** (`'tenant'` → `tenant`).
- Enum `resident_type` on the live schema = `{owner,tenant,family_member,subtenant}` (value `tenant` valid).
- Local `cargo test --test suite_6 buildings_units_owners_residents_happy_path` against real PG running as the authoritative confirm; CI `test-shard` is the merge gate.

No product code change in this PR — the repo fix is already on `dev` from #2503; this only re-enables the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)