### PR TITLE
gh-issue-2532: wire layout publish/webhook/revalidate event emission + sink

### DIFF
--- a/backend/crates/db/migrations/00225_create_layout_change_events.sql
+++ b/backend/crates/db/migrations/00225_create_layout_change_events.sql
@@ -1,0 +1,135 @@
+-- Migration 00225: Layout Publish/Webhook Analytics Events (sink + retention)
+--
+-- Creates the append-only sink for the layout publish → outbound webhook →
+-- reality-web ISR revalidation pipeline, closing gap C of
+-- docs/data/layout-publish-event-tracking.md (the events were defined there but
+-- nothing persisted them). Producers:
+--   layout_change_published   — api-server routes/layout/admin.rs (one per
+--                               successful publish/rollback/kill/unkill)
+--   layout_webhook_dispatched — api-server routes/layout/webhook.rs (outbound
+--                               delivery outcome, incl. the unconfigured no-op)
+--   layout_revalidate_received— reality-web /api/layout-revalidate (receiver)
+--
+-- Mirrors the support_tooling_events pattern (migration 00163 + 00165 + 00222):
+-- a deliberately narrow table with rich per-event props in JSONB, DB-level
+-- triggers that reject UPDATE/DELETE so the trail is append-only / tamper-
+-- evident, and a DB-native retention prune whose sanctioned DELETE path is
+-- gated by the app.retention_prune GUC.
+--
+-- NO RLS: like layout_configs / layout_config_versions / layout_kill_flags
+-- (migration 00221) these are platform-admin-owned GLOBAL rows, not tenant-
+-- scoped. Access is gated at the application layer (superadmin routes). Because
+-- the table carries no FORCE-RLS policy, the retention prune does NOT need to
+-- assert app.is_super_admin (unlike cleanup_old_support_tooling_events); it only
+-- opens the immutability-trigger's sanctioned DELETE path.
+--
+-- Retention: 730 days (24 months) — the same sanctioned lifetime as
+-- support_tooling_events (00222), long enough for security / accountability
+-- investigations, bounded enough to honour GDPR storage limitation
+-- (Art. 5(1)(e)). Defined UP FRONT (privacy finding on issue #2532) rather than
+-- deferred. The period is a function parameter (DEFAULT 730) so operators can
+-- override per-invocation without a schema change. Wiring the prune into the
+-- api-server background scheduler is a separate follow-up (same posture as
+-- support_tooling_events); this migration + repository method establish the
+-- retention definition itself.
+
+CREATE TABLE layout_change_events (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    event_kind    TEXT        NOT NULL
+                  CHECK (event_kind IN (
+                      'layout_change_published',
+                      'layout_webhook_dispatched',
+                      'layout_revalidate_received'
+                  )),
+    -- Layout screen id, e.g. 'reality/listing-detail'. Nullable: the receiver
+    -- records an event even on the invalid_body path where no screen parsed.
+    screen        TEXT,
+    -- Correlation id shared across the three events for one mutation
+    -- (gap D). Nullable so a bare/legacy delivery can still be recorded.
+    delivery_id   UUID,
+    -- Acting platform SuperAdmin for layout_change_published. FK with
+    -- ON DELETE SET NULL so the audit trail survives (anonymised) account
+    -- deletion — matches the privacy posture in the events doc §7. NULL for
+    -- operational events (webhook_dispatched / revalidate_received) which carry
+    -- no admin identity.
+    published_by  UUID        REFERENCES users(id) ON DELETE SET NULL,
+    -- Rich per-event dimensions (change_kind, layout_version, target_tenant,
+    -- dispatch_outcome, revalidate_outcome, http_status, tags, …). JSONB so new
+    -- event kinds can add fields without a schema migration. Never carries the
+    -- webhook signature/secret or the layout config payload (events doc §7).
+    props         JSONB       NOT NULL DEFAULT '{}',
+    occurred_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Immutability trigger — UPDATE is always rejected; DELETE is rejected unless
+-- the caller is inside the sanctioned retention path (app.retention_prune =
+-- 'on', set transaction-locally by cleanup_old_layout_change_events). Any other
+-- UPDATE/DELETE is tampering and is refused, preserving append-only semantics.
+-- Same defence as support_tooling_events (migration 00163 + 00222).
+CREATE OR REPLACE FUNCTION layout_change_events_immutable()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        RAISE EXCEPTION 'layout_change_events rows are immutable';
+    END IF;
+
+    -- TG_OP = 'DELETE': allow only inside the sanctioned retention path.
+    IF current_setting('app.retention_prune', true) IS DISTINCT FROM 'on' THEN
+        RAISE EXCEPTION 'layout_change_events rows are immutable';
+    END IF;
+
+    RETURN OLD;
+END;
+$$;
+
+CREATE TRIGGER layout_change_events_no_update
+    BEFORE UPDATE ON layout_change_events
+    FOR EACH ROW EXECUTE FUNCTION layout_change_events_immutable();
+
+CREATE TRIGGER layout_change_events_no_delete
+    BEFORE DELETE ON layout_change_events
+    FOR EACH ROW EXECUTE FUNCTION layout_change_events_immutable();
+
+-- DB-native retention prune. Mirrors cleanup_old_support_tooling_events (00222):
+-- DELETE aged rows by timestamp inside the sanctioned path, return the deleted
+-- count. The GUC is set transaction-locally (is_local = true) and reset before
+-- return, so delete rights never bleed onto the pooled connection or any
+-- subsequent statement in the same transaction. No app.is_super_admin needed —
+-- the table has no RLS policy.
+CREATE OR REPLACE FUNCTION cleanup_old_layout_change_events(retention_days INTEGER DEFAULT 730)
+RETURNS BIGINT AS $$
+DECLARE
+    deleted_count BIGINT;
+BEGIN
+    PERFORM set_config('app.retention_prune', 'on', true);
+
+    DELETE FROM layout_change_events
+    WHERE occurred_at < NOW() - (retention_days || ' days')::INTERVAL;
+
+    GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+    PERFORM set_config('app.retention_prune', 'off', true);
+
+    RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cleanup_old_layout_change_events IS
+    'Retention prune for layout_change_events: deletes layout publish/webhook/'
+    'revalidate analytics events older than the retention period (default 730 '
+    'days / 24 months, GDPR Art. 5(1)(e) storage limitation). Deletes are gated '
+    'by the app.retention_prune GUC so the append-only immutability trigger '
+    'still blocks every other UPDATE/DELETE.';
+
+-- Time-range queries (dashboards, prune scans).
+CREATE INDEX layout_change_events_occurred_at_idx
+    ON layout_change_events (occurred_at DESC);
+
+-- Filter by event type.
+CREATE INDEX layout_change_events_kind_idx
+    ON layout_change_events (event_kind);
+
+-- Join the three events of one mutation on the shared correlation id.
+CREATE INDEX layout_change_events_delivery_id_idx
+    ON layout_change_events (delivery_id)
+    WHERE delivery_id IS NOT NULL;

--- a/backend/crates/db/src/repositories/layout.rs
+++ b/backend/crates/db/src/repositories/layout.rs
@@ -21,6 +21,34 @@ pub enum LayoutPublishError {
     Sqlx(#[from] SqlxError),
 }
 
+/// The three layout-pipeline analytics event kinds persisted to
+/// `layout_change_events` (migration `00225_create_layout_change_events.sql`).
+///
+/// The string values are the canonical event names from
+/// `docs/data/layout-publish-event-tracking.md` §2 and MUST stay byte-for-byte
+/// aligned with the table's `event_kind` CHECK constraint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutChangeEventKind {
+    /// A layout mutation (publish/rollback/kill/unkill) succeeded in the DB.
+    Published,
+    /// The outbound webhook attempt resolved (delivered / non-2xx / transport
+    /// error / skipped-unconfigured).
+    WebhookDispatched,
+    /// The reality-web `/api/layout-revalidate` receiver returned.
+    RevalidateReceived,
+}
+
+impl LayoutChangeEventKind {
+    /// Stable wire string — matches the `layout_change_events` CHECK constraint.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LayoutChangeEventKind::Published => "layout_change_published",
+            LayoutChangeEventKind::WebhookDispatched => "layout_webhook_dispatched",
+            LayoutChangeEventKind::RevalidateReceived => "layout_revalidate_received",
+        }
+    }
+}
+
 /// Stateless repository for the layout control plane. Global tables
 /// (configs/versions/kills/manifests) are platform-admin-owned and carry no
 /// RLS — call them with the unscoped pool. `layout_tenant_overrides` is
@@ -406,5 +434,99 @@ impl LayoutRepository {
         .bind(updated_by)
         .fetch_one(executor)
         .await
+    }
+
+    /// Append a layout-pipeline analytics event to the append-only
+    /// `layout_change_events` sink (migration `00225`), returning the new row id.
+    ///
+    /// Callers treat this as **fire-and-forget**: a failure to persist an
+    /// analytics event MUST NOT change the outcome of the layout mutation, the
+    /// webhook delivery, or the revalidation (events doc §7). Callers log the
+    /// error and continue.
+    ///
+    /// # Arguments
+    /// * `kind`         — which of the three event kinds fired.
+    /// * `screen`       — layout screen id (`None` only on the receiver's
+    ///                    invalid-body path where no screen parsed).
+    /// * `delivery_id`  — correlation id shared across the three events for one
+    ///                    mutation (gap D).
+    /// * `published_by` — acting SuperAdmin for `Published`; `None` for the
+    ///                    operational `WebhookDispatched` event.
+    /// * `props`        — structured per-event dimensions serialised to JSONB.
+    pub async fn record_change_event<'e, E>(
+        &self,
+        executor: E,
+        kind: LayoutChangeEventKind,
+        screen: Option<&str>,
+        delivery_id: Option<Uuid>,
+        published_by: Option<Uuid>,
+        props: &serde_json::Value,
+    ) -> Result<Uuid, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO layout_change_events (event_kind, screen, delivery_id, published_by, props)
+             VALUES ($1, $2, $3, $4, $5)
+             RETURNING id",
+        )
+        .bind(kind.as_str())
+        .bind(screen)
+        .bind(delivery_id)
+        .bind(published_by)
+        .bind(props)
+        .fetch_one(executor)
+        .await
+    }
+
+    /// Prune `layout_change_events` older than the retention period, returning
+    /// the number of rows deleted.
+    ///
+    /// Retention (TTL) entry point for the append-only layout analytics trail
+    /// (migration `00225`). Calls the DB-native
+    /// `cleanup_old_layout_change_events(retention_days)`, mirroring
+    /// `cleanup_old_support_tooling_events`: the function opens the sanctioned
+    /// `app.retention_prune` path so the immutability trigger permits these —
+    /// and only these — deletes; every other `UPDATE`/`DELETE` stays rejected.
+    ///
+    /// `retention_days` defaults to 730 (24 months) at the SQL layer; callers
+    /// pass an explicit value so the policy is visible at the call site.
+    pub async fn cleanup_old_layout_change_events<'e, E>(
+        &self,
+        executor: E,
+        retention_days: i32,
+    ) -> Result<i64, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_scalar::<_, i64>("SELECT cleanup_old_layout_change_events($1)")
+            .bind(retention_days)
+            .fetch_one(executor)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LayoutChangeEventKind;
+
+    /// Pin the wire strings: they are the canonical event names in
+    /// docs/data/layout-publish-event-tracking.md §2 AND the values in the
+    /// `layout_change_events` CHECK constraint (migration 00225). A drift here
+    /// silently breaks the INSERT or the doc contract.
+    #[test]
+    fn layout_change_event_kind_strings_are_stable() {
+        assert_eq!(
+            LayoutChangeEventKind::Published.as_str(),
+            "layout_change_published"
+        );
+        assert_eq!(
+            LayoutChangeEventKind::WebhookDispatched.as_str(),
+            "layout_webhook_dispatched"
+        );
+        assert_eq!(
+            LayoutChangeEventKind::RevalidateReceived.as_str(),
+            "layout_revalidate_received"
+        );
     }
 }

--- a/backend/crates/db/src/repositories/mod.rs
+++ b/backend/crates/db/src/repositories/mod.rs
@@ -125,7 +125,7 @@ pub use health_monitoring::{
     MetricStats, MetricStatus,
 };
 pub use help::{FaqEntry, HelpArticle, HelpCategory, HelpRepository, Tooltip};
-pub use layout::{LayoutPublishError, LayoutRepository};
+pub use layout::{LayoutChangeEventKind, LayoutPublishError, LayoutRepository};
 pub use membership::MembershipRepository;
 pub use messaging::MessagingRepository;
 pub use meter::MeterRepository;

--- a/backend/crates/db/tests/suite_4.rs
+++ b/backend/crates/db/tests/suite_4.rs
@@ -8,6 +8,8 @@
 
 mod common;
 
+#[path = "suites/layout_change_events_retention_tests.rs"]
+mod layout_change_events_retention_tests;
 #[path = "suites/report_schedule_scheduler_rls_tests.rs"]
 mod report_schedule_scheduler_rls_tests;
 #[path = "suites/repository_tests.rs"]

--- a/backend/crates/db/tests/suites/layout_change_events_retention_tests.rs
+++ b/backend/crates/db/tests/suites/layout_change_events_retention_tests.rs
@@ -1,0 +1,134 @@
+//! DB-backed regression tests for the layout_change_events sink + retention
+//! policy (migration `00225_create_layout_change_events.sql`, issue #2532).
+//!
+//! Background
+//! ----------
+//! `layout_change_events` is the append-only sink for the layout publish →
+//! webhook → revalidate pipeline. Like `support_tooling_events` it is
+//! tamper-evident: triggers reject every UPDATE/DELETE except the sanctioned
+//! retention prune (`cleanup_old_layout_change_events`, gated by the
+//! `app.retention_prune` GUC). Unlike support_tooling_events it carries no
+//! RLS (global platform-admin table, precedent: layout_configs).
+//!
+//! These tests pin four properties:
+//!   1. `record_change_event` inserts a row and returns its id.
+//!   2. The retention prune deletes rows older than the window and keeps newer
+//!      ones (returning the deleted count).
+//!   3. An ordinary DELETE (outside the sanctioned path) is still rejected.
+//!   4. An ordinary UPDATE is still rejected.
+
+use db::repositories::{LayoutChangeEventKind, LayoutRepository};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn count_events(pool: &PgPool) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM layout_change_events")
+        .fetch_one(pool)
+        .await
+        .expect("count events")
+}
+
+/// Insert a row with an explicit `occurred_at` — the immutability trigger
+/// forbids UPDATE, so a test cannot backdate a row after the fact.
+async fn insert_event_at(pool: &PgPool, days_ago: i64) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO layout_change_events (event_kind, screen, props, occurred_at)
+        VALUES ('layout_change_published', 'reality/listing-detail', '{}'::jsonb,
+                NOW() - ($1 || ' days')::INTERVAL)
+        RETURNING id
+        "#,
+    )
+    .bind(days_ago.to_string())
+    .fetch_one(pool)
+    .await
+    .expect("insert layout_change_events row")
+}
+
+#[sqlx::test]
+async fn record_change_event_inserts_and_returns_id(pool: PgPool) {
+    let repo = LayoutRepository::new();
+    let delivery_id = Uuid::new_v4();
+    let props = serde_json::json!({ "change_kind": "published", "layout_version": 3 });
+
+    let id = repo
+        .record_change_event(
+            &pool,
+            LayoutChangeEventKind::Published,
+            Some("reality/listing-detail"),
+            Some(delivery_id),
+            None,
+            &props,
+        )
+        .await
+        .expect("record_change_event should succeed");
+
+    let (kind, screen, got_delivery): (String, Option<String>, Option<Uuid>) = sqlx::query_as(
+        "SELECT event_kind, screen, delivery_id FROM layout_change_events WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_one(&pool)
+    .await
+    .expect("fetch inserted row");
+    assert_eq!(kind, "layout_change_published");
+    assert_eq!(screen.as_deref(), Some("reality/listing-detail"));
+    assert_eq!(got_delivery, Some(delivery_id));
+}
+
+#[sqlx::test]
+async fn retention_prune_deletes_aged_rows_and_keeps_recent(pool: PgPool) {
+    // One row past the 730-day window, one comfortably inside it.
+    let old_id = insert_event_at(&pool, 800).await;
+    let recent_id = insert_event_at(&pool, 10).await;
+    assert_eq!(count_events(&pool).await, 2);
+
+    let deleted = LayoutRepository::new()
+        .cleanup_old_layout_change_events(&pool, 730)
+        .await
+        .expect("retention prune should succeed");
+    assert_eq!(deleted, 1, "exactly the aged row should be pruned");
+
+    let surviving: Vec<Uuid> = sqlx::query_scalar::<_, Uuid>("SELECT id FROM layout_change_events")
+        .fetch_all(&pool)
+        .await
+        .expect("select surviving ids");
+    assert_eq!(surviving, vec![recent_id]);
+    assert!(
+        !surviving.contains(&old_id),
+        "aged row must have been pruned"
+    );
+}
+
+#[sqlx::test]
+async fn ordinary_delete_is_still_rejected(pool: PgPool) {
+    let id = insert_event_at(&pool, 5).await;
+
+    let err = sqlx::query("DELETE FROM layout_change_events WHERE id = $1")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .expect_err("ordinary DELETE must be rejected");
+    assert!(
+        err.to_string().contains("immutable"),
+        "unexpected error: {err}"
+    );
+
+    assert_eq!(count_events(&pool).await, 1);
+}
+
+#[sqlx::test]
+async fn update_is_still_rejected(pool: PgPool) {
+    let id = insert_event_at(&pool, 5).await;
+
+    let err = sqlx::query(
+        "UPDATE layout_change_events SET event_kind = 'layout_webhook_dispatched' WHERE id = $1",
+    )
+    .bind(id)
+    .execute(&pool)
+    .await
+    .expect_err("UPDATE must always be rejected");
+    assert!(
+        err.to_string().contains("immutable"),
+        "unexpected error: {err}"
+    );
+}

--- a/backend/servers/api-server/src/routes/layout/admin.rs
+++ b/backend/servers/api-server/src/routes/layout/admin.rs
@@ -3,8 +3,9 @@ use crate::state::AppState;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::Json;
-use db::repositories::LayoutRepository;
+use db::repositories::{LayoutChangeEventKind, LayoutRepository};
 use db::RlsPool;
+use uuid::Uuid;
 
 use super::types::{
     KillRequest, PreviewResolveRequest, PublishRequest, PutDraftRequest, PutManifestRequest,
@@ -33,6 +34,37 @@ fn internal_error(err: impl std::fmt::Display) -> (StatusCode, Json<ValidationEr
             errors: vec!["internal server error".into()],
         }),
     )
+}
+
+/// Persist a `layout_change_published` analytics event to the append-only sink
+/// (migration 00225). Fire-and-forget: a failure is logged at `warn!` and never
+/// fails the admin mutation, which already committed (events doc §7).
+async fn record_change_published(
+    repo: &LayoutRepository,
+    conn: &mut sqlx::PgConnection,
+    screen: &str,
+    delivery_id: Uuid,
+    published_by: Option<Uuid>,
+    props: serde_json::Value,
+) {
+    if let Err(e) = repo
+        .record_change_event(
+            &mut *conn,
+            LayoutChangeEventKind::Published,
+            Some(screen),
+            Some(delivery_id),
+            published_by,
+            &props,
+        )
+        .await
+    {
+        tracing::warn!(
+            error = %e,
+            screen = %screen,
+            delivery_id = %delivery_id,
+            "failed to persist layout_change_published event"
+        );
+    }
 }
 
 #[utoipa::path(get, path = "/api/v1/platform-admin/layout/screens", tag = "Layout Admin",
@@ -327,7 +359,33 @@ pub async fn publish(
             ),
             db::repositories::LayoutPublishError::Sqlx(e) => internal_error(e),
         })?;
-    webhook::notify_layout_change(&req.screen, "published");
+
+    // One correlation id shared by the published event, the outbound webhook,
+    // and (echoed) the receiver's revalidate event (events doc gap D).
+    let delivery_id = Uuid::new_v4();
+    let props = serde_json::json!({
+        "event": LayoutChangeEventKind::Published.as_str(),
+        "change_kind": "published",
+        "published_by": admin_id,
+        "layout_version": row.published_version,
+        "target_tenant": "*",
+    });
+    record_change_published(
+        &repo,
+        &mut conn,
+        &req.screen,
+        delivery_id,
+        Some(admin_id),
+        props,
+    )
+    .await;
+    webhook::notify_layout_change(
+        state.db.clone(),
+        &req.screen,
+        "published",
+        Some(row.published_version),
+        delivery_id,
+    );
     Ok(Json(serde_json::to_value(row).unwrap_or_default()))
 }
 
@@ -352,7 +410,8 @@ pub async fn rollback(
         .acquire_public()
         .await
         .map_err(internal_error)?;
-    let row = LayoutRepository::new()
+    let repo = LayoutRepository::new();
+    let row = repo
         .rollback(&mut conn, &req.screen, req.version, Some(admin_id))
         .await
         .map_err(|e| match e {
@@ -364,7 +423,33 @@ pub async fn rollback(
             ),
             other => internal_error(other),
         })?;
-    webhook::notify_layout_change(&req.screen, "rolled_back");
+
+    let delivery_id = Uuid::new_v4();
+    let props = serde_json::json!({
+        "event": LayoutChangeEventKind::Published.as_str(),
+        "change_kind": "rolled_back",
+        "published_by": admin_id,
+        "layout_version": row.published_version,
+        // The source version requested — distinct from the new layout_version.
+        "rolled_back_to": req.version,
+        "target_tenant": "*",
+    });
+    record_change_published(
+        &repo,
+        &mut conn,
+        &req.screen,
+        delivery_id,
+        Some(admin_id),
+        props,
+    )
+    .await;
+    webhook::notify_layout_change(
+        state.db.clone(),
+        &req.screen,
+        "rolled_back",
+        Some(row.published_version),
+        delivery_id,
+    );
     Ok(Json(serde_json::to_value(row).unwrap_or_default()))
 }
 
@@ -389,11 +474,32 @@ pub async fn kill(
         .acquire_public()
         .await
         .map_err(internal_error)?;
-    LayoutRepository::new()
-        .kill(&mut **conn, &req.screen, &req.section_type, Some(admin_id))
+    let repo = LayoutRepository::new();
+    repo.kill(&mut **conn, &req.screen, &req.section_type, Some(admin_id))
         .await
         .map_err(internal_error)?;
-    webhook::notify_layout_change(&req.screen, "killed");
+
+    let delivery_id = Uuid::new_v4();
+    let props = serde_json::json!({
+        "event": LayoutChangeEventKind::Published.as_str(),
+        "change_kind": "killed",
+        "published_by": admin_id,
+        // kill/unkill bypass the publish gate (spec §5) — no version row; the
+        // killed section identifies the change instead (events doc §5.1).
+        "layout_version": serde_json::Value::Null,
+        "section_type": req.section_type,
+        "target_tenant": "*",
+    });
+    record_change_published(
+        &repo,
+        &mut conn,
+        &req.screen,
+        delivery_id,
+        Some(admin_id),
+        props,
+    )
+    .await;
+    webhook::notify_layout_change(state.db.clone(), &req.screen, "killed", None, delivery_id);
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -469,7 +575,7 @@ pub async fn unkill(
     headers: axum::http::HeaderMap,
     Json(req): Json<KillRequest>,
 ) -> Result<StatusCode, (StatusCode, Json<ValidationErrorsResponse>)> {
-    let _admin = extract_super_admin_token(&headers, &state).map_err(|_| {
+    let (admin_id, _) = extract_super_admin_token(&headers, &state).map_err(|_| {
         (
             StatusCode::FORBIDDEN,
             Json(ValidationErrorsResponse {
@@ -482,12 +588,31 @@ pub async fn unkill(
         .acquire_public()
         .await
         .map_err(internal_error)?;
-    let removed = LayoutRepository::new()
+    let repo = LayoutRepository::new();
+    let removed = repo
         .unkill(&mut **conn, &req.screen, &req.section_type)
         .await
         .map_err(internal_error)?;
     if removed {
-        webhook::notify_layout_change(&req.screen, "unkilled");
+        let delivery_id = Uuid::new_v4();
+        let props = serde_json::json!({
+            "event": LayoutChangeEventKind::Published.as_str(),
+            "change_kind": "unkilled",
+            "published_by": admin_id,
+            "layout_version": serde_json::Value::Null,
+            "section_type": req.section_type,
+            "target_tenant": "*",
+        });
+        record_change_published(
+            &repo,
+            &mut conn,
+            &req.screen,
+            delivery_id,
+            Some(admin_id),
+            props,
+        )
+        .await;
+        webhook::notify_layout_change(state.db.clone(), &req.screen, "unkilled", None, delivery_id);
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err((

--- a/backend/servers/api-server/src/routes/layout/webhook.rs
+++ b/backend/servers/api-server/src/routes/layout/webhook.rs
@@ -35,8 +35,11 @@
 //! `warn!` only — the admin operation already succeeded.
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use db::repositories::{LayoutChangeEventKind, LayoutRepository};
+use db::DbPool;
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
+use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -83,56 +86,136 @@ pub fn sign_timestamped_payload(secret: &str, timestamp: i64, body: &[u8]) -> St
     sign_payload(secret, &signed)
 }
 
-/// Notify an external webhook endpoint that a layout change occurred.
+/// Build the outbound webhook body bytes.
+///
+/// The body carries the correlation `delivery_id` (gap D) and the post-mutation
+/// `published_version` (gap A) in addition to `screen`/`event`, so the receiver
+/// can echo the id back on `layout_revalidate_received` and dashboards can join
+/// the three events of one mutation. The reality-web receiver validates only
+/// `screen` and tolerates extra fields, and the HMAC covers the whole body, so
+/// widening the shape is signature-safe.
+///
+/// `published_version` is `None` for `killed`/`unkilled` (which create no
+/// version row); it serialises to JSON `null`.
+pub fn build_webhook_body(
+    screen: &str,
+    event: &str,
+    published_version: Option<i32>,
+    delivery_id: Uuid,
+) -> Vec<u8> {
+    serde_json::json!({
+        "screen": screen,
+        "event": event,
+        "published_version": published_version,
+        "delivery_id": delivery_id,
+    })
+    .to_string()
+    .into_bytes()
+}
+
+/// Persist a `layout_webhook_dispatched` analytics event to the append-only
+/// sink (migration 00225). Fire-and-forget: a persistence failure is logged at
+/// `warn!` and never affects the admin mutation or the delivery.
+async fn record_dispatched(
+    pool: DbPool,
+    screen: String,
+    event: &'static str,
+    published_version: Option<i32>,
+    delivery_id: Uuid,
+    dispatch_outcome: &'static str,
+    http_status: Option<u16>,
+) {
+    let props = serde_json::json!({
+        "event": LayoutChangeEventKind::WebhookDispatched.as_str(),
+        "change_kind": event,
+        "dispatch_outcome": dispatch_outcome,
+        "http_status": http_status,
+        "published_version": published_version,
+        // target_tenant: layout config is global/platform-owned (events doc §4.3).
+        "target_tenant": "*",
+    });
+    if let Err(e) = LayoutRepository::new()
+        .record_change_event(
+            &pool,
+            LayoutChangeEventKind::WebhookDispatched,
+            Some(&screen),
+            Some(delivery_id),
+            None,
+            &props,
+        )
+        .await
+    {
+        tracing::warn!(
+            error = %e,
+            screen = %screen,
+            event = %event,
+            delivery_id = %delivery_id,
+            "failed to persist layout_webhook_dispatched event"
+        );
+    }
+}
+
+/// Notify an external webhook endpoint that a layout change occurred, and record
+/// a `layout_webhook_dispatched` analytics event for the attempt.
 ///
 /// Reads `LAYOUT_WEBHOOK_URL` and `LAYOUT_WEBHOOK_SECRET` from the environment
 /// at call time (no startup plumbing needed). When either variable is absent or
-/// empty the call is a no-op (logged at `debug!` only).
+/// empty the outbound POST is skipped, but a `skipped_unconfigured` analytics
+/// event is still recorded so "webhook silently off" is observable.
 ///
-/// On success the notification is fire-and-forget (`tokio::spawn`): a non-2xx
-/// response or a network error is logged as `warn!` but does not propagate to
-/// the caller.
+/// The notification and the analytics write are fire-and-forget (`tokio::spawn`):
+/// a non-2xx response, a network error, or a failed analytics insert is logged
+/// as `warn!` but does not propagate to the caller.
 ///
 /// # Parameters
-/// - `screen` — the layout screen identifier (e.g. `"home"`)
-/// - `event`  — one of `"published"`, `"rolled_back"`, `"killed"`, `"unkilled"`
-pub fn notify_layout_change(screen: &str, event: &'static str) {
-    let url = match std::env::var("LAYOUT_WEBHOOK_URL")
-        .ok()
-        .filter(|s| !s.is_empty())
-    {
-        Some(u) => u,
-        None => {
-            tracing::debug!(
-                screen = %screen,
-                event = %event,
-                "LAYOUT_WEBHOOK_URL not set — skipping layout-change notification"
-            );
-            return;
-        }
-    };
-
-    let secret = match std::env::var("LAYOUT_WEBHOOK_SECRET")
-        .ok()
-        .filter(|s| !s.is_empty())
-    {
-        Some(s) => s,
-        None => {
-            tracing::debug!(
-                screen = %screen,
-                event = %event,
-                "LAYOUT_WEBHOOK_SECRET not set — skipping layout-change notification"
-            );
-            return;
-        }
-    };
-
-    // Owned copies so the spawned task is `'static`.
+/// - `pool`              — DB handle for the append-only analytics sink.
+/// - `screen`            — the layout screen identifier (e.g. `"home"`).
+/// - `event`             — one of `"published"`, `"rolled_back"`, `"killed"`,
+///   `"unkilled"`.
+/// - `published_version` — the post-mutation version (gap A); `None` for
+///   `killed`/`unkilled`.
+/// - `delivery_id`       — correlation id (gap D) shared with the
+///   `layout_change_published` event and echoed to the receiver.
+pub fn notify_layout_change(
+    pool: DbPool,
+    screen: &str,
+    event: &'static str,
+    published_version: Option<i32>,
+    delivery_id: Uuid,
+) {
     let screen = screen.to_owned();
 
-    let body = serde_json::json!({ "screen": screen, "event": event })
-        .to_string()
-        .into_bytes();
+    let url = std::env::var("LAYOUT_WEBHOOK_URL")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let secret = std::env::var("LAYOUT_WEBHOOK_SECRET")
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    let (url, secret) = match (url, secret) {
+        (Some(u), Some(s)) => (u, s),
+        _ => {
+            // Unconfigured: skip the POST but still record the event so the
+            // "webhook off" state is observable in analytics.
+            tracing::debug!(
+                screen = %screen,
+                event = %event,
+                "LAYOUT_WEBHOOK_URL/SECRET not set — skipping layout-change notification"
+            );
+            tokio::spawn(record_dispatched(
+                pool,
+                screen,
+                event,
+                published_version,
+                delivery_id,
+                "skipped_unconfigured",
+                None,
+            ));
+            return;
+        }
+    };
+
+    let body = build_webhook_body(&screen, event, published_version, delivery_id);
 
     // Replay protection (issue #2485): ship a signed unix-seconds timestamp and
     // sign over "{timestamp}.{body}" so the reality-web receiver can reject any
@@ -152,11 +235,21 @@ pub fn notify_layout_change(screen: &str, event: &'static str) {
                     error = %e,
                     "layout-change webhook: failed to build HTTP client"
                 );
+                record_dispatched(
+                    pool,
+                    screen,
+                    event,
+                    published_version,
+                    delivery_id,
+                    "transport_error",
+                    None,
+                )
+                .await;
                 return;
             }
         };
 
-        match client
+        let (outcome, http_status): (&'static str, Option<u16>) = match client
             .post(&url)
             .header("Content-Type", "application/json")
             .header(TIMESTAMP_HEADER, timestamp.to_string())
@@ -166,20 +259,24 @@ pub fn notify_layout_change(screen: &str, event: &'static str) {
             .await
         {
             Ok(resp) if resp.status().is_success() => {
+                let status = resp.status();
                 tracing::debug!(
                     screen = %screen,
                     event = %event,
-                    status = %resp.status(),
+                    status = %status,
                     "layout-change webhook delivered"
                 );
+                ("delivered", Some(status.as_u16()))
             }
             Ok(resp) => {
+                let status = resp.status();
                 tracing::warn!(
                     screen = %screen,
                     event = %event,
-                    status = %resp.status(),
+                    status = %status,
                     "layout-change webhook returned non-2xx"
                 );
+                ("non_2xx", Some(status.as_u16()))
             }
             Err(e) => {
                 tracing::warn!(
@@ -188,8 +285,20 @@ pub fn notify_layout_change(screen: &str, event: &'static str) {
                     error = %e,
                     "layout-change webhook delivery failed"
                 );
+                ("transport_error", None)
             }
-        }
+        };
+
+        record_dispatched(
+            pool,
+            screen,
+            event,
+            published_version,
+            delivery_id,
+            outcome,
+            http_status,
+        )
+        .await;
     });
 }
 
@@ -325,5 +434,37 @@ mod tests {
             sign_payload(KNOWN_SECRET, KNOWN_BODY),
             "timestamped and body-only signatures must diverge"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // Webhook body shape (issue #2532): the body must carry delivery_id
+    // (gap D) and published_version (gap A) so the receiver can correlate
+    // events and dashboards can join a publish → revalidate trace. These
+    // tests fail on `dev` (the body was only {screen, event}).
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn build_webhook_body_carries_delivery_id_and_version() {
+        let delivery_id = Uuid::from_u128(0x1234_5678_9abc_def0_1122_3344_5566_7788);
+        let bytes = build_webhook_body("reality/listing-detail", "published", Some(7), delivery_id);
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("body is valid JSON");
+
+        assert_eq!(v["screen"], "reality/listing-detail");
+        assert_eq!(v["event"], "published");
+        assert_eq!(v["published_version"], 7);
+        assert_eq!(v["delivery_id"], delivery_id.to_string());
+    }
+
+    #[test]
+    fn build_webhook_body_null_version_for_kills() {
+        let delivery_id = Uuid::nil();
+        let bytes = build_webhook_body("home", "killed", None, delivery_id);
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("body is valid JSON");
+
+        assert!(
+            v["published_version"].is_null(),
+            "kill/unkill carry no version — must serialise as null"
+        );
+        assert_eq!(v["delivery_id"], delivery_id.to_string());
     }
 }

--- a/docs/data/layout-publish-event-tracking.md
+++ b/docs/data/layout-publish-event-tracking.md
@@ -29,11 +29,22 @@ affected ISR cache tags. The relevant code:
 | Inbound receiver + revalidation | `frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts` |
 | Host-scoped fetch tags | `frontend/apps/reality-web/src/lib/layout.ts` (`getResolvedLayout`) |
 
-Today the webhook body is only `{"screen": <string>, "event": <string>}` and
-**no analytics event is persisted** for this flow (unlike
+> **Implementation status (issue #2532).** The producers are now wired. All
+> three events are emitted, and the two api-server events are persisted to the
+> append-only `layout_change_events` sink (migration
+> `00225_create_layout_change_events.sql`). The webhook body now carries
+> `delivery_id` (gap D) and `published_version` (gap A). Gaps A, C, D and the
+> retention window (Section 7) are closed; gap B emits `target_tenant = "*"`
+> until per-tenant override-publish lands; `layout_revalidate_received` is
+> emitted from reality-web via the `trackEvent` bus (its cross-service
+> persistence to the sink remains a follow-up — reality-web SSR has no DB
+> handle). See Section 6 for the per-gap status.
+
+Historically the webhook body was only `{"screen": <string>, "event": <string>}`
+and **no analytics event was persisted** for this flow (unlike
 `support_tooling_events`, see `docs/data/support-data-retention-privacy.md`).
-The events below define what SHOULD be captured, and Section 6 lists the
-minimal plumbing each dimension needs.
+The events below define what is captured, and Section 6 tracks the status of
+each dimension.
 
 ## 2. Event taxonomy
 
@@ -185,17 +196,16 @@ return path.
 The events above are the **target contract**. Current reality and the minimal
 change to close each gap:
 
-| # | Gap | Today | To close |
-|---|-----|-------|----------|
-| A | `layout_version` not delivered | `notify_layout_change(screen, event)` drops `row.published_version` | widen the notifier signature to accept the version (and identity); handlers already hold `row` |
-| B | `target_tenant` not delivered | global publish is implicitly `"*"`; per-tenant overrides (`layout_tenant_overrides`) are not wired to any mutation handler | emit `"*"` for global changes now; add the org id when override-publish lands |
-| B' | reality-web tenant attribution | host is available via `Host` header/tag but not recorded | read the host in `route.ts` when emitting |
-| C | No event is persisted | flow emits only `tracing` logs (`debug!`/`warn!`) | add an append-only sink — reuse the `support_tooling_events` pattern (immutable table + fire-and-forget writer) rather than inventing a new mechanism |
-| D | No `delivery_id` correlation | each stage is independent | generate a uuid at publish time, include it in the webhook body, echo it back from the receiver |
+| # | Gap | Status (issue #2532) |
+|---|-----|----------------------|
+| A | `layout_version` not delivered | **Closed.** `notify_layout_change(pool, screen, event, published_version, delivery_id)` carries the version; `build_webhook_body` puts it on the wire. `null` for kill/unkill. |
+| B | `target_tenant` not delivered | **Partial.** Global changes emit `target_tenant = "*"`; a real org id follows when per-tenant override-publish lands. |
+| B' | reality-web tenant attribution | **Closed.** `route.ts` reads the `Host` header into `target_tenant` (falling back to `"*"`). |
+| C | No event is persisted | **Closed (backend).** `layout_change_published` + `layout_webhook_dispatched` persist to the append-only `layout_change_events` table (migration `00225`, `support_tooling_events` pattern). `layout_revalidate_received` emits via `trackEvent` but is **not yet** persisted cross-service — reality-web SSR has no DB handle; an ingest endpoint is a follow-up. |
+| D | No `delivery_id` correlation | **Closed.** A uuid is generated per mutation in `admin.rs`, shared with the persisted `layout_change_published`, put in the webhook body, and echoed by the receiver. |
 
-None of these gaps are required by *this* definitions task; they are the
-implementation backlog that this schema unblocks. Recording them here prevents
-a future implementer from inventing a divergent field set.
+Recording the status here prevents a future implementer from inventing a
+divergent field set.
 
 ## 7. Privacy & retention posture
 
@@ -212,10 +222,14 @@ Consistent with `docs/data/support-data-retention-privacy.md`:
   `support_tooling_events` — DB triggers reject `UPDATE`/`DELETE`,
   `published_by` FK `ON DELETE RESTRICT`/`SET NULL` so the trail survives
   account deletion (anonymised).
-- **Retention.** No retention window is defined for layout audit history today;
-  the same GDPR storage-limitation gap flagged for `audit_logs` /
-  `support_tooling_events` (Art. 5(1)(e)) applies. Define and document a
-  retention period before treating this as compliant.
+- **Retention.** Defined up front (issue #2532): the `layout_change_events`
+  sink prunes rows older than **730 days (24 months)** via the DB-native
+  `cleanup_old_layout_change_events(retention_days)` (migration `00225`),
+  matching the `support_tooling_events` window (migration `00222`) and honouring
+  GDPR storage limitation (Art. 5(1)(e)). Deletes are gated by the
+  `app.retention_prune` GUC so the append-only immutability trigger still blocks
+  every other `UPDATE`/`DELETE`. Wiring the prune into the api-server background
+  scheduler is a separate follow-up (same posture as support_tooling_events).
 
 ## 8. Open questions (verify before relying on this doc)
 

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
@@ -7,6 +7,11 @@ vi.mock('next/cache', () => ({
 }));
 
 import { revalidateTag } from 'next/cache';
+import {
+  __clearAnalyticsSinks,
+  type AnalyticsEvent,
+  registerAnalyticsSink,
+} from '@/lib/analytics';
 import { isTimestampFresh, layoutTagsFor, POST, parseWebhookTimestamp } from './route';
 
 // ---------------------------------------------------------------------------
@@ -292,5 +297,92 @@ describe('POST /api/layout-revalidate', () => {
     // Verify by checking the module's exported keys directly
     const routeModule = { POST, layoutTagsFor } as Record<string, unknown>;
     expect(routeModule['GET']).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// layout_revalidate_received analytics (issue #2532)
+//
+// The receiver must emit one operational event on every return path, echoing
+// the delivery_id (gap D) when the webhook body carries it. These assertions
+// fail on `dev`, where the route emitted nothing.
+// ---------------------------------------------------------------------------
+
+describe('layout_revalidate_received emission', () => {
+  let events: AnalyticsEvent[];
+  let unregister: () => void;
+
+  beforeEach(() => {
+    vi.mocked(revalidateTag).mockClear();
+    events = [];
+    unregister = registerAnalyticsSink((e) => events.push(e));
+  });
+
+  afterEach(() => {
+    unregister();
+    __clearAnalyticsSinks();
+    vi.unstubAllEnvs();
+  });
+
+  it('emits revalidated with tags and echoed delivery_id on success', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const deliveryId = '11111111-2222-3333-4444-555555555555';
+    const body = JSON.stringify({
+      screen: 'reality/listing-detail',
+      event: 'published',
+      delivery_id: deliveryId,
+    });
+    const res = await POST(signedRequest(SECRET, body));
+    expect(res.status).toBe(200);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe('layout_revalidate_received');
+    expect(events[0].properties).toMatchObject({
+      revalidate_outcome: 'revalidated',
+      http_status: 200,
+      screen: 'reality/listing-detail',
+      tags: ['layout:listing-detail'],
+      delivery_id: deliveryId,
+    });
+  });
+
+  it('emits disabled (503) when the secret is unset', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', '');
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    const res = await POST(signedRequest(SECRET, body));
+    expect(res.status).toBe(503);
+    expect(events).toHaveLength(1);
+    expect(events[0].properties).toMatchObject({
+      revalidate_outcome: 'disabled',
+      http_status: 503,
+    });
+  });
+
+  it('emits invalid_signature (401) on a bad signature', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    const req = makeRequest(body, {
+      'X-Webhook-Timestamp': String(nowTs()),
+      'X-Webhook-Signature': 'sha256=invalidsignature==',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(events).toHaveLength(1);
+    expect(events[0].properties).toMatchObject({
+      revalidate_outcome: 'invalid_signature',
+      http_status: 401,
+    });
+  });
+
+  it('emits invalid_screen (422) when the screen has no slash', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'listing-detail' });
+    const res = await POST(signedRequest(SECRET, body));
+    expect(res.status).toBe(422);
+    expect(events).toHaveLength(1);
+    expect(events[0].properties).toMatchObject({
+      revalidate_outcome: 'invalid_screen',
+      http_status: 422,
+    });
   });
 });

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
@@ -7,11 +7,7 @@ vi.mock('next/cache', () => ({
 }));
 
 import { revalidateTag } from 'next/cache';
-import {
-  __clearAnalyticsSinks,
-  type AnalyticsEvent,
-  registerAnalyticsSink,
-} from '@/lib/analytics';
+import { __clearAnalyticsSinks, type AnalyticsEvent, registerAnalyticsSink } from '@/lib/analytics';
 import { isTimestampFresh, layoutTagsFor, POST, parseWebhookTimestamp } from './route';
 
 // ---------------------------------------------------------------------------

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
@@ -1,6 +1,54 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import { revalidateTag } from 'next/cache';
 import { NextResponse } from 'next/server';
+import { trackEvent } from '@/lib/analytics';
+
+// ---------------------------------------------------------------------------
+// Analytics: layout_revalidate_received (issue #2532).
+//
+// The receiver emits one operational event on every return path so the
+// layout publish → webhook → revalidate pipeline is observable end to end
+// (docs/data/layout-publish-event-tracking.md §5.3). Emission is fire-and-
+// forget via the shared `trackEvent` bus — it never throws and never changes
+// the HTTP outcome. `delivery_id` is echoed from the webhook body (gap D) when
+// present so this event joins the api-server `layout_change_published` /
+// `layout_webhook_dispatched` events for the same mutation.
+// ---------------------------------------------------------------------------
+
+/** Receiver-side revalidate outcomes (events doc §4.4). */
+type RevalidateOutcome =
+  | 'revalidated'
+  | 'disabled'
+  | 'invalid_signature'
+  | 'invalid_body'
+  | 'invalid_screen';
+
+function emitRevalidateReceived(props: {
+  outcome: RevalidateOutcome;
+  httpStatus: number;
+  targetTenant: string;
+  screen?: string | null;
+  tags?: string[];
+  deliveryId?: string | null;
+}): void {
+  trackEvent('layout_revalidate_received', {
+    revalidate_outcome: props.outcome,
+    http_status: props.httpStatus,
+    target_tenant: props.targetTenant,
+    screen: props.screen ?? null,
+    tags: props.tags ?? [],
+    delivery_id: props.deliveryId ?? null,
+  });
+}
+
+/** Extract a string `delivery_id` from an already-parsed body, else null. */
+function deliveryIdOf(body: unknown): string | null {
+  if (typeof body === 'object' && body !== null) {
+    const raw = (body as Record<string, unknown>).delivery_id;
+    if (typeof raw === 'string') return raw;
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // Exported helper — maps a screen id to its cache tags.
@@ -58,9 +106,14 @@ export function isTimestampFresh(
 // ---------------------------------------------------------------------------
 
 export async function POST(request: Request): Promise<NextResponse> {
+  // Tenant scope on the receiver is expressed as the request host (events doc
+  // §4.3); fall back to the global sentinel when absent.
+  const targetTenant = request.headers.get('host') ?? '*';
+
   // 1. Secret must be configured
   const secret = process.env.LAYOUT_WEBHOOK_SECRET;
   if (!secret) {
+    emitRevalidateReceived({ outcome: 'disabled', httpStatus: 503, targetTenant });
     return NextResponse.json({ error: 'disabled' }, { status: 503 });
   }
 
@@ -75,12 +128,15 @@ export async function POST(request: Request): Promise<NextResponse> {
   // 3. Replay protection (issue #2485): require a fresh signed timestamp.
   // Reject a missing/malformed timestamp, or one outside the ±TOLERANCE_SECS
   // window, BEFORE the HMAC check — a captured delivery is only valid briefly.
+  // These auth rejections fold into the `invalid_signature` analytics outcome.
   const timestamp = parseWebhookTimestamp(request.headers.get('X-Webhook-Timestamp'));
   if (timestamp === null) {
+    emitRevalidateReceived({ outcome: 'invalid_signature', httpStatus: 401, targetTenant });
     return NextResponse.json({ error: 'missing timestamp' }, { status: 401 });
   }
   const nowSecs = Math.floor(Date.now() / 1000);
   if (!isTimestampFresh(timestamp, nowSecs)) {
+    emitRevalidateReceived({ outcome: 'invalid_signature', httpStatus: 401, targetTenant });
     return NextResponse.json({ error: 'stale timestamp' }, { status: 401 });
   }
 
@@ -95,6 +151,7 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   // Guard unequal lengths before timingSafeEqual (it throws on length mismatch)
   if (headerBuf.length !== expectedBuf.length || !timingSafeEqual(headerBuf, expectedBuf)) {
+    emitRevalidateReceived({ outcome: 'invalid_signature', httpStatus: 401, targetTenant });
     return NextResponse.json({ error: 'invalid signature' }, { status: 401 });
   }
 
@@ -103,14 +160,20 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     body = JSON.parse(rawBody);
   } catch {
+    emitRevalidateReceived({ outcome: 'invalid_body', httpStatus: 422, targetTenant });
     return NextResponse.json({ error: 'invalid body' }, { status: 422 });
   }
+
+  // Echo the correlation id from the (now-verified, HMAC-covered) body when
+  // present — the api-server adds it to the webhook payload (gap D).
+  const deliveryId = deliveryIdOf(body);
 
   if (
     typeof body !== 'object' ||
     body === null ||
     typeof (body as Record<string, unknown>).screen !== 'string'
   ) {
+    emitRevalidateReceived({ outcome: 'invalid_body', httpStatus: 422, targetTenant, deliveryId });
     return NextResponse.json({ error: 'invalid body' }, { status: 422 });
   }
 
@@ -118,12 +181,26 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   // 6. Validate screen contains a slash and has non-empty second segment
   if (!screen.includes('/')) {
+    emitRevalidateReceived({
+      outcome: 'invalid_screen',
+      httpStatus: 422,
+      targetTenant,
+      screen,
+      deliveryId,
+    });
     return NextResponse.json({ error: 'invalid screen' }, { status: 422 });
   }
 
   // 7. Revalidate tags
   const tags = layoutTagsFor(screen);
   if (!tags) {
+    emitRevalidateReceived({
+      outcome: 'invalid_screen',
+      httpStatus: 422,
+      targetTenant,
+      screen,
+      deliveryId,
+    });
     return NextResponse.json({ error: 'invalid screen' }, { status: 422 });
   }
 
@@ -131,5 +208,13 @@ export async function POST(request: Request): Promise<NextResponse> {
     revalidateTag(tag, 'default');
   }
 
+  emitRevalidateReceived({
+    outcome: 'revalidated',
+    httpStatus: 200,
+    targetTenant,
+    screen,
+    tags,
+    deliveryId,
+  });
   return NextResponse.json({ revalidated: true, tags });
 }


### PR DESCRIPTION
## Task
Follow-up: wire layout publish/webhook event emission (spec-only, no producers) (Closes #2532). Implement the emit call-sites the doc pins — `layout_change_published` in `backend/servers/api-server/src/routes/layout/admin.rs`, `layout_webhook_dispatched` in `.../layout/webhook.rs` (widen `notify_layout_change` to carry `published_version` + `delivery_id`), and `layout_revalidate_received` in `frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts`; add an append-only sink table (reuse `support_tooling_events` pattern) with retention defined up front.

Closes #2532

## Owner
pm-backend

## What landed (full scope)
Closes gaps **A / C / D** and the retention gap of `docs/data/layout-publish-event-tracking.md`; the three events were spec-only with zero producers.

- **Sink table** — migration `00225_create_layout_change_events.sql`: append-only `layout_change_events` following the `support_tooling_events` pattern (immutable UPDATE/DELETE triggers, JSONB `props`, indexes on `occurred_at` / `event_kind` / `delivery_id`). **No RLS** (global platform-admin table, matching `layout_configs` in 00221). **Retention defined up front** (privacy finding): `cleanup_old_layout_change_events(retention_days DEFAULT 730)`, gated by the `app.retention_prune` GUC so immutability holds for every other mutation. 730-day window matches `support_tooling_events` (00222).
- **db** — `LayoutChangeEventKind` + `LayoutRepository::record_change_event` / `cleanup_old_layout_change_events` (fire-and-forget), plus a stability unit test.
- **api-server `admin.rs`** — each of publish/rollback/kill/unkill generates a per-mutation `delivery_id`, persists `layout_change_published` (with `published_by`, `layout_version`, `change_kind`, `target_tenant="*"`, and `rolled_back_to`/`section_type` where relevant), and threads `published_version` + `delivery_id` into the notifier. `unkill` now captures the admin id for attribution.
- **api-server `webhook.rs`** — `notify_layout_change` widened to `(pool, screen, event, published_version, delivery_id)`. New `build_webhook_body` puts `published_version` + `delivery_id` on the wire (gaps A/D). Persists `layout_webhook_dispatched` on every outcome — `delivered` / `non_2xx` / `transport_error` / `skipped_unconfigured` (so "webhook off" is observable) — with `http_status`.
- **reality-web `route.ts`** — emits `layout_revalidate_received` on every return path via the existing `trackEvent` bus (code reuse), echoing `delivery_id` from the (HMAC-covered) body and reading the host into `target_tenant`. Body-shape check already tolerates the extra field.
- **docs** — `layout-publish-event-tracking.md` updated: gaps A/C/D + retention closed, B partial (`"*"` until per-tenant override-publish), status callout added.

## Verification
Local `just verify` / `verify-impact.sh` could not complete in this environment for two env reasons unrelated to the diff (see below). The verifiable, highest-value slice was run synchronously and is green:

```
DB clippy:  cd backend && cargo clippy -p db --all-targets -- -D warnings   → Finished, exit 0
DB tests:   cd backend && DATABASE_URL=postgres://…:5433 cargo test -p db --test suite_4 layout_change_events
              running 4 tests
              retention_prune_deletes_aged_rows_and_keeps_recent ... ok
              record_change_event_inserts_and_returns_id ... ok
              ordinary_delete_is_still_rejected ... ok
              update_is_still_rejected ... ok
              test result: ok. 4 passed; 0 failed
cargo fmt --all -- --check → clean
```

The DB tests exercise migration 00225 end-to-end against real Postgres: the table + immutability triggers + the retention prune (aged rows deleted, recent kept, ordinary UPDATE/DELETE still rejected).

### Deferred to CI (environment-blocked, not code)
- **api-server clippy/tests** — the `utoipa-swagger-ui` build script downloads swagger-ui from `github.com/.../v5.17.14.zip`, which the agent proxy returns **403** for; every worktree on this host has the resulting 378-byte corrupt zip cached, so api-server cannot be compiled here at all. The api-server changes (admin.rs / webhook.rs) follow existing patterns in those files; `backend.yml` will clippy+test them.
- **reality-web biome/typecheck/test** — the fresh worktree has no `node_modules`; `frontend.yml` will run them. New Vitest cases assert the emit fires with the right `revalidate_outcome` / `http_status` and echoed `delivery_id`; new webhook unit tests (`build_webhook_body_*`) assert the widened body — both fail on `dev`.

## CI parity
Skipped: not flagged hot-path (this is analytics/audit plumbing; no auth/billing/data-integrity path changed). The one security-adjacent concern — never logging the webhook signature/secret — is honoured (excluded from all event props).

## Scope drift
`scope-check.sh --owner pm-backend` reports drift (exit 2) on:
- `frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts` (+ test)
- `docs/data/layout-publish-event-tracking.md`

Justified: the task explicitly requires the reality-web `layout_revalidate_received` emit and the doc gap-closure. Reviewer to confirm.

## Code-reuse review
`reuse-grep.sh` clean. Reuse was deliberate: the sink mirrors `support_tooling_events` (table + retention GUC pattern) rather than a new mechanism, and the frontend emit uses the existing `@/lib/analytics` `trackEvent` bus.

## Notes
- `layout_revalidate_received` is **emitted** but not yet **persisted** cross-service — reality-web SSR has no DB handle; an ingest endpoint is a follow-up (noted in the doc). Both api-server events persist to the sink.
- Wiring `cleanup_old_layout_change_events` into the background scheduler is a separate follow-up (same posture as `support_tooling_events`); this PR establishes the retention definition + repository entry point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWssAhtmu4t762J2c4zHpi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWssAhtmu4t762J2c4zHpi)_