### PR TITLE
code-review-mobile-native-kmp-android-sso-deeplink-missing-csrf-state: verify CSRF state on Android SSO deep-link

### DIFF
--- a/mobile-native/CLAUDE.md
+++ b/mobile-native/CLAUDE.md
@@ -147,6 +147,22 @@ openapi-generator generate \
 | Android | ktor-client-android |
 | iOS | ktor-client-darwin |
 
+## SSO deep-link CSRF contract
+
+The SSO callback (`reality://sso?token=…&state=…`) is delivered through an **exported** deep-link
+intent-filter, so any app/browser/notification can hand it to us. **Both platforms MUST verify a
+per-flow `state` nonce before validating the token** — skipping it allows session fixation / account
+takeover (an attacker's token silently signs the victim in).
+
+- **Android** — `SsoStateStore` (commonMain): `mint()` before opening the SSO hop (append
+  `&state=<nonce>`); `MainActivity.handleDeepLink` calls `consume(target.state)` and validates the
+  token only on a match. Default-reject: an unsolicited callback with no pending flow is dropped.
+- **iOS** — `AuthManager.beginSsoFlow()` / `consumeSsoState(_:)` (owns its own nonce; does not use
+  the KMP store).
+
+`DeepLinkTarget.Sso` carries `state: String?`; a `null`/mismatched state is rejected. Nonces are
+single-use (cleared on every `consume`).
+
 ## Screen-Map integration
 
 When implementing or modifying a screen in this KMP app:

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/MainActivity.kt
@@ -2,6 +2,7 @@ package three.two.bit.ppt.reality
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,6 +21,7 @@ import androidx.navigation.compose.rememberNavController
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.api.ApiConfig
 import three.two.bit.ppt.reality.auth.SsoService
+import three.two.bit.ppt.reality.auth.SsoStateStore
 import three.two.bit.ppt.reality.listing.ListingRepository
 import three.two.bit.ppt.reality.navigation.DeepLinkRouter
 import three.two.bit.ppt.reality.navigation.DeepLinkTarget
@@ -87,12 +89,28 @@ class MainActivity : ComponentActivity() {
 
         when (val target = DeepLinkRouter.parse(uri.toString())) {
             // SSO is handled out-of-band: validate the token instead of navigating.
+            //
+            // CSRF / session-fixation guard (parity with iOS `AuthManager.consumeSsoState`): the
+            // `reality://sso` intent-filter is `exported`, so any browser, notification, or other
+            // app can deliver this intent carrying an attacker-controlled token. Only validate the
+            // token when the callback's `state` matches the per-flow nonce this app minted (via
+            // `SsoStateStore.mint`) before starting the SSO hop. A missing/forged `state` — or an
+            // unsolicited deep link with no pending nonce at all — is rejected here, before the
+            // token ever reaches the session-creating endpoint.
             is DeepLinkTarget.Sso ->
-                lifecycleScope.launch { ssoService.validateAndLogin(target.token) }
+                if (SsoStateStore.consume(target.state)) {
+                    lifecycleScope.launch { ssoService.validateAndLogin(target.token) }
+                } else {
+                    Log.w(TAG, "Rejected SSO deep link: CSRF state mismatch or no pending flow")
+                }
             // Navigable targets are deferred until the NavHost is composed.
             null -> Unit
             else -> pendingDeepLink.value = target
         }
+    }
+
+    private companion object {
+        private const val TAG = "MainActivity"
     }
 }
 

--- a/mobile-native/shared/src/androidMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.android.kt
+++ b/mobile-native/shared/src/androidMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.android.kt
@@ -1,0 +1,22 @@
+package three.two.bit.ppt.reality.auth
+
+import java.security.SecureRandom
+
+/** Cryptographically-secure RNG, seeded once per process. */
+private val secureRandom = SecureRandom()
+
+/**
+ * Android CSRF nonce: 32 random bytes from [SecureRandom] rendered as a 64-char lowercase hex
+ * string — matching the iOS `AuthManager.makeSsoState()` output shape.
+ */
+internal actual fun generateSsoNonce(): String {
+    val bytes = ByteArray(32)
+    secureRandom.nextBytes(bytes)
+    return buildString(bytes.size * 2) {
+        for (b in bytes) {
+            val v = b.toInt() and 0xff
+            append("0123456789abcdef"[v ushr 4])
+            append("0123456789abcdef"[v and 0x0f])
+        }
+    }
+}

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.kt
@@ -1,0 +1,72 @@
+package three.two.bit.ppt.reality.auth
+
+/**
+ * Single-slot CSRF nonce store for the mobile SSO deep-link flow (Epic 10A-SSO).
+ *
+ * The Reality Portal SSO round-trip re-enters the app through the OS deep-link handler
+ * (`reality://sso?token=…&state=…`). Because that intent-filter is `exported` (any browser,
+ * notification, or other app can deliver it), a `token` on its own is not trustworthy: an attacker
+ * can hand the victim a link carrying the attacker's session token and silently sign the victim into
+ * the attacker's account (session fixation → account takeover).
+ *
+ * This store is the Kotlin counterpart of the iOS `AuthManager.beginSsoFlow()` /
+ * `consumeSsoState(_:)` pair — closing the Android-vs-iOS parity gap. Before starting the SSO
+ * browser hop, a caller mints a nonce with [mint] and appends it to the outbound URL as `&state=…`;
+ * when the callback deep link arrives, [MainActivity][consume] verifies the echoed `state` matches
+ * the pending nonce and only then validates the token.
+ *
+ * Semantics (mirroring iOS exactly):
+ * - **Single slot** — a new flow overwrites any previously pending nonce (last-writer-wins).
+ * - **Single use** — [consume] clears the pending nonce regardless of outcome, so a replay of the
+ *   same deep link is rejected on the second delivery.
+ * - **Default-reject** — with no pending nonce (fresh process, or after a consume), [consume]
+ *   returns `false` for any input. An unsolicited, externally-injected `reality://sso` deep link is
+ *   therefore rejected out of the box.
+ *
+ * A [SsoStateStore] instance is process-local, single-threaded in practice (mint from the UI, consume
+ * from the deep-link handler on the main thread) — matching the plain-`var` design of the iOS
+ * implementation.
+ */
+object SsoStateStore {
+
+    private var pending: String? = null
+
+    /**
+     * Mint a fresh CSRF nonce, persist it as the single pending value, and return it. Callers MUST
+     * append the returned value to the outbound SSO URL as the `state` query parameter so the server
+     * echoes it back to the [DeepLinkTarget.Sso] callback.
+     */
+    fun mint(): String {
+        val nonce = generateSsoNonce()
+        pending = nonce
+        return nonce
+    }
+
+    /**
+     * Consume the pending nonce.
+     *
+     * Returns `true` iff [received] is non-empty and equals the value most recently produced by
+     * [mint] (and a nonce is in fact outstanding). The stored value is cleared after a single check,
+     * regardless of outcome, so a replay or a probe with a missing/empty `state` is rejected.
+     */
+    fun consume(received: String?): Boolean {
+        val expected = pending
+        pending = null
+        return !expected.isNullOrEmpty() && !received.isNullOrEmpty() && received == expected
+    }
+
+    /** True when a nonce is currently outstanding (mostly for introspection/tests). */
+    fun hasPending(): Boolean = pending != null
+
+    /** Clear any pending nonce (e.g. on logout, or between tests). */
+    fun reset() {
+        pending = null
+    }
+}
+
+/**
+ * Platform-provided 64-character hex CSRF nonce (≈256 bits). Android uses `java.security.SecureRandom`;
+ * iOS provides a UUID-based value (the KMP store is not exercised by the iOS app, which owns its own
+ * nonce in `AuthManager`, but an `actual` is required for the shared module to compile).
+ */
+internal expect fun generateSsoNonce(): String

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.kt
@@ -6,8 +6,8 @@ package three.two.bit.ppt.reality.auth
  * The Reality Portal SSO round-trip re-enters the app through the OS deep-link handler
  * (`reality://sso?token=…&state=…`). Because that intent-filter is `exported` (any browser,
  * notification, or other app can deliver it), a `token` on its own is not trustworthy: an attacker
- * can hand the victim a link carrying the attacker's session token and silently sign the victim into
- * the attacker's account (session fixation → account takeover).
+ * can hand the victim a link carrying the attacker's session token and silently sign the victim
+ * into the attacker's account (session fixation → account takeover).
  *
  * This store is the Kotlin counterpart of the iOS `AuthManager.beginSsoFlow()` /
  * `consumeSsoState(_:)` pair — closing the Android-vs-iOS parity gap. Before starting the SSO
@@ -23,9 +23,9 @@ package three.two.bit.ppt.reality.auth
  *   returns `false` for any input. An unsolicited, externally-injected `reality://sso` deep link is
  *   therefore rejected out of the box.
  *
- * A [SsoStateStore] instance is process-local, single-threaded in practice (mint from the UI, consume
- * from the deep-link handler on the main thread) — matching the plain-`var` design of the iOS
- * implementation.
+ * A [SsoStateStore] instance is process-local, single-threaded in practice (mint from the UI,
+ * consume from the deep-link handler on the main thread) — matching the plain-`var` design of the
+ * iOS implementation.
  */
 object SsoStateStore {
 
@@ -33,8 +33,8 @@ object SsoStateStore {
 
     /**
      * Mint a fresh CSRF nonce, persist it as the single pending value, and return it. Callers MUST
-     * append the returned value to the outbound SSO URL as the `state` query parameter so the server
-     * echoes it back to the [DeepLinkTarget.Sso] callback.
+     * append the returned value to the outbound SSO URL as the `state` query parameter so the
+     * server echoes it back to the [DeepLinkTarget.Sso] callback.
      */
     fun mint(): String {
         val nonce = generateSsoNonce()
@@ -46,8 +46,9 @@ object SsoStateStore {
      * Consume the pending nonce.
      *
      * Returns `true` iff [received] is non-empty and equals the value most recently produced by
-     * [mint] (and a nonce is in fact outstanding). The stored value is cleared after a single check,
-     * regardless of outcome, so a replay or a probe with a missing/empty `state` is rejected.
+     * [mint] (and a nonce is in fact outstanding). The stored value is cleared after a single
+     * check, regardless of outcome, so a replay or a probe with a missing/empty `state` is
+     * rejected.
      */
     fun consume(received: String?): Boolean {
         val expected = pending
@@ -65,8 +66,9 @@ object SsoStateStore {
 }
 
 /**
- * Platform-provided 64-character hex CSRF nonce (≈256 bits). Android uses `java.security.SecureRandom`;
- * iOS provides a UUID-based value (the KMP store is not exercised by the iOS app, which owns its own
- * nonce in `AuthManager`, but an `actual` is required for the shared module to compile).
+ * Platform-provided 64-character hex CSRF nonce (≈256 bits). Android uses
+ * `java.security.SecureRandom`; iOS provides a UUID-based value (the KMP store is not exercised by
+ * the iOS app, which owns its own nonce in `AuthManager`, but an `actual` is required for the
+ * shared module to compile).
  */
 internal expect fun generateSsoNonce(): String

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouter.kt
@@ -17,9 +17,17 @@ sealed class DeepLinkTarget {
     data object Inquiries : DeepLinkTarget()
 
     /**
-     * SSO callback: `reality://sso?token=…`. Handled by validating the token, not by navigation.
+     * SSO callback: `reality://sso?token=…&state=…`. Handled by validating the token, not by
+     * navigation.
+     *
+     * [state] is the per-flow CSRF nonce the app minted (via `SsoStateStore.mint`) before starting
+     * the SSO browser hop; the server echoes it back on the callback so the app can detect a forged
+     * or replayed deep link. It is nullable because a malicious/external caller can deliver a
+     * `reality://sso?token=…` intent with no `state` at all — the handler must be able to represent
+     * (and then reject) that case. Both mobile platforms require a matching `state`: iOS via
+     * `AuthManager.consumeSsoState`, Android via `SsoStateStore.consume`.
      */
-    data class Sso(val token: String) : DeepLinkTarget()
+    data class Sso(val token: String, val state: String? = null) : DeepLinkTarget()
 }
 
 /**
@@ -123,7 +131,10 @@ object DeepLinkRouter {
             "search" -> DeepLinkTarget.Search
             "favorites" -> DeepLinkTarget.Favorites
             "inquiries" -> DeepLinkTarget.Inquiries
-            "sso" -> queryParam(queryPart, "token")?.let { DeepLinkTarget.Sso(it) }
+            "sso" ->
+                queryParam(queryPart, "token")?.let { token ->
+                    DeepLinkTarget.Sso(token, queryParam(queryPart, "state"))
+                }
             else -> null
         }
     }

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoStateStoreTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoStateStoreTest.kt
@@ -1,0 +1,92 @@
+package three.two.bit.ppt.reality.auth
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Contract for the SSO CSRF nonce store — the Kotlin counterpart of iOS
+ * `AuthManager.beginSsoFlow()` / `consumeSsoState(_:)`.
+ *
+ * These pin the security-critical behaviour behind the Android `MainActivity` SSO deep-link handler:
+ * an SSO callback token is validated ONLY when its `state` matches a nonce this app minted for a
+ * pending flow. They fail to even compile on `dev` (the store does not exist there), which is the
+ * regression guard for the account-takeover fix.
+ */
+class SsoStateStoreTest {
+
+    @BeforeTest fun clear() = SsoStateStore.reset()
+
+    @AfterTest fun cleanup() = SsoStateStore.reset()
+
+    @Test
+    fun matching_state_is_accepted() {
+        val nonce = SsoStateStore.mint()
+        assertTrue(SsoStateStore.consume(nonce), "the minted nonce must be accepted")
+    }
+
+    @Test
+    fun mismatched_state_is_rejected() {
+        SsoStateStore.mint()
+        assertFalse(SsoStateStore.consume("not-the-real-nonce"))
+    }
+
+    @Test
+    fun null_state_is_rejected_even_with_pending_nonce() {
+        SsoStateStore.mint()
+        assertFalse(SsoStateStore.consume(null))
+    }
+
+    @Test
+    fun empty_state_is_rejected() {
+        SsoStateStore.mint()
+        assertFalse(SsoStateStore.consume(""))
+    }
+
+    @Test
+    fun unsolicited_callback_with_no_pending_flow_is_rejected() {
+        // Fresh store — no mint() — must reject any input. This is the core account-takeover guard:
+        // an externally-injected `reality://sso?token=…` with no legitimate flow behind it fails.
+        assertFalse(SsoStateStore.consume("anything"))
+        assertFalse(SsoStateStore.consume(null))
+    }
+
+    @Test
+    fun nonce_is_single_use_second_consume_fails() {
+        val nonce = SsoStateStore.mint()
+        assertTrue(SsoStateStore.consume(nonce))
+        // A replay of the same deep link must be rejected on the second delivery.
+        assertFalse(SsoStateStore.consume(nonce))
+    }
+
+    @Test
+    fun mismatch_clears_pending_so_later_correct_value_also_fails() {
+        val nonce = SsoStateStore.mint()
+        assertFalse(SsoStateStore.consume("wrong"))
+        // The failed probe consumed (cleared) the pending nonce — the real value no longer works.
+        assertFalse(SsoStateStore.consume(nonce))
+    }
+
+    @Test
+    fun new_flow_overwrites_previous_pending_nonce() {
+        val first = SsoStateStore.mint()
+        val second = SsoStateStore.mint()
+        assertNotEquals(first, second)
+        assertFalse(SsoStateStore.consume(first), "the superseded nonce must not be accepted")
+        // Re-mint because the failed consume cleared state, then verify the latest wins.
+        val latest = SsoStateStore.mint()
+        assertTrue(SsoStateStore.consume(latest))
+    }
+
+    @Test
+    fun mint_produces_distinct_high_entropy_nonces() {
+        val nonces = (1..16).map { SsoStateStore.mint() }.toSet()
+        assertEquals(16, nonces.size, "every mint() must yield a distinct nonce")
+        // 32 bytes -> 64 hex chars on Android; the UUID-based iOS value is also 64 chars.
+        assertTrue(nonces.all { it.length >= 32 }, "nonce should carry meaningful entropy")
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoStateStoreTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoStateStoreTest.kt
@@ -12,10 +12,10 @@ import kotlin.test.assertTrue
  * Contract for the SSO CSRF nonce store — the Kotlin counterpart of iOS
  * `AuthManager.beginSsoFlow()` / `consumeSsoState(_:)`.
  *
- * These pin the security-critical behaviour behind the Android `MainActivity` SSO deep-link handler:
- * an SSO callback token is validated ONLY when its `state` matches a nonce this app minted for a
- * pending flow. They fail to even compile on `dev` (the store does not exist there), which is the
- * regression guard for the account-takeover fix.
+ * These pin the security-critical behaviour behind the Android `MainActivity` SSO deep-link
+ * handler: an SSO callback token is validated ONLY when its `state` matches a nonce this app minted
+ * for a pending flow. They fail to even compile on `dev` (the store does not exist there), which is
+ * the regression guard for the account-takeover fix.
  */
 class SsoStateStoreTest {
 

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/navigation/DeepLinkRouterTest.kt
@@ -66,6 +66,36 @@ class DeepLinkRouterTest {
     }
 
     @Test
+    fun parse_sso_deep_link_extracts_state_nonce() {
+        // CSRF `state` nonce must be carried through parsing so the handler can compare it against
+        // the pending flow nonce (parity with iOS `consumeSsoState`). Regression guard for the
+        // account-takeover fix.
+        val target = DeepLinkRouter.parse("reality://sso?token=tok-42&state=nonce-abc")
+        assertEquals(DeepLinkTarget.Sso("tok-42", "nonce-abc"), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_state_is_order_independent() {
+        // `state` may precede `token` in the query string.
+        val target = DeepLinkRouter.parse("reality://sso?state=nonce-abc&token=tok-42")
+        assertEquals(DeepLinkTarget.Sso("tok-42", "nonce-abc"), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_without_state_leaves_state_null() {
+        // An externally-injected link with no `state` must parse to a null state so the handler can
+        // reject it. `Sso("tok-42")` is `Sso("tok-42", null)` via the default arg.
+        val target = DeepLinkRouter.parse("reality://sso?token=tok-42")
+        assertEquals(DeepLinkTarget.Sso("tok-42", null), target)
+    }
+
+    @Test
+    fun parse_sso_deep_link_percent_decodes_state() {
+        val target = DeepLinkRouter.parse("reality://sso?token=t&state=ab%2Bcd")
+        assertEquals(DeepLinkTarget.Sso("t", "ab+cd"), target)
+    }
+
+    @Test
     fun parse_sso_deep_link_percent_decodes_token() {
         // A real JWT/opaque token may contain reserved chars that get percent-encoded in the URL.
         // The shared router must decode them so the token matches what Android's

--- a/mobile-native/shared/src/iosMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.ios.kt
+++ b/mobile-native/shared/src/iosMain/kotlin/three/two/bit/ppt/reality/auth/SsoStateStore.ios.kt
@@ -1,0 +1,17 @@
+package three.two.bit.ppt.reality.auth
+
+import platform.Foundation.NSUUID
+
+/**
+ * iOS CSRF nonce.
+ *
+ * The KMP [SsoStateStore] is not exercised by the iOS app — SwiftUI owns its own nonce in
+ * `AuthManager.beginSsoFlow()` / `consumeSsoState(_:)` — but the shared module still needs an
+ * `actual` for every target to compile. This mirrors the UUID-based fallback in
+ * `AuthManager.makeSsoState()`: two v4 UUIDs concatenated and stripped to 64 hex chars.
+ */
+internal actual fun generateSsoNonce(): String {
+    val a = NSUUID().UUIDString().replace("-", "").lowercase()
+    val b = NSUUID().UUIDString().replace("-", "").lowercase()
+    return a + b
+}


### PR DESCRIPTION
## Task
SECURITY: Android SSO deep-link handler skips CSRF state check — `reality://sso?token=…` enables account takeover. Achieve parity with the existing iOS `AuthManager.consumeSsoState` mechanism.

## Changes (mobile-native/** only)
- `DeepLinkRouter.kt` — `DeepLinkTarget.Sso` now carries `state: String?` (default null; backward-compatible); `parse` extracts the `state` query param.
- `SsoStateStore.kt` (commonMain) — new single-slot, single-use, default-reject CSRF nonce store (`mint`/`consume`/`reset`) mirroring iOS; `expect fun generateSsoNonce()` with androidMain (`SecureRandom`, 64-char hex) + iosMain actuals.
- `MainActivity.handleDeepLink` — validates the token only when `SsoStateStore.consume(target.state)` matches; otherwise logs and drops. Closes the account-takeover vector (unsolicited/forged `reality://sso?token=…` with no pending flow is rejected).
- Tests (commonTest): extended `DeepLinkRouterTest` (state parsing) + new `SsoStateStoreTest` (mismatch/null/empty/no-pending/single-use/replay) — the IG3 regression evidence (fails to compile on `dev`).
- `mobile-native/CLAUDE.md` — documents the two-platform state-nonce contract.

## Verification
Local verify gate (`cd mobile-native && ./gradlew spotlessCheck test`) is **unrunnable in the dispatcher's cloud env** — no Android SDK, AGP `com.android.application:9.3.0` unresolvable via the egress proxy (the plan's `local-only (C5 — ADB device)` condition). Code validated by manual review; the real gate runs in **`mobile-native.yml` CI** on this PR. Kept **draft** until that job is green.

## Notes
- No outbound Android SSO-initiation flow exists today (LoginScreen is email/password only), so this is a default-reject posture: it breaks no working flow and closes the vuln immediately. A future Android SSO-initiation UI must call `SsoStateStore.mint()` and append `&state=`.
- Scope-drift is expected/justified: all paths are under `mobile-native/**` (outside pm-security's backend/frontend owner areas), but the finding itself is a mobile-native security issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JERLCe3REKf6WmvnJ7EVPj)_