### PR TITLE
test(api-server): un-quarantine report-scope/rbac/host tests — Wave B2 (BIT-566)

### DIFF
--- a/backend/servers/api-server/src/routes/organizations/mod.rs
+++ b/backend/servers/api-server/src/routes/organizations/mod.rs
@@ -15,6 +15,12 @@ pub mod settings;
 // Re-export all public types so `main.rs` (OpenApi derive) can reference them
 // via `routes::organizations::*` without change.
 pub use core::{
+    // types
+    CreateOrganizationRequest,
+    DeleteOrganizationResponse,
+    ListOrganizationsResponse,
+    OrganizationResponse,
+    UpdateOrganizationRequest,
     // handler fns (needed for utoipa __path_* re-export below)
     __path_create_organization,
     __path_delete_organization,
@@ -22,31 +28,25 @@ pub use core::{
     __path_list_my_organizations,
     __path_list_organizations,
     __path_update_organization,
-    // types
-    CreateOrganizationRequest,
-    DeleteOrganizationResponse,
-    ListOrganizationsResponse,
-    OrganizationResponse,
-    UpdateOrganizationRequest,
 };
 pub use members::{
-    __path_add_organization_member, __path_list_organization_members,
-    __path_remove_organization_member, __path_update_organization_member, AddMemberRequest,
-    AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
-    UpdateMemberRequest, UpdateMemberResponse,
+    AddMemberRequest, AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
+    UpdateMemberRequest, UpdateMemberResponse, __path_add_organization_member,
+    __path_list_organization_members, __path_remove_organization_member,
+    __path_update_organization_member,
 };
 pub use roles::{
-    __path_create_organization_role, __path_delete_organization_role, __path_get_organization_role,
-    __path_list_organization_roles, __path_update_organization_role, CreateRoleRequest,
-    CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse, RoleResponse,
-    UpdateRoleRequest, UpdateRoleResponse,
+    CreateRoleRequest, CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse,
+    RoleResponse, UpdateRoleRequest, UpdateRoleResponse, __path_create_organization_role,
+    __path_delete_organization_role, __path_get_organization_role, __path_list_organization_roles,
+    __path_update_organization_role,
 };
 pub use settings::{
-    __path_export_organization_data, __path_get_organization_branding,
-    __path_get_organization_settings, __path_update_organization_branding,
-    __path_update_organization_settings, ExportMember, ExportQuery, ExportRole,
-    OrganizationBrandingResponse, OrganizationExportResponse, OrganizationSettingsResponse,
-    UpdateOrganizationBrandingRequest, UpdateOrganizationSettingsRequest,
+    ExportMember, ExportQuery, ExportRole, OrganizationBrandingResponse,
+    OrganizationExportResponse, OrganizationSettingsResponse, UpdateOrganizationBrandingRequest,
+    UpdateOrganizationSettingsRequest, __path_export_organization_data,
+    __path_get_organization_branding, __path_get_organization_settings,
+    __path_update_organization_branding, __path_update_organization_settings,
 };
 
 use axum::Router;

--- a/backend/servers/api-server/src/routes/organizations/mod.rs
+++ b/backend/servers/api-server/src/routes/organizations/mod.rs
@@ -15,12 +15,6 @@ pub mod settings;
 // Re-export all public types so `main.rs` (OpenApi derive) can reference them
 // via `routes::organizations::*` without change.
 pub use core::{
-    // types
-    CreateOrganizationRequest,
-    DeleteOrganizationResponse,
-    ListOrganizationsResponse,
-    OrganizationResponse,
-    UpdateOrganizationRequest,
     // handler fns (needed for utoipa __path_* re-export below)
     __path_create_organization,
     __path_delete_organization,
@@ -28,25 +22,31 @@ pub use core::{
     __path_list_my_organizations,
     __path_list_organizations,
     __path_update_organization,
+    // types
+    CreateOrganizationRequest,
+    DeleteOrganizationResponse,
+    ListOrganizationsResponse,
+    OrganizationResponse,
+    UpdateOrganizationRequest,
 };
 pub use members::{
-    AddMemberRequest, AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
-    UpdateMemberRequest, UpdateMemberResponse, __path_add_organization_member,
-    __path_list_organization_members, __path_remove_organization_member,
-    __path_update_organization_member,
+    __path_add_organization_member, __path_list_organization_members,
+    __path_remove_organization_member, __path_update_organization_member, AddMemberRequest,
+    AddMemberResponse, ListMembersResponse, MemberResponse, RemoveMemberResponse,
+    UpdateMemberRequest, UpdateMemberResponse,
 };
 pub use roles::{
-    CreateRoleRequest, CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse,
-    RoleResponse, UpdateRoleRequest, UpdateRoleResponse, __path_create_organization_role,
-    __path_delete_organization_role, __path_get_organization_role, __path_list_organization_roles,
-    __path_update_organization_role,
+    __path_create_organization_role, __path_delete_organization_role, __path_get_organization_role,
+    __path_list_organization_roles, __path_update_organization_role, CreateRoleRequest,
+    CreateRoleResponse, DeleteRoleResponse, GetRoleResponse, ListRolesResponse, RoleResponse,
+    UpdateRoleRequest, UpdateRoleResponse,
 };
 pub use settings::{
-    ExportMember, ExportQuery, ExportRole, OrganizationBrandingResponse,
-    OrganizationExportResponse, OrganizationSettingsResponse, UpdateOrganizationBrandingRequest,
-    UpdateOrganizationSettingsRequest, __path_export_organization_data,
-    __path_get_organization_branding, __path_get_organization_settings,
-    __path_update_organization_branding, __path_update_organization_settings,
+    __path_export_organization_data, __path_get_organization_branding,
+    __path_get_organization_settings, __path_update_organization_branding,
+    __path_update_organization_settings, ExportMember, ExportQuery, ExportRole,
+    OrganizationBrandingResponse, OrganizationExportResponse, OrganizationSettingsResponse,
+    UpdateOrganizationBrandingRequest, UpdateOrganizationSettingsRequest,
 };
 
 use axum::Router;

--- a/backend/servers/api-server/tests/suites/principal_platform_host_tests.rs
+++ b/backend/servers/api-server/tests/suites/principal_platform_host_tests.rs
@@ -128,7 +128,6 @@ fn ensure_jwt_secret() {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_host_allows_platform_principal(pool: PgPool) {
     ensure_jwt_secret();
 
@@ -156,7 +155,6 @@ async fn platform_host_allows_platform_principal(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_host_rejects_staff_principal(pool: PgPool) {
     ensure_jwt_secret();
 
@@ -176,7 +174,6 @@ async fn platform_host_rejects_staff_principal(pool: PgPool) {
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn platform_host_rejects_public_principal(pool: PgPool) {
     ensure_jwt_secret();
 

--- a/backend/servers/api-server/tests/suites/report_schedule_org_scope_jwt_tests.rs
+++ b/backend/servers/api-server/tests/suites/report_schedule_org_scope_jwt_tests.rs
@@ -135,7 +135,6 @@ fn cross_tenant_req(
 /// that drops the org clause and starts mutating the Org A row would be
 /// caught (the response would become `200` or a different 4xx).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -202,7 +201,6 @@ async fn pause_schedule_from_other_org_returns_404(pool: PgPool) {
 /// the cross-tenant resume from Org B must return `404` and leave the row
 /// paused.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_from_other_org_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -267,7 +265,6 @@ async fn resume_schedule_from_other_org_returns_404(pool: PgPool) {
 /// Org B for an Org A schedule must therefore return `404` (schedule not
 /// found in caller's org), not `200` with an empty list and not `401`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_for_other_org_schedule_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -311,7 +308,6 @@ async fn list_executions_for_other_org_schedule_returns_404(pool: PgPool) {
 /// an attacker cannot distinguish "exists in another org" from "does not
 /// exist" by status code or response body.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_unknown_schedule_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/report_schedule_rbac_tests.rs
+++ b/backend/servers/api-server/tests/suites/report_schedule_rbac_tests.rs
@@ -131,7 +131,6 @@ fn put_schedule_req_auth(
 /// proved the outer auth gate worked. This rewrite exercises the actual
 /// RBAC predicate.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_without_manager_role_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -205,7 +204,6 @@ async fn update_schedule_without_manager_role_is_rejected(pool: PgPool) {
 /// repository UPDATE was never executed. This rewrite forces the org-scoped
 /// WHERE clause to actually fire.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_from_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -274,7 +272,6 @@ async fn update_schedule_from_other_org_is_rejected(pool: PgPool) {
 /// be rejected with 4xx by `AuthUser` before any DB access. This is the
 /// legitimate outer-gate test and is intentionally kept as-is.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_without_any_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 

--- a/backend/servers/api-server/tests/suites/report_schedule_sibling_scope_tests.rs
+++ b/backend/servers/api-server/tests/suites/report_schedule_sibling_scope_tests.rs
@@ -170,7 +170,6 @@ fn assert_rejected(status: StatusCode, label: &str) {
 
 /// Unauthenticated request to pause a schedule must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "pause-noauth").await;
@@ -191,7 +190,6 @@ async fn pause_schedule_without_auth_is_rejected(pool: PgPool) {
 /// In TestApp (no JWT) the auth gate fires first → 401.
 /// Either way the cross-tenant mutation is never applied.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -233,7 +231,6 @@ async fn pause_schedule_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to resume a schedule must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "resume-noauth").await;
@@ -263,7 +260,6 @@ async fn resume_schedule_without_auth_is_rejected(pool: PgPool) {
 
 /// A cross-tenant request to resume another org's schedule must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -318,7 +314,6 @@ async fn resume_schedule_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to list executions must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "list-exec-noauth").await;
@@ -337,7 +332,6 @@ async fn list_executions_without_auth_is_rejected(pool: PgPool) {
 
 /// A cross-tenant request to list another org's execution history must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -368,7 +362,6 @@ async fn list_executions_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to get an execution must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "get-exec-noauth").await;
@@ -388,7 +381,6 @@ async fn get_execution_without_auth_is_rejected(pool: PgPool) {
 
 /// A cross-tenant request to read another org's execution must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -418,7 +410,6 @@ async fn get_execution_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to get a download URL must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "dl-url-noauth").await;
@@ -439,7 +430,6 @@ async fn get_execution_download_url_without_auth_is_rejected(pool: PgPool) {
 /// A cross-tenant request to get a download URL for another org's execution
 /// must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -469,7 +459,6 @@ async fn get_execution_download_url_cross_tenant_is_rejected(pool: PgPool) {
 
 /// Unauthenticated request to retry an execution must be rejected.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_without_auth_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "retry-noauth").await;
@@ -490,7 +479,6 @@ async fn retry_execution_without_auth_is_rejected(pool: PgPool) {
 /// A cross-tenant request to retry another org's failed execution must be rejected,
 /// and the execution must remain in its original 'failed' state.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_cross_tenant_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -553,7 +541,6 @@ async fn retry_execution_cross_tenant_is_rejected(pool: PgPool) {
 /// row, and the handler maps `AppError::NotFound` to `404 SCHEDULE_NOT_FOUND`.
 /// The Org A schedule must remain active.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn pause_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -617,7 +604,6 @@ async fn pause_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// schedule owned by `org_a`. Must hit the org-scoped WHERE and return 404.
 /// Org A's schedule must remain paused.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn resume_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -694,7 +680,6 @@ async fn resume_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// lives in `org_a`), and returns 404 `SCHEDULE_NOT_FOUND` before any
 /// executions are listed.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn list_executions_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -748,7 +733,6 @@ async fn list_executions_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// `report_schedules.organization_id`, finds no row, and returns 404
 /// `EXECUTION_NOT_FOUND`.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -798,7 +782,6 @@ async fn get_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// `get_execution_scoped(id, org_b)` before generating any URL, finds no row,
 /// and returns 404 `EXECUTION_NOT_FOUND` — no download URL is leaked.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_execution_download_url_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -853,7 +836,6 @@ async fn get_execution_download_url_cross_tenant_authenticated_returns_404(pool:
 /// `AppError::NotFound` → `404 EXECUTION_NOT_FOUND`. The execution must
 /// remain in `failed` state (not reset to `pending`).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn retry_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
 
@@ -925,7 +907,6 @@ async fn retry_execution_cross_tenant_authenticated_returns_404(pool: PgPool) {
 /// no row, and returns `AppError::NotFound` → `404 SCHEDULE_NOT_FOUND`.
 /// Org A's schedule recipients must be unchanged.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn update_schedule_cross_tenant_authenticated_returns_404(pool: PgPool) {
     use serde_json::json;
 

--- a/backend/servers/api-server/tests/suites/reports_export_org_scope_tests.rs
+++ b/backend/servers/api-server/tests/suites/reports_export_org_scope_tests.rs
@@ -76,7 +76,6 @@ async fn setup(pool: &PgPool, app: &TestApp) -> (String, Uuid, Uuid) {
 /// not match the caller's tenant (Org B). On dev it trusts the body and
 /// proceeds; the fix returns 403.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn export_report_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org_a, org_b) = setup(&pool, &app).await;
@@ -108,7 +107,6 @@ async fn export_report_for_other_org_is_rejected(pool: PgPool) {
 /// owned by Org A; the caller is in Org B. On dev it returns the status; the
 /// fix returns 404.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_export_job_status_for_other_org_is_rejected(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, org_a, org_b) = setup(&pool, &app).await;
@@ -133,7 +131,6 @@ async fn get_export_job_status_for_other_org_is_rejected(pool: PgPool) {
 
 /// Same-tenant export job status is readable (the guard must not over-reject).
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]
 async fn get_export_job_status_for_own_org_is_allowed(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let (token, _org_a, org_b) = setup(&pool, &app).await;


### PR DESCRIPTION
## Summary

- Removes BIT-351 quarantine `#[ignore]` markers from 5 test files / **32 tests** in `tests/suites/`
- Wave B2 (security-lite) of BIT-354 repair epic

**Files de-quarantined:**
- `principal_platform_host_tests.rs` — 3 tests (RequestPrincipal × PlatformHost header isolation)
- `report_schedule_org_scope_jwt_tests.rs` — 4 tests (JWT org-scope: pause/resume/executions cross-tenant 404)
- `report_schedule_rbac_tests.rs` — 3 tests (RBAC: Resident 403, cross-org Manager 404, no-auth 4xx)
- `report_schedule_sibling_scope_tests.rs` — 19 tests (auth-gate + authenticated cross-tenant isolation matrix)
- `reports_export_org_scope_tests.rs` — 3 tests (export IDOR: foreign-org 403, cross-org job 404, own-org 200)

## Verification

- Schema reviewed: `report_schedules`, `report_executions`, `background_jobs` — all columns used by seed helpers exist
- Route handlers reviewed: org-isolation logic confirmed present (`RlsConnection` scoped WHERE, `org_id` check on background_jobs export)
- CI `test` gate (suite_7 + suite_8) will provide the real verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)