### PR TITLE
feat(acc): wire sent/cancelled invoice lifecycle (UC-ACC-05.17)

### DIFF
--- a/backend/crates/db/src/models/accounting.rs
+++ b/backend/crates/db/src/models/accounting.rs
@@ -24,15 +24,21 @@ pub struct Contact {
 }
 
 /// Status of an issued invoice.
+///
+/// Full lifecycle (UC-ACC-05.17): draft → issued → sent → paid/partially_paid/
+/// overdue, with cancelled reachable from issued/sent/overdue while nothing is
+/// paid. The DB CHECK (migration 00202) allows the same set.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type, ToSchema)]
 #[sqlx(type_name = "TEXT", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum InvoiceStatus {
     Draft,
     Issued,
+    Sent,
     Paid,
     PartiallyPaid,
     Overdue,
+    Cancelled,
 }
 
 /// VAT rate types for CZ/SK.

--- a/backend/crates/db/src/repositories/acc_invoicing.rs
+++ b/backend/crates/db/src/repositories/acc_invoicing.rs
@@ -137,6 +137,30 @@ impl AccInvoicingRepository {
             .await
     }
 
+    /// Cancel an unpaid document (UC-ACC-05.17). Only `issued`/`sent`/`overdue`
+    /// documents with a zero `paid_amount` can be cancelled — drafts are simply
+    /// deleted, and once any payment landed the correction path is a credit
+    /// note (UC-ACC-05.7). Returns `None` when the guard does not match, so a
+    /// concurrent payment confirmation can never race a cancellation.
+    pub async fn cancel_invoice_rls<'e, E>(
+        &self,
+        executor: E,
+        id: Uuid,
+    ) -> Result<Option<AccInvoiceExt>, sqlx::Error>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let sql = format!(
+            "UPDATE invoice SET status = 'cancelled', updated_at = NOW() \
+             WHERE id = $1 AND status IN ('issued', 'sent', 'overdue') AND paid_amount = 0 \
+             RETURNING {INVOICE_EXT_COLUMNS}"
+        );
+        sqlx::query_as::<_, AccInvoiceExt>(sqlx::AssertSqlSafe(sql.as_str()))
+            .bind(id)
+            .fetch_optional(executor)
+            .await
+    }
+
     /// Set FX rate + base-currency amount on a foreign-currency invoice
     /// (UC-ACC-05.4). The handler computes `base_currency_amount` via
     /// `accounting_core::money::to_base_currency`.

--- a/backend/crates/db/src/repositories/accounting.rs
+++ b/backend/crates/db/src/repositories/accounting.rs
@@ -472,6 +472,10 @@ impl AccountingRepository {
     }
 
     /// Update invoice paid amount and status based on a match confirmation.
+    ///
+    /// Cancelled documents are excluded by the WHERE guard: a payment applied
+    /// to a cancelled invoice must not resurrect it as paid — callers get
+    /// `None` (same as an unknown id) and surface the mismatch (UC-ACC-05.17).
     pub async fn update_invoice_payment_status_rls<'e, E>(
         &self,
         executor: E,
@@ -495,7 +499,7 @@ impl AccountingRepository {
                     ELSE 'issued'
                 END,
                 updated_at = NOW()
-            WHERE id = $2
+            WHERE id = $2 AND status <> 'cancelled'
             RETURNING *
             "#,
         )

--- a/backend/crates/db/tests/acc_invoice_lifecycle_tests.rs
+++ b/backend/crates/db/tests/acc_invoice_lifecycle_tests.rs
@@ -1,0 +1,171 @@
+//! Invoice status-lifecycle guard tests (UC-ACC-05.17).
+//!
+//! Verifies the repo-level state machine added for the `sent`/`cancelled`
+//! lifecycle wiring, against a live migrated DB:
+//!   1. `mark_sent_rls` advances ONLY `issued` → `sent`;
+//!   2. `cancel_invoice_rls` cancels ONLY unpaid `issued`/`sent`/`overdue`
+//!      documents (drafts are deleted instead; paid documents need a credit
+//!      note) and is not re-appliable to an already-cancelled document;
+//!   3. `update_invoice_payment_status_rls` refuses to touch a cancelled
+//!      document — a late payment confirmation cannot resurrect it as paid.
+//!
+//! Guards, not RLS, are under test — the superuser test pool (which bypasses
+//! RLS) is intentionally fine here; RLS coverage lives in
+//! `accounting_rls_repo_tests.rs` / `acc_mvp_rls_tests.rs`.
+
+use db::repositories::acc_invoicing::AccInvoicingRepository;
+use db::repositories::accounting::AccountingRepository;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO organizations (name, slug, contact_email, status)
+           VALUES ($1, $2, $3, 'active') RETURNING id"#,
+    )
+    .bind(format!("Acc {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@acc.test"))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_contact(pool: &PgPool, org: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO contact (tenant_id, name) VALUES ($1, 'Acme s.r.o.') RETURNING id",
+    )
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .expect("seed contact")
+}
+
+/// Seed an invoice in the given lifecycle state with the given paid amount.
+async fn seed_invoice(
+    pool: &PgPool,
+    org: Uuid,
+    contact: Uuid,
+    status: &str,
+    paid_amount: Decimal,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"INSERT INTO invoice
+             (tenant_id, contact_id, number, issue_date, due_date,
+              total_amount, base_amount, vat_amount, status, paid_amount)
+           VALUES ($1, $2, $3, CURRENT_DATE, CURRENT_DATE, 120, 100, 20, $4, $5)
+           RETURNING id"#,
+    )
+    .bind(org)
+    .bind(contact)
+    .bind(format!("F-{}", Uuid::new_v4().simple()))
+    .bind(status)
+    .bind(paid_amount)
+    .fetch_one(pool)
+    .await
+    .expect("seed invoice")
+}
+
+async fn status_of(pool: &PgPool, id: Uuid) -> String {
+    sqlx::query_scalar("SELECT status FROM invoice WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .expect("read status")
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn mark_sent_advances_only_issued(pool: PgPool) {
+    let org = seed_org(&pool, "lifecycle-sent").await;
+    let contact = seed_contact(&pool, org).await;
+    let repo = AccInvoicingRepository::new(pool.clone());
+
+    // issued → sent
+    let issued = seed_invoice(&pool, org, contact, "issued", dec!(0)).await;
+    let sent = repo
+        .mark_sent_rls(&pool, issued)
+        .await
+        .expect("mark_sent query")
+        .expect("issued must advance to sent");
+    assert_eq!(sent.status, "sent");
+    assert_eq!(status_of(&pool, issued).await, "sent");
+
+    // Every other state is refused (None), unchanged in the DB.
+    for state in ["draft", "sent", "paid", "partially_paid", "cancelled"] {
+        let id = seed_invoice(&pool, org, contact, state, dec!(0)).await;
+        let refused = repo.mark_sent_rls(&pool, id).await.expect("query ok");
+        assert!(refused.is_none(), "{state} must not advance to sent");
+        assert_eq!(status_of(&pool, id).await, state);
+    }
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn cancel_allows_only_unpaid_issued_sent_overdue(pool: PgPool) {
+    let org = seed_org(&pool, "lifecycle-cancel").await;
+    let contact = seed_contact(&pool, org).await;
+    let repo = AccInvoicingRepository::new(pool.clone());
+
+    // Unpaid issued/sent/overdue → cancelled.
+    for state in ["issued", "sent", "overdue"] {
+        let id = seed_invoice(&pool, org, contact, state, dec!(0)).await;
+        let cancelled = repo
+            .cancel_invoice_rls(&pool, id)
+            .await
+            .expect("cancel query")
+            .unwrap_or_else(|| panic!("unpaid {state} must be cancellable"));
+        assert_eq!(cancelled.status, "cancelled");
+        assert_eq!(status_of(&pool, id).await, "cancelled");
+
+        // Cancel is not re-appliable (already cancelled → None).
+        assert!(repo.cancel_invoice_rls(&pool, id).await.unwrap().is_none());
+    }
+
+    // Drafts and paid lifecycles are refused.
+    for state in ["draft", "paid", "partially_paid", "cancelled"] {
+        let id = seed_invoice(&pool, org, contact, state, dec!(0)).await;
+        let refused = repo.cancel_invoice_rls(&pool, id).await.expect("query ok");
+        assert!(refused.is_none(), "{state} must not be cancellable");
+        assert_eq!(status_of(&pool, id).await, state);
+    }
+
+    // A partial payment on an otherwise-cancellable state blocks cancellation
+    // (paid_amount guard, independent of status).
+    let part_paid = seed_invoice(&pool, org, contact, "issued", dec!(50)).await;
+    assert!(
+        repo.cancel_invoice_rls(&pool, part_paid)
+            .await
+            .unwrap()
+            .is_none(),
+        "any received payment must block cancellation"
+    );
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn payment_update_cannot_resurrect_cancelled(pool: PgPool) {
+    let org = seed_org(&pool, "lifecycle-pay").await;
+    let contact = seed_contact(&pool, org).await;
+    let repo = AccountingRepository::new(pool.clone());
+
+    let cancelled = seed_invoice(&pool, org, contact, "cancelled", dec!(0)).await;
+    let result = repo
+        .update_invoice_payment_status_rls(&pool, cancelled, dec!(120))
+        .await
+        .expect("payment update query");
+    assert!(
+        result.is_none(),
+        "a payment applied to a cancelled invoice must be a no-op"
+    );
+    assert_eq!(status_of(&pool, cancelled).await, "cancelled");
+
+    // Sanity: the same delta on an issued invoice still settles it in full.
+    let issued = seed_invoice(&pool, org, contact, "issued", dec!(0)).await;
+    let paid = repo
+        .update_invoice_payment_status_rls(&pool, issued, dec!(120))
+        .await
+        .expect("payment update query")
+        .expect("issued invoice accepts payment");
+    assert_eq!(paid.paid_amount, dec!(120));
+    assert_eq!(status_of(&pool, issued).await, "paid");
+}

--- a/backend/servers/accounting-server/src/main.rs
+++ b/backend/servers/accounting-server/src/main.rs
@@ -175,6 +175,8 @@ fn cors_layer() -> CorsLayer {
         routes::invoices::update_invoice,
         routes::invoices::delete_invoice,
         routes::invoices::issue_invoice,
+        routes::invoices::mark_sent,
+        routes::invoices::cancel_invoice,
         routes::invoices::set_exchange_rate,
         routes::invoices::create_credit_note,
         routes::invoices::duplicate_invoice,

--- a/backend/servers/accounting-server/src/routes/invoices.rs
+++ b/backend/servers/accounting-server/src/routes/invoices.rs
@@ -769,7 +769,9 @@ pub async fn create_credit_note(
             StatusCode::INTERNAL_SERVER_ERROR
         })?
         .ok_or(StatusCode::NOT_FOUND)?;
-    if original.status == "draft" {
+    if original.status == "draft" || original.status == "cancelled" {
+        // Drafts have no legal number to correct; cancelled documents carry no
+        // receivable to reverse (UC-ACC-05.17).
         return Err(StatusCode::BAD_REQUEST);
     }
 
@@ -1072,6 +1074,183 @@ pub async fn list_links(
 
     rls.release().await;
     Ok(Json(links))
+}
+
+/// Mark an issued invoice as sent (UC-ACC-05.10 / .17).
+///
+/// Records the delivery step of the lifecycle: only `issued` advances to
+/// `sent`. The guard lives in the UPDATE (`mark_sent_rls`), so a concurrent
+/// transition cannot double-fire. Email transport is the
+/// [`hooks::DocumentMailer`] seam — both that flow and out-of-band delivery
+/// ("I sent it myself") record the transition through this endpoint.
+#[utoipa::path(
+    post,
+    path = "/api/v1/invoices/{id}/send",
+    params(("id" = Uuid, Path, description = "Invoice id")),
+    responses(
+        (status = 200, description = "Marked sent", body = AccInvoiceExt),
+        (status = 400, description = "Not in issued state"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Not found")
+    ),
+    tag = "Invoices"
+)]
+pub async fn mark_sent(
+    Path(id): Path<Uuid>,
+    State(state): State<AppState>,
+    mut rls: RlsConnection,
+    auth: AuthUser,
+) -> Result<Json<AccInvoiceExt>, StatusCode> {
+    authz::require_role(rls.role(), authz::MUTATE_MIN_ROLE).map_err(|_| StatusCode::FORBIDDEN)?;
+
+    let tenant_id = rls.tenant_id();
+
+    let mut tx = rls.begin().await.map_err(|e| {
+        tracing::error!("Failed to start transaction: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    // Load first to distinguish 404 (unknown/foreign id) from 400 (wrong state).
+    let existing = state
+        .invoicing_repo
+        .find_invoice_ext_rls(&mut *tx, id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load invoice {id}: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    if existing.status != "issued" {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let sent = state
+        .invoicing_repo
+        .mark_sent_rls(&mut *tx, id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to mark invoice {id} sent: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        // None: the issued guard in the UPDATE stopped a concurrent transition.
+        .ok_or(StatusCode::BAD_REQUEST)?;
+
+    let entry = audit::record(
+        tenant_id,
+        Some(auth.user_id),
+        "send",
+        "invoice",
+        Some(id),
+        serde_json::json!({ "number": sent.number, "status": "sent" }),
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    state
+        .platform_repo
+        .record_audit_rls(&mut *tx, entry)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to record audit: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tx.commit().await.map_err(|e| {
+        tracing::error!("Failed to commit: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    rls.release().await;
+    Ok(Json(sent))
+}
+
+/// Cancel an unpaid document (UC-ACC-05.17).
+///
+/// Lifecycle rules: drafts are deleted (not cancelled), and once any payment
+/// has landed the correction path is a credit note (UC-ACC-05.7) — so only
+/// `issued`/`sent`/`overdue` documents with `paid_amount = 0` cancel. The
+/// same guard is repeated inside the UPDATE (`cancel_invoice_rls`), so a
+/// payment confirmation committing concurrently can never be swallowed by a
+/// cancellation. The number allocated at issue stays consumed — the document
+/// is retained (gapless numbering, UC-ACC-02.3), only its status changes.
+#[utoipa::path(
+    post,
+    path = "/api/v1/invoices/{id}/cancel",
+    params(("id" = Uuid, Path, description = "Invoice id")),
+    responses(
+        (status = 200, description = "Cancelled", body = AccInvoiceExt),
+        (status = 400, description = "Not cancellable (draft, paid, or already cancelled)"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Not found")
+    ),
+    tag = "Invoices"
+)]
+pub async fn cancel_invoice(
+    Path(id): Path<Uuid>,
+    State(state): State<AppState>,
+    mut rls: RlsConnection,
+    auth: AuthUser,
+) -> Result<Json<AccInvoiceExt>, StatusCode> {
+    authz::require_role(rls.role(), authz::MUTATE_MIN_ROLE).map_err(|_| StatusCode::FORBIDDEN)?;
+
+    let tenant_id = rls.tenant_id();
+
+    let mut tx = rls.begin().await.map_err(|e| {
+        tracing::error!("Failed to start transaction: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    let existing = state
+        .invoicing_repo
+        .find_invoice_ext_rls(&mut *tx, id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load invoice {id}: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        .ok_or(StatusCode::NOT_FOUND)?;
+    if !matches!(existing.status.as_str(), "issued" | "sent" | "overdue")
+        || existing.paid_amount != Decimal::ZERO
+    {
+        return Err(StatusCode::BAD_REQUEST);
+    }
+
+    let cancelled = state
+        .invoicing_repo
+        .cancel_invoice_rls(&mut *tx, id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to cancel invoice {id}: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+        // None: the UPDATE guard stopped a concurrent payment/transition race.
+        .ok_or(StatusCode::BAD_REQUEST)?;
+
+    let entry = audit::record(
+        tenant_id,
+        Some(auth.user_id),
+        "cancel",
+        "invoice",
+        Some(id),
+        serde_json::json!({ "number": cancelled.number, "status": "cancelled" }),
+    )
+    .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    state
+        .platform_repo
+        .record_audit_rls(&mut *tx, entry)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to record audit: {e}");
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tx.commit().await.map_err(|e| {
+        tracing::error!("Failed to commit: {e}");
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    rls.release().await;
+    Ok(Json(cancelled))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/servers/accounting-server/src/routes/mod.rs
+++ b/backend/servers/accounting-server/src/routes/mod.rs
@@ -117,6 +117,8 @@ pub fn api_router() -> Router<AppState> {
                 )
                 .route("/{id}/items", get(invoices::list_invoice_items))
                 .route("/{id}/issue", post(invoices::issue_invoice))
+                .route("/{id}/send", post(invoices::mark_sent))
+                .route("/{id}/cancel", post(invoices::cancel_invoice))
                 .route("/{id}/exchange-rate", post(invoices::set_exchange_rate))
                 .route("/{id}/credit-note", post(invoices::create_credit_note))
                 .route("/{id}/duplicate", post(invoices::duplicate_invoice))


### PR DESCRIPTION
## Summary
- The 00202 migration already allows the full invoice status lifecycle, but nothing could reach `sent` or `cancelled`. This wires it end-to-end.
- `POST /api/v1/invoices/{id}/send` — issued → sent via the existing (previously unwired) `mark_sent_rls` guard, with audit entry.
- `POST /api/v1/invoices/{id}/cancel` — new `cancel_invoice_rls`: only **unpaid** `issued`/`sent`/`overdue` documents cancel (drafts are deleted; anything paid needs a credit note). The guard is repeated inside the UPDATE so a concurrent payment confirmation can never race a cancellation.
- `update_invoice_payment_status_rls` now refuses cancelled documents — a late payment match cannot resurrect a cancelled invoice as paid.
- Credit notes can no longer be raised against cancelled originals.
- `InvoiceStatus` enum gains `Sent` + `Cancelled` (now matches the DB CHECK from 00202).

Part of the Phase A "close the MVP loop" sequence from `.research/accounting/portal-functionality-analysis-2026-07-22.md` (on the analysis branch).

## Verification
```
$ cargo check -p db -p accounting-server -p api-server        # rustc 1.94.1
Finished `dev` profile [unoptimized + debuginfo] target(s) in 13m 06s  (exit 0)

$ cargo clippy -p db -p accounting-server -- -D warnings
exit 0, no warnings

$ DATABASE_URL=... cargo test -p db --test acc_invoice_lifecycle_tests   # live migrated PG 16
test payment_update_cannot_resurrect_cancelled ... ok
test mark_sent_advances_only_issued ... ok
test cancel_allows_only_unpaid_issued_sent_overdue ... ok
test result: ok. 3 passed; 0 failed
```

## Test coverage
New `backend/crates/db/tests/acc_invoice_lifecycle_tests.rs` (3 sqlx tests, not quarantined): every non-issued state refuses `mark_sent`; every draft/paid state refuses cancel; partial payment blocks cancel; cancel is not re-appliable; payment update is a no-op on cancelled while still settling issued invoices.

## Out-of-scope items I noticed
- `sent`-ness is lost when a confirmed match is later unapplied (status reverts to `issued` per PAP-325) — needs status history to preserve, deliberately not added here.
- Follow-ups queued separately: invoice PDF render (UC-ACC-05.9) and PAY by square QR (UC-ACC-05.8).