### PR TITLE
code-review-ppt-web-core-authctx-init-stale-role: route AuthContext cold-boot init through refreshTokenInternal

### DIFF
--- a/frontend/apps/ppt-web/src/contexts/AuthContext.init-refresh.test.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.init-refresh.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * AuthContext cold-boot init refresh — role-staleness regression (#574 gap).
+ *
+ * Context: #574 taught the runtime silent-refresh path (refreshTokenInternal)
+ * to re-derive the user's role from the fresh access token + persisted tenant
+ * memberships, so a server-side role change (e.g. a promotion to org_admin)
+ * propagates on the next token refresh without a full re-login.
+ *
+ * The gap this suite guards: the AuthProvider mount/init effect had its OWN
+ * inline copy of the refresh call for the cold-boot case (a persisted refresh
+ * token but no live access token — e.g. the access token was cleared or the
+ * tab was closed past its lifetime). That inline path rotated the tokens but
+ * re-hydrated `user` straight from storage, bypassing deriveActiveRole — so on
+ * a cold boot the user kept a STALE role until the next runtime refresh.
+ *
+ * The fix routes the init cold-boot branch through refreshTokenInternal, the
+ * same routine the runtime path uses. This suite asserts that a cold boot
+ * picks up the fresh role.
+ *
+ * Renders the REAL AuthProvider, mocking only the api-client network boundary.
+ */
+/// <reference types="vitest/globals" />
+
+// jsdom under vitest 4 does not expose localStorage by default. Provide an
+// in-memory shim before any SUT module is imported (mirrors the shim in the
+// sibling AuthContext.login-refresh.test.tsx suite).
+function makeStorageShim(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (k) => (store.has(k) ? (store.get(k) as string) : null),
+    key: (i) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k) => {
+      store.delete(k);
+    },
+    setItem: (k, v) => {
+      store.set(k, String(v));
+    },
+  };
+}
+
+function installStorage(name: 'localStorage' | 'sessionStorage') {
+  const shim = makeStorageShim();
+  if (typeof globalThis[name] === 'undefined') {
+    Object.defineProperty(globalThis, name, { value: shim, configurable: true, writable: true });
+  }
+  if (typeof window !== 'undefined' && typeof window[name] === 'undefined') {
+    Object.defineProperty(window, name, { value: shim, configurable: true, writable: true });
+  }
+}
+installStorage('localStorage');
+installStorage('sessionStorage');
+
+import type { AuthApi, RefreshTokenResponse } from '@ppt/api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import type React from 'react';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthProvider, useAuth } from './AuthContext';
+
+// ---------------------------------------------------------------------------
+// Mocks — only the api-client network boundary.
+// ---------------------------------------------------------------------------
+
+const refreshTokenSpy = vi.fn<(req: { refreshToken: string }) => Promise<RefreshTokenResponse>>();
+
+const fakeAuthApi: Partial<AuthApi> = {
+  refreshToken: refreshTokenSpy as unknown as AuthApi['refreshToken'],
+};
+
+vi.mock('@ppt/api-client', async () => {
+  const actual = await vi.importActual<typeof import('@ppt/api-client')>('@ppt/api-client');
+  return {
+    ...actual,
+    createAuthApi: vi.fn(() => fakeAuthApi),
+    setTokenProvider: vi.fn(),
+    clearTokenProvider: vi.fn(),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Constants + helpers
+// ---------------------------------------------------------------------------
+
+const ACCESS_TOKEN_KEY = 'ppt_access_token';
+const REFRESH_TOKEN_KEY = 'ppt_refresh_token';
+const USER_KEY = 'ppt_user';
+const TENANTS_KEY = 'ppt_tenants';
+
+/** Build a (structurally valid, unsigned) JWT carrying the given claims. */
+function makeJwt(claims: Record<string, unknown>): string {
+  const b64url = (obj: unknown) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${b64url({ alg: 'none', typ: 'JWT' })}.${b64url(claims)}.sig`;
+}
+
+/** Exposes the live auth context to the surrounding test scope. */
+function AuthHarness({
+  ctxRef,
+}: {
+  ctxRef: { current: ReturnType<typeof useAuth> | null };
+}): React.ReactElement {
+  const auth = useAuth();
+  useEffect(() => {
+    ctxRef.current = auth;
+  });
+  return <div data-testid="auth-state">{auth.isAuthenticated ? 'authed' : 'anon'}</div>;
+}
+
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: Infinity } },
+  });
+}
+
+function renderAuthApp(): { ctxRef: { current: ReturnType<typeof useAuth> | null } } {
+  const ctxRef: { current: ReturnType<typeof useAuth> | null } = { current: null };
+  render(
+    <QueryClientProvider client={makeQueryClient()}>
+      <AuthProvider>
+        <AuthHarness ctxRef={ctxRef} />
+      </AuthProvider>
+    </QueryClientProvider>
+  );
+  return { ctxRef };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthContext cold-boot init — role re-derivation (#574 gap)', () => {
+  beforeEach(() => {
+    refreshTokenSpy.mockReset();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  /**
+   * Seed a cold-boot session: a persisted refresh token, a stored user with a
+   * STALE role, and tenants reflecting a server-side promotion — but NO live
+   * access token, so the init effect must take the cold-boot refresh branch.
+   */
+  function seedColdBootSession() {
+    localStorage.setItem(REFRESH_TOKEN_KEY, 'cold-refresh');
+    localStorage.setItem(USER_KEY, JSON.stringify({ id: 'u-1', email: 'a@b.c', role: 'manager' }));
+    // Server has since promoted this membership to org_admin.
+    localStorage.setItem(
+      TENANTS_KEY,
+      JSON.stringify([{ tenantId: 't-1', tenantName: 'Acme', role: 'org_admin' }])
+    );
+  }
+
+  it('re-derives the fresh role on cold boot instead of keeping the stale stored role', async () => {
+    seedColdBootSession();
+    // Rotation returns a fresh access token whose tenant_id claim selects the
+    // (now promoted) membership.
+    refreshTokenSpy.mockResolvedValue({
+      accessToken: makeJwt({ sub: 'u-1', tenant_id: 't-1' }),
+      refreshToken: 'fresh-refresh',
+    });
+
+    const { ctxRef } = renderAuthApp();
+
+    await waitFor(() => {
+      expect(ctxRef.current?.isLoading).toBe(false);
+    });
+
+    // Cold-boot refresh went through refreshTokenInternal exactly once.
+    expect(refreshTokenSpy).toHaveBeenCalledTimes(1);
+    expect(refreshTokenSpy).toHaveBeenCalledWith({ refreshToken: 'cold-refresh' });
+
+    // Session is authenticated and the role reflects the server-side promotion,
+    // NOT the stale 'manager' stored on the user record. This is the assertion
+    // that fails against the pre-fix inline init path.
+    await waitFor(() => {
+      expect(ctxRef.current?.isAuthenticated).toBe(true);
+    });
+    expect(ctxRef.current?.user?.role).toBe('org_admin');
+
+    // Fresh tokens + the updated user role are persisted for the next boot.
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe('fresh-refresh');
+    const storedUser = JSON.parse(localStorage.getItem(USER_KEY) as string);
+    expect(storedUser.role).toBe('org_admin');
+  });
+
+  it('clears the session cleanly when the cold-boot refresh is rejected', async () => {
+    seedColdBootSession();
+    refreshTokenSpy.mockRejectedValue(new Error('refresh_token_revoked'));
+
+    const { ctxRef } = renderAuthApp();
+
+    await waitFor(() => {
+      expect(ctxRef.current?.isLoading).toBe(false);
+    });
+
+    // A revoked cold-boot refresh must leave a clean anonymous session — storage
+    // purged, no half-authenticated state.
+    expect(ctxRef.current?.isAuthenticated).toBe(false);
+    expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(USER_KEY)).toBeNull();
+    expect(localStorage.getItem(TENANTS_KEY)).toBeNull();
+  });
+});

--- a/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
@@ -367,11 +367,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (storedUser) {
         const storedTenants = tokenStorage.getTenants();
         const derivedRole = deriveActiveRole(response.accessToken, storedTenants ?? undefined);
-        if (derivedRole != null) {
-          const updated = { ...storedUser, role: derivedRole };
-          tokenStorage.setUser(updated);
-          setUser(updated);
-        }
+        // Always re-hydrate `user` from the stored record (applying the freshly
+        // derived role when one is available). Restoring the user here — rather
+        // than only when a role could be derived — is what lets the cold-boot
+        // init path funnel through this routine safely: it both refreshes the
+        // role (#574) and re-authenticates the session in one place.
+        const updated = derivedRole != null ? { ...storedUser, role: derivedRole } : storedUser;
+        tokenStorage.setUser(updated);
+        setUser(updated);
       }
 
       return response.accessToken;
@@ -399,18 +402,19 @@ export function AuthProvider({ children }: AuthProviderProps) {
           // In production, we might verify with the server
           setUser(storedUser);
         } else if (refreshTokenValue) {
-          // Try to refresh the token using the API client
+          // Cold-boot refresh: route through refreshTokenInternal (the SAME
+          // routine used by the runtime silent-refresh path) rather than
+          // calling authApi.refreshToken inline. The inline version persisted
+          // the rotated tokens but re-hydrated `user` straight from storage,
+          // so a server-side role change was NOT picked up on a cold boot —
+          // the user kept a stale role until the next runtime refresh or a
+          // full re-login. refreshTokenInternal re-derives the role from the
+          // fresh access token + persisted tenant memberships (#574) and owns
+          // its own failure cleanup (clear + de-auth + rethrow).
           try {
-            const authApi = getAuthApi();
-            const response = await authApi.refreshToken({ refreshToken: refreshTokenValue });
-            tokenStorage.setAccessToken(response.accessToken);
-            tokenStorage.setRefreshToken(response.refreshToken);
-            // Note: refresh doesn't return user, so we keep stored user if available
-            if (storedUser) {
-              setUser(storedUser);
-            }
+            await refreshTokenInternal();
           } catch {
-            tokenStorage.clear();
+            // refreshTokenInternal already cleared storage and reset the user.
           }
         }
       } catch {
@@ -422,7 +426,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     };
 
     initializeAuth();
-  }, []);
+    // refreshTokenInternal is a stable useCallback([]) reference, so this
+    // effect still runs exactly once on mount (no re-run loop).
+  }, [refreshTokenInternal]);
 
   /**
    * Refresh the access token with request queuing.


### PR DESCRIPTION
## Task
AuthContext init bypasses refreshTokenInternal → stale role on cold-boot refresh (#574 fix gap). In `frontend/apps/ppt-web/src/contexts/AuthContext.tsx`, the init/cold-boot path must go through the same refresh routine (`refreshTokenInternal`) so the user role is not stale after a cold-boot token refresh. Add a regression test.

## Owner
pm-backend (hint only — this code lives in ppt-web frontend; specialist selected: **react-web**)

## What changed
- **`AuthContext.tsx` init effect:** the cold-boot branch (persisted refresh token, no live access token) previously called `authApi.refreshToken` inline, rotating tokens but re-hydrating `user` straight from storage — bypassing the `deriveActiveRole` re-derivation added in #574. On a cold boot the user kept a **stale role** until the next runtime refresh or a full re-login. It now routes through `refreshTokenInternal`, the same routine the runtime silent-refresh path uses, so the role is re-derived from the fresh access token + persisted tenant memberships.
- **`refreshTokenInternal`:** now always re-hydrates the stored `user` (applying the derived role when one is available, else the stored user as-is) instead of only when a role could be derived. This makes it safe to own re-authentication for the init path — the runtime flow is unaffected (it re-sets the already-current user).
- Init effect dep array now lists `refreshTokenInternal` (a stable `useCallback([])` reference, so still runs exactly once on mount — no re-run loop).

## Regression test
`AuthContext.init-refresh.test.tsx` (new):
- **stale-role**: seeds a cold-boot session (refresh token + stored user with stale `manager` role + tenants promoted to `org_admin` server-side + no live access token); asserts the mounted `AuthProvider` re-derives `org_admin`. Verified **fails on base** (role stayed `manager`) and passes with the fix — IG3 satisfied via separate `test:` then `fix:` commits.
- **clean-logout**: a rejected cold-boot refresh leaves a clean anonymous session (storage purged, no half-auth state).

## Verification
```
VERIFY-PLAN base=6fa5e2e5639300412a310022d50cc9d1feff0e3d files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/contexts/AuthContext.init-refresh.test.tsx apps/ppt-web/src/contexts/AuthContext.tsx
  cd frontend && pnpm --filter "...[6fa5e2e...]" typecheck
  cd frontend && pnpm --filter "...[6fa5e2e...]" test
```
```
VERIFY OK b76bd610cd75d4e3bcbf652c6a760fc6c45fc5cf
```
Full ppt-web suite: **104 test files, 1601 tests passed** (biome + typecheck + vitest, impact-scoped gate).

## Scope drift
`scope-check.sh --owner pm-backend` → exit 2. The dispatcher hint `owner_role=pm-backend` maps to `backend/**`, but this task legitimately lives in the frontend — the task text itself notes the mismatch ("the code lives in ppt-web frontend; specialist react-web"). Drifting paths (both intended):
- `frontend/apps/ppt-web/src/contexts/AuthContext.tsx`
- `frontend/apps/ppt-web/src/contexts/AuthContext.init-refresh.test.tsx`

## Code-reuse review
`reuse-grep.sh --specialist react-web` → no warnings. Reuses the existing `refreshTokenInternal` / `deriveActiveRole` helpers rather than adding new ones.

## CI parity (Band C — hot-path only)
skipped: `just verify` is green; this is an auth-adjacent client-state change with no backend/security/billing/data-integrity surface. Frontend gate already replicates the `frontend.yml` job (biome + typecheck + vitest).

## Remote-tested
skipped: ppt-bridge MCP not connected.

## Notes
- Rebased onto current `origin/dev` (`6fa5e2e`) mid-task after the dispatcher advanced the branch; the `login()` `trackSignupLoggedIn('email_password')` instrumentation added there is preserved (edits were re-applied on top of the current file, not an older copy).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WhGn1oFmj47dFA1mZWnhVd)_