### PR TITLE
refactor-layout-editor-styles-followthrough-2026-07-23: extract remaining layout-editor component styles

### DIFF
--- a/frontend/apps/admin-web/src/features/layout-editor/LayoutManifestsPage.styles.ts
+++ b/frontend/apps/admin-web/src/features/layout-editor/LayoutManifestsPage.styles.ts
@@ -1,0 +1,114 @@
+/**
+ * Presentational style constants for LayoutManifestsPage.
+ *
+ * Extracted from the page so the list query / upload-validation logic reads
+ * without the inline CSSProperties noise (same pattern as
+ * LayoutEditorPage.styles.ts, #2464). Plain module constants — no behaviour.
+ */
+
+import type React from 'react';
+
+export const PAGE_STYLE: React.CSSProperties = {
+  padding: '24px',
+  maxWidth: 900,
+  margin: '0 auto',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 24,
+};
+
+export const CARD_STYLE: React.CSSProperties = {
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 'var(--ppt-radius-lg, 10px)',
+  padding: '20px 24px',
+  background: 'var(--ppt-bg-surface, #fff)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+};
+
+export const CARD_TITLE_STYLE: React.CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+  color: 'var(--ppt-fg-primary, #111827)',
+  margin: 0,
+};
+
+export const TABLE_STYLE: React.CSSProperties = {
+  width: '100%',
+  borderCollapse: 'collapse',
+  fontSize: 13,
+};
+
+export const TH_STYLE: React.CSSProperties = {
+  textAlign: 'left',
+  padding: '6px 10px',
+  fontWeight: 600,
+  color: 'var(--ppt-fg-secondary, #6b7280)',
+  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+};
+
+export const TD_STYLE: React.CSSProperties = {
+  padding: '6px 10px',
+  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+  verticalAlign: 'top',
+};
+
+export const PRE_STYLE: React.CSSProperties = {
+  margin: '8px 0 0 0',
+  padding: '8px',
+  background: 'var(--ppt-bg-muted, #f9fafb)',
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 6,
+  fontSize: 11,
+  overflowX: 'auto',
+  maxHeight: 200,
+  overflowY: 'auto',
+};
+
+export const SELECT_STYLE: React.CSSProperties = {
+  padding: '6px 10px',
+  fontSize: 14,
+  borderRadius: 6,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  minWidth: 140,
+};
+
+export const TEXTAREA_STYLE: React.CSSProperties = {
+  width: '100%',
+  minHeight: 160,
+  padding: '8px 10px',
+  fontSize: 13,
+  fontFamily: 'monospace',
+  borderRadius: 6,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  resize: 'vertical',
+  boxSizing: 'border-box',
+};
+
+export const BTN_PRIMARY: React.CSSProperties = {
+  padding: '6px 16px',
+  fontSize: 14,
+  borderRadius: 6,
+  cursor: 'pointer',
+  border: '1px solid transparent',
+  fontWeight: 500,
+  background: 'var(--ppt-primary-600, #2563eb)',
+  color: '#fff',
+  borderColor: 'var(--ppt-primary-600, #2563eb)',
+};
+
+export const ALERT_STYLE: React.CSSProperties = {
+  background: 'var(--ppt-danger-50, #fef2f2)',
+  border: '1px solid var(--ppt-danger-200, #fecaca)',
+  borderRadius: 8,
+  padding: '10px 14px',
+  color: 'var(--ppt-danger-800, #991b1b)',
+  fontSize: 13,
+};
+
+export const HINT_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--ppt-fg-secondary, #6b7280)',
+  fontFamily: 'monospace',
+};

--- a/frontend/apps/admin-web/src/features/layout-editor/LayoutManifestsPage.tsx
+++ b/frontend/apps/admin-web/src/features/layout-editor/LayoutManifestsPage.tsx
@@ -16,122 +16,26 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAdminAuth } from '../../auth/AdminAuthContext';
 import { useToast } from '../../components/Toast';
 import { listManifests, type Manifest, putManifest } from './api';
-
-// ---------------------------------------------------------------------------
-// Styles
-// ---------------------------------------------------------------------------
-
-const PAGE_STYLE: React.CSSProperties = {
-  padding: '24px',
-  maxWidth: 900,
-  margin: '0 auto',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 24,
-};
-
-const CARD_STYLE: React.CSSProperties = {
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 'var(--ppt-radius-lg, 10px)',
-  padding: '20px 24px',
-  background: 'var(--ppt-bg-surface, #fff)',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 16,
-};
-
-const CARD_TITLE_STYLE: React.CSSProperties = {
-  fontSize: 16,
-  fontWeight: 600,
-  color: 'var(--ppt-fg-primary, #111827)',
-  margin: 0,
-};
-
-const TABLE_STYLE: React.CSSProperties = {
-  width: '100%',
-  borderCollapse: 'collapse',
-  fontSize: 13,
-};
-
-const TH_STYLE: React.CSSProperties = {
-  textAlign: 'left',
-  padding: '6px 10px',
-  fontWeight: 600,
-  color: 'var(--ppt-fg-secondary, #6b7280)',
-  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
-};
-
-const TD_STYLE: React.CSSProperties = {
-  padding: '6px 10px',
-  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
-  verticalAlign: 'top',
-};
-
-const PRE_STYLE: React.CSSProperties = {
-  margin: '8px 0 0 0',
-  padding: '8px',
-  background: 'var(--ppt-bg-muted, #f9fafb)',
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 6,
-  fontSize: 11,
-  overflowX: 'auto',
-  maxHeight: 200,
-  overflowY: 'auto',
-};
-
-const SELECT_STYLE: React.CSSProperties = {
-  padding: '6px 10px',
-  fontSize: 14,
-  borderRadius: 6,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  minWidth: 140,
-};
-
-const TEXTAREA_STYLE: React.CSSProperties = {
-  width: '100%',
-  minHeight: 160,
-  padding: '8px 10px',
-  fontSize: 13,
-  fontFamily: 'monospace',
-  borderRadius: 6,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  resize: 'vertical',
-  boxSizing: 'border-box',
-};
-
-const BTN_PRIMARY: React.CSSProperties = {
-  padding: '6px 16px',
-  fontSize: 14,
-  borderRadius: 6,
-  cursor: 'pointer',
-  border: '1px solid transparent',
-  fontWeight: 500,
-  background: 'var(--ppt-primary-600, #2563eb)',
-  color: '#fff',
-  borderColor: 'var(--ppt-primary-600, #2563eb)',
-};
-
-const ALERT_STYLE: React.CSSProperties = {
-  background: 'var(--ppt-danger-50, #fef2f2)',
-  border: '1px solid var(--ppt-danger-200, #fecaca)',
-  borderRadius: 8,
-  padding: '10px 14px',
-  color: 'var(--ppt-danger-800, #991b1b)',
-  fontSize: 13,
-};
-
-const HINT_STYLE: React.CSSProperties = {
-  fontSize: 12,
-  color: 'var(--ppt-fg-secondary, #6b7280)',
-  fontFamily: 'monospace',
-};
+import {
+  ALERT_STYLE,
+  BTN_PRIMARY,
+  CARD_STYLE,
+  CARD_TITLE_STYLE,
+  HINT_STYLE,
+  PAGE_STYLE,
+  PRE_STYLE,
+  SELECT_STYLE,
+  TABLE_STYLE,
+  TD_STYLE,
+  TEXTAREA_STYLE,
+  TH_STYLE,
+} from './LayoutManifestsPage.styles';
 
 // ---------------------------------------------------------------------------
 // Component

--- a/frontend/apps/admin-web/src/features/layout-editor/PreviewPanel.styles.ts
+++ b/frontend/apps/admin-web/src/features/layout-editor/PreviewPanel.styles.ts
@@ -1,0 +1,60 @@
+/**
+ * Presentational style constants for PreviewPanel.
+ *
+ * Extracted from the component so the bridge/resolve lifecycle logic reads
+ * without the inline CSSProperties noise (same pattern as
+ * LayoutEditorPage.styles.ts, #2464). Plain module constants — no behaviour.
+ * Inline, --ppt-* token vars — admin-web house style.
+ */
+
+import type React from 'react';
+
+export const PANEL_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+};
+
+export const ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  gap: 8,
+  alignItems: 'center',
+  flexWrap: 'wrap',
+};
+
+export const INPUT_STYLE: React.CSSProperties = {
+  flex: 1,
+  minWidth: 240,
+  padding: '6px 10px',
+  fontSize: 14,
+  borderRadius: 6,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+};
+
+export const BTN_STYLE: React.CSSProperties = {
+  padding: '6px 14px',
+  fontSize: 14,
+  borderRadius: 6,
+  cursor: 'pointer',
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  fontWeight: 500,
+  background: 'var(--ppt-bg-subtle, #f3f4f6)',
+  color: 'var(--ppt-fg-primary, #111827)',
+};
+
+export const ERROR_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--ppt-danger-600, #dc2626)',
+};
+
+export const NOTE_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  color: 'var(--ppt-warning-700, #b45309)',
+};
+
+export const IFRAME_STYLE: React.CSSProperties = {
+  width: '100%',
+  height: 600,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 8,
+};

--- a/frontend/apps/admin-web/src/features/layout-editor/PreviewPanel.tsx
+++ b/frontend/apps/admin-web/src/features/layout-editor/PreviewPanel.tsx
@@ -15,6 +15,15 @@ import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { previewResolve, type ScreenConfig } from './api';
+import {
+  BTN_STYLE,
+  ERROR_STYLE,
+  IFRAME_STYLE,
+  INPUT_STYLE,
+  NOTE_STYLE,
+  PANEL_STYLE,
+  ROW_STYLE,
+} from './PreviewPanel.styles';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -34,60 +43,6 @@ export interface Props {
   token: string | null;
   onSectionSelected: (type: string) => void;
 }
-
-// ---------------------------------------------------------------------------
-// Styles
-// ---------------------------------------------------------------------------
-
-const PANEL_STYLE: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 12,
-};
-
-const ROW_STYLE: React.CSSProperties = {
-  display: 'flex',
-  gap: 8,
-  alignItems: 'center',
-  flexWrap: 'wrap',
-};
-
-const INPUT_STYLE: React.CSSProperties = {
-  flex: 1,
-  minWidth: 240,
-  padding: '6px 10px',
-  fontSize: 14,
-  borderRadius: 6,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-};
-
-const BTN_STYLE: React.CSSProperties = {
-  padding: '6px 14px',
-  fontSize: 14,
-  borderRadius: 6,
-  cursor: 'pointer',
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  fontWeight: 500,
-  background: 'var(--ppt-bg-subtle, #f3f4f6)',
-  color: 'var(--ppt-fg-primary, #111827)',
-};
-
-const ERROR_STYLE: React.CSSProperties = {
-  fontSize: 12,
-  color: 'var(--ppt-danger-600, #dc2626)',
-};
-
-const NOTE_STYLE: React.CSSProperties = {
-  fontSize: 12,
-  color: 'var(--ppt-warning-700, #b45309)',
-};
-
-const IFRAME_STYLE: React.CSSProperties = {
-  width: '100%',
-  height: 600,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 8,
-};
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/frontend/apps/admin-web/src/features/layout-editor/RailsEditor.styles.ts
+++ b/frontend/apps/admin-web/src/features/layout-editor/RailsEditor.styles.ts
@@ -1,0 +1,73 @@
+/**
+ * Presentational style constants for RailsEditor.
+ *
+ * Extracted from the component so the controlled-input logic reads without the
+ * inline CSSProperties noise (same pattern as LayoutEditorPage.styles.ts, #2464).
+ * These are plain module constants — no behaviour, no state.
+ * Inline, --ppt-* token vars — admin-web house style.
+ */
+
+import type React from 'react';
+
+export const SECTION_STYLE: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+};
+
+export const GLOBAL_ROW_STYLE: React.CSSProperties = {
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 'var(--ppt-radius-lg, 10px)',
+  padding: '12px 16px',
+  background: 'var(--ppt-bg-surface, #fff)',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+};
+
+export const TABLE_STYLE: React.CSSProperties = {
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 'var(--ppt-radius-lg, 10px)',
+  background: 'var(--ppt-bg-surface, #fff)',
+  overflow: 'hidden',
+};
+
+export const TH_STYLE: React.CSSProperties = {
+  padding: '8px 12px',
+  textAlign: 'left',
+  fontSize: 12,
+  fontWeight: 600,
+  color: 'var(--ppt-fg-secondary, #6b7280)',
+  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+  background: 'var(--ppt-bg-muted, #f9fafb)',
+};
+
+export const TD_STYLE: React.CSSProperties = {
+  padding: '8px 12px',
+  fontSize: 13,
+  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
+  verticalAlign: 'middle',
+};
+
+export const TYPE_LABEL_STYLE: React.CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 13,
+  fontWeight: 600,
+  color: 'var(--ppt-fg-primary, #111827)',
+};
+
+export const INPUT_STYLE: React.CSSProperties = {
+  width: '100%',
+  padding: '4px 8px',
+  fontSize: 12,
+  fontFamily: 'monospace',
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 6,
+  boxSizing: 'border-box',
+};
+
+export const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 13,
+  fontWeight: 500,
+  color: 'var(--ppt-fg-primary, #111827)',
+};

--- a/frontend/apps/admin-web/src/features/layout-editor/RailsEditor.tsx
+++ b/frontend/apps/admin-web/src/features/layout-editor/RailsEditor.tsx
@@ -12,10 +12,19 @@
  * same derive-unless-editing discipline as SectionTreeEditor's props textarea).
  */
 
-import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Rails } from './api';
+import {
+  GLOBAL_ROW_STYLE,
+  INPUT_STYLE,
+  LABEL_STYLE,
+  SECTION_STYLE,
+  TABLE_STYLE,
+  TD_STYLE,
+  TH_STYLE,
+  TYPE_LABEL_STYLE,
+} from './RailsEditor.styles';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,73 +35,6 @@ interface Props {
   sectionTypes: string[];
   onChange: (next: Rails) => void;
 }
-
-// ---------------------------------------------------------------------------
-// Styles (inline, --ppt-* token vars — admin-web house style)
-// ---------------------------------------------------------------------------
-
-const SECTION_STYLE: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 16,
-};
-
-const GLOBAL_ROW_STYLE: React.CSSProperties = {
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 'var(--ppt-radius-lg, 10px)',
-  padding: '12px 16px',
-  background: 'var(--ppt-bg-surface, #fff)',
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-};
-
-const TABLE_STYLE: React.CSSProperties = {
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 'var(--ppt-radius-lg, 10px)',
-  background: 'var(--ppt-bg-surface, #fff)',
-  overflow: 'hidden',
-};
-
-const TH_STYLE: React.CSSProperties = {
-  padding: '8px 12px',
-  textAlign: 'left',
-  fontSize: 12,
-  fontWeight: 600,
-  color: 'var(--ppt-fg-secondary, #6b7280)',
-  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
-  background: 'var(--ppt-bg-muted, #f9fafb)',
-};
-
-const TD_STYLE: React.CSSProperties = {
-  padding: '8px 12px',
-  fontSize: 13,
-  borderBottom: '1px solid var(--ppt-border-default, #e5e7eb)',
-  verticalAlign: 'middle',
-};
-
-const TYPE_LABEL_STYLE: React.CSSProperties = {
-  fontFamily: 'monospace',
-  fontSize: 13,
-  fontWeight: 600,
-  color: 'var(--ppt-fg-primary, #111827)',
-};
-
-const INPUT_STYLE: React.CSSProperties = {
-  width: '100%',
-  padding: '4px 8px',
-  fontSize: 12,
-  fontFamily: 'monospace',
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 6,
-  boxSizing: 'border-box',
-};
-
-const LABEL_STYLE: React.CSSProperties = {
-  fontSize: 13,
-  fontWeight: 500,
-  color: 'var(--ppt-fg-primary, #111827)',
-};
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/frontend/apps/admin-web/src/features/layout-editor/SectionTreeEditor.styles.ts
+++ b/frontend/apps/admin-web/src/features/layout-editor/SectionTreeEditor.styles.ts
@@ -1,0 +1,137 @@
+/**
+ * Presentational style constants + helpers for SectionTreeEditor.
+ *
+ * Extracted from the component so the controlled-list logic (reorder, kill,
+ * props editing) reads without the inline CSSProperties noise (same pattern as
+ * LayoutEditorPage.styles.ts, #2464). The badgeStyle/btnStyle helpers are pure
+ * variant->CSSProperties functions — no state, no behaviour.
+ * Inline, --ppt-* token vars — admin-web house style.
+ */
+
+import type React from 'react';
+
+export const ROW_STYLE: React.CSSProperties = {
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 'var(--ppt-radius-lg, 10px)',
+  padding: '12px 16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  background: 'var(--ppt-bg-surface, #fff)',
+};
+
+export const ROW_HEADER_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  flexWrap: 'wrap',
+};
+
+export const TYPE_LABEL_STYLE: React.CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 13,
+  fontWeight: 600,
+  color: 'var(--ppt-fg-primary, #111827)',
+};
+
+export const TEXTAREA_STYLE: React.CSSProperties = {
+  width: '100%',
+  minHeight: 80,
+  fontFamily: 'monospace',
+  fontSize: 12,
+  padding: 8,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  borderRadius: 6,
+  resize: 'vertical',
+  boxSizing: 'border-box',
+};
+
+export const ERROR_STYLE: React.CSSProperties = {
+  color: 'var(--ppt-danger-600, #dc2626)',
+  fontSize: 12,
+  marginTop: 2,
+};
+
+export const ADD_ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  gap: 8,
+  alignItems: 'center',
+  paddingTop: 8,
+  borderTop: '1px solid var(--ppt-border-default, #e5e7eb)',
+  marginTop: 8,
+};
+
+// Inline replacements for ui-kit Badge / Button (admin-web uses no ui-kit)
+export const BADGE_BASE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  borderRadius: 4,
+  padding: '1px 6px',
+  fontSize: 11,
+  fontWeight: 600,
+  lineHeight: '18px',
+};
+
+export const BADGE_VARIANT: Record<string, React.CSSProperties> = {
+  secondary: {
+    background: 'var(--ppt-bg-subtle, #f3f4f6)',
+    color: 'var(--ppt-fg-secondary, #6b7280)',
+  },
+  warning: {
+    background: 'var(--ppt-warning-100, #fef3c7)',
+    color: 'var(--ppt-warning-700, #b45309)',
+  },
+  danger: { background: 'var(--ppt-danger-100, #fee2e2)', color: 'var(--ppt-danger-700, #b91c1c)' },
+};
+
+export const BTN_BASE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: 6,
+  padding: '3px 10px',
+  fontSize: 12,
+  fontWeight: 500,
+  cursor: 'pointer',
+  border: '1px solid transparent',
+  lineHeight: '18px',
+  background: 'none',
+};
+
+export const BTN_VARIANT: Record<string, React.CSSProperties> = {
+  ghost: { color: 'var(--ppt-fg-secondary, #6b7280)', border: '1px solid transparent' },
+  danger: {
+    background: 'var(--ppt-danger-600, #dc2626)',
+    color: '#fff',
+    border: '1px solid var(--ppt-danger-700, #b91c1c)',
+  },
+  secondary: {
+    background: 'var(--ppt-bg-subtle, #f3f4f6)',
+    color: 'var(--ppt-fg-primary, #111827)',
+    border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  },
+  primary: {
+    background: 'var(--ppt-primary-600, #2563eb)',
+    color: '#fff',
+    border: '1px solid var(--ppt-primary-700, #1d4ed8)',
+  },
+};
+
+export function badgeStyle(variant: string): React.CSSProperties {
+  return { ...BADGE_BASE, ...(BADGE_VARIANT[variant] ?? {}) };
+}
+
+export function btnStyle(variant: string, disabled?: boolean): React.CSSProperties {
+  return {
+    ...BTN_BASE,
+    ...(BTN_VARIANT[variant] ?? {}),
+    ...(disabled ? { opacity: 0.4, cursor: 'not-allowed' } : {}),
+  };
+}
+
+export const SELECT_STYLE: React.CSSProperties = {
+  padding: '5px 8px',
+  borderRadius: 6,
+  border: '1px solid var(--ppt-border-default, #e5e7eb)',
+  fontSize: 13,
+};

--- a/frontend/apps/admin-web/src/features/layout-editor/SectionTreeEditor.tsx
+++ b/frontend/apps/admin-web/src/features/layout-editor/SectionTreeEditor.tsx
@@ -13,10 +13,20 @@
  * per-section JSON parse error flag; everything else derives from props.
  */
 
-import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Manifest, SectionConfig } from './api';
+import {
+  ADD_ROW_STYLE,
+  badgeStyle,
+  btnStyle,
+  ERROR_STYLE,
+  ROW_HEADER_STYLE,
+  ROW_STYLE,
+  SELECT_STYLE,
+  TEXTAREA_STYLE,
+  TYPE_LABEL_STYLE,
+} from './SectionTreeEditor.styles';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -31,136 +41,6 @@ interface Props {
   onUnkill: (type: string) => void;
   highlightType?: string;
 }
-
-// ---------------------------------------------------------------------------
-// Styles (inline, --ppt-* token vars — admin-web house style)
-// ---------------------------------------------------------------------------
-
-const ROW_STYLE: React.CSSProperties = {
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 'var(--ppt-radius-lg, 10px)',
-  padding: '12px 16px',
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-  background: 'var(--ppt-bg-surface, #fff)',
-};
-
-const ROW_HEADER_STYLE: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: 8,
-  flexWrap: 'wrap',
-};
-
-const TYPE_LABEL_STYLE: React.CSSProperties = {
-  fontFamily: 'monospace',
-  fontSize: 13,
-  fontWeight: 600,
-  color: 'var(--ppt-fg-primary, #111827)',
-};
-
-const TEXTAREA_STYLE: React.CSSProperties = {
-  width: '100%',
-  minHeight: 80,
-  fontFamily: 'monospace',
-  fontSize: 12,
-  padding: 8,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  borderRadius: 6,
-  resize: 'vertical',
-  boxSizing: 'border-box',
-};
-
-const ERROR_STYLE: React.CSSProperties = {
-  color: 'var(--ppt-danger-600, #dc2626)',
-  fontSize: 12,
-  marginTop: 2,
-};
-
-const ADD_ROW_STYLE: React.CSSProperties = {
-  display: 'flex',
-  gap: 8,
-  alignItems: 'center',
-  paddingTop: 8,
-  borderTop: '1px solid var(--ppt-border-default, #e5e7eb)',
-  marginTop: 8,
-};
-
-// Inline replacements for ui-kit Badge / Button (admin-web uses no ui-kit)
-const BADGE_BASE: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  borderRadius: 4,
-  padding: '1px 6px',
-  fontSize: 11,
-  fontWeight: 600,
-  lineHeight: '18px',
-};
-
-const BADGE_VARIANT: Record<string, React.CSSProperties> = {
-  secondary: {
-    background: 'var(--ppt-bg-subtle, #f3f4f6)',
-    color: 'var(--ppt-fg-secondary, #6b7280)',
-  },
-  warning: {
-    background: 'var(--ppt-warning-100, #fef3c7)',
-    color: 'var(--ppt-warning-700, #b45309)',
-  },
-  danger: { background: 'var(--ppt-danger-100, #fee2e2)', color: 'var(--ppt-danger-700, #b91c1c)' },
-};
-
-const BTN_BASE: React.CSSProperties = {
-  display: 'inline-flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  borderRadius: 6,
-  padding: '3px 10px',
-  fontSize: 12,
-  fontWeight: 500,
-  cursor: 'pointer',
-  border: '1px solid transparent',
-  lineHeight: '18px',
-  background: 'none',
-};
-
-const BTN_VARIANT: Record<string, React.CSSProperties> = {
-  ghost: { color: 'var(--ppt-fg-secondary, #6b7280)', border: '1px solid transparent' },
-  danger: {
-    background: 'var(--ppt-danger-600, #dc2626)',
-    color: '#fff',
-    border: '1px solid var(--ppt-danger-700, #b91c1c)',
-  },
-  secondary: {
-    background: 'var(--ppt-bg-subtle, #f3f4f6)',
-    color: 'var(--ppt-fg-primary, #111827)',
-    border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  },
-  primary: {
-    background: 'var(--ppt-primary-600, #2563eb)',
-    color: '#fff',
-    border: '1px solid var(--ppt-primary-700, #1d4ed8)',
-  },
-};
-
-function badgeStyle(variant: string): React.CSSProperties {
-  return { ...BADGE_BASE, ...(BADGE_VARIANT[variant] ?? {}) };
-}
-
-function btnStyle(variant: string, disabled?: boolean): React.CSSProperties {
-  return {
-    ...BTN_BASE,
-    ...(BTN_VARIANT[variant] ?? {}),
-    ...(disabled ? { opacity: 0.4, cursor: 'not-allowed' } : {}),
-  };
-}
-
-const SELECT_STYLE: React.CSSProperties = {
-  padding: '5px 8px',
-  borderRadius: 6,
-  border: '1px solid var(--ppt-border-default, #e5e7eb)',
-  fontSize: 13,
-};
 
 // ---------------------------------------------------------------------------
 // Component


### PR DESCRIPTION
Auto: Follow-through on #2464 LayoutEditorPage style extraction — apply same pattern to remaining layout-editor components to reduce inline-style churn

---
_Generated by [Claude Code](https://claude.ai/code/session_012AYeknvQdPXuDSkbKiU9oV)_