### PR TITLE
test(api-server): un-quarantine AI/automation Wave D2 residual (BIT-610)

### DIFF
--- a/backend/crates/db/src/repositories/automation.rs
+++ b/backend/crates/db/src/repositories/automation.rs
@@ -37,8 +37,13 @@ impl AutomationRepository {
                 organization_id, name, description, trigger_type, trigger_config,
                 conditions, actions, is_active, created_by
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, COALESCE($8, true), $9)
-            RETURNING *
+            -- trigger_type is a Postgres ENUM (workflow_automation_trigger); the String
+            -- bind must be cast on encode, and cast back to text on decode.
+            VALUES ($1, $2, $3, $4::workflow_automation_trigger, $5, $6, $7, COALESCE($8, true), $9)
+            RETURNING
+                id, organization_id, name, description, trigger_type::text AS trigger_type,
+                trigger_config, conditions, actions, is_active, last_run_at, next_run_at,
+                run_count, error_count, last_error, created_by, created_at, updated_at
             "#,
         )
         .bind(organization_id)
@@ -62,7 +67,13 @@ impl AutomationRepository {
     /// is derived from the persisted row itself rather than from a caller.
     pub async fn get_rule(&self, id: Uuid) -> Result<Option<WorkflowAutomationRule>, SqlxError> {
         sqlx::query_as::<_, WorkflowAutomationRule>(
-            "SELECT * FROM workflow_automation_rules WHERE id = $1",
+            r#"
+            SELECT
+                id, organization_id, name, description, trigger_type::text AS trigger_type,
+                trigger_config, conditions, actions, is_active, last_run_at, next_run_at,
+                run_count, error_count, last_error, created_by, created_at, updated_at
+            FROM workflow_automation_rules WHERE id = $1
+            "#,
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -81,7 +92,13 @@ impl AutomationRepository {
         organization_id: Uuid,
     ) -> Result<Option<WorkflowAutomationRule>, SqlxError> {
         sqlx::query_as::<_, WorkflowAutomationRule>(
-            "SELECT * FROM workflow_automation_rules WHERE id = $1 AND organization_id = $2",
+            r#"
+            SELECT
+                id, organization_id, name, description, trigger_type::text AS trigger_type,
+                trigger_config, conditions, actions, is_active, last_run_at, next_run_at,
+                run_count, error_count, last_error, created_by, created_at, updated_at
+            FROM workflow_automation_rules WHERE id = $1 AND organization_id = $2
+            "#,
         )
         .bind(id)
         .bind(organization_id)
@@ -95,7 +112,13 @@ impl AutomationRepository {
         organization_id: Uuid,
     ) -> Result<Vec<WorkflowAutomationRule>, SqlxError> {
         sqlx::query_as::<_, WorkflowAutomationRule>(
-            "SELECT * FROM workflow_automation_rules WHERE organization_id = $1 ORDER BY created_at DESC",
+            r#"
+            SELECT
+                id, organization_id, name, description, trigger_type::text AS trigger_type,
+                trigger_config, conditions, actions, is_active, last_run_at, next_run_at,
+                run_count, error_count, last_error, created_by, created_at, updated_at
+            FROM workflow_automation_rules WHERE organization_id = $1 ORDER BY created_at DESC
+            "#,
         )
         .bind(organization_id)
         .fetch_all(&self.pool)
@@ -124,7 +147,10 @@ impl AutomationRepository {
                 is_active = COALESCE($8, is_active),
                 updated_at = NOW()
             WHERE id = $1 AND organization_id = $2
-            RETURNING *
+            RETURNING
+                id, organization_id, name, description, trigger_type::text AS trigger_type,
+                trigger_config, conditions, actions, is_active, last_run_at, next_run_at,
+                run_count, error_count, last_error, created_by, created_at, updated_at
             "#,
         )
         .bind(id)
@@ -335,7 +361,12 @@ impl AutomationRepository {
     /// List all templates.
     pub async fn list_templates(&self) -> Result<Vec<WorkflowAutomationTemplate>, SqlxError> {
         sqlx::query_as::<_, WorkflowAutomationTemplate>(
-            "SELECT * FROM workflow_automation_templates ORDER BY category, name",
+            r#"
+            SELECT
+                id, name, description, category, trigger_type::text AS trigger_type,
+                trigger_config_template, actions_template, is_system, created_at
+            FROM workflow_automation_templates ORDER BY category, name
+            "#,
         )
         .fetch_all(&self.pool)
         .await
@@ -347,7 +378,12 @@ impl AutomationRepository {
         id: Uuid,
     ) -> Result<Option<WorkflowAutomationTemplate>, SqlxError> {
         sqlx::query_as::<_, WorkflowAutomationTemplate>(
-            "SELECT * FROM workflow_automation_templates WHERE id = $1",
+            r#"
+            SELECT
+                id, name, description, category, trigger_type::text AS trigger_type,
+                trigger_config_template, actions_template, is_system, created_at
+            FROM workflow_automation_templates WHERE id = $1
+            "#,
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -403,7 +439,11 @@ impl AutomationRepository {
     pub async fn get_due_rules(&self) -> Result<Vec<WorkflowAutomationRule>, SqlxError> {
         sqlx::query_as::<_, WorkflowAutomationRule>(
             r#"
-            SELECT * FROM workflow_automation_rules
+            SELECT
+                id, organization_id, name, description, trigger_type::text AS trigger_type,
+                trigger_config, conditions, actions, is_active, last_run_at, next_run_at,
+                run_count, error_count, last_error, created_by, created_at, updated_at
+            FROM workflow_automation_rules
             WHERE is_active = true
               AND trigger_type = 'schedule'
               AND (next_run_at IS NULL OR next_run_at <= NOW())

--- a/backend/crates/db/src/repositories/equipment.rs
+++ b/backend/crates/db/src/repositories/equipment.rs
@@ -280,7 +280,12 @@ impl EquipmentRepository {
     {
         sqlx::query_as(
             r#"
-            SELECT em.* FROM equipment_maintenance em
+            SELECT em.id, em.equipment_id, em.maintenance_type, em.description,
+                em.performed_by, em.external_vendor, em.cost,
+                COALESCE(em.parts_replaced, '{}') AS parts_replaced,
+                em.fault_id, em.scheduled_date, em.completed_date,
+                em.status, em.notes, em.created_at, em.updated_at
+            FROM equipment_maintenance em
             JOIN equipment e ON e.id = em.equipment_id
             WHERE em.id = $1 AND e.organization_id = $2
             "#,
@@ -309,7 +314,12 @@ impl EquipmentRepository {
     {
         sqlx::query_as(
             r#"
-            SELECT em.* FROM equipment_maintenance em
+            SELECT em.id, em.equipment_id, em.maintenance_type, em.description,
+                em.performed_by, em.external_vendor, em.cost,
+                COALESCE(em.parts_replaced, '{}') AS parts_replaced,
+                em.fault_id, em.scheduled_date, em.completed_date,
+                em.status, em.notes, em.created_at, em.updated_at
+            FROM equipment_maintenance em
             JOIN equipment e ON e.id = em.equipment_id
             WHERE em.equipment_id = $1 AND e.organization_id = $2
             ORDER BY COALESCE(em.completed_date, em.scheduled_date) DESC NULLS LAST
@@ -360,7 +370,10 @@ impl EquipmentRepository {
                   WHERE e.id = equipment_maintenance.equipment_id
                     AND e.organization_id = $11
               )
-            RETURNING *
+            RETURNING
+                id, equipment_id, maintenance_type, description, performed_by, external_vendor,
+                cost, COALESCE(parts_replaced, '{}') AS parts_replaced, fault_id,
+                scheduled_date, completed_date, status, notes, created_at, updated_at
             "#,
         )
         .bind(id)

--- a/backend/crates/db/src/repositories/registry.rs
+++ b/backend/crates/db/src/repositories/registry.rs
@@ -115,8 +115,11 @@ impl RegistryRepository {
             None => return Ok(None),
         };
 
-        // `units` has no `unit_number` column — the display value is `designation`.
-        let unit_info: Option<(String, String)> = sqlx::query_as(
+        // `units` has no `unit_number` column — the display value is `designation`
+        // (NOT NULL). `buildings.name` is nullable ("Optional building name",
+        // migration 00007), so it MUST decode as `Option<String>` — a nameless
+        // building otherwise fails the row decode and 500s this endpoint.
+        let unit_info: Option<(String, Option<String>)> = sqlx::query_as(
             r#"
             SELECT u.designation AS unit_number, b.name as building_name
             FROM units u
@@ -146,7 +149,7 @@ impl RegistryRepository {
         Ok(Some(PetRegistrationWithDetails {
             registration,
             unit_number: unit_info.as_ref().map(|(u, _)| u.clone()),
-            building_name: unit_info.map(|(_, b)| b),
+            building_name: unit_info.and_then(|(_, b)| b),
             owner_name,
             reviewed_by_name,
         }))
@@ -402,8 +405,11 @@ impl RegistryRepository {
             None => return Ok(None),
         };
 
-        // `units` has no `unit_number` column — the display value is `designation`.
-        let unit_info: Option<(String, String)> = sqlx::query_as(
+        // `units` has no `unit_number` column — the display value is `designation`
+        // (NOT NULL). `buildings.name` is nullable ("Optional building name",
+        // migration 00007), so it MUST decode as `Option<String>` — a nameless
+        // building otherwise fails the row decode and 500s this endpoint.
+        let unit_info: Option<(String, Option<String>)> = sqlx::query_as(
             r#"
             SELECT u.designation AS unit_number, b.name as building_name
             FROM units u
@@ -448,7 +454,7 @@ impl RegistryRepository {
         Ok(Some(VehicleRegistrationWithDetails {
             registration,
             unit_number: unit_info.as_ref().map(|(u, _)| u.clone()),
-            building_name: unit_info.map(|(_, b)| b),
+            building_name: unit_info.and_then(|(_, b)| b),
             owner_name,
             reviewed_by_name,
             parking_spot_number,

--- a/backend/crates/db/src/repositories/sentiment.rs
+++ b/backend/crates/db/src/repositories/sentiment.rs
@@ -284,16 +284,32 @@ impl SentimentRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
+        // Upsert: a bare UPDATE ... RETURNING + fetch_one raised `RowNotFound`
+        // (→ 500) for an org that never materialized a thresholds row, whereas
+        // `get_thresholds` auto-creates one. Insert defaults on first write and
+        // COALESCE-merge on conflict so PUT /thresholds is create-or-update.
+        // The INSERT-side literal defaults mirror migration 00043.
         sqlx::query_as(
             r#"
-            UPDATE sentiment_thresholds SET
-                negative_threshold = COALESCE($2, negative_threshold),
-                alert_on_spike = COALESCE($3, alert_on_spike),
-                spike_threshold_change = COALESCE($4, spike_threshold_change),
-                min_messages_for_alert = COALESCE($5, min_messages_for_alert),
-                enabled = COALESCE($6, enabled),
+            INSERT INTO sentiment_thresholds (
+                organization_id, negative_threshold, alert_on_spike,
+                spike_threshold_change, min_messages_for_alert, enabled
+            )
+            VALUES (
+                $1,
+                COALESCE($2, -0.3),
+                COALESCE($3, TRUE),
+                COALESCE($4, 0.2),
+                COALESCE($5, 5),
+                COALESCE($6, TRUE)
+            )
+            ON CONFLICT (organization_id) DO UPDATE SET
+                negative_threshold = COALESCE($2, sentiment_thresholds.negative_threshold),
+                alert_on_spike = COALESCE($3, sentiment_thresholds.alert_on_spike),
+                spike_threshold_change = COALESCE($4, sentiment_thresholds.spike_threshold_change),
+                min_messages_for_alert = COALESCE($5, sentiment_thresholds.min_messages_for_alert),
+                enabled = COALESCE($6, sentiment_thresholds.enabled),
                 updated_at = NOW()
-            WHERE organization_id = $1
             RETURNING *
             "#,
         )

--- a/backend/servers/api-server/tests/suites/ai_automation_batch1_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_automation_batch1_tests.rs
@@ -395,6 +395,18 @@ async fn test_delete_parking_spot_not_found_returns_client_error(pool: PgPool) {
     );
 }
 
+async fn seed_registry_rules(pool: &PgPool, org_id: Uuid, building_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO building_registry_rules (tenant_id, building_id) VALUES ($1, $2) \
+         ON CONFLICT (tenant_id, building_id) DO NOTHING",
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .execute(pool)
+    .await
+    .expect("seed registry rules");
+}
+
 // ---------------------------------------------------------------------------
 // Registry — Building Rules & Statistics
 // ---------------------------------------------------------------------------
@@ -405,6 +417,7 @@ async fn test_get_registry_rules_returns_200(pool: PgPool) {
     let user = TestUser::default();
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "reg-rules-1").await;
     let building = seed_building(&pool, org_id).await;
+    seed_registry_rules(&pool, org_id, building).await;
 
     let uri = format!("/api/v1/registry/buildings/{building}/rules");
     let resp = app

--- a/backend/servers/api-server/tests/suites/ai_automation_batch1_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_automation_batch1_tests.rs
@@ -399,7 +399,6 @@ async fn test_delete_parking_spot_not_found_returns_client_error(pool: PgPool) {
 // Registry — Building Rules & Statistics
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_get_registry_rules_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;

--- a/backend/servers/api-server/tests/suites/ai_automation_batch2_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_automation_batch2_tests.rs
@@ -117,10 +117,21 @@ async fn test_list_automation_rules_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "auto-rule-1").await;
+    // Automation endpoints authenticate via `RequestPrincipal` (host-resolved
+    // tenant + active `user_memberships`), not `RlsConnection`.
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("resolve user id");
+    seed_user_membership(&pool, user_id, org_id).await;
 
     let uri = format!("/api/v1/automation/organizations/{org_id}/rules");
     let resp = app
-        .execute(authed(&token, Method::GET, &uri, None, org_id))
+        .execute(inject_tenant(
+            authed(&token, Method::GET, &uri, None, org_id),
+            org_id,
+        ))
         .await;
     assert_eq!(resp.status, StatusCode::OK, "list automation rules");
 }
@@ -130,6 +141,12 @@ async fn test_create_automation_rule_returns_201(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "auto-rule-2").await;
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("resolve user id");
+    seed_user_membership(&pool, user_id, org_id).await;
 
     let uri = format!("/api/v1/automation/organizations/{org_id}/rules");
     let body = json!({
@@ -139,7 +156,10 @@ async fn test_create_automation_rule_returns_201(pool: PgPool) {
         "actions": [{"type": "notify", "config": {}}]
     });
     let resp = app
-        .execute(authed(&token, Method::POST, &uri, Some(body), org_id))
+        .execute(inject_tenant(
+            authed(&token, Method::POST, &uri, Some(body), org_id),
+            org_id,
+        ))
         .await;
     assert_eq!(resp.status, StatusCode::CREATED, "create automation rule");
 }
@@ -166,13 +186,22 @@ async fn test_list_automation_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "auto-tmpl-1").await;
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("resolve user id");
+    seed_user_membership(&pool, user_id, org_id).await;
 
     let resp = app
-        .execute(authed(
-            &token,
-            Method::GET,
-            "/api/v1/automation/templates",
-            None,
+        .execute(inject_tenant(
+            authed(
+                &token,
+                Method::GET,
+                "/api/v1/automation/templates",
+                None,
+                org_id,
+            ),
             org_id,
         ))
         .await;
@@ -460,7 +489,7 @@ async fn test_list_equipment_returns_200(pool: PgPool) {
         .execute(authed(
             &token,
             Method::GET,
-            "/api/v1/ai/equipment/",
+            "/api/v1/ai/equipment",
             None,
             org_id,
         ))
@@ -576,7 +605,7 @@ async fn test_create_workflow_returns_201(pool: PgPool) {
         .execute(authed(
             &token,
             Method::POST,
-            "/api/v1/ai/workflows/",
+            "/api/v1/ai/workflows",
             Some(body),
             org_id,
         ))
@@ -594,7 +623,7 @@ async fn test_list_workflows_returns_200(pool: PgPool) {
         .execute(authed(
             &token,
             Method::GET,
-            "/api/v1/ai/workflows/",
+            "/api/v1/ai/workflows",
             None,
             org_id,
         ))
@@ -644,13 +673,25 @@ async fn test_list_workflow_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "ai-wf-5").await;
+    // Templates endpoints use `RequestPrincipal`, which resolves the tenant from
+    // a `ResolvedTenant` extension (normally set by `host_tenant_middleware`,
+    // absent under `TestApp`) and requires an active `user_memberships` row.
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("resolve user id");
+    seed_user_membership(&pool, user_id, org_id).await;
 
     let resp = app
-        .execute(authed(
-            &token,
-            Method::GET,
-            "/api/v1/ai/workflows/templates",
-            None,
+        .execute(inject_tenant(
+            authed(
+                &token,
+                Method::GET,
+                "/api/v1/ai/workflows/templates",
+                None,
+                org_id,
+            ),
             org_id,
         ))
         .await;
@@ -662,13 +703,24 @@ async fn test_list_builtin_workflow_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let user = TestUser::default();
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "ai-wf-6").await;
+    // Templates endpoints use `RequestPrincipal` — inject the resolved tenant and
+    // seed an active `user_memberships` row so the membership check passes.
+    let user_id = sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(&user.email)
+        .fetch_one(&pool)
+        .await
+        .expect("resolve user id");
+    seed_user_membership(&pool, user_id, org_id).await;
 
     let resp = app
-        .execute(authed(
-            &token,
-            Method::GET,
-            "/api/v1/ai/workflows/templates/builtin",
-            None,
+        .execute(inject_tenant(
+            authed(
+                &token,
+                Method::GET,
+                "/api/v1/ai/workflows/templates/builtin",
+                None,
+                org_id,
+            ),
             org_id,
         ))
         .await;

--- a/backend/servers/api-server/tests/suites/ai_automation_batch2_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_automation_batch2_tests.rs
@@ -112,7 +112,6 @@ async fn seed_workflow(pool: &PgPool, org_id: Uuid, creator: Uuid) -> Uuid {
 // Automation — Rules
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_list_automation_rules_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -126,7 +125,6 @@ async fn test_list_automation_rules_returns_200(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::OK, "list automation rules");
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_create_automation_rule_returns_201(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -163,7 +161,6 @@ async fn test_get_automation_rule_not_found(pool: PgPool) {
     );
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_list_automation_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -429,7 +426,6 @@ async fn test_get_sentiment_dashboard_returns_200(pool: PgPool) {
 // AI Equipment
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_create_equipment_returns_201(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -454,7 +450,6 @@ async fn test_create_equipment_returns_201(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::CREATED, "create ai equipment");
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_list_equipment_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -567,7 +562,6 @@ async fn test_list_maintenance_returns_200(pool: PgPool) {
 // AI Workflows
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_create_workflow_returns_201(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -590,7 +584,6 @@ async fn test_create_workflow_returns_201(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::CREATED, "create workflow");
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_list_workflows_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -646,7 +639,6 @@ async fn test_list_workflow_executions_returns_200(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::OK, "list workflow executions");
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_list_workflow_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -665,7 +657,6 @@ async fn test_list_workflow_templates_returns_200(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::OK, "list workflow templates");
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_list_builtin_workflow_templates_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;

--- a/backend/servers/api-server/tests/suites/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_automation_batch3_tests.rs
@@ -172,7 +172,6 @@ async fn test_delete_automation_rule_not_found(pool: PgPool) {
 // AI Chat — delete session, list messages (need seeded session via POST)
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_delete_chat_session_roundtrip(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -246,7 +245,6 @@ async fn test_list_chat_messages_roundtrip(pool: PgPool) {
 // AI Sentiment — update thresholds, acknowledge alert (not-found path)
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_update_sentiment_thresholds_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -290,7 +288,6 @@ async fn test_acknowledge_sentiment_alert_not_found(pool: PgPool) {
 // AI Workflows — update, delete, list/add actions, workflow templates
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_workflow_actions_roundtrip(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -402,7 +399,6 @@ async fn test_update_equipment_returns_200(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::OK, "update equipment");
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn test_delete_equipment_returns_200(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;

--- a/backend/servers/api-server/tests/suites/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_automation_batch3_tests.rs
@@ -329,7 +329,7 @@ async fn test_workflow_actions_roundtrip(pool: PgPool) {
     let action_body = json!({
         "workflow_id": wf_id,
         "action_order": 1,
-        "action_type": "notify",
+        "action_type": "send_notification",
         "action_config": {}
     });
     let add_resp = app

--- a/backend/servers/api-server/tests/suites/ai_automation_batch3_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_automation_batch3_tests.rs
@@ -202,7 +202,12 @@ async fn test_delete_chat_session_roundtrip(pool: PgPool) {
     let del_resp = app
         .execute(authed(&token, Method::DELETE, &uri, None, org_id))
         .await;
-    assert_eq!(del_resp.status, StatusCode::OK, "delete chat session");
+    // The delete handler returns 204 No Content on success.
+    assert_eq!(
+        del_resp.status,
+        StatusCode::NO_CONTENT,
+        "delete chat session"
+    );
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -300,7 +305,7 @@ async fn test_workflow_actions_roundtrip(pool: PgPool) {
         .execute(authed(
             &token,
             Method::POST,
-            "/api/v1/ai/workflows/",
+            "/api/v1/ai/workflows",
             Some(create_body),
             org_id,
         ))
@@ -411,5 +416,6 @@ async fn test_delete_equipment_returns_200(pool: PgPool) {
     let resp = app
         .execute(authed(&token, Method::DELETE, &uri, None, org_id))
         .await;
-    assert_eq!(resp.status, StatusCode::OK, "delete equipment");
+    // The delete handler returns 204 No Content on success.
+    assert_eq!(resp.status, StatusCode::NO_CONTENT, "delete equipment");
 }

--- a/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
@@ -189,7 +189,6 @@ async fn create_chat_session_succeeds(pool: PgPool) {
     assert!(resp.json_value()["id"].is_string());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_chat_sessions_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -243,7 +242,6 @@ async fn delete_chat_session_succeeds(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::NO_CONTENT, "body: {}", resp.text());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_chat_messages_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -263,7 +261,6 @@ async fn list_chat_messages_succeeds(pool: PgPool) {
     assert!(resp.json_value().is_array());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn provide_chat_feedback_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -312,7 +309,6 @@ async fn get_sentiment_trends_succeeds(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_sentiment_alerts_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -358,7 +354,6 @@ async fn get_sentiment_thresholds_succeeds(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn update_sentiment_thresholds_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -392,7 +387,6 @@ async fn get_sentiment_dashboard_succeeds(pool: PgPool) {
 // AI Equipment — ai/equipment.rs (11 endpoints, RlsConnection)
 // ---------------------------------------------------------------------------
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn create_equipment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -416,7 +410,6 @@ async fn create_equipment_succeeds(pool: PgPool) {
     assert!(resp.json_value()["id"].is_string());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_equipment_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -530,7 +523,6 @@ async fn create_equipment_maintenance_succeeds(pool: PgPool) {
     assert!(resp.json_value()["id"].is_string());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn update_equipment_maintenance_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -633,7 +625,6 @@ async fn create_pet_registration_succeeds(pool: PgPool) {
     assert!(resp.json_value()["registration"]["id"].is_string());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_pet_registrations_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -647,7 +638,6 @@ async fn list_pet_registrations_succeeds(pool: PgPool) {
     assert!(resp.json_value().is_array());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn get_pet_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -760,7 +750,6 @@ async fn create_vehicle_registration_succeeds(pool: PgPool) {
     assert!(resp.json_value()["registration"]["id"].is_string());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_vehicle_registrations_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -774,7 +763,6 @@ async fn list_vehicle_registrations_succeeds(pool: PgPool) {
     assert!(resp.json_value().is_array());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn get_vehicle_registration_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -883,7 +871,6 @@ async fn create_parking_spot_succeeds(pool: PgPool) {
     assert!(resp.json_value()["spot"]["id"].is_string());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_parking_spots_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
@@ -956,7 +943,6 @@ async fn delete_parking_spot_succeeds(pool: PgPool) {
     assert_eq!(resp.status, StatusCode::NO_CONTENT, "body: {}", resp.text());
 }
 
-#[ignore = "BIT-351 quarantine: schema/route not implemented (BIT-568)"]
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn get_registry_rules_succeeds(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;

--- a/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
@@ -286,7 +286,9 @@ async fn provide_chat_feedback_succeeds(pool: PgPool) {
         .execute(
             session
                 .post(&format!("/api/v1/ai/chat/messages/{msg_id}/feedback"))
-                .json(json!({"rating": 5, "helpful": true, "feedback_text": "Very helpful"}))
+                // `ProvideFeedback` requires `message_id` in the body (the handler
+                // re-derives it from the path, but the field is non-optional).
+                .json(json!({"message_id": msg_id, "rating": 5, "helpful": true, "feedback_text": "Very helpful"}))
                 .build(),
         )
         .await;
@@ -409,7 +411,7 @@ async fn create_equipment_succeeds(pool: PgPool) {
     let resp = app
         .execute(
             session
-                .post("/api/v1/ai/equipment/")
+                .post("/api/v1/ai/equipment")
                 .json(json!({
                     "building_id": building_id,
                     "name": "Elevator",
@@ -429,7 +431,7 @@ async fn list_equipment_succeeds(pool: PgPool) {
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "leq").await;
     let session = app.session(token, org_id);
     let resp = app
-        .execute(session.get("/api/v1/ai/equipment/").build())
+        .execute(session.get("/api/v1/ai/equipment").build())
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
     assert!(resp.json_value()["equipment"].is_array());
@@ -548,7 +550,10 @@ async fn update_equipment_maintenance_succeeds(pool: PgPool) {
         .execute(
             session
                 .put(&format!("/api/v1/ai/equipment/maintenance/{maint_id}"))
-                .json(json!({"maintenance_type": "repair"}))
+                // `maintenance_type` is a TEXT column with a CHECK constraint
+                // (preventive|corrective|emergency|inspection); "repair" is not a
+                // permitted value and violated the constraint → 500.
+                .json(json!({"maintenance_type": "corrective"}))
                 .build(),
         )
         .await;

--- a/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
@@ -199,7 +199,7 @@ async fn list_chat_sessions_succeeds(pool: PgPool) {
         .execute(session.get("/api/v1/ai/chat/sessions").build())
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
-    assert!(resp.json_value().is_array());
+    assert!(resp.json_value()["sessions"].is_array());
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -258,7 +258,7 @@ async fn list_chat_messages_succeeds(pool: PgPool) {
         )
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
-    assert!(resp.json_value().is_array());
+    assert!(resp.json_value()["messages"].is_array());
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -274,7 +274,7 @@ async fn provide_chat_feedback_succeeds(pool: PgPool) {
         .execute(
             session
                 .post(&format!("/api/v1/ai/chat/messages/{msg_id}/feedback"))
-                .json(json!({"rating": "positive", "comment": "Very helpful"}))
+                .json(json!({"rating": 5, "helpful": true, "feedback_text": "Very helpful"}))
                 .build(),
         )
         .await;
@@ -319,7 +319,7 @@ async fn list_sentiment_alerts_succeeds(pool: PgPool) {
         .execute(session.get("/api/v1/ai/sentiment/alerts").build())
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
-    assert!(resp.json_value().is_array());
+    assert!(resp.json_value()["alerts"].is_array());
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]

--- a/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_chat_sentiment_equipment_batch4_tests.rs
@@ -166,6 +166,18 @@ async fn seed_parking_spot(pool: &PgPool, org_id: Uuid, building_id: Uuid) -> Uu
     .expect("seed parking spot")
 }
 
+async fn seed_registry_rules(pool: &PgPool, org_id: Uuid, building_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO building_registry_rules (tenant_id, building_id) VALUES ($1, $2) \
+         ON CONFLICT (tenant_id, building_id) DO NOTHING",
+    )
+    .bind(org_id)
+    .bind(building_id)
+    .execute(pool)
+    .await
+    .expect("seed registry rules");
+}
+
 // ---------------------------------------------------------------------------
 // AI Chat Sessions — ai/sessions.rs chat section (6 endpoints)
 // send_message is excluded: makes live LLM calls.
@@ -635,7 +647,7 @@ async fn list_pet_registrations_succeeds(pool: PgPool) {
         .execute(session.get("/api/v1/registry/pets").build())
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
-    assert!(resp.json_value().is_array());
+    assert!(resp.json_value()["registrations"].is_array());
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -760,7 +772,7 @@ async fn list_vehicle_registrations_succeeds(pool: PgPool) {
         .execute(session.get("/api/v1/registry/vehicles").build())
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
-    assert!(resp.json_value().is_array());
+    assert!(resp.json_value()["registrations"].is_array());
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -881,7 +893,7 @@ async fn list_parking_spots_succeeds(pool: PgPool) {
         .execute(session.get("/api/v1/registry/parking-spots").build())
         .await;
     assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
-    assert!(resp.json_value().is_array());
+    assert!(resp.json_value()["spots"].is_array());
 }
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -949,6 +961,7 @@ async fn get_registry_rules_succeeds(pool: PgPool) {
     let user = TestUser::new();
     let (token, org_id) = create_authenticated_user_with_org(&app, &user, "grr").await;
     let building_id = seed_building(&pool, org_id).await;
+    seed_registry_rules(&pool, org_id, building_id).await;
     let session = app.session(token, org_id);
     let resp = app
         .execute(


### PR DESCRIPTION
## BIT-354 Wave D2 — AI/automation residual (BIT-610)

Removes the `BIT-351 quarantine` `#[ignore]` markers from the 28 residual AI/automation success-path tests left after Wave D (PR #2513) landed the passing batch.

**Files** (`backend/servers/api-server/tests/suites/`):
- ai_chat_sentiment_equipment_batch4_tests.rs (14)
- ai_automation_batch2_tests.rs (9)
- ai_automation_batch3_tests.rs (4)
- ai_automation_batch1_tests.rs (1)

### Triage
All 28 endpoints have registered routes (registry / automation / ai-equipment / ai-workflows / ai-chat / ai-sentiment) — **no DELETE candidates**. The `schema/route not implemented` reason is stale; these are runtime (seed/enum-decode) residuals, not missing features.

### Plan
First push un-ignores all 28 to get the real CI-shard failure map (no local Rust host available; rbuild tunnel down). Follow-up commits on this same PR apply precise seed/enum-decode (`col::text AS col`) fixes per failure; genuine 404s (none expected) would be deleted with a note.

Done when these 4 files have zero `BIT-351 quarantine` markers on dev and CI is green.

Ref BIT-354 / BIT-610 / tail BIT-601.

🤖 Generated with [Claude Code](https://claude.com/claude-code)