### PR TITLE
data-fault-kpi-unification-2026-07-23: unify FaultStatusCount metric with fault KPIs

### DIFF
--- a/backend/crates/db/src/repositories/fault.rs
+++ b/backend/crates/db/src/repositories/fault.rs
@@ -37,6 +37,47 @@ use serde_json::Value as JsonValue;
 use sqlx::{Error as SqlxError, Executor, FromRow, Postgres};
 use uuid::Uuid;
 
+/// Canonical fault-by-status KPI definition — the single source of truth.
+///
+/// Both the owner/portfolio fault statistics ([`FaultStatistics::by_status`]) and
+/// the platform-admin support-data diagnostics (`SupportData.fault_by_status`)
+/// derive their per-status fault counts from this one query, so the two
+/// dashboards can never disagree. This unifies the dual `FaultStatusCount`
+/// definition flagged in the 2026-05-28 pm-data decision — do not reintroduce a
+/// second inline `GROUP BY status` count; call this instead.
+///
+/// Scope:
+/// - `org_id = None` counts faults across **all** organisations (platform scope,
+///   used by the support-data admin page).
+/// - `org_id = Some(_)` scopes to a single organisation, optionally narrowed to
+///   one building via `building_id`.
+///
+/// Rows are ordered by descending count so callers can render "top statuses"
+/// directly.
+pub async fn fault_counts_by_status<'e, E>(
+    executor: E,
+    org_id: Option<Uuid>,
+    building_id: Option<Uuid>,
+) -> Result<Vec<StatusCount>, SqlxError>
+where
+    E: Executor<'e, Database = Postgres>,
+{
+    sqlx::query_as::<_, StatusCount>(
+        r#"
+        SELECT status::text AS status, COUNT(*) AS count
+        FROM faults
+        WHERE ($1::uuid IS NULL OR organization_id = $1)
+          AND ($2::uuid IS NULL OR building_id = $2)
+        GROUP BY status
+        ORDER BY count DESC
+        "#,
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .fetch_all(executor)
+    .await
+}
+
 /// Row struct for fault with details query.
 #[derive(Debug, FromRow)]
 struct FaultDetailsRow {
@@ -1265,21 +1306,8 @@ impl FaultRepository {
         .fetch_one(&self.pool)
         .await?;
 
-        // By status
-        let by_status = sqlx::query_as::<_, StatusCount>(
-            r#"
-            SELECT status::text as status, COUNT(*) as count
-            FROM faults
-            WHERE organization_id = $1
-              AND ($2::uuid IS NULL OR building_id = $2)
-            GROUP BY status
-            ORDER BY count DESC
-            "#,
-        )
-        .bind(org_id)
-        .bind(building_id)
-        .fetch_all(&self.pool)
-        .await?;
+        // By status — canonical KPI definition (single source of truth).
+        let by_status = fault_counts_by_status(&self.pool, Some(org_id), building_id).await?;
 
         // By category
         let by_category = sqlx::query_as::<_, CategoryCount>(

--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -31,6 +31,7 @@ use crate::models::platform_admin::{
     AdminOrganizationDetail, OrganizationDetailMetrics, OrganizationMetrics,
 };
 use crate::models::Organization;
+use crate::repositories::fault::fault_counts_by_status;
 use crate::DbPool;
 use chrono::{DateTime, Utc};
 use sqlx::Error as SqlxError;
@@ -627,24 +628,12 @@ impl PlatformAdminRepository {
             .fetch_one(&mut *tx)
             .await?;
 
-        // 5. Fault counts per status
-        let fault_rows = sqlx::query_as::<_, (String, i64)>(
-            r#"
-            SELECT status::text, COUNT(*) AS cnt
-            FROM faults
-            GROUP BY status
-            ORDER BY cnt DESC
-            "#,
-        )
-        .fetch_all(&mut *tx)
-        .await?;
+        // 5. Fault counts per status — canonical KPI definition shared with the
+        //    owner/portfolio fault statistics (single source of truth). Platform
+        //    scope => no organisation/building filter.
+        let fault_by_status = fault_counts_by_status(&mut *tx, None, None).await?;
 
         tx.commit().await?;
-
-        let fault_by_status = fault_rows
-            .into_iter()
-            .map(|(status, count)| FaultStatusCount { status, count })
-            .collect();
 
         Ok(SupportData {
             total_orgs,

--- a/backend/crates/db/tests/suite_2.rs
+++ b/backend/crates/db/tests/suite_2.rs
@@ -21,6 +21,8 @@ mod esg_force_rls_cross_tenant_tests;
 mod esignature_workflow_repo_tests;
 #[path = "suites/facility_enum_decode_tests.rs"]
 mod facility_enum_decode_tests;
+#[path = "suites/fault_kpi_unification_tests.rs"]
+mod fault_kpi_unification_tests;
 #[path = "suites/favorite_alert_read_idempotent_tests.rs"]
 mod favorite_alert_read_idempotent_tests;
 #[path = "suites/form_rls_repo_tests.rs"]

--- a/backend/crates/db/tests/suites/fault_kpi_unification_tests.rs
+++ b/backend/crates/db/tests/suites/fault_kpi_unification_tests.rs
@@ -1,0 +1,175 @@
+//! Regression guard for the unified fault-by-status KPI definition
+//! (2026-05-28 pm-data decision, `data-fault-kpi-unification-2026-07-23`).
+//!
+//! Background
+//! ----------
+//! Two code paths reported per-status fault counts from their own inline
+//! `GROUP BY status` query:
+//!
+//! * the owner/portfolio statistics — `FaultRepository::get_statistics().by_status`
+//!   (organisation-scoped, optionally building-scoped), and
+//! * the platform-admin support-data diagnostics —
+//!   `PlatformAdminRepository::get_support_data().fault_by_status` (global).
+//!
+//! Because the two SQL fragments were maintained independently, a change to one
+//! (a different `WHERE`, a status renamed, a filter added) could silently make
+//! the two dashboards disagree. Both now derive from the single
+//! `db::repositories::fault::fault_counts_by_status` definition. This test pins
+//! the contract: the global support-data counts must equal the sum of the
+//! per-organisation statistics counts, status by status.
+
+use std::collections::BTreeMap;
+
+use db::repositories::{FaultRepository, PlatformAdminRepository};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Org {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@orgs.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO buildings (organization_id, street, city, postal_code)
+        VALUES ($1, 'Test Street 1', 'Bratislava', '81101')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed building")
+}
+
+async fn seed_reporter(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'KPI Reporter', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed reporter")
+}
+
+/// Insert `n` faults with the given `status` for one org/building/reporter.
+async fn seed_faults(
+    pool: &PgPool,
+    org_id: Uuid,
+    building_id: Uuid,
+    reporter_id: Uuid,
+    status: &str,
+    n: i64,
+) {
+    for _ in 0..n {
+        sqlx::query(
+            r#"
+            INSERT INTO faults (organization_id, building_id, reporter_id, title, description, status)
+            VALUES ($1, $2, $3, 'Broken thing', 'It is broken', $4::fault_status)
+            "#,
+        )
+        .bind(org_id)
+        .bind(building_id)
+        .bind(reporter_id)
+        .bind(status)
+        .execute(pool)
+        .await
+        .expect("seed fault");
+    }
+}
+
+fn counts_map<I>(rows: I) -> BTreeMap<String, i64>
+where
+    I: IntoIterator<Item = (String, i64)>,
+{
+    rows.into_iter().collect()
+}
+
+/// The platform-admin (global) fault-by-status counts must exactly equal the
+/// sum of the per-organisation owner/portfolio statistics counts — i.e. both
+/// dashboards read from one shared definition and can never disagree.
+#[sqlx::test(migrations = "./migrations")]
+async fn support_data_and_owner_stats_agree_on_fault_status_counts(pool: PgPool) {
+    let org_a = seed_org(&pool, "kpi-a").await;
+    let org_b = seed_org(&pool, "kpi-b").await;
+    let bld_a = seed_building(&pool, org_a).await;
+    let bld_b = seed_building(&pool, org_b).await;
+    let rep_a = seed_reporter(&pool, "kpi-a@reporters.test").await;
+    let rep_b = seed_reporter(&pool, "kpi-b@reporters.test").await;
+
+    // Org A: 2 new, 1 closed. Org B: 1 new, 3 resolved.
+    seed_faults(&pool, org_a, bld_a, rep_a, "new", 2).await;
+    seed_faults(&pool, org_a, bld_a, rep_a, "closed", 1).await;
+    seed_faults(&pool, org_b, bld_b, rep_b, "new", 1).await;
+    seed_faults(&pool, org_b, bld_b, rep_b, "resolved", 3).await;
+
+    let fault_repo = FaultRepository::new(pool.clone());
+    let admin_repo = PlatformAdminRepository::new(pool.clone());
+
+    let stats_a = fault_repo
+        .get_statistics(org_a, None)
+        .await
+        .expect("owner stats A");
+    let stats_b = fault_repo
+        .get_statistics(org_b, None)
+        .await
+        .expect("owner stats B");
+    let support = admin_repo.get_support_data().await.expect("support data");
+
+    // Per-org owner statistics carry exactly what was seeded.
+    let map_a = counts_map(
+        stats_a
+            .by_status
+            .iter()
+            .map(|c| (c.status.clone(), c.count)),
+    );
+    assert_eq!(map_a.get("new"), Some(&2), "org A new");
+    assert_eq!(map_a.get("closed"), Some(&1), "org A closed");
+    assert_eq!(map_a.get("resolved"), None, "org A has no resolved");
+
+    let map_b = counts_map(
+        stats_b
+            .by_status
+            .iter()
+            .map(|c| (c.status.clone(), c.count)),
+    );
+    assert_eq!(map_b.get("new"), Some(&1), "org B new");
+    assert_eq!(map_b.get("resolved"), Some(&3), "org B resolved");
+
+    // The shared-definition invariant: global == sum of per-org, per status.
+    let global = counts_map(
+        support
+            .fault_by_status
+            .iter()
+            .map(|c| (c.status.clone(), c.count)),
+    );
+
+    let mut expected: BTreeMap<String, i64> = BTreeMap::new();
+    for (status, count) in map_a.iter().chain(map_b.iter()) {
+        *expected.entry(status.clone()).or_insert(0) += *count;
+    }
+
+    assert_eq!(
+        global, expected,
+        "support-data global fault-by-status must equal the sum of per-org owner statistics"
+    );
+    assert_eq!(global.get("new"), Some(&3), "global new = 2 (A) + 1 (B)");
+    assert_eq!(global.get("closed"), Some(&1), "global closed = 1 (A)");
+    assert_eq!(global.get("resolved"), Some(&3), "global resolved = 3 (B)");
+}


### PR DESCRIPTION
Auto: Unify FaultStatusCount metric with owner/portfolio fault KPIs into one shared definition (open decision from 2026-05-28)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8dh94ZjeJKcmzKWdxErwC)_