### PR TITLE
data-audit-oauth-token-usage-2026-07-23: add OAuth token-usage analytics data layer

### DIFF
--- a/backend/crates/db/migrations/00224_create_oauth_token_events.sql
+++ b/backend/crates/db/migrations/00224_create_oauth_token_events.sql
@@ -1,0 +1,32 @@
+-- Epic 10A (data audit): OAuth token-usage analytics.
+-- Records issuance / refresh / revocation events per OAuth client so the
+-- platform-admin ecosystem-health dashboard can report first-party OAuth
+-- token usage. System-scoped like the other oauth_* provider tables
+-- (see 00028_create_oauth_provider.sql): no org_id / no tenant RLS — these
+-- rows are platform-level and read only by super admins.
+
+CREATE TABLE IF NOT EXISTS oauth_token_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    -- Lifecycle event: 'issued' | 'refreshed' | 'revoked'
+    event_type VARCHAR(16) NOT NULL CHECK (event_type IN ('issued', 'refreshed', 'revoked')),
+    client_id VARCHAR(64) NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+    -- Nullable: client-level revocations are not tied to a single user.
+    user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+    -- Which token the event concerns: 'access' | 'refresh'
+    token_type VARCHAR(16) NOT NULL DEFAULT 'access' CHECK (token_type IN ('access', 'refresh')),
+    -- OAuth grant_type for issuance/refresh events (authorization_code, refresh_token, …)
+    grant_type VARCHAR(32),
+    scopes JSONB NOT NULL DEFAULT '[]',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Dashboard queries roll up per client, over a recent time window.
+CREATE INDEX IF NOT EXISTS idx_oauth_token_events_client_id ON oauth_token_events(client_id);
+CREATE INDEX IF NOT EXISTS idx_oauth_token_events_created_at ON oauth_token_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_oauth_token_events_client_created
+    ON oauth_token_events(client_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_oauth_token_events_event_type ON oauth_token_events(event_type);
+
+-- Note: like the other oauth_* provider tables, RLS is intentionally omitted.
+-- These are platform-level analytics rows written by the OAuth service and
+-- read only through super-admin dashboards.

--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -30,6 +30,7 @@ pub mod messaging;
 pub mod meter;
 pub mod notification_preference;
 pub mod oauth;
+pub mod oauth_token_event;
 pub mod organization;
 pub mod organization_member;
 pub mod password_reset;
@@ -238,6 +239,10 @@ pub use oauth::{
     OAuthClientSummary, OAuthError, OAuthRefreshToken, OAuthScope, RegisterClientRequest,
     RegisterClientResponse, RevokeTokenRequest, ScopeDisplay, TokenRequest, TokenResponse,
     UpdateOAuthClient, UserGrantWithClient, UserGrantWithClientRow, UserOAuthGrant,
+};
+pub use oauth_token_event::{
+    CreateOAuthTokenEvent, OAuthClientTokenUsage, OAuthTokenEvent, OAuthTokenEventTotals,
+    OAuthTokenEventType, OAuthTokenKind,
 };
 pub use organization::{
     CreateOrganization, Organization, OrganizationStatus, OrganizationSummary, UpdateOrganization,

--- a/backend/crates/db/src/models/oauth_token_event.rs
+++ b/backend/crates/db/src/models/oauth_token_event.rs
@@ -1,0 +1,175 @@
+//! OAuth token-usage analytics models (Epic 10A — data audit).
+//!
+//! These models back the `oauth_token_events` table, which records
+//! issuance / refresh / revocation of first-party OAuth tokens per client so
+//! the platform-admin ecosystem-health dashboard can surface OAuth usage.
+//! The table is system-scoped (no org / RLS) like the other `oauth_*` tables.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+/// Lifecycle event tracked for per-client OAuth token-usage analytics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthTokenEventType {
+    /// A new access (and optionally refresh) token was minted.
+    Issued,
+    /// A refresh token was exchanged for a new access token.
+    Refreshed,
+    /// An access or refresh token was revoked.
+    Revoked,
+}
+
+impl OAuthTokenEventType {
+    /// Stable database representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Issued => "issued",
+            Self::Refreshed => "refreshed",
+            Self::Revoked => "revoked",
+        }
+    }
+
+    /// Parse from the database representation.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "issued" => Some(Self::Issued),
+            "refreshed" => Some(Self::Refreshed),
+            "revoked" => Some(Self::Revoked),
+            _ => None,
+        }
+    }
+}
+
+/// Which token an event concerns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OAuthTokenKind {
+    /// Short-lived access token.
+    Access,
+    /// Long-lived refresh token.
+    Refresh,
+}
+
+impl OAuthTokenKind {
+    /// Stable database representation.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Access => "access",
+            Self::Refresh => "refresh",
+        }
+    }
+
+    /// Parse from the database representation.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "access" => Some(Self::Access),
+            "refresh" => Some(Self::Refresh),
+            _ => None,
+        }
+    }
+}
+
+/// A recorded OAuth token lifecycle event (row of `oauth_token_events`).
+#[derive(Debug, Clone, FromRow)]
+pub struct OAuthTokenEvent {
+    pub id: Uuid,
+    pub event_type: String,
+    pub client_id: String,
+    pub user_id: Option<Uuid>,
+    pub token_type: String,
+    pub grant_type: Option<String>,
+    pub scopes: sqlx::types::Json<Vec<String>>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Data for recording a new token event.
+#[derive(Debug, Clone)]
+pub struct CreateOAuthTokenEvent {
+    pub event_type: OAuthTokenEventType,
+    pub client_id: String,
+    pub user_id: Option<Uuid>,
+    pub token_type: OAuthTokenKind,
+    /// OAuth `grant_type` (e.g. `authorization_code`, `refresh_token`); absent
+    /// for revocations.
+    pub grant_type: Option<String>,
+    pub scopes: Vec<String>,
+}
+
+impl CreateOAuthTokenEvent {
+    /// Convenience constructor for an issuance event.
+    pub fn issued(
+        client_id: impl Into<String>,
+        user_id: Option<Uuid>,
+        scopes: Vec<String>,
+    ) -> Self {
+        Self {
+            event_type: OAuthTokenEventType::Issued,
+            client_id: client_id.into(),
+            user_id,
+            token_type: OAuthTokenKind::Access,
+            grant_type: Some("authorization_code".to_string()),
+            scopes,
+        }
+    }
+
+    /// Convenience constructor for a refresh event.
+    pub fn refreshed(
+        client_id: impl Into<String>,
+        user_id: Option<Uuid>,
+        scopes: Vec<String>,
+    ) -> Self {
+        Self {
+            event_type: OAuthTokenEventType::Refreshed,
+            client_id: client_id.into(),
+            user_id,
+            token_type: OAuthTokenKind::Access,
+            grant_type: Some("refresh_token".to_string()),
+            scopes,
+        }
+    }
+
+    /// Convenience constructor for a revocation event.
+    pub fn revoked(
+        client_id: impl Into<String>,
+        user_id: Option<Uuid>,
+        token_type: OAuthTokenKind,
+    ) -> Self {
+        Self {
+            event_type: OAuthTokenEventType::Revoked,
+            client_id: client_id.into(),
+            user_id,
+            token_type,
+            grant_type: None,
+            scopes: Vec::new(),
+        }
+    }
+}
+
+/// Per-client rollup of token-usage counts for the ecosystem-health dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuthClientTokenUsage {
+    pub client_id: String,
+    /// Client display name (NULL if the client row was removed).
+    pub client_name: Option<String>,
+    pub issued_count: i64,
+    pub refreshed_count: i64,
+    pub revoked_count: i64,
+    /// Timestamp of the most recent event for this client in the window.
+    pub last_event_at: Option<DateTime<Utc>>,
+}
+
+/// Whole-ecosystem token-usage totals over a time window.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct OAuthTokenEventTotals {
+    pub issued_count: i64,
+    pub refreshed_count: i64,
+    pub revoked_count: i64,
+    /// Distinct clients that produced at least one event in the window.
+    pub active_clients: i64,
+}

--- a/backend/crates/db/src/repositories/mod.rs
+++ b/backend/crates/db/src/repositories/mod.rs
@@ -38,6 +38,7 @@ pub mod meter;
 pub mod notification_event;
 pub mod notification_preference;
 pub mod oauth;
+pub mod oauth_token_event;
 pub mod onboarding;
 pub mod organization;
 pub mod organization_member;
@@ -131,6 +132,7 @@ pub use meter::MeterRepository;
 pub use notification_event::{total_counts, NotificationEventRepository};
 pub use notification_preference::NotificationPreferenceRepository;
 pub use oauth::OAuthRepository;
+pub use oauth_token_event::OAuthTokenEventRepository;
 pub use onboarding::{
     OnboardingRepository, OnboardingTour, TourStep, TourWithProgress, UserOnboardingProgress,
 };

--- a/backend/crates/db/src/repositories/oauth_token_event.rs
+++ b/backend/crates/db/src/repositories/oauth_token_event.rs
@@ -1,0 +1,230 @@
+//! OAuth token-usage analytics repository (Epic 10A — data audit).
+//!
+//! Records per-client OAuth token lifecycle events (issuance / refresh /
+//! revocation) and rolls them up for the platform-admin ecosystem-health
+//! dashboard. Recording is intended to be best-effort: callers on the token
+//! issuance/refresh/revocation paths should log-and-ignore any error returned
+//! by [`OAuthTokenEventRepository::record`] so analytics never breaks the
+//! OAuth flow itself.
+
+use crate::models::oauth_token_event::{
+    CreateOAuthTokenEvent, OAuthClientTokenUsage, OAuthTokenEvent, OAuthTokenEventTotals,
+};
+use crate::DbPool;
+use chrono::{DateTime, Utc};
+use sqlx::Error as SqlxError;
+
+/// Repository for OAuth token-usage analytics.
+#[derive(Clone)]
+pub struct OAuthTokenEventRepository {
+    pool: DbPool,
+}
+
+impl OAuthTokenEventRepository {
+    /// Create a new `OAuthTokenEventRepository`.
+    pub fn new(pool: DbPool) -> Self {
+        Self { pool }
+    }
+
+    /// Record a single OAuth token lifecycle event.
+    ///
+    /// Best-effort: callers on the hot OAuth path should not fail token
+    /// issuance if this returns an error — log and continue.
+    pub async fn record(&self, data: CreateOAuthTokenEvent) -> Result<OAuthTokenEvent, SqlxError> {
+        let event = sqlx::query_as::<_, OAuthTokenEvent>(
+            r#"
+            INSERT INTO oauth_token_events
+                (event_type, client_id, user_id, token_type, grant_type, scopes)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING *
+            "#,
+        )
+        .bind(data.event_type.as_str())
+        .bind(&data.client_id)
+        .bind(data.user_id)
+        .bind(data.token_type.as_str())
+        .bind(&data.grant_type)
+        .bind(sqlx::types::Json(&data.scopes))
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(event)
+    }
+
+    /// Per-client token-usage rollup for events at or after `since`, ordered by
+    /// issuance volume. Powers the ecosystem-health dashboard's per-client view.
+    pub async fn usage_per_client(
+        &self,
+        since: DateTime<Utc>,
+    ) -> Result<Vec<OAuthClientTokenUsage>, SqlxError> {
+        let rows = sqlx::query_as::<_, OAuthClientTokenUsage>(
+            r#"
+            SELECT
+                e.client_id AS client_id,
+                c.name      AS client_name,
+                COUNT(*) FILTER (WHERE e.event_type = 'issued')    AS issued_count,
+                COUNT(*) FILTER (WHERE e.event_type = 'refreshed') AS refreshed_count,
+                COUNT(*) FILTER (WHERE e.event_type = 'revoked')   AS revoked_count,
+                MAX(e.created_at)                                  AS last_event_at
+            FROM oauth_token_events e
+            LEFT JOIN oauth_clients c ON c.client_id = e.client_id
+            WHERE e.created_at >= $1
+            GROUP BY e.client_id, c.name
+            ORDER BY issued_count DESC, e.client_id ASC
+            "#,
+        )
+        .bind(since)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows)
+    }
+
+    /// Whole-ecosystem token-usage totals for events at or after `since`.
+    pub async fn totals(&self, since: DateTime<Utc>) -> Result<OAuthTokenEventTotals, SqlxError> {
+        let totals = sqlx::query_as::<_, OAuthTokenEventTotals>(
+            r#"
+            SELECT
+                COUNT(*) FILTER (WHERE event_type = 'issued')    AS issued_count,
+                COUNT(*) FILTER (WHERE event_type = 'refreshed') AS refreshed_count,
+                COUNT(*) FILTER (WHERE event_type = 'revoked')   AS revoked_count,
+                COUNT(DISTINCT client_id)                        AS active_clients
+            FROM oauth_token_events
+            WHERE created_at >= $1
+            "#,
+        )
+        .bind(since)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(totals)
+    }
+
+    /// Delete events older than `cutoff`. Retention housekeeping for the
+    /// analytics table; returns the number of rows removed.
+    pub async fn cleanup_before(&self, cutoff: DateTime<Utc>) -> Result<u64, SqlxError> {
+        let result = sqlx::query(
+            r#"
+            DELETE FROM oauth_token_events WHERE created_at < $1
+            "#,
+        )
+        .bind(cutoff)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::oauth_token_event::{CreateOAuthTokenEvent, OAuthTokenKind};
+    use chrono::Duration;
+
+    /// Insert a minimal OAuth client and return its `client_id`.
+    async fn make_client(pool: &sqlx::PgPool, client_id: &str) {
+        sqlx::query(
+            "INSERT INTO oauth_clients (client_id, client_secret_hash, name) \
+             VALUES ($1, 'secret-hash', 'Test Client')",
+        )
+        .bind(client_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn record_and_rollup_per_client(pool: sqlx::PgPool) {
+        let repo = OAuthTokenEventRepository::new(pool.clone());
+        make_client(&pool, "client-a").await;
+        make_client(&pool, "client-b").await;
+
+        // client-a: 2 issued, 1 refreshed, 1 revoked
+        repo.record(CreateOAuthTokenEvent::issued(
+            "client-a",
+            None,
+            vec!["profile".to_string()],
+        ))
+        .await
+        .unwrap();
+        repo.record(CreateOAuthTokenEvent::issued("client-a", None, vec![]))
+            .await
+            .unwrap();
+        repo.record(CreateOAuthTokenEvent::refreshed("client-a", None, vec![]))
+            .await
+            .unwrap();
+        repo.record(CreateOAuthTokenEvent::revoked(
+            "client-a",
+            None,
+            OAuthTokenKind::Refresh,
+        ))
+        .await
+        .unwrap();
+
+        // client-b: 1 issued
+        repo.record(CreateOAuthTokenEvent::issued("client-b", None, vec![]))
+            .await
+            .unwrap();
+
+        let since = Utc::now() - Duration::hours(1);
+        let usage = repo.usage_per_client(since).await.unwrap();
+        assert_eq!(usage.len(), 2);
+
+        // Ordered by issued_count DESC → client-a first.
+        let a = &usage[0];
+        assert_eq!(a.client_id, "client-a");
+        assert_eq!(a.client_name.as_deref(), Some("Test Client"));
+        assert_eq!(a.issued_count, 2);
+        assert_eq!(a.refreshed_count, 1);
+        assert_eq!(a.revoked_count, 1);
+        assert!(a.last_event_at.is_some());
+
+        let b = &usage[1];
+        assert_eq!(b.client_id, "client-b");
+        assert_eq!(b.issued_count, 1);
+        assert_eq!(b.refreshed_count, 0);
+        assert_eq!(b.revoked_count, 0);
+
+        let totals = repo.totals(since).await.unwrap();
+        assert_eq!(totals.issued_count, 3);
+        assert_eq!(totals.refreshed_count, 1);
+        assert_eq!(totals.revoked_count, 1);
+        assert_eq!(totals.active_clients, 2);
+    }
+
+    #[sqlx::test(migrator = "crate::MIGRATOR")]
+    async fn window_and_cleanup_filter_by_time(pool: sqlx::PgPool) {
+        let repo = OAuthTokenEventRepository::new(pool.clone());
+        make_client(&pool, "client-a").await;
+
+        // One recent event and one back-dated event.
+        repo.record(CreateOAuthTokenEvent::issued("client-a", None, vec![]))
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO oauth_token_events (event_type, client_id, token_type, created_at) \
+             VALUES ('issued', 'client-a', 'access', NOW() - INTERVAL '10 days')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Window of last hour sees only the recent event.
+        let recent = repo.totals(Utc::now() - Duration::hours(1)).await.unwrap();
+        assert_eq!(recent.issued_count, 1);
+
+        // Full window sees both.
+        let all = repo.totals(Utc::now() - Duration::days(30)).await.unwrap();
+        assert_eq!(all.issued_count, 2);
+
+        // Cleanup removes only the back-dated row.
+        let removed = repo
+            .cleanup_before(Utc::now() - Duration::days(1))
+            .await
+            .unwrap();
+        assert_eq!(removed, 1);
+        let after = repo.totals(Utc::now() - Duration::days(30)).await.unwrap();
+        assert_eq!(after.issued_count, 1);
+    }
+}


### PR DESCRIPTION
Auto: Add analytics tracking for OAuth token issuance/refresh/revocation events per client (Epic 10A shipped; needed for platform-admin ecosystem health dashboard)

---
_Generated by [Claude Code](https://claude.ai/code/session_012AYeknvQdPXuDSkbKiU9oV)_