### PR TITLE
test-scheduler-target-ids-regression-2026-07-23: regression test for scheduler malformed target_ids silent-parse (PR #2436)

### DIFF
--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -2072,4 +2072,88 @@ mod tests {
         let ids = parse_announcement_target_ids(Uuid::new_v4(), "all", &payload);
         assert!(ids.is_empty(), "null target_ids degrades to empty");
     }
+
+    // ------------------------------------------------------------------
+    // Regression (PR #2436): the malformed-parse must NOT be silent. IG3.
+    //
+    // The `*_falls_back_to_empty` tests above only pin the *return value*
+    // (empty Vec). That value is identical to the pre-#2436 behaviour,
+    // which parsed with `serde_json::from_value(...).unwrap_or_default()`
+    // and swallowed the error silently — so those tests pass on BOTH the
+    // pre-fix and post-fix code and cannot guard the regression the fix
+    // actually made: emitting a diagnostic `warn` so a broken announcement
+    // is discoverable instead of silently publishing zero notifications.
+    //
+    // This test captures the tracing output and asserts a WARN event
+    // carrying the diagnostic message and the announcement id. It FAILS on
+    // the pre-fix silent `unwrap_or_default()` (no event emitted) and PASSES
+    // on current dev — the discriminating property IG3 requires.
+    // ------------------------------------------------------------------
+
+    /// A `MakeWriter` that appends every subscriber write into a shared
+    /// buffer so a `#[test]` can inspect what tracing emitted.
+    #[derive(Clone)]
+    struct CaptureWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn test_parse_target_ids_malformed_emits_diagnostic_warning() {
+        let buf = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(CaptureWriter(buf.clone()))
+            .with_max_level(tracing::Level::WARN)
+            .with_ansi(false)
+            .finish();
+
+        let announcement_id = Uuid::new_v4();
+        let payload = serde_json::json!({ "not": "a uuid array" });
+
+        // `parse_announcement_target_ids` is synchronous, so a thread-local
+        // default subscriber captures its `warn!` deterministically.
+        let ids = tracing::subscriber::with_default(subscriber, || {
+            parse_announcement_target_ids(announcement_id, "building", &payload)
+        });
+
+        assert!(
+            ids.is_empty(),
+            "malformed target_ids must still degrade to an empty target set"
+        );
+
+        let captured = String::from_utf8(buf.lock().unwrap_or_else(|e| e.into_inner()).clone())
+            .expect("captured tracing output is valid utf-8");
+
+        assert!(
+            captured.contains("Failed to parse announcement target_ids"),
+            "the malformed parse must emit a diagnostic warn, not silently \
+             swallow the error (pre-#2436 used unwrap_or_default()); captured: {captured:?}"
+        );
+        assert!(
+            captured.contains("WARN"),
+            "the diagnostic must be emitted at WARN level; captured: {captured:?}"
+        );
+        assert!(
+            captured.contains(&announcement_id.to_string()),
+            "the warn must carry the announcement id so the broken row is \
+             diagnosable; captured: {captured:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Task
Backfill regression test for scheduler malformed target_ids parse (fix in #2436, merged) — currently no test asserts the silent-parse behavior is gone. IG3: the test should fail on the pre-fix behavior and pass on current dev.

## Owner
pm-qa

## What / why
PR #2436 replaced `serde_json::from_value(announcement.target_ids.clone()).unwrap_or_default()` with `parse_announcement_target_ids(...)`, whose sole behavioural change is emitting a `tracing::warn!` on a malformed payload (both pre- and post-fix return an empty `Vec`).

The existing `test_parse_target_ids_*_falls_back_to_empty` tests only assert the empty-`Vec` return value — which is **identical** to the pre-fix behaviour — so they pass on both pre- and post-fix code and do **not** guard the regression. The genuine IG3 gap was a test asserting the diagnostic warn is emitted (i.e. that the parse is no longer silent).

This adds `test_parse_target_ids_malformed_emits_diagnostic_warning`: it installs a thread-local `tracing` subscriber over a capturing `MakeWriter`, calls the (synchronous, private) `parse_announcement_target_ids` with a malformed payload, and asserts a **WARN** event carrying the diagnostic message and the announcement id. Self-contained — uses the already-present `tracing-subscriber` dep, no new crates.

## IG3 evidence (fails pre-fix, passes on dev)
- **Post-fix (current dev):** `PASS` — `cargo test -p api-server --lib services::scheduler::tests::test_parse_target_ids_malformed_emits_diagnostic_warning` → `ok`.
- **Pre-fix (silent `unwrap_or_default()`) — locally simulated by reverting the fn body:** `FAILED` with `the malformed parse must emit a diagnostic warn, not silently swallow the error (pre-#2436 used unwrap_or_default()); captured: ""`. The reversion was restored before committing (diff is +84/−0, test-only).

## Verification
Ran the impact-scoped gate steps manually (`just` not installed in this env; used `scripts/verify-impact.sh` plan verbatim). A local PostgreSQL 16 cluster was stood up for the DB-backed `#[sqlx::test]`s, and `utoipa-swagger-ui`'s download-based build was satisfied from the npm `swagger-ui-dist` mirror via `SWAGGER_UI_DOWNLOAD_URL` (GitHub archive downloads are egress-blocked in this env).

```
VERIFY-PLAN base=8bbebbeb049e648596739774c4fe9c8389363f8d files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` → **clean** (exit 0)
- `cargo clippy -p api-server --all-targets -- -D warnings` → **clean** (exit 0)
- `cargo test -p api-server --lib services::scheduler::tests` → **18 passed, 0 failed** (incl. the new test and both `#[sqlx::test]` fan-out tests against the local DB)
- Full `cargo test -p api-server` → all lib tests green; one integration test (`airbnb_oauth_routes_tests::token_exchange_returns_503_when_not_configured`) flaked with `PoolTimedOut` under full-parallel per-test-DB load and **passes deterministically in isolation** (unrelated to this diff, which is a single lib unit test).

## Scope drift
`scope-check.sh --owner pm-qa` reports drift (exit 2): `backend/servers/api-server/src/services/scheduler.rs`. Justified — the regression must exercise the **private** `fn parse_announcement_target_ids`, which is only reachable from an inline `#[cfg(test)]` module in the source file; pm-qa's `backend/**/tests/**` areas (external integration tests) cannot see a private fn. Change is test-only (`#[cfg(test)]`), no production code touched.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → none.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only, no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in this session).

## Notes
- Pure test backfill: no `fix:` commit pairs with the `test:` commit because the fix already shipped in #2436 (goal-check IG3 WARN is expected for a backfill vector).
- This is a legacy dispatcher task with no `.research/plans/<slug>.md`; goal-check IG1/IG2/IG8 reference the plan-based flow and don't apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_012niN8m6xzatp6HJVf4ruqG)_