### PR TITLE
gh-issue-2560: fix reality-web Docker build — copy api-client node_modules into builder stage

### DIFF
--- a/docker/frontend/reality-web.Dockerfile
+++ b/docker/frontend/reality-web.Dockerfile
@@ -53,9 +53,19 @@ RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
 # Dockerfile sidesteps this by `COPY --from=deps /app/ ./` (whole tree);
 # reality-web keeps the selective list because next.js's standalone
 # output expects this exact layout for the runtime image.
+#
+# 2026-07-29: added `api-client` — reality-web pulls in `@ppt/api-client`
+# transitively (`@ppt/shared`'s src/index.ts re-exports it, and shared is
+# consumed at source), whose package.json declares `@tanstack/react-query`
+# and `@tanstack/query-core` as direct deps. Under pnpm's isolated layout
+# those materialize in `packages/api-client/node_modules`, which was never
+# copied here, so `next build`'s Turbopack type-check failed with 38
+# `Cannot find module '@tanstack/react-query'` errors, all in
+# `packages/api-client/src/**`. See #2560.
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages/shared/node_modules ./packages/shared/node_modules
 COPY --from=deps /app/packages/ui-kit/node_modules ./packages/ui-kit/node_modules
+COPY --from=deps /app/packages/api-client/node_modules ./packages/api-client/node_modules
 COPY --from=deps /app/packages/reality-api-client/node_modules ./packages/reality-api-client/node_modules
 COPY --from=deps /app/packages/dev-panel/node_modules ./packages/dev-panel/node_modules
 COPY --from=deps /app/packages/sitemap/node_modules ./packages/sitemap/node_modules


### PR DESCRIPTION
## Task

ci: reality-web Docker build has failed on every run since 2026-06-17 — no frontend image published for 6 weeks (Closes #2560)

`docker/frontend/reality-web.Dockerfile`'s builder stage enumerated per-package `node_modules` selectively but omitted `packages/api-client/node_modules`. reality-web consumes `@ppt/shared` at source level, and `packages/shared/src/index.ts:11` does `export * from '@ppt/api-client'`, so Turbopack compiles `packages/api-client/src/**` during `next build`. `api-client` declares `@tanstack/react-query` + `@tanstack/query-core` as direct deps, which under pnpm's isolated layout live in `packages/api-client/node_modules` — never copied to the builder stage. Result: 38 unresolved `@tanstack/react-query` errors (all in `packages/api-client/src/**`), failing every `docker-frontend.yml` run since 2026-06-17.

## Owner

pm-tech-lead (hint) — actual change class: CI/Docker infra under `docker/frontend/`.

## Fix

Added the single missing line, matching the file's existing selective-copy structure:

```dockerfile
COPY --from=deps /app/packages/api-client/node_modules ./packages/api-client/node_modules
```

Chosen over the whole-tree (`COPY --from=deps /app/ ./`) alternative because it best matches the file's existing structure — the file deliberately keeps a selective enumeration with an in-file comment explaining why it does not mirror `ppt-web.Dockerfile` — and is the minimal, lowest-regression-risk change (identical in form to the six sibling COPY lines). The adjacent comment block was updated to record api-client as the new culprit and the accurate transitive path, consistent with how the block already documents the prior dev-panel fix.

Out of scope (deliberately not touched, per issue's "two unrelated observations"): `git: not found` noise and the corepack pnpm 8.14 vs 9.15 mismatch.

## Verification

```
VERIFY-PLAN base=15bebae53b60e96fbf0062294e7633849902f1ba files=1
VERIFY OK 1bfcc226b4e1ab73db65f0ea34f1925e8bd1ac82
```

The impact-scoped gate resolves to an empty build plan — a Dockerfile-only change has no crate/frontend compile impact, so there is no local unit to run. Additional checks performed for this change class:

- `git diff --check` — clean (no whitespace errors).
- Confirmed the COPY source path is present in the deps-stage graph: `packages/api-client/package.json` is copied into the `deps` stage (line 20) and `pnpm install` runs there, so `packages/api-client/node_modules` exists in that stage.
- Traced and confirmed the build-graph path: reality-web → `@ppt/shared` (source) → `@ppt/api-client` (source) → `@tanstack/react-query`.

Deferred to CI (`docker-frontend.yml`): the actual multi-stage `docker build` of the `ppt-reality-web` matrix leg — not runnable in this environment (no local Docker).

## Scope drift

`scope-check.sh --owner pm-tech-lead` returned exit 2 for `docker/frontend/reality-web.Dockerfile` (outside pm-tech-lead's mapped code areas). This is expected: the task is a CI/Docker infra fix and owner_role was a hint only. Single file, no code paths touched.

## Code-reuse review

N/A — a Dockerfile change introduces no new code symbols; `reuse-grep` has nothing to flag.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change). The relevant real-world check is `docker-frontend.yml` itself, which this PR fixes.

## Remote-tested

skipped

## Notes

- This is the second occurrence of this Dockerfile's selective-copy list silently breaking when a workspace package gains a runtime dep (the first being `dev-panel`, documented in the same comment block). The one-line fix keeps the existing structure; a future maintainer wanting to eliminate the drift class entirely could switch to `ppt-web.Dockerfile`'s whole-tree `COPY --from=deps /app/ ./` — left as a deliberate non-goal here to keep the fix minimal.

---
_Generated by [Claude Code](https://claude.ai/code/session_016xvxfjjsWf1GuztTtmohFA)_