### PR TITLE
gh-issue-2530: instrument the full signup funnel, not just the onboarding tour (Closes #2530)

### DIFF
--- a/frontend/apps/admin-web/src/features/onboarding/analytics.test.ts
+++ b/frontend/apps/admin-web/src/features/onboarding/analytics.test.ts
@@ -13,6 +13,10 @@ import {
 } from '../../lib/analytics';
 import {
   ONBOARDING_EVENTS,
+  SIGNUP_EVENTS,
+  trackEmailVerified,
+  trackRegistrationSubmitted,
+  trackSignupLoggedIn,
   trackStepCompleted,
   trackTourCompleted,
   trackTourReset,
@@ -90,5 +94,43 @@ describe('onboarding funnel analytics', () => {
     expect(() => trackTourCompleted(TOUR)).not.toThrow();
     // The well-behaved sink still received the event.
     expect(captured).toHaveLength(1);
+  });
+});
+
+describe('signup funnel analytics (issue #2530)', () => {
+  it('fires registration_submitted with the signup method', () => {
+    trackRegistrationSubmitted();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe(SIGNUP_EVENTS.registrationSubmitted);
+    expect(captured[0].properties).toMatchObject({ method: 'email_password' });
+    expect(captured[0].timestamp).toEqual(expect.any(String));
+  });
+
+  it('fires email_verified', () => {
+    trackEmailVerified();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe(SIGNUP_EVENTS.emailVerified);
+  });
+
+  it('fires logged_in with an overridable method', () => {
+    trackSignupLoggedIn('sso');
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe(SIGNUP_EVENTS.loggedIn);
+    expect(captured[0].properties).toMatchObject({ method: 'sso' });
+  });
+
+  it('emits the full funnel in order when driven end-to-end', () => {
+    trackRegistrationSubmitted();
+    trackEmailVerified();
+    trackSignupLoggedIn();
+    trackTourStarted(TOUR);
+    trackTourCompleted(TOUR);
+    expect(captured.map((e) => e.event)).toEqual([
+      SIGNUP_EVENTS.registrationSubmitted,
+      SIGNUP_EVENTS.emailVerified,
+      SIGNUP_EVENTS.loggedIn,
+      ONBOARDING_EVENTS.tourStarted,
+      ONBOARDING_EVENTS.tourCompleted,
+    ]);
   });
 });

--- a/frontend/apps/admin-web/src/features/onboarding/analytics.ts
+++ b/frontend/apps/admin-web/src/features/onboarding/analytics.ts
@@ -1,17 +1,25 @@
 /**
  * Onboarding / signup funnel instrumentation (Epic 10B, Story 10B.6).
  *
- * The onboarding tour is the last leg of the signup funnel. Until now the
+ * The onboarding tour is the *last* leg of the signup funnel. Until now the
  * TourOverlay drove `start` / `complete-step` / `complete` / `skip` / `reset`
  * mutations but fired no analytics, so the funnel was invisible to the data
  * team. These helpers emit one canonical event per funnel transition, fired
  * from `OnboardingToursPage` only after the corresponding server mutation
  * succeeds (so events count real conversions, not attempts).
+ *
+ * The earlier funnel legs — registration submit, email verification and first
+ * login — are captured by the `signup.*` events below (issue #2530). Their
+ * call-sites live in the auth flows: the admin login page (`LoginPage`) and,
+ * for the manager app, ppt-web's `RegisterPage` + `AuthContext.login` (which
+ * emit the same canonical names through ppt-web's own copy of the analytics
+ * bus, since Vite apps can't cross-import). Keeping every funnel name in one
+ * schema block lets the data team stitch the stages together end-to-end.
  */
 
 import { trackEvent } from '../../lib/analytics';
 
-/** Canonical funnel event names — keep in sync with the data-team schema. */
+/** Canonical onboarding-tour funnel event names — keep in sync with the data-team schema. */
 export const ONBOARDING_EVENTS = {
   tourStarted: 'onboarding.tour_started',
   stepCompleted: 'onboarding.step_completed',
@@ -21,6 +29,38 @@ export const ONBOARDING_EVENTS = {
 } as const;
 
 export type OnboardingEventName = (typeof ONBOARDING_EVENTS)[keyof typeof ONBOARDING_EVENTS];
+
+/**
+ * Canonical *signup* funnel event names — the earlier legs that precede the
+ * onboarding tour. Emitted after the corresponding auth mutation succeeds so
+ * the funnel counts real conversions (registered → verified → logged in →
+ * onboarding tour), not attempts. Keep in sync with the data-team schema.
+ */
+export const SIGNUP_EVENTS = {
+  registrationSubmitted: 'signup.registration_submitted',
+  emailVerified: 'signup.email_verified',
+  loggedIn: 'signup.logged_in',
+} as const;
+
+export type SignupEventName = (typeof SIGNUP_EVENTS)[keyof typeof SIGNUP_EVENTS];
+
+/** Signup methods a funnel event can be attributed to (no PII in properties). */
+export type SignupMethod = 'email_password' | 'sso';
+
+/** Registration form submitted and accepted by the server (UC-14.1). */
+export function trackRegistrationSubmitted(method: SignupMethod = 'email_password'): void {
+  trackEvent(SIGNUP_EVENTS.registrationSubmitted, { method });
+}
+
+/** Email verification link confirmed by the server. */
+export function trackEmailVerified(): void {
+  trackEvent(SIGNUP_EVENTS.emailVerified, {});
+}
+
+/** A successful login (the funnel counts the first, but the event is idempotent). */
+export function trackSignupLoggedIn(method: SignupMethod = 'email_password'): void {
+  trackEvent(SIGNUP_EVENTS.loggedIn, { method });
+}
 
 interface TourRef {
   tourId: string;

--- a/frontend/apps/admin-web/src/pages/LoginPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/LoginPage.test.tsx
@@ -1,12 +1,28 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AdminAuthProvider } from '../auth/AdminAuthContext';
+import {
+  __clearAnalyticsSinks,
+  type AnalyticsEvent,
+  registerAnalyticsSink,
+} from '../lib/analytics';
 import { LoginPage } from './LoginPage';
 
 describe('LoginPage', () => {
+  let captured: AnalyticsEvent[];
+
+  beforeEach(() => {
+    captured = [];
+    registerAnalyticsSink((e) => captured.push(e));
+  });
+
+  afterEach(() => {
+    __clearAnalyticsSinks();
+  });
+
   it('calls login API and stores token on success', async () => {
     const login = vi.fn().mockResolvedValue({ accessToken: 'tk' });
     const user = userEvent.setup();
@@ -21,5 +37,41 @@ describe('LoginPage', () => {
     await user.type(screen.getByLabelText(/password/i), 'secret');
     await user.click(screen.getByRole('button', { name: /sign in/i }));
     expect(login).toHaveBeenCalledWith({ email: 'admin@example.com', password: 'secret' });
+  });
+
+  it('emits signup.logged_in on a successful (non-MFA) login', async () => {
+    const login = vi.fn().mockResolvedValue({ accessToken: 'tk' });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <AdminAuthProvider>
+          <LoginPage loginFn={login} />
+        </AdminAuthProvider>
+      </MemoryRouter>
+    );
+    await user.type(screen.getByLabelText(/email/i), 'admin@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    const events = captured.filter((e) => e.event === 'signup.logged_in');
+    expect(events).toHaveLength(1);
+    expect(events[0].properties).toMatchObject({ method: 'email_password' });
+  });
+
+  it('does not emit signup.logged_in when the server defers for MFA', async () => {
+    const login = vi.fn().mockResolvedValue({ accessToken: '', mfaRequired: true });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <AdminAuthProvider>
+          <LoginPage loginFn={login} />
+        </AdminAuthProvider>
+      </MemoryRouter>
+    );
+    await user.type(screen.getByLabelText(/email/i), 'admin@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(captured.some((e) => e.event === 'signup.logged_in')).toBe(false);
   });
 });

--- a/frontend/apps/admin-web/src/pages/LoginPage.tsx
+++ b/frontend/apps/admin-web/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import { type FormEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
+import { trackSignupLoggedIn } from '../features/onboarding/analytics';
 
 export interface LoginResponse {
   /** Empty string when `mfaRequired: true` (server defers the token until MFA passes). */
@@ -69,6 +70,10 @@ export function LoginPage({ loginFn = defaultLoginFn }: LoginPageProps) {
         return;
       }
       auth.setToken(resp.accessToken);
+      // Signup-funnel: first login is the leg between email verification and
+      // the onboarding tour (issue #2530). Fired only after a real,
+      // non-MFA-deferred token is issued.
+      trackSignupLoggedIn('email_password');
       navigate('/', { replace: true });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'login failed');

--- a/frontend/apps/admin-web/src/pages/OnboardingToursPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/OnboardingToursPage.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Wiring regression test for OnboardingToursPage (issue #2530, tests finding).
+ *
+ * PR #2515 unit-tested the `features/onboarding/analytics.ts` helpers but left
+ * the actual `onSuccess` emitters in this page untested — a dropped or
+ * misplaced `trackTour*` call (incl. the auto-start on open and the
+ * last-step → complete chain) would not be caught. These tests mount the page
+ * with mocked mutations that resolve synchronously and assert each canonical
+ * event fires on the corresponding mutation success.
+ */
+/// <reference types="vitest/globals" />
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ONBOARDING_EVENTS } from '../features/onboarding/analytics';
+import {
+  __clearAnalyticsSinks,
+  type AnalyticsEvent,
+  registerAnalyticsSink,
+} from '../lib/analytics';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// A mutation hook whose `.mutate(arg, opts)` resolves synchronously by invoking
+// the caller's `onSuccess` — this is precisely the boundary the page wires its
+// `trackTour*` emitters onto.
+function okMutation() {
+  return {
+    mutate: (_arg: unknown, opts?: { onSuccess?: () => void }) => opts?.onSuccess?.(),
+    isPending: false,
+  };
+}
+
+const TOUR = {
+  id: 'row-1',
+  tour_id: 't1',
+  name: 'Welcome',
+  description: 'Getting started',
+  steps: [
+    { id: 's1', title: 'Step 1', content: 'a' },
+    { id: 's2', title: 'Step 2', content: 'b' },
+  ],
+  target_roles: [],
+  is_active: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+vi.mock('@ppt/api-client', () => ({
+  useOnboardingStatus: () => ({
+    data: { needs_onboarding: true, tours: [{ tour: TOUR, progress: null }] },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+  useStartOnboardingTour: okMutation,
+  useCompleteOnboardingStep: okMutation,
+  useCompleteOnboardingTour: okMutation,
+  useSkipOnboardingTour: okMutation,
+  useResetOnboardingTour: okMutation,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en' } }),
+}));
+
+vi.mock('../components/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+// The overlay is replaced with a thin harness exposing the page's handler
+// props as buttons, so we can drive each funnel transition deterministically.
+vi.mock('../features/onboarding/TourOverlay', () => ({
+  TourOverlay: (props: {
+    onCompleteStep: (stepId: string, isLast: boolean) => void;
+    onSkipTour: () => void;
+    onResetTour: () => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => props.onCompleteStep('s1', false)}>
+        complete-step
+      </button>
+      <button type="button" onClick={() => props.onCompleteStep('s2', true)}>
+        complete-last
+      </button>
+      <button type="button" onClick={props.onSkipTour}>
+        skip
+      </button>
+      <button type="button" onClick={props.onResetTour}>
+        reset
+      </button>
+    </div>
+  ),
+}));
+
+// Imported after the mocks are registered.
+import OnboardingToursPage from './OnboardingToursPage';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let captured: AnalyticsEvent[];
+
+function events() {
+  return captured.map((e) => e.event);
+}
+
+/** Renders the page and opens the (auto-starting) tour overlay. */
+async function renderAndOpen() {
+  const user = userEvent.setup();
+  render(<OnboardingToursPage />);
+  // The single not-started tour card exposes a start button (auto-start on open).
+  await user.click(screen.getByRole('button', { name: 'onboarding.startTour' }));
+  return user;
+}
+
+beforeEach(() => {
+  captured = [];
+  registerAnalyticsSink((e) => captured.push(e));
+});
+
+afterEach(() => {
+  __clearAnalyticsSinks();
+  vi.clearAllMocks();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('OnboardingToursPage analytics wiring', () => {
+  it('emits tour_started when a tour is opened and auto-started', async () => {
+    await renderAndOpen();
+    expect(events()).toContain(ONBOARDING_EVENTS.tourStarted);
+    const started = captured.find((e) => e.event === ONBOARDING_EVENTS.tourStarted);
+    expect(started?.properties).toMatchObject({ tour_id: 't1', tour_name: 'Welcome' });
+  });
+
+  it('emits step_completed on a non-final step without completing the tour', async () => {
+    const user = await renderAndOpen();
+    captured = []; // drop the auto-start event
+    await user.click(screen.getByRole('button', { name: 'complete-step' }));
+    expect(events()).toEqual([ONBOARDING_EVENTS.stepCompleted]);
+    expect(captured[0].properties).toMatchObject({
+      tour_id: 't1',
+      step_id: 's1',
+      is_last_step: false,
+    });
+  });
+
+  it('chains step_completed → tour_completed on the final step', async () => {
+    const user = await renderAndOpen();
+    captured = [];
+    await user.click(screen.getByRole('button', { name: 'complete-last' }));
+    // Order matters: the completion event must follow the final step event.
+    expect(events()).toEqual([ONBOARDING_EVENTS.stepCompleted, ONBOARDING_EVENTS.tourCompleted]);
+    expect(captured[0].properties).toMatchObject({ step_id: 's2', is_last_step: true });
+    expect(captured[1].properties).toMatchObject({ tour_id: 't1', tour_name: 'Welcome' });
+  });
+
+  it('emits tour_skipped on skip', async () => {
+    const user = await renderAndOpen();
+    captured = [];
+    await user.click(screen.getByRole('button', { name: 'skip' }));
+    expect(events()).toEqual([ONBOARDING_EVENTS.tourSkipped]);
+    expect(captured[0].properties).toMatchObject({ tour_id: 't1' });
+  });
+
+  it('emits tour_reset on reset', async () => {
+    const user = await renderAndOpen();
+    captured = [];
+    await user.click(screen.getByRole('button', { name: 'reset' }));
+    expect(events()).toEqual([ONBOARDING_EVENTS.tourReset]);
+    expect(captured[0].properties).toMatchObject({ tour_id: 't1' });
+  });
+});

--- a/frontend/apps/ppt-web/src/contexts/AuthContext.login-refresh.test.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.login-refresh.test.tsx
@@ -63,6 +63,11 @@ import { useEffect } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProtectedRoute } from '../components/ProtectedRoute';
+import {
+  __clearAnalyticsSinks,
+  type AnalyticsEvent,
+  registerAnalyticsSink,
+} from '../lib/analytics';
 import { AuthProvider, useAuth } from './AuthContext';
 
 // ---------------------------------------------------------------------------
@@ -247,6 +252,59 @@ describe('AuthContext.login — email/password flow (Story 79.2)', () => {
     expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBeNull();
     expect(ctxRef.current?.isAuthenticated).toBe(false);
     expect(screen.getByText('Login page')).toBeInTheDocument();
+  });
+});
+
+describe('AuthContext.login — signup-funnel analytics (issue #2530)', () => {
+  let captured: AnalyticsEvent[];
+
+  beforeEach(() => {
+    loginSpy.mockReset();
+    refreshTokenSpy.mockReset();
+    localStorage.clear();
+    sessionStorage.clear();
+    captured = [];
+    registerAnalyticsSink((e) => captured.push(e));
+  });
+
+  afterEach(() => {
+    __clearAnalyticsSinks();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it('emits signup.logged_in after a successful email/password login', async () => {
+    loginSpy.mockResolvedValue(makeLoginResponse());
+    const { ctxRef } = renderAuthApp('/dashboard');
+
+    await waitFor(() => {
+      expect(ctxRef.current?.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await ctxRef.current?.login({ email: 'manager@example.com', password: 'pw' });
+    });
+
+    const signupEvents = captured.filter((e) => e.event === 'signup.logged_in');
+    expect(signupEvents).toHaveLength(1);
+    expect(signupEvents[0].properties).toMatchObject({ method: 'email_password' });
+  });
+
+  it('does not emit signup.logged_in when login rejects', async () => {
+    loginSpy.mockRejectedValue(new Error('invalid_credentials'));
+    const { ctxRef } = renderAuthApp('/dashboard');
+
+    await waitFor(() => {
+      expect(ctxRef.current?.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await expect(ctxRef.current?.login({ email: 'x@y.z', password: 'wrong' })).rejects.toThrow(
+        'invalid_credentials'
+      );
+    });
+
+    expect(captured.some((e) => e.event === 'signup.logged_in')).toBe(false);
   });
 });
 

--- a/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
@@ -35,6 +35,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { trackSignupLoggedIn } from '../features/auth/analytics';
 import { AUTHED_QUERY_KEY_ROOTS } from '../lib/queryKeys';
 
 export type { AuthErrorCode, AuthUser };
@@ -470,6 +471,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       }
 
       setUser(userWithRole);
+      // Signup-funnel: the "first login" leg between email verification and
+      // the onboarding tour (issue #2530). Fired only after tokens/user are
+      // persisted and the session is authenticated.
+      trackSignupLoggedIn('email_password');
     } finally {
       setIsLoading(false);
     }

--- a/frontend/apps/ppt-web/src/features/auth/analytics.test.ts
+++ b/frontend/apps/ppt-web/src/features/auth/analytics.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the ppt-web signup-funnel analytics helpers (issue #2530).
+ * Locks in the canonical `signup.*` event names + payloads and the shared bus
+ * safety guarantees (dataLayer mirroring, never-throws).
+ */
+/// <reference types="vitest/globals" />
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __clearAnalyticsSinks,
+  type AnalyticsEvent,
+  registerAnalyticsSink,
+} from '../../lib/analytics';
+import {
+  SIGNUP_EVENTS,
+  trackEmailVerified,
+  trackRegistrationSubmitted,
+  trackSignupLoggedIn,
+} from './analytics';
+
+let captured: AnalyticsEvent[];
+
+beforeEach(() => {
+  captured = [];
+  registerAnalyticsSink((e) => captured.push(e));
+});
+
+afterEach(() => {
+  __clearAnalyticsSinks();
+  (globalThis as { dataLayer?: unknown[] }).dataLayer = undefined;
+});
+
+describe('ppt-web signup funnel analytics', () => {
+  it('fires registration_submitted with the signup method', () => {
+    trackRegistrationSubmitted();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].event).toBe(SIGNUP_EVENTS.registrationSubmitted);
+    expect(captured[0].properties).toMatchObject({ method: 'email_password' });
+    expect(captured[0].timestamp).toEqual(expect.any(String));
+  });
+
+  it('fires email_verified and logged_in with an overridable method', () => {
+    trackEmailVerified();
+    trackSignupLoggedIn('sso');
+    expect(captured.map((e) => e.event)).toEqual([
+      SIGNUP_EVENTS.emailVerified,
+      SIGNUP_EVENTS.loggedIn,
+    ]);
+    expect(captured[1].properties).toMatchObject({ method: 'sso' });
+  });
+
+  it('uses names identical to the admin-web schema so the funnel stitches', () => {
+    expect(SIGNUP_EVENTS).toEqual({
+      registrationSubmitted: 'signup.registration_submitted',
+      emailVerified: 'signup.email_verified',
+      loggedIn: 'signup.logged_in',
+    });
+  });
+
+  it('mirrors events onto window.dataLayer when present', () => {
+    (globalThis as { dataLayer?: unknown[] }).dataLayer = [];
+    trackRegistrationSubmitted();
+    const dl = (globalThis as { dataLayer?: Array<Record<string, unknown>> }).dataLayer;
+    expect(dl).toHaveLength(1);
+    expect(dl?.[0]).toMatchObject({
+      event: SIGNUP_EVENTS.registrationSubmitted,
+      method: 'email_password',
+    });
+  });
+
+  it('never throws when a sink misbehaves', () => {
+    registerAnalyticsSink(() => {
+      throw new Error('boom');
+    });
+    expect(() => trackSignupLoggedIn()).not.toThrow();
+    expect(captured).toHaveLength(1);
+  });
+});

--- a/frontend/apps/ppt-web/src/features/auth/analytics.ts
+++ b/frontend/apps/ppt-web/src/features/auth/analytics.ts
@@ -1,0 +1,43 @@
+/**
+ * Signup-funnel instrumentation for the ppt-web (manager) auth flows
+ * (issue #2530).
+ *
+ * PR #2515 instrumented only the onboarding-tour leg (in admin-web). The
+ * earlier funnel legs live in ppt-web: registration submit (`RegisterPage`)
+ * and first login (`AuthContext.login`). These helpers emit one canonical
+ * `signup.*` event per transition, fired only after the corresponding server
+ * call succeeds (so events count real conversions, not attempts).
+ *
+ * The event names MUST stay identical to admin-web's
+ * `features/onboarding/analytics.ts` `SIGNUP_EVENTS` so the data team can
+ * stitch both apps into one funnel.
+ */
+
+import { trackEvent } from '../../lib/analytics';
+
+/** Canonical signup funnel event names — keep in sync with admin-web + the data-team schema. */
+export const SIGNUP_EVENTS = {
+  registrationSubmitted: 'signup.registration_submitted',
+  emailVerified: 'signup.email_verified',
+  loggedIn: 'signup.logged_in',
+} as const;
+
+export type SignupEventName = (typeof SIGNUP_EVENTS)[keyof typeof SIGNUP_EVENTS];
+
+/** Signup methods a funnel event can be attributed to (no PII in properties). */
+export type SignupMethod = 'email_password' | 'sso';
+
+/** Registration form submitted and accepted by the server (UC-14.1). */
+export function trackRegistrationSubmitted(method: SignupMethod = 'email_password'): void {
+  trackEvent(SIGNUP_EVENTS.registrationSubmitted, { method });
+}
+
+/** Email verification link confirmed by the server. */
+export function trackEmailVerified(): void {
+  trackEvent(SIGNUP_EVENTS.emailVerified, {});
+}
+
+/** A successful login (the funnel counts the first, but the event is idempotent). */
+export function trackSignupLoggedIn(method: SignupMethod = 'email_password'): void {
+  trackEvent(SIGNUP_EVENTS.loggedIn, { method });
+}

--- a/frontend/apps/ppt-web/src/features/auth/pages/RegisterPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/auth/pages/RegisterPage.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Wiring test for RegisterPage's signup-funnel instrumentation (issue #2530).
+ *
+ * Asserts the registration-submit leg of the funnel emits
+ * `signup.registration_submitted` — and only after the server accepts the
+ * registration (never on a validation failure or a rejected request).
+ */
+/// <reference types="vitest/globals" />
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __clearAnalyticsSinks,
+  type AnalyticsEvent,
+  registerAnalyticsSink,
+} from '../../../lib/analytics';
+import { SIGNUP_EVENTS } from '../analytics';
+import { RegisterPage } from './RegisterPage';
+
+const registerFn = vi.fn();
+
+vi.mock('../authApiClient', () => ({
+  getAuthApi: () => ({ register: registerFn }),
+}));
+
+let captured: AnalyticsEvent[];
+
+function fillValidForm(container: HTMLElement) {
+  const set = (id: string, value: string) => {
+    const el = container.querySelector<HTMLInputElement>(`#${id}`);
+    if (!el) throw new Error(`missing input #${id}`);
+    fireEvent.change(el, { target: { value } });
+  };
+  set('firstName', 'Ada');
+  set('lastName', 'Lovelace');
+  set('email', 'ada@example.com');
+  set('password', 'supersecret');
+  set('confirmPassword', 'supersecret');
+}
+
+beforeEach(() => {
+  captured = [];
+  registerFn.mockReset();
+  registerAnalyticsSink((e) => captured.push(e));
+});
+
+afterEach(() => {
+  __clearAnalyticsSinks();
+});
+
+describe('RegisterPage signup-funnel wiring', () => {
+  function renderPage() {
+    return render(
+      <MemoryRouter>
+        <RegisterPage />
+      </MemoryRouter>
+    );
+  }
+
+  it('emits registration_submitted after a successful register call', async () => {
+    registerFn.mockResolvedValue({});
+    const { container } = renderPage();
+    fillValidForm(container);
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(registerFn).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(captured.map((e) => e.event)).toEqual([SIGNUP_EVENTS.registrationSubmitted]);
+    });
+    expect(captured[0].properties).toMatchObject({ method: 'email_password' });
+  });
+
+  it('does not emit when the register request rejects', async () => {
+    registerFn.mockRejectedValue(new Error('EMAIL_ALREADY_EXISTS'));
+    const { container } = renderPage();
+    fillValidForm(container);
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    await waitFor(() => {
+      expect(registerFn).toHaveBeenCalledTimes(1);
+    });
+    expect(captured).toHaveLength(0);
+  });
+
+  it('does not emit (or call the API) when client-side validation fails', async () => {
+    registerFn.mockResolvedValue({});
+    const { container } = renderPage();
+    // Leave fields empty → validation blocks the submit.
+    fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+    await Promise.resolve();
+    expect(registerFn).not.toHaveBeenCalled();
+    expect(captured).toHaveLength(0);
+  });
+});

--- a/frontend/apps/ppt-web/src/features/auth/pages/RegisterPage.tsx
+++ b/frontend/apps/ppt-web/src/features/auth/pages/RegisterPage.tsx
@@ -10,6 +10,7 @@ import type React from 'react';
 import { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link, useNavigate } from 'react-router-dom';
+import { trackRegistrationSubmitted } from '../analytics';
 import { getAuthApi } from '../authApiClient';
 import '../styles/AuthPage.css';
 
@@ -109,6 +110,9 @@ export function RegisterPage() {
           firstName: firstName.trim(),
           lastName: lastName.trim(),
         });
+        // Signup-funnel: first (and earliest) leg — fired only after the
+        // server accepts the registration (issue #2530).
+        trackRegistrationSubmitted('email_password');
         setSubmitted(true);
       } catch (error) {
         setErrors({ general: getErrorKey(error) });

--- a/frontend/apps/ppt-web/src/lib/analytics.ts
+++ b/frontend/apps/ppt-web/src/lib/analytics.ts
@@ -1,0 +1,84 @@
+/**
+ * Lightweight, transport-agnostic analytics event bus for ppt-web.
+ *
+ * Mirror of `admin-web/src/lib/analytics.ts` (issue #2530). The two apps are
+ * separate Vite bundles and cannot cross-import, so each keeps its own copy of
+ * this dependency-free bus. Keep the shape (and the `signup.*` event schema in
+ * `features/auth/analytics.ts`) in sync with admin-web so the data team sees a
+ * single funnel.
+ *
+ * The app has no bundled analytics SDK (PostHog / Segment / GA are injected at
+ * deploy time, if at all). This module gives feature code a single,
+ * dependency-free `trackEvent` entry point that:
+ *
+ *   1. pushes a GTM-style record onto `window.dataLayer` when one is present
+ *      (the deploy-time tag manager consumes it), and
+ *   2. fans the event out to any in-process sinks registered via
+ *      `registerAnalyticsSink` (used by tests and by future in-app dashboards).
+ *
+ * Analytics must never break the UX: every sink call is wrapped so a throwing
+ * sink can't bubble into a React event handler.
+ */
+
+export interface AnalyticsEvent {
+  /** Dot-namespaced event name, e.g. `signup.registration_submitted`. */
+  event: string;
+  /** Arbitrary, JSON-serialisable event properties. */
+  properties: Record<string, unknown>;
+  /** ISO-8601 capture timestamp. */
+  timestamp: string;
+}
+
+export type AnalyticsSink = (event: AnalyticsEvent) => void;
+
+const sinks = new Set<AnalyticsSink>();
+
+/**
+ * Register an in-process analytics sink. Returns an unsubscribe function.
+ */
+export function registerAnalyticsSink(sink: AnalyticsSink): () => void {
+  sinks.add(sink);
+  return () => {
+    sinks.delete(sink);
+  };
+}
+
+/** Test/reset hook — drops all registered in-process sinks. */
+export function __clearAnalyticsSinks(): void {
+  sinks.clear();
+}
+
+interface DataLayerWindow {
+  dataLayer?: unknown[];
+}
+
+/**
+ * Emit an analytics event. Safe to call from any render/event-handler path —
+ * it never throws.
+ */
+export function trackEvent(event: string, properties: Record<string, unknown> = {}): void {
+  const payload: AnalyticsEvent = {
+    event,
+    properties,
+    timestamp: new Date().toISOString(),
+  };
+
+  // 1. GTM-style dataLayer (deploy-time tag manager), if present.
+  try {
+    const dl = (globalThis as DataLayerWindow).dataLayer;
+    if (Array.isArray(dl)) {
+      dl.push({ event, ...properties, timestamp: payload.timestamp });
+    }
+  } catch {
+    // Never let analytics transport break the caller.
+  }
+
+  // 2. In-process sinks.
+  for (const sink of sinks) {
+    try {
+      sink(payload);
+    } catch {
+      // Swallow — a broken sink must not break the UX.
+    }
+  }
+}


### PR DESCRIPTION
## Task
Follow-up: instrument the full signup funnel, not just the onboarding tour (Closes #2530)

Post-merge review of PR #2515 found the "signup funnel" work only instrumented the onboarding-tour leg. The earlier legs (registration submit, email verification, first login) emitted nothing, so the funnel could not be measured end-to-end. This wires canonical `signup.*` events onto the funnel legs that actually exist in the code, plus the named test gap.

## Owner
pm-frontend (primary) / pm-data

## What changed
**Canonical `signup.*` schema** (added alongside `ONBOARDING_EVENTS`, kept identical across both apps so the data team can stitch stages):
- `signup.registration_submitted`, `signup.email_verified`, `signup.logged_in`

**admin-web** (`frontend/apps/admin-web/`):
- `features/onboarding/analytics.ts` — add `SIGNUP_EVENTS` + `trackRegistrationSubmitted` / `trackEmailVerified` / `trackSignupLoggedIn`.
- `pages/LoginPage.tsx` — emit `signup.logged_in` on a successful, non-MFA-deferred login.

**ppt-web** (`frontend/apps/ppt-web/`) — this is where the registration + first-login legs actually live:
- `lib/analytics.ts` — a per-app copy of the dependency-free `trackEvent` bus. Vite apps can't cross-import `admin-web/src/lib/analytics.ts`, and there's no shared web-utils package, so each app keeps its own copy (documented in both files). Moving it to a shared package would be a refactor beyond this task's scope.
- `features/auth/analytics.ts` — the same `SIGNUP_EVENTS` + trackers.
- `features/auth/pages/RegisterPage.tsx` — emit `signup.registration_submitted` after the server accepts the registration.
- `contexts/AuthContext.tsx` — emit `signup.logged_in` after `login()` persists tokens/session.

**Scope notes (intentionally NOT done — would be auth-flow redesign / out of scope):**
- No `signup.email_verified` call-site exists: `verifyEmail` is defined in `@ppt/api-client` but consumed by no page in either app. The canonical event name is added to the schema so future wiring is trivial, but no verify page was built.
- Auth flows themselves are untouched (only analytics emitters added).

## Tests
- `admin-web/src/pages/OnboardingToursPage.test.tsx` (NEW, the named gap) — mounts the page with mocked mutations and asserts each tour event fires on mutation success, incl. auto-start on open and the last-step → tour_completed chain.
- `admin-web/src/features/onboarding/analytics.test.ts` — extended with signup trackers + end-to-end funnel ordering.
- `admin-web/src/pages/LoginPage.test.tsx` — asserts `signup.logged_in` fires on success and NOT on an MFA-deferred response.
- `ppt-web/src/features/auth/analytics.test.ts` (NEW) — signup trackers, dataLayer mirroring, schema-parity, never-throws.
- `ppt-web/src/features/auth/pages/RegisterPage.test.tsx` (NEW) — emits only after a successful register; not on reject or validation failure.
- `ppt-web/src/contexts/AuthContext.login-refresh.test.tsx` — extended: `signup.logged_in` on login success, none on reject.

## Verification
```
VERIFY-PLAN base=d7170dad0bb7874d7587d2c728e9d146d1716178 files=12
  cd frontend && pnpm exec biome check <12 changed files>
  cd frontend && pnpm --filter "...[<base>]" typecheck
  cd frontend && pnpm --filter "...[<base>]" test
```
- biome check (12 changed files): **PASS**
- typecheck (admin-web + ppt-web): **PASS** (exit 0 both)
- ppt-web full suite: **PASS** — 1599/1599
- admin-web `src` suite: 259/260 — the single failure is **pre-existing and unrelated**:
  `CapabilitiesAdminPage.test.tsx` asserts `CAPABILITIES.length === 17` but the registry has 18. Those files are **byte-identical to `dev`** and are **not in this diff** (`git diff dev...HEAD` touches none of them), so the failure reproduces on `dev`.
- The impact gate's `pnpm --filter test` also reports 4 "failed files" that are Playwright e2e specs (`e2e/specs/*.spec.ts`, `PlatformHealthPage` `@requires-backend`) erroneously collected by admin-web's `include`-less vitest config — also pre-existing and unrelated to this diff.

**Net: every changed file's tests are green; the deterministic gate's red is 100% pre-existing `dev` breakage outside this task's scope.** Not fixed here to avoid scope drift (CapabilitiesAdminPage count is a different domain; the admin-web vitest `include` gap is test-infra).

Scope check (`owner=pm-frontend`): clean, no drift — diff is entirely under `frontend/**`.
Code-reuse pre-flight: no warnings. (The analytics bus is intentionally duplicated per-app as noted above.)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (analytics instrumentation; no security/auth/billing/data-integrity logic change).

## Remote-tested
skipped.

## Notes
- Draft: the deterministic verify gate does not go fully green **only because of pre-existing, unrelated `dev` test breakage** (see Verification). All changed-file suites pass. Flagging for reviewer adjudication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018PvzhEGsq3vbfhYPArv8xS

---
_Generated by [Claude Code](https://claude.ai/code/session_018PvzhEGsq3vbfhYPArv8xS)_