### PR TITLE
gh-issue-2537: cross-tenant IDOR + error-branch tests for lease-abstraction import

### DIFF
--- a/backend/servers/api-server/tests/suites/documents_forms_batch2_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/suites/documents_forms_batch2_happy_path_tests.rs
@@ -135,6 +135,24 @@ async fn seed_lease_extraction(pool: &PgPool, document_id: Uuid, review_status: 
     .expect("seed lease_extraction")
 }
 
+/// Seed a lease_extraction that is MISSING the required-for-import fields
+/// (`tenant_name` and `monthly_rent` are NULL). `validate_import` must then
+/// report `can_import: false` with a non-empty error list. `lease_start_date`
+/// is kept populated so the two NULLs are the only validation errors.
+async fn seed_lease_extraction_missing_required(pool: &PgPool, document_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO lease_extractions \
+         (document_id, tenant_name, lease_start_date, lease_end_date, monthly_rent, \
+          overall_confidence, fields_extracted, fields_flagged, review_status) \
+         VALUES ($1, NULL, '2026-01-01', '2026-12-31', NULL, 95.00, 3, 2, 'pending') \
+         RETURNING id",
+    )
+    .bind(document_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed lease_extraction with missing required fields")
+}
+
 /// Seed a lease_imports row directly (status defaults to 'pending').
 async fn seed_lease_import(pool: &PgPool, extraction_id: Uuid) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(
@@ -251,5 +269,233 @@ async fn get_import_succeeds(pool: PgPool) {
         body["id"].as_str(),
         Some(import_id.to_string().as_str()),
         "returned import id must match the seeded one; body: {body}"
+    );
+}
+
+// ===========================================================================
+// Negative cases (#2537 follow-up): cross-tenant IDOR + error branches.
+//
+// The lease-abstraction import handlers resolve the org exclusively from the
+// JWT `tenant_id` claim and gate every read through `get_extraction_for_org`
+// (extraction -> document -> organization join) and a unit -> building ->
+// organization ownership check. The cases below exercise those guards plus the
+// import state machine (`review_status`) and the validation error path.
+// ===========================================================================
+
+/// Seed a second organisation with its own admin user and return
+/// `(org_id, building_id, unit_id)`. Used to prove that resources belonging to
+/// one org are invisible / rejected when acted on under a different org's token.
+async fn seed_second_org(app: &TestApp, pool: &PgPool, slug: &str) -> (Uuid, Uuid, Uuid) {
+    let other_user = TestUser::new();
+    let (_login, org_id) = create_authenticated_user_with_org(app, &other_user, slug).await;
+    let building_id = seed_building(pool, org_id).await;
+    let unit_id = seed_unit(pool, building_id).await;
+    (org_id, building_id, unit_id)
+}
+
+/// Cross-tenant IDOR: an extraction seeded under org A must be a 404 (not a 403)
+/// when validated with an org-B token — `get_extraction_for_org` filters by the
+/// caller's org, so org B simply cannot see the row.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn validate_import_cross_tenant_returns_404(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Org A owns the extraction + a valid unit.
+    let user_a = TestUser::new();
+    let (_login_a, org_a) = create_authenticated_user_with_org(&app, &user_a, "la-idor-a").await;
+    let user_a_id = user_id_for(&pool, &user_a.email).await;
+    let building_a = seed_building(&pool, org_a).await;
+    let unit_a = seed_unit(&pool, building_a).await;
+    let doc_id = seed_lease_document(&pool, org_a, user_a_id).await;
+    let ext_id = seed_lease_extraction(&pool, doc_id, "pending").await;
+
+    // Org B: different org, its own admin — token carries org B's tenant_id.
+    let user_b = TestUser::new();
+    let (_login_b, org_b) = create_authenticated_user_with_org(&app, &user_b, "la-idor-b").await;
+    let user_b_id = user_id_for(&pool, &user_b.email).await;
+    let token_b = mint_tenant_token(user_b_id, org_b);
+
+    let resp = app
+        .execute(
+            app.post(&format!(
+                "/api/v1/lease-abstraction/extractions/{ext_id}/validate"
+            ))
+            .bearer(&token_b)
+            .json(json!({ "unit_id": unit_a }))
+            .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "org B must not see org A's extraction (404, not 403/200); body: {}",
+        resp.text()
+    );
+}
+
+/// Cross-tenant IDOR on the import read path: an import row seeded under org A
+/// is a 404 for org B.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn get_import_cross_tenant_returns_404(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Org A owns the document/extraction/import chain.
+    let user_a = TestUser::new();
+    let (_login_a, org_a) =
+        create_authenticated_user_with_org(&app, &user_a, "la-idor-imp-a").await;
+    let user_a_id = user_id_for(&pool, &user_a.email).await;
+    let doc_id = seed_lease_document(&pool, org_a, user_a_id).await;
+    let ext_id = seed_lease_extraction(&pool, doc_id, "approved").await;
+    let import_id = seed_lease_import(&pool, ext_id).await;
+
+    // Org B tries to read org A's import by id.
+    let user_b = TestUser::new();
+    let (_login_b, org_b) =
+        create_authenticated_user_with_org(&app, &user_b, "la-idor-imp-b").await;
+    let user_b_id = user_id_for(&pool, &user_b.email).await;
+    let token_b = mint_tenant_token(user_b_id, org_b);
+
+    let resp = app
+        .execute(
+            app.get(&format!("/api/v1/lease-abstraction/imports/{import_id}"))
+                .bearer(&token_b)
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "org B must not read org A's import (404); body: {}",
+        resp.text()
+    );
+}
+
+/// Cross-org unit: the extraction belongs to the caller's org, but the supplied
+/// `unit_id` belongs to a *different* org's building — the unit-ownership guard
+/// must reject with 403 (not silently import into a foreign building).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn validate_import_foreign_unit_returns_403(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Caller's org owns the extraction.
+    let user = TestUser::new();
+    let (_login, org_id) = create_authenticated_user_with_org(&app, &user, "la-foreign-unit").await;
+    let user_id = user_id_for(&pool, &user.email).await;
+    let token = mint_tenant_token(user_id, org_id);
+    let doc_id = seed_lease_document(&pool, org_id, user_id).await;
+    let ext_id = seed_lease_extraction(&pool, doc_id, "pending").await;
+
+    // A second org owns the unit the caller tries to target.
+    let (_other_org, _other_building, foreign_unit) =
+        seed_second_org(&app, &pool, "la-foreign-unit-other").await;
+
+    let resp = app
+        .execute(
+            app.post(&format!(
+                "/api/v1/lease-abstraction/extractions/{ext_id}/validate"
+            ))
+            .bearer(&token)
+            .json(json!({ "unit_id": foreign_unit }))
+            .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "unit from another org must be rejected with 403; body: {}",
+        resp.text()
+    );
+}
+
+/// Import state machine: an extraction that has not been human-approved
+/// (`review_status = 'pending'`) cannot be imported — the handler returns 409
+/// CONFLICT before touching the lease tables.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn import_pending_extraction_returns_409(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = TestUser::new();
+    let (_login, org_id) =
+        create_authenticated_user_with_org(&app, &user, "la-import-pending").await;
+    let user_id = user_id_for(&pool, &user.email).await;
+    let token = mint_tenant_token(user_id, org_id);
+
+    let building_id = seed_building(&pool, org_id).await;
+    let unit_id = seed_unit(&pool, building_id).await;
+    let doc_id = seed_lease_document(&pool, org_id, user_id).await;
+    // Not approved — the review_status gate fires before any import work.
+    let ext_id = seed_lease_extraction(&pool, doc_id, "pending").await;
+
+    let resp = app
+        .execute(
+            app.post(&format!(
+                "/api/v1/lease-abstraction/extractions/{ext_id}/import"
+            ))
+            .bearer(&token)
+            .json(json!({ "unit_id": unit_id }))
+            .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::CONFLICT,
+        "a pending (un-approved) extraction must not import (409); body: {}",
+        resp.text()
+    );
+}
+
+/// Validation error path: an extraction missing required fields (NULL
+/// `tenant_name` and `monthly_rent`) validates as `can_import: false` with a
+/// non-empty issues list naming the offending fields.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn validate_import_missing_fields_reports_issues(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let user = TestUser::new();
+    let (_login, org_id) =
+        create_authenticated_user_with_org(&app, &user, "la-validate-missing").await;
+    let user_id = user_id_for(&pool, &user.email).await;
+    let token = mint_tenant_token(user_id, org_id);
+
+    let building_id = seed_building(&pool, org_id).await;
+    let unit_id = seed_unit(&pool, building_id).await;
+    let doc_id = seed_lease_document(&pool, org_id, user_id).await;
+    let ext_id = seed_lease_extraction_missing_required(&pool, doc_id).await;
+
+    let resp = app
+        .execute(
+            app.post(&format!(
+                "/api/v1/lease-abstraction/extractions/{ext_id}/validate"
+            ))
+            .bearer(&token)
+            .json(json!({ "unit_id": unit_id }))
+            .build(),
+        )
+        .await;
+
+    // The request itself is well-formed (200) — the *payload* reports the
+    // extraction cannot be imported.
+    assert_eq!(resp.status, StatusCode::OK, "body: {}", resp.text());
+    let body = resp.json_value();
+    assert_eq!(
+        body["can_import"].as_bool(),
+        Some(false),
+        "extraction is missing required fields, so import must be disallowed; body: {body}"
+    );
+    let issues = body["errors"]
+        .as_array()
+        .expect("validation response must carry an errors array");
+    assert!(
+        !issues.is_empty(),
+        "missing required fields must produce a non-empty issues array; body: {body}"
+    );
+    let fields: Vec<&str> = issues.iter().filter_map(|i| i["field"].as_str()).collect();
+    assert!(
+        fields.contains(&"tenant_name") && fields.contains(&"monthly_rent"),
+        "issues must name the missing fields (tenant_name, monthly_rent); got {fields:?}"
     );
 }


### PR DESCRIPTION
## Task
Follow-up: add cross-tenant IDOR + error-branch tests for lease-abstraction import (Closes #2537). In `backend/servers/api-server/tests/suites/documents_forms_batch2_happy_path_tests.rs` add negative cases: seed extraction/import under org A, call with an org-B `tenant_id` token (assert 404); call validate/import with a `unit_id` whose building belongs to a second org (assert 403); seed a 'pending' extraction and POST /import (assert 409 CONFLICT); and a validate test with null `tenant_name`/`monthly_rent` asserting `can_import:false` with a non-empty issues array.

Closes #2537

## Owner
pm-qa

## What changed
Test-only. Adds 5 negative cases (and one NULL-fields seed helper + one second-org seed helper) alongside the existing 3 happy-path tests in the same file:

| Test | Endpoint | Asserts |
|------|----------|---------|
| `validate_import_cross_tenant_returns_404` | POST `…/extractions/{id}/validate` | org-B token on org-A extraction → **404** (not 403/200) — `get_extraction_for_org` org-scoped join hides the row |
| `get_import_cross_tenant_returns_404` | GET `…/imports/{id}` | org-B token on org-A import → **404** — `get_import` org-scoped join |
| `validate_import_foreign_unit_returns_403` | POST `…/extractions/{id}/validate` | own extraction + a `unit_id` from a second org's building → **403** (unit-ownership guard) |
| `import_pending_extraction_returns_409` | POST `…/extractions/{id}/import` | `review_status='pending'` → **409 CONFLICT** before any lease write |
| `validate_import_missing_fields_reports_issues` | POST `…/extractions/{id}/validate` | NULL `tenant_name`/`monthly_rent` → 200 body `can_import:false` + non-empty issues array naming both fields |

Note: the validation payload's issue list is serialized as `errors` (see `ImportValidationResult`); the test asserts `body["errors"]` is non-empty and contains `tenant_name` + `monthly_rent`.

## Verification
VERIFY-PLAN base=9f3099d93bcd15e31a94f458e51cf06ecaee4893 files=1
```
cd backend && cargo fmt --all -- --check          # PASS
cd backend && cargo clippy -p api-server --all-targets -- -D warnings   # PASS (exit 0)
cd backend && cargo test -p api-server            # module below: 8 passed / 0 failed
```
Targeted run of the changed module (against a locally-bootstrapped Postgres 16):
```
running 8 tests
test documents_forms_batch2_happy_path_tests::import_to_lease_succeeds ... ok
test documents_forms_batch2_happy_path_tests::get_import_succeeds ... ok
test documents_forms_batch2_happy_path_tests::import_pending_extraction_returns_409 ... ok
test documents_forms_batch2_happy_path_tests::get_import_cross_tenant_returns_404 ... ok
test documents_forms_batch2_happy_path_tests::validate_import_missing_fields_reports_issues ... ok
test documents_forms_batch2_happy_path_tests::validate_import_cross_tenant_returns_404 ... ok
test documents_forms_batch2_happy_path_tests::validate_import_foreign_unit_returns_403 ... ok
test documents_forms_batch2_happy_path_tests::validate_import_succeeds ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 289 filtered out; finished in 60.18s
```
Scope-check (`--owner pm-qa`): exit 0, no drift. Reuse-grep (`rust-backend`): exit 0, no warnings.

Environment note: the dispatcher sandbox blocks GitHub egress, so `utoipa-swagger-ui`'s build script could not download Swagger UI. Worked around locally by sourcing `swagger-ui-dist@5.17.14` from the allow-listed npm registry and pointing `SWAGGER_UI_DOWNLOAD_URL` at a `file://` zip — a build-only accommodation, no repo changes. CI (with normal network + Postgres service) runs the standard gate unchanged.

## CI parity (Band C — hot-path only)
This is IDOR/authz-adjacent but test-only (no production code touched). Full gate replicated locally: fmt + clippy(-D warnings) + tests all green.

## Remote-tested
skipped (ppt-bridge MCP not connected)

## Notes
- Purely additive test file; no `src/` changes. Scope-drift false.
- Seed helpers mirror the existing happy-path helpers in the same file (direct row seeding, `mint_tenant_token` local helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWssAhtmu4t762J2c4zHpi

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWssAhtmu4t762J2c4zHpi)_