### PR TITLE
data-reality-portal-listing-view-events-2026-07-23: add listing.viewed analytics event

### DIFF
--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
@@ -7,12 +7,15 @@
 'use client';
 
 import type { ListingDetail } from '@ppt/reality-api-client';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useEffect } from 'react';
 import { Footer, Header } from '@/components/ui';
 import type { ResolvedScreen } from '@/lib/layout';
 import { DEFAULT_LISTING_DETAIL_LAYOUT } from '@/lib/layout';
 import { ContactForm } from './ContactForm';
 import { LayoutSections, Placeholder } from './LayoutSections';
+import { trackListingViewed } from './listingAnalytics';
 import { listingRegistry } from './sections/registry';
 import { useListingPreviewLayout } from './useListingPreviewLayout';
 
@@ -80,6 +83,28 @@ export function ListingDetailContent({ listing, jsonLd, layout }: ListingDetailC
 
   const { previewLayout, inPreview, sendSectionClick } =
     useListingPreviewLayout('reality/listing-detail');
+
+  const searchParams = useSearchParams();
+
+  // Emit one `listing.viewed` analytics event per real listing view. Keyed on
+  // the listing id (via primitive deps) so re-renders within the same listing
+  // don't double-count, and skipped while a layout preview is being pushed
+  // (preview traffic must not pollute conversion metrics). view-source /
+  // filter-state / session context are derived inside `trackListingViewed`.
+  const listingId = listing?.id;
+  const listingSlug = listing?.slug;
+  const listingTransactionType = listing?.transactionType;
+  useEffect(() => {
+    if (!listingId || !listingSlug || inPreview) return;
+    trackListingViewed({
+      listingId,
+      slug: listingSlug,
+      transactionType: listingTransactionType,
+      searchParams,
+      referrer: typeof document !== 'undefined' ? document.referrer : '',
+      origin: typeof window !== 'undefined' ? window.location.origin : '',
+    });
+  }, [listingId, listingSlug, listingTransactionType, inPreview, searchParams]);
 
   if (!listing) {
     return <ListingNotFound />;

--- a/frontend/apps/reality-web/src/components/listings/listingAnalytics.test.ts
+++ b/frontend/apps/reality-web/src/components/listings/listingAnalytics.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Regression test for the Reality Portal listing-view instrumentation
+ * (foundational for realtor conversion metrics). Locks in that every listing
+ * view emits a canonical `listing.viewed` event carrying view-source,
+ * filter-state, and anonymous session context — and that view-source /
+ * filter-state are derived correctly from the referrer + current URL.
+ */
+/// <reference types="vitest/globals" />
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { __clearAnalyticsSinks, type AnalyticsEvent, registerAnalyticsSink } from '@/lib/analytics';
+import { __resetEphemeralSessionId } from '@/lib/analytics-session';
+import { deriveListingViewContext, LISTING_EVENTS, trackListingViewed } from './listingAnalytics';
+
+const ORIGIN = 'https://rlt.sk';
+
+let captured: AnalyticsEvent[];
+
+beforeEach(() => {
+  captured = [];
+  registerAnalyticsSink((e) => captured.push(e));
+  try {
+    globalThis.sessionStorage?.clear();
+  } catch {
+    /* no sessionStorage in this env */
+  }
+  __resetEphemeralSessionId();
+});
+
+afterEach(() => {
+  __clearAnalyticsSinks();
+});
+
+describe('deriveListingViewContext — view-source', () => {
+  it('classifies the results page as `search`', () => {
+    const ctx = deriveListingViewContext(null, `${ORIGIN}/sk/listings?city=Bratislava`, ORIGIN);
+    expect(ctx.viewSource).toBe('search');
+  });
+
+  it('classifies a related listing referrer as `listing`', () => {
+    const ctx = deriveListingViewContext(null, `${ORIGIN}/sk/listings/other-flat`, ORIGIN);
+    expect(ctx.viewSource).toBe('listing');
+  });
+
+  it('classifies the home page, favorites and realtor referrers', () => {
+    expect(deriveListingViewContext(null, `${ORIGIN}/sk`, ORIGIN).viewSource).toBe('home');
+    expect(deriveListingViewContext(null, `${ORIGIN}/cs/favorites`, ORIGIN).viewSource).toBe(
+      'favorites'
+    );
+    expect(deriveListingViewContext(null, `${ORIGIN}/en/realtor/xyz`, ORIGIN).viewSource).toBe(
+      'realtor'
+    );
+  });
+
+  it('treats a foreign origin as `external` and no referrer as `direct`', () => {
+    expect(
+      deriveListingViewContext(null, 'https://google.com/search?q=flat', ORIGIN).viewSource
+    ).toBe('external');
+    expect(deriveListingViewContext(null, '', ORIGIN).viewSource).toBe('direct');
+  });
+
+  it('lets an explicit ?source= on the current URL win', () => {
+    const params = new URLSearchParams('source=newsletter');
+    const ctx = deriveListingViewContext(params, `${ORIGIN}/sk/listings`, ORIGIN);
+    expect(ctx.viewSource).toBe('newsletter');
+  });
+});
+
+describe('deriveListingViewContext — filter-state', () => {
+  it('extracts snake_case filters from the referrer query', () => {
+    const referrer = `${ORIGIN}/sk/listings?city=Bratislava&transactionType=rent&priceMax=900&sortBy=price`;
+    const ctx = deriveListingViewContext(null, referrer, ORIGIN);
+    expect(ctx.filterState).toEqual({
+      city: 'Bratislava',
+      transaction_type: 'rent',
+      price_max: '900',
+      sort_by: 'price',
+    });
+  });
+
+  it('ignores non-filter params and empty values', () => {
+    const referrer = `${ORIGIN}/sk/listings?page=3&source=x&city=`;
+    const ctx = deriveListingViewContext(null, referrer, ORIGIN);
+    expect(ctx.filterState).toEqual({});
+  });
+
+  it('lets current-URL filters override referrer filters', () => {
+    const params = new URLSearchParams('city=Kosice');
+    const referrer = `${ORIGIN}/sk/listings?city=Bratislava&roomsMin=2`;
+    const ctx = deriveListingViewContext(params, referrer, ORIGIN);
+    expect(ctx.filterState).toEqual({ city: 'Kosice', rooms_min: '2' });
+  });
+});
+
+describe('trackListingViewed', () => {
+  it('emits listing.viewed with the full payload', () => {
+    trackListingViewed({
+      listingId: 'listing-1',
+      slug: 'sunny-flat',
+      transactionType: 'rent',
+      searchParams: null,
+      referrer: `${ORIGIN}/sk/listings?city=Bratislava`,
+      origin: ORIGIN,
+    });
+
+    expect(captured).toHaveLength(1);
+    const event = captured[0];
+    expect(event.event).toBe(LISTING_EVENTS.listingViewed);
+    expect(event.timestamp).toEqual(expect.any(String));
+    expect(event.properties).toMatchObject({
+      listing_id: 'listing-1',
+      slug: 'sunny-flat',
+      transaction_type: 'rent',
+      view_source: 'search',
+      filter_state: { city: 'Bratislava' },
+    });
+    expect(event.properties.session_id).toEqual(expect.any(String));
+    expect((event.properties.session_id as string).length).toBeGreaterThan(0);
+    expect(event.properties.referrer).toEqual(expect.any(String));
+  });
+
+  it('reuses one session id across views in the same session', () => {
+    trackListingViewed({ listingId: 'a', slug: 'a', origin: ORIGIN });
+    trackListingViewed({ listingId: 'b', slug: 'b', origin: ORIGIN });
+    expect(captured).toHaveLength(2);
+    expect(captured[0].properties.session_id).toBe(captured[1].properties.session_id);
+  });
+
+  it('falls back to view_source=direct with no referrer', () => {
+    trackListingViewed({ listingId: 'c', slug: 'c', origin: ORIGIN });
+    expect(captured[0].properties.view_source).toBe('direct');
+  });
+});

--- a/frontend/apps/reality-web/src/components/listings/listingAnalytics.ts
+++ b/frontend/apps/reality-web/src/components/listings/listingAnalytics.ts
@@ -1,0 +1,176 @@
+/**
+ * Listing-view instrumentation for the Reality Portal (foundational for the
+ * realtor conversion funnel).
+ *
+ * Every public listing-detail view emits one canonical `listing.viewed` event
+ * carrying the three dimensions the data team needs to attribute conversions:
+ *
+ *   - **view-source**   — where the visit came from (search results, a related
+ *                         listing, the home page, favorites, an external site,
+ *                         or a direct hit), so views can be bucketed by channel.
+ *   - **filter-state**  — the search filters that were active when the visitor
+ *                         clicked through, so we can correlate filters → views.
+ *   - **session context** — an anonymous per-tab session id (plus referrer) so a
+ *                         visitor's views stitch into one browsing session.
+ *
+ * `deriveListingViewContext` is a pure function (no DOM access) so the
+ * source/filter derivation is unit-testable; the React layer only supplies the
+ * current `URLSearchParams`, `document.referrer`, and origin.
+ */
+
+import { trackEvent } from '@/lib/analytics';
+import { getSessionContext } from '@/lib/analytics-session';
+
+/** Canonical listing event names — keep in sync with the data-team schema. */
+export const LISTING_EVENTS = {
+  listingViewed: 'listing.viewed',
+} as const;
+
+export type ListingEventName = (typeof LISTING_EVENTS)[keyof typeof LISTING_EVENTS];
+
+/**
+ * Search filter query keys → snake_case property names. These mirror the
+ * params written by the listings results page (`getFiltersFromUrl` /
+ * `updateFilters`). `page`/`source` are intentionally excluded — they are
+ * pagination/attribution, not filters.
+ */
+export const FILTER_PARAM_KEYS: Record<string, string> = {
+  q: 'q',
+  transactionType: 'transaction_type',
+  propertyType: 'property_type',
+  priceMin: 'price_min',
+  priceMax: 'price_max',
+  areaMin: 'area_min',
+  areaMax: 'area_max',
+  roomsMin: 'rooms_min',
+  city: 'city',
+  district: 'district',
+  sortBy: 'sort_by',
+  sortOrder: 'sort_order',
+};
+
+/** Minimal read interface satisfied by the DOM `URLSearchParams`. */
+export interface ReadableParams {
+  get(key: string): string | null;
+}
+
+export type ViewSource =
+  | 'search'
+  | 'listing'
+  | 'home'
+  | 'favorites'
+  | 'realtor'
+  | 'internal'
+  | 'external'
+  | 'direct';
+
+export interface ListingViewContext {
+  viewSource: ViewSource;
+  filterState: Record<string, string>;
+}
+
+/** Strip a locale prefix (`/sk`, `/cs`, …) so path matching is locale-agnostic. */
+function normalizePath(pathname: string): string {
+  const stripped = pathname.replace(/^\/[a-z]{2}(?=\/|$)/, '');
+  return stripped === '' ? '/' : stripped;
+}
+
+/** Classify an internal referrer path into a coarse view-source bucket. */
+function sourceFromInternalPath(pathname: string): ViewSource {
+  const path = normalizePath(pathname);
+  if (path === '/') return 'home';
+  if (path.startsWith('/favorites')) return 'favorites';
+  if (path.startsWith('/realtor')) return 'realtor';
+  if (path.startsWith('/listings/')) return 'listing'; // detail → related detail
+  if (path === '/listings') return 'search';
+  return 'internal';
+}
+
+/** Collect the active filter params from a params source into snake_case keys. */
+function collectFilters(params: ReadableParams | null): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!params) return out;
+  for (const [queryKey, propKey] of Object.entries(FILTER_PARAM_KEYS)) {
+    const value = params.get(queryKey);
+    if (value != null && value !== '') out[propKey] = value;
+  }
+  return out;
+}
+
+/**
+ * Derive `{ viewSource, filterState }` from the current page's search params,
+ * the referrer URL, and the current origin. Pure — no DOM/globals touched.
+ *
+ * Precedence for view-source: an explicit `?source=` on the current URL wins
+ * (curated/marketing links), otherwise it is inferred from the referrer.
+ * Filter-state is merged from the referrer's query (the search that led here)
+ * and any filters forwarded onto the current URL, with the current URL winning.
+ */
+export function deriveListingViewContext(
+  searchParams: ReadableParams | null,
+  referrer: string,
+  origin: string
+): ListingViewContext {
+  let referrerParams: URLSearchParams | null = null;
+  let referrerSource: ViewSource = 'direct';
+
+  if (referrer) {
+    try {
+      const url = new URL(referrer);
+      const sameOrigin = !!origin && url.origin === origin;
+      if (sameOrigin) {
+        referrerParams = url.searchParams;
+        referrerSource = sourceFromInternalPath(url.pathname);
+      } else {
+        referrerSource = 'external';
+      }
+    } catch {
+      referrerSource = 'external';
+    }
+  }
+
+  const explicit = searchParams?.get('source');
+  const viewSource = (explicit as ViewSource) || referrerSource;
+
+  // Referrer filters first, current-URL filters override (forward-compatible
+  // with links that explicitly carry the originating filters).
+  const filterState = { ...collectFilters(referrerParams), ...collectFilters(searchParams) };
+
+  return { viewSource, filterState };
+}
+
+export interface TrackListingViewedInput {
+  listingId: string;
+  slug: string;
+  transactionType?: string;
+  /** Current page search params (`useSearchParams()`), if any. */
+  searchParams?: ReadableParams | null;
+  /** `document.referrer` — passed in so the emit path stays testable. */
+  referrer?: string;
+  /** `window.location.origin` — used to detect internal vs external referrers. */
+  origin?: string;
+}
+
+/**
+ * Emit the canonical `listing.viewed` event with view-source, filter-state, and
+ * anonymous session context. Fire once per listing view (e.g. from a mount
+ * effect keyed on the listing id). Never throws.
+ */
+export function trackListingViewed(input: TrackListingViewedInput): void {
+  const { viewSource, filterState } = deriveListingViewContext(
+    input.searchParams ?? null,
+    input.referrer ?? '',
+    input.origin ?? ''
+  );
+  const session = getSessionContext();
+
+  trackEvent(LISTING_EVENTS.listingViewed, {
+    listing_id: input.listingId,
+    slug: input.slug,
+    transaction_type: input.transactionType,
+    view_source: viewSource,
+    filter_state: filterState,
+    session_id: session.sessionId,
+    referrer: session.referrer,
+  });
+}

--- a/frontend/apps/reality-web/src/lib/analytics-session.ts
+++ b/frontend/apps/reality-web/src/lib/analytics-session.ts
@@ -1,0 +1,77 @@
+/**
+ * Anonymous analytics session context for reality-web.
+ *
+ * Conversion metrics need to stitch a visitor's listing views together across
+ * a single browsing session without identifying the person. This module mints
+ * a random, per-tab session id on first use and persists it in `sessionStorage`
+ * (cleared when the tab closes — deliberately shorter-lived than a tracking
+ * cookie, and gated by the same "no PII" contract as the rest of the portal).
+ *
+ * Everything here is SSR-safe: on the server (or when storage is unavailable /
+ * blocked) it degrades to an ephemeral in-memory id rather than throwing, so a
+ * caller in a React effect never has to guard the environment itself.
+ */
+
+/** `sessionStorage` key holding the anonymous session id. */
+export const ANALYTICS_SESSION_KEY = 'ppt-analytics-session';
+
+/** Shape handed to event helpers so views can be grouped per session. */
+export interface AnalyticsSessionContext {
+  /** Random per-tab identifier — not tied to any user account. */
+  sessionId: string;
+  /** Referrer URL captured at emit time (may be empty). */
+  referrer: string;
+}
+
+/** In-memory fallback id when `sessionStorage` is unavailable (SSR, privacy). */
+let ephemeralSessionId: string | null = null;
+
+function randomId(): string {
+  try {
+    const c = (globalThis as { crypto?: Crypto }).crypto;
+    if (c?.randomUUID) return c.randomUUID();
+  } catch {
+    // Fall through to the Math.random path below.
+  }
+  return `sess-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Return the current anonymous session id, creating and persisting one on first
+ * use. Never throws — falls back to an ephemeral id when storage is blocked.
+ */
+export function getSessionId(): string {
+  try {
+    const storage = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+    if (storage) {
+      const existing = storage.getItem(ANALYTICS_SESSION_KEY);
+      if (existing) return existing;
+      const fresh = randomId();
+      storage.setItem(ANALYTICS_SESSION_KEY, fresh);
+      return fresh;
+    }
+  } catch {
+    // sessionStorage can throw in private mode / when disabled — degrade below.
+  }
+  if (!ephemeralSessionId) ephemeralSessionId = randomId();
+  return ephemeralSessionId;
+}
+
+/** Best-effort document referrer; empty string on the server. */
+export function getReferrer(): string {
+  try {
+    return (globalThis as { document?: Document }).document?.referrer ?? '';
+  } catch {
+    return '';
+  }
+}
+
+/** Assemble the session context attached to every analytics event. */
+export function getSessionContext(): AnalyticsSessionContext {
+  return { sessionId: getSessionId(), referrer: getReferrer() };
+}
+
+/** Test hook — drop the in-memory fallback id. */
+export function __resetEphemeralSessionId(): void {
+  ephemeralSessionId = null;
+}

--- a/frontend/apps/reality-web/src/lib/analytics.ts
+++ b/frontend/apps/reality-web/src/lib/analytics.ts
@@ -1,0 +1,80 @@
+/**
+ * Lightweight, transport-agnostic analytics event bus for reality-web.
+ *
+ * The public portal has no bundled analytics SDK (PostHog / Segment / GA are
+ * injected at deploy time via the tag manager, if at all). This module gives
+ * feature code a single, dependency-free `trackEvent` entry point that:
+ *
+ *   1. pushes a GTM-style record onto `window.dataLayer` when one is present
+ *      (the deploy-time tag manager consumes it), and
+ *   2. fans the event out to any in-process sinks registered via
+ *      `registerAnalyticsSink` (used by tests and by future in-app dashboards).
+ *
+ * Analytics must never break the UX: every sink call is wrapped so a throwing
+ * sink can't bubble into a React render/effect path. The bus is intentionally
+ * a byte-for-byte sibling of admin-web's `lib/analytics.ts` so the two apps
+ * share one event schema and one dataLayer contract.
+ */
+
+export interface AnalyticsEvent {
+  /** Dot-namespaced event name, e.g. `listing.viewed`. */
+  event: string;
+  /** Arbitrary, JSON-serialisable event properties. */
+  properties: Record<string, unknown>;
+  /** ISO-8601 capture timestamp. */
+  timestamp: string;
+}
+
+export type AnalyticsSink = (event: AnalyticsEvent) => void;
+
+const sinks = new Set<AnalyticsSink>();
+
+/**
+ * Register an in-process analytics sink. Returns an unsubscribe function.
+ */
+export function registerAnalyticsSink(sink: AnalyticsSink): () => void {
+  sinks.add(sink);
+  return () => {
+    sinks.delete(sink);
+  };
+}
+
+/** Test/reset hook — drops all registered in-process sinks. */
+export function __clearAnalyticsSinks(): void {
+  sinks.clear();
+}
+
+interface DataLayerWindow {
+  dataLayer?: unknown[];
+}
+
+/**
+ * Emit an analytics event. Safe to call from any render/event-handler/effect
+ * path — it never throws.
+ */
+export function trackEvent(event: string, properties: Record<string, unknown> = {}): void {
+  const payload: AnalyticsEvent = {
+    event,
+    properties,
+    timestamp: new Date().toISOString(),
+  };
+
+  // 1. GTM-style dataLayer (deploy-time tag manager), if present.
+  try {
+    const dl = (globalThis as DataLayerWindow).dataLayer;
+    if (Array.isArray(dl)) {
+      dl.push({ event, ...properties, timestamp: payload.timestamp });
+    }
+  } catch {
+    // Never let analytics transport break the caller.
+  }
+
+  // 2. In-process sinks.
+  for (const sink of sinks) {
+    try {
+      sink(payload);
+    } catch {
+      // Swallow — a broken sink must not break the UX.
+    }
+  }
+}


### PR DESCRIPTION
Auto: Add listing-view analytics events (reality-web + mobile-native) with view-source, filter-state, session context — foundational for realtor conversion metrics

Owner: pm-data

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2ByAdgRV7h25MLDe3avTX)_