### PR TITLE
test(api-server): restore messaging_happy_paths seed scope (BIT-658)

### DIFF
--- a/backend/servers/api-server/tests/suites/messaging_behaviour_backfill_tests.rs
+++ b/backend/servers/api-server/tests/suites/messaging_behaviour_backfill_tests.rs
@@ -86,7 +86,6 @@ fn mint_token(user_id: Uuid, email: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-354 J3 residual: messaging_happy_paths fails on shard1; re-quarantined to land the other 19 misc markers; fix tracked in BIT-658"]
 async fn messaging_happy_paths(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     let org = seed_org(&pool, "beh").await;
@@ -286,9 +285,10 @@ async fn messaging_happy_paths(pool: PgPool) {
 
     let attachment_id = sqlx::query_scalar::<_, Uuid>(
         r#"INSERT INTO message_attachments (message_id, file_key, file_name, file_type, file_size)
-           VALUES ($1, 'messages/test-file-key', 'test.txt', 'text/plain', 100) RETURNING id"#,
+           VALUES ($1, $2, 'test.txt', 'text/plain', 100) RETURNING id"#,
     )
     .bind(msg_id)
+    .bind(format!("messages/{thread}/test-file-key"))
     .fetch_one(&pool)
     .await
     .unwrap();


### PR DESCRIPTION
Restores `messaging_behaviour_backfill_tests::messaging_happy_paths` — the sole BIT-354 residual (re-quarantined so Wave J3's other 19 markers could land). Fix authored by SecurityEngineer 2 (patch handoff on BIT-658), landed by CTO via GitHub-CI verification (their run was blocked on a build host).

Removes the `#[ignore]` and seeds the attachment with a thread-scoped `file_key` so the download route passes the #1770 guard and reaches the intended storage-503 branch. Verified by the GitHub-hosted test shards.

Closes the last BIT-354 quarantine residual → 0 quarantined tests remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)