### PR TITLE
sec-mobile-layout-cache-tenant-scope-test-2026-07-23: assert mobile layout cache is tenant-scoped + cleared on logout+re-login

### DIFF
--- a/frontend/apps/mobile/src/features/layout/layout.test.tsx
+++ b/frontend/apps/mobile/src/features/layout/layout.test.tsx
@@ -255,6 +255,91 @@ describe('layoutCache', () => {
   });
 });
 
+// ─── 2b. logout → re-login round-trip (#2486) ────────────────────────────────
+// The pieces above are proven in isolation (scoped key; prefix sweep). This
+// block ties them into the single session-boundary flow the fix has to
+// guarantee end to end: a layout written under user A must NOT survive a
+// logout to activate for the *next* login on a shared device — neither for a
+// different user (B) nor for user A re-authenticating. It drives the REAL
+// writeCachedLayout / readCachedLayout / resetLocalData against one shared
+// in-memory store so nothing is stubbed between write and read.
+describe('layoutCache — logout + re-login round-trip (#2486)', () => {
+  // A single backing store shared by every mocked AsyncStorage method, so the
+  // write → sweep → read sequence flows through the production code paths.
+  function wireSharedStore(initial: Iterable<[string, string]> = []) {
+    const store = new Map<string, string>(initial);
+    (mockAsyncStorage.setItem as jest.Mock).mockImplementation(async (k: string, v: string) => {
+      store.set(k, v);
+    });
+    (mockAsyncStorage.getItem as jest.Mock).mockImplementation(async (k: string) =>
+      store.has(k) ? (store.get(k) as string) : null
+    );
+    (mockAsyncStorage.removeItem as jest.Mock).mockImplementation(async (k: string) => {
+      store.delete(k);
+    });
+    (mockAsyncStorage.getAllKeys as jest.Mock).mockImplementation(async () =>
+      Array.from(store.keys())
+    );
+    (mockAsyncStorage.removeMany as jest.Mock).mockImplementation(async (keys: string[]) => {
+      for (const k of keys) store.delete(k);
+    });
+    return store;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('user A layout does not survive logout to activate for user B on re-login', async () => {
+    const store = wireSharedStore([['ppt_access_token', 'tok-a']]);
+
+    // 1. User A is logged in and their dashboard layout gets cached.
+    await writeCachedLayout('user-a', 'ppt/dashboard', SAMPLE_LAYOUT);
+    expect(await readCachedLayout('user-a', 'ppt/dashboard')).toEqual(SAMPLE_LAYOUT);
+
+    // 2. User A logs out — the session-teardown purge runs.
+    await resetLocalData();
+    expect(store.has('ppt_layout_user-a_ppt_dashboard')).toBe(false);
+
+    // 3. User B logs in on the same device and opens the dashboard: the read
+    //    misses (scoped key never existed AND the sweep cleared everything),
+    //    so B falls back to the default layout + a fresh fetch — never A's
+    //    tenant-customized layout.
+    expect(await readCachedLayout('user-b', 'ppt/dashboard')).toBeNull();
+  });
+
+  it('user A re-authenticating starts from a cleared cache, not the pre-logout layout', async () => {
+    wireSharedStore();
+
+    // User A caches a layout, then logs out.
+    await writeCachedLayout('user-a', 'ppt/dashboard', SAMPLE_LAYOUT);
+    await resetLocalData();
+
+    // Re-login as the SAME user must not resurrect the pre-logout entry — the
+    // logout sweep is unconditional, so the read is a miss until a fresh fetch
+    // repopulates it.
+    expect(await readCachedLayout('user-a', 'ppt/dashboard')).toBeNull();
+
+    // A post-re-login fetch re-populates the (again tenant-scoped) cache, and
+    // that new entry is readable — proving the cache is cleared, not disabled.
+    const freshLayout: ResolvedScreen = { ...SAMPLE_LAYOUT, version: 9 };
+    await writeCachedLayout('user-a', 'ppt/dashboard', freshLayout);
+    expect(await readCachedLayout('user-a', 'ppt/dashboard')).toEqual(freshLayout);
+  });
+
+  it('logout purge leaves the auth token intact so re-login is not forced to re-auth blindly', async () => {
+    const store = wireSharedStore([['ppt_access_token', 'tok-a']]);
+    await writeCachedLayout('user-a', 'ppt/dashboard', SAMPLE_LAYOUT);
+
+    await resetLocalData();
+
+    // Only tenant-cache namespaces are swept; the auth-token key (which is not
+    // under a tenant prefix) must be left for the auth layer to manage.
+    expect(store.has('ppt_layout_user-a_ppt_dashboard')).toBe(false);
+    expect(store.get('ppt_access_token')).toBe('tok-a');
+  });
+});
+
 // ─── 3. useDashboardLayout hook ───────────────────────────────────────────────
 
 describe('useDashboardLayout hook', () => {


### PR DESCRIPTION
## Task
Add mobile test asserting LAYOUT_CACHE_KEY is cleared/tenant-scoped on logout+re-login (follows #2486 fix, which has landed/merged).

## Owner
pm-qa

## What changed
Adds a `layoutCache — logout + re-login round-trip (#2486)` describe block to
`frontend/apps/mobile/src/features/layout/layout.test.tsx`.

The suite already proved the two pieces in isolation — the scoped key
("does not activate org A layout for org B") and the prefix sweep ("layout
cache is cleared on logout via the ppt_layout_ prefix sweep"). This block ties
them into the single session-boundary flow the fix must guarantee end to end,
driving the **real** `writeCachedLayout` / `readCachedLayout` / `resetLocalData`
against one shared in-memory AsyncStorage store (nothing stubbed between write
and read):

1. `user A layout does not survive logout to activate for user B on re-login` —
   write under `user-a` → `resetLocalData()` (logout) → `readCachedLayout('user-b', …)` is `null`.
2. `user A re-authenticating starts from a cleared cache, not the pre-logout layout` —
   same-user re-login also misses; a fresh post-login write repopulates and is
   readable (proves the cache is *cleared*, not disabled).
3. `logout purge leaves the auth token intact` — only tenant-cache namespaces
   are swept; a non-prefixed `ppt_access_token` survives.

Test-only follow-up; no production code touched. The regression it guards would
fail if `LAYOUT_CACHE_KEY` stopped embedding the scope id or `resetLocalData`
stopped sweeping the `ppt_layout_` prefix.

## Verification
```
VERIFY-PLAN base=8bbebbeb049e648596739774c4fe9c8389363f8d files=1
  cd frontend && pnpm exec biome check apps/mobile/src/features/layout/layout.test.tsx
  cd frontend && pnpm --filter "...[8bbebbeb049e648596739774c4fe9c8389363f8d]" typecheck
  cd frontend && pnpm --filter "...[8bbebbeb049e648596739774c4fe9c8389363f8d]" test
```
```
VERIFY OK e0e7ef3de8df48c92d480a802d99c52b6150aa92
```
Full frontend impact suite: 47 suites / 594 tests passed (layout.test.tsx: 19/19,
including the 3 new round-trip tests).

## Scope drift
`scope-check.sh --owner pm-qa` flags `frontend/apps/mobile/src/features/layout/layout.test.tsx`
as outside pm-qa's expected globs (`frontend/**/tests/**`, `frontend/**/__tests__/**`).
This is a **justified** drift: the mobile app (like the rest of the frontend)
co-locates `*.test.tsx` next to source, so pm-qa's `**/tests/**` glob never
matches this project's actual test layout. The change is a single test file.

## Code-reuse review
`reuse-grep.sh --specialist react-native` — no warnings.

## CI parity (Band C — hot-path only)
skipped: test-only change, no security/auth/billing/data-integrity production
code touched (the underlying #2486 fix already merged in #2432/#2492).

## Remote-tested
skipped

## Notes
- Legacy dispatcher task: no `.research/plans/*.md` file exists for this id and
  the branch name (`auto-impl/…`) was fixed by the dispatcher, so `goal-check.sh`
  IG1/IG2 report structural mismatches. IG7 (the verify gate) passed; IG3 is a
  WARN because this is a pure test follow-up to an already-merged fix, so there
  is no paired `fix:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012niN8m6xzatp6HJVf4ruqG

---
_Generated by [Claude Code](https://claude.ai/code/session_012niN8m6xzatp6HJVf4ruqG)_