### PR TITLE
gh-issue-2561: rebase+retry version-bump push to fix GH006 on concurrent dev merges

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -66,23 +66,43 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Bump patch version
-        if: steps.detect.outputs.skip != 'true'
-        run: ./scripts/bump-version.sh patch
-
+      # Recompute the bump against the current tip of dev, then push, retrying
+      # on a non-fast-forward rejection. cancel-in-progress: false queues runs
+      # rather than dropping them, so by the time a queued run reaches the front
+      # of the queue `dev` has advanced — at minimum by the preceding run's own
+      # chore(version:) commit — and this run's checkout is stale. A bare push
+      # would then be non-fast-forward and the protected-branch hook declines it
+      # (GH006). Re-fetching and RECOMPUTING the bump (not replaying a stale
+      # commit) against fresh `dev` each attempt keeps the push fast-forward and
+      # avoids a double-bump.
       - name: Commit and push version bump
         if: steps.detect.outputs.skip != 'true'
         run: |
-          VERSION=$(cat VERSION | tr -d '[:space:]')
-          git add VERSION
-          git add backend/Cargo.toml 2>/dev/null || true
-          git add frontend/package.json 2>/dev/null || true
-          git add "frontend/apps/*/package.json" 2>/dev/null || true
-          git add "frontend/packages/*/package.json" 2>/dev/null || true
-          git add mobile-native/gradle.properties 2>/dev/null || true
-          git add docs/api/typespec/main.tsp 2>/dev/null || true
-          git diff --cached --quiet && echo "No version files changed" && exit 0
+          for attempt in 1 2 3; do
+            git fetch origin dev
+            git reset --hard origin/dev
 
-          git commit -m "chore(version): bump to $VERSION"
-          git push origin HEAD:dev
-          echo "Version bumped to $VERSION and pushed to dev"
+            ./scripts/bump-version.sh patch
+
+            VERSION=$(cat VERSION | tr -d '[:space:]')
+            git add VERSION
+            git add backend/Cargo.toml 2>/dev/null || true
+            git add frontend/package.json 2>/dev/null || true
+            git add "frontend/apps/*/package.json" 2>/dev/null || true
+            git add "frontend/packages/*/package.json" 2>/dev/null || true
+            git add mobile-native/gradle.properties 2>/dev/null || true
+            git add docs/api/typespec/main.tsp 2>/dev/null || true
+            if git diff --cached --quiet; then
+              echo "No version files changed"
+              exit 0
+            fi
+
+            git commit -m "chore(version): bump to $VERSION"
+            if git push origin HEAD:dev; then
+              echo "Version bumped to $VERSION and pushed to dev"
+              exit 0
+            fi
+            echo "push rejected (attempt $attempt) — dev moved, retrying"
+          done
+          echo "ERROR: failed to push version bump after 3 attempts" >&2
+          exit 1


### PR DESCRIPTION
## Task
ci: version-bump push has no rebase/retry — GH006 whenever two merges to dev land close together (Closes #2561)

## Owner
pm-tech-lead (change class: CI/DevOps — `Version Bump` GitHub Actions workflow)

## Problem
`.github/workflows/version-bump.yml`'s "Commit and push version bump" step did a bare `git push origin HEAD:dev` with no fetch/rebase/retry. Because `concurrency.cancel-in-progress: false` queues runs rather than dropping them, a queued run reaches the front of the queue with a checkout of its own now-stale `dev` sha. `dev` has since advanced (at minimum by the preceding run's own `chore(version:)` commit), so the push is non-fast-forward and the `dev` ruleset's `non_fast_forward` rule makes the protected-branch hook decline it → `GH006`.

## Fix
Replaced the standalone "Bump patch version" step + bare push with a single `fetch + reset --hard origin/dev + recompute + push` retry loop (3 attempts):

- Each attempt re-fetches `dev`, resets to its current tip, and **recomputes** the bump by re-running `scripts/bump-version.sh patch` against the fresh `VERSION` — not a stale replay of a `0.3.218` commit. Per the issue, recomputing avoids both the double-bump and the rebase conflict a replay would cause.
- On a non-fast-forward rejection the loop retries; after 3 failed attempts it exits 1.
- The `concurrency` block, the `.research/`-only skip guard, `Configure git`, and `Setup Node` steps are all preserved unchanged.

The standalone bump step was folded in because `reset --hard origin/dev` inside the loop would discard any pre-loop bump — recomputing on each attempt is the correct shape.

## Verification
```
VERIFY-PLAN base=3f8f76cbd14a13b08e79d99dd2f1465a5a57400d files=2
VERIFY OK 790981a9108083fc75ed9a75915db35a08d3037e
```
- `git diff --check` — clean
- YAML parse (PyYAML `safe_load`) — OK
- `scripts/verify-impact.sh --base dev` — VERIFY OK (workflow-YAML-only diff → empty compile/test band, as expected)
- scope-check (`--owner pm-tech-lead`) — exit 0, no drift
- reuse-grep (generic) — no warnings

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Change is confined to `.github/workflows/version-bump.yml` (1 file). No `.research/**` files were modified by this commit.
- The retry loop uses `reset --hard origin/dev` (clean re-sync) rather than `git rebase origin/dev`; since the only local change each attempt is a freshly recomputed bump, reset+recompute is simpler and cannot hit rebase conflicts.

Closes #2561

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8V7HkHtTbK81GC3PmyKKc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8V7HkHtTbK81GC3PmyKKc)_