### PR TITLE
gh-issue-2557: dedupe private seed_org/set_ctx in db test suites (Closes #2557)

### DIFF
--- a/backend/crates/db/tests/suites/acc_mvp_rls_tests.rs
+++ b/backend/crates/db/tests/suites/acc_mvp_rls_tests.rs
@@ -14,6 +14,7 @@
 //! test runs under a dedicated NOSUPERUSER/NOBYPASSRLS role on a single pinned
 //! connection — the same technique as `accounting_rls_repo_tests.rs`.
 
+use crate::common::seed_org;
 use sqlx::PgPool;
 use uuid::Uuid;
 
@@ -38,19 +39,6 @@ const NEW_TABLES: &[&str] = &[
     "acc_audit_log",
     "acc_two_factor",
 ];
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"INSERT INTO organizations (name, slug, contact_email, status)
-           VALUES ($1, $2, $3, 'active') RETURNING id"#,
-    )
-    .bind(format!("Acc {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@acc.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn set_request_ctx(
     conn: &mut sqlx::PgConnection,

--- a/backend/crates/db/tests/suites/accounting_provider_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/accounting_provider_rls_repo_tests.rs
@@ -1,35 +1,10 @@
 //! RLS isolation tests for external accounting provider integration (PAP-191).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::accounting_provider::{AccountingProviderAuthFlow, AccountingProviderConnection};
 use db::repositories::accounting_provider::AccountingProviderRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Acct Provider {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@accounting-provider.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]

--- a/backend/crates/db/tests/suites/accounting_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/accounting_rls_repo_tests.rs
@@ -1,37 +1,12 @@
 //! RLS isolation tests for native Accounting MVP (PAP-206).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::accounting::{Contact, CreateInvoice, CreateInvoiceItem, Invoice, UpdateInvoice};
 use db::repositories::accounting::AccountingRepository;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Accounting {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@accounting.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
 #[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]

--- a/backend/crates/db/tests/suites/ai_chat_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/ai_chat_rls_repo_tests.rs
@@ -37,36 +37,11 @@
 //! soft-delete guard, so the bound role needs `organizations` SELECT + the
 //! helper-function EXECUTE grants).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::CreateChatSession;
 use db::repositories::AiChatRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("AiChat {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@aichat.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/api_ecosystem_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/api_ecosystem_rls_repo_tests.rs
@@ -40,36 +40,11 @@
 //! experiences it. Mirrors `llm_document_rls_repo_tests.rs` /
 //! `sentiment_rls_repo_tests.rs` (the PAP-67 precedent PAP-80 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::CreateEnhancedWebhookSubscription;
 use db::repositories::ApiEcosystemRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Ecosystem {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@ecosystem.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/auth_policy_tests.rs
+++ b/backend/crates/db/tests/suites/auth_policy_tests.rs
@@ -4,25 +4,9 @@
 //! Migration 00142 creates `org_auth_policies`; `AuthPolicy::for_org` reads
 //! that row and falls back to the platform default when no row exists.
 
+use crate::common::seed_org;
 use db::models::AuthPolicy;
 use sqlx::PgPool;
-use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("AuthPolicy {slug}"))
-    .bind(format!("ap-{slug}"))
-    .bind(format!("{slug}@n2.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 #[sqlx::test]
 #[ignore = "BIT-351 quarantine: pre-existing blind-CI test failure (schema/seed never migrated or repo decode drift); never green on the real PR gate. Repair tracked in BIT-352."]

--- a/backend/crates/db/tests/suites/board_meetings_list_join_tests.rs
+++ b/backend/crates/db/tests/suites/board_meetings_list_join_tests.rs
@@ -8,26 +8,11 @@
 //! return the populated joined name — it fails on the old `u.full_name` SQL and
 //! passes with `u.name`.
 
+use crate::common::seed_org;
 use db::models::board_meetings::{BoardMemberQuery, MotionQuery};
 use db::repositories::BoardMeetingRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Board {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@board.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str, name: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/budget_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/budget_rls_repo_tests.rs
@@ -43,36 +43,11 @@
 //! the way the production owner role experiences it. Mirrors
 //! `reserve_funds_rls_repo_tests.rs` (the sibling PAP-67 precedent).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{BudgetQuery, CreateBudget};
 use db::repositories::BudgetRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Budget {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@budget.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/building_certification_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/building_certification_rls_repo_tests.rs
@@ -39,38 +39,13 @@
 //! `reserve_funds_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the
 //! PAP-67 precedent this follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::building_certification::{
     CertificationLevel, CertificationProgram, CreateBuildingCertification,
 };
 use db::repositories::BuildingCertificationRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("BC {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@bc.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/dispute_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/suites/dispute_cross_tenant_tests.rs
@@ -3,26 +3,11 @@
 //! able to drive the state machine of a dispute in org B by guessing its
 //! UUID. The repo enforces this with `WHERE id = $2 AND organization_id = $3`.
 
+use crate::common::seed_org;
 use db::models::{FileDispute, UpdateDisputeStatus};
 use db::repositories::DisputeRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Dispute {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@dispute.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/dispute_lifecycle_tests.rs
+++ b/backend/crates/db/tests/suites/dispute_lifecycle_tests.rs
@@ -18,6 +18,7 @@
 //! skipped locally and run in CI (`backend.yml`) — Band A/B locally, Band C in
 //! CI (see PR body).
 
+use crate::common::seed_org;
 use db::models::disputes::{dispute_state_machine, dispute_status};
 use db::models::{AddEvidence, FileDispute, UpdateDisputeStatus};
 use db::repositories::DisputeRepository;
@@ -27,22 +28,6 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("DisputeLifecycle {slug}"))
-    .bind(format!("dispute-lifecycle-{slug}"))
-    .bind(format!("{slug}@dispute-lifecycle.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/document_shares_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/suites/document_shares_rls_cross_tenant_tests.rs
@@ -32,34 +32,9 @@
 //! `own-share-is-visible` assertion fails. After 00178 the caller sees exactly
 //! its own org's share and never the other org's.
 
+use crate::common::{seed_org, set_ctx};
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Shares {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@shares.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/document_template_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/suites/document_template_cross_tenant_tests.rs
@@ -17,6 +17,7 @@
 //! isolated migrated database per test. With no local Postgres they are skipped
 //! locally and run in CI (`backend.yml`).
 
+use crate::common::seed_org;
 use db::models::{CreateTemplate, UpdateTemplate};
 use db::repositories::DocumentTemplateRepository;
 use sqlx::PgPool;
@@ -25,22 +26,6 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("TemplateIDOR {slug}"))
-    .bind(format!("template-idor-{slug}"))
-    .bind(format!("{slug}@template-idor.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/emergency_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/emergency_rls_repo_tests.rs
@@ -36,6 +36,7 @@
 //! `vendor_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the PAP-67
 //! precedent PAP-80 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{CreateEmergencyProtocol, EmergencyProtocolQuery};
 use db::repositories::EmergencyRepository;
 use sqlx::PgPool;
@@ -51,32 +52,6 @@ fn any_protocols() -> EmergencyProtocolQuery {
         limit: None,
         offset: None,
     }
-}
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Emergency {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@emergency.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
 }
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {

--- a/backend/crates/db/tests/suites/enhanced_tenant_screening_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/enhanced_tenant_screening_rls_repo_tests.rs
@@ -34,36 +34,11 @@
 //! policy the way the production owner role experiences it. Mirrors
 //! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-74 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::enhanced_tenant_screening::CreateAiRiskScoringModel;
 use db::repositories::enhanced_tenant_screening::EnhancedTenantScreeningRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Screen {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@screen.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/equipment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/equipment_rls_repo_tests.rs
@@ -35,36 +35,11 @@
 //! the policy the way the production owner role experiences it. Mirrors
 //! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-71 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{CreateEquipment, EquipmentQuery};
 use db::repositories::EquipmentRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("EQ {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@eq.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/esg_force_rls_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/suites/esg_force_rls_cross_tenant_tests.rs
@@ -34,22 +34,10 @@
 //! NOBYPASSRLS` role, grants it table + function access, and `SET ROLE`s to
 //! it so `FORCE` binds exactly as the production owner role experiences it.
 
+use crate::common::seed_org;
 use db::repositories::EsgReportingRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        "INSERT INTO organizations (name, slug, contact_email, status) \
-         VALUES ($1, $2, $3, 'active') RETURNING id",
-    )
-    .bind(format!("ESG {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@esg.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/esignature_workflow_repo_tests.rs
+++ b/backend/crates/db/tests/suites/esignature_workflow_repo_tests.rs
@@ -20,6 +20,7 @@
 //! not to exercise RLS enforcement (that is done via the static
 //! `check-rls-enforcement.sh --strict` scanner once the table is migrated).
 
+use crate::common::seed_org;
 use db::repositories::IntegrationRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -49,19 +50,6 @@ async fn ensure_esignature_workflows_table(pool: &PgPool) {
     .execute(pool)
     .await
     .expect("create esignature_workflows table");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        "INSERT INTO organizations (name, slug, contact_email, status) \
-         VALUES ($1, $2, $3, 'active') RETURNING id",
-    )
-    .bind(format!("ESig {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@esig.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
 }
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {

--- a/backend/crates/db/tests/suites/fault_kpi_unification_tests.rs
+++ b/backend/crates/db/tests/suites/fault_kpi_unification_tests.rs
@@ -20,25 +20,10 @@
 
 use std::collections::BTreeMap;
 
+use crate::common::seed_org;
 use db::repositories::{FaultRepository, PlatformAdminRepository};
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Org {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@orgs.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_building(pool: &PgPool, org_id: Uuid) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/form_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/form_rls_repo_tests.rs
@@ -29,6 +29,7 @@
 //! to it so `FORCE` actually enforces the policy the way the production
 //! owner role experiences it. Mirrors `budget_rls_repo_tests.rs`.
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{
     CreateForm, CreateFormField, FormListQuery, FormSubmissionParams, SubmitForm, UpdateForm,
 };
@@ -36,32 +37,6 @@ use db::repositories::FormRepository;
 use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Form {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@form.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/government_portal_connection_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/suites/government_portal_connection_cross_org_idor_tests.rs
@@ -19,26 +19,11 @@
 //! cargo test -p db --test government_portal_connection_cross_org_idor_tests
 //! ```
 
+use crate::common::seed_org;
 use db::models::{CreatePortalConnection, GovernmentPortalType};
 use db::repositories::GovernmentPortalRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Gov Portal {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@govportal.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/inquiry_mark_read_idor_tests.rs
+++ b/backend/crates/db/tests/suites/inquiry_mark_read_idor_tests.rs
@@ -3,25 +3,10 @@
 //! `mark_inquiry_read_for_realtor` only flips a row if the caller actually
 //! owns it.
 
+use crate::common::seed_org;
 use db::repositories::RealityPortalRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Inq IDOR {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@inq.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_pm_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/insurance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/insurance_rls_repo_tests.rs
@@ -36,37 +36,12 @@
 //! the policy the way the production owner role experiences it. Mirrors
 //! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-73 follows).
 
+use crate::common::{seed_org, set_ctx};
 use chrono::NaiveDate;
 use db::models::{CreateInsurancePolicy, InsurancePolicyQuery};
 use db::repositories::InsuranceRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Ins {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@ins.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/integration_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/integration_rls_repo_tests.rs
@@ -51,36 +51,11 @@
 //! it. Mirrors `sentiment_rls_repo_tests.rs` / `emergency_rls_repo_tests.rs`
 //! (the PAP-67 precedent PAP-80 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::CreateWebhookSubscription;
 use db::repositories::IntegrationRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Integration {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@integration.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/lease_units_join_tests.rs
+++ b/backend/crates/db/tests/suites/lease_units_join_tests.rs
@@ -30,6 +30,7 @@
 //! paths through the repo — no raw-SQL seeding — and asserts the enum-backed
 //! `status` / `termination_reason` decode as text.
 
+use crate::common::seed_org;
 use chrono::{Duration, Utc};
 use db::models::lease::{ApplicationListQuery, CreateLease, LeaseListQuery, TerminateLease};
 use db::repositories::LeaseRepository;
@@ -38,22 +39,6 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 const DESIGNATION: &str = "A-101-JOIN";
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Lease {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@lease.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_building(pool: &PgPool, org: Uuid) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/legal_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/legal_rls_repo_tests.rs
@@ -37,36 +37,11 @@
 //! `equipment_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the PAP-67
 //! precedent PAP-109 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{CreateLegalDocument, LegalDocumentQuery};
 use db::repositories::LegalRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("LEGAL {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@legal.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/llm_document_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/llm_document_rls_repo_tests.rs
@@ -37,35 +37,10 @@
 //! `sentiment_rls_repo_tests.rs` / `work_order` (the PAP-67 precedent PAP-80
 //! follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::repositories::LlmDocumentRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("LlmDoc {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@llmdoc.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/membership_revocation_tests.rs
+++ b/backend/crates/db/tests/suites/membership_revocation_tests.rs
@@ -7,26 +7,11 @@
 //! equivalent — same JWT presented across the revoke — is in
 //! `backend/servers/api-server/tests/token_scope_tests.rs`.
 
+use crate::common::seed_org;
 use db::models::membership::GrantMembership;
 use db::repositories::MembershipRepository;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Phase 2 {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@phase2.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     let row = sqlx::query(

--- a/backend/crates/db/tests/suites/migration_templates_pagination_tests.rs
+++ b/backend/crates/db/tests/suites/migration_templates_pagination_tests.rs
@@ -25,27 +25,12 @@
 //! directly under that superuser; the RLS test drops to a dedicated
 //! `NOSUPERUSER NOBYPASSRLS` role so `FORCE ROW LEVEL SECURITY` actually binds.
 
+use crate::common::seed_org;
 use db::models::ImportDataType;
 use db::repositories::MigrationRepository;
 use serde_json::json;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Org {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@migtmpl.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 /// Create `n` org-scoped templates, then flatten their `updated_at` to a single
 /// fixed instant so ordering within the page depends solely on the `id DESC`

--- a/backend/crates/db/tests/suites/news_article_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/suites/news_article_cross_tenant_tests.rs
@@ -17,26 +17,11 @@
 //! cross-tenant op succeeds; post-fix it resolves to `None` / `false` and the
 //! victim row is untouched.
 
+use crate::common::seed_org;
 use db::models::news_article::{CreateArticle, CreateArticleComment, CreateArticleMedia};
 use db::repositories::NewsArticleRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("News {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@news.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/payment_management_tests.rs
+++ b/backend/crates/db/tests/suites/payment_management_tests.rs
@@ -8,6 +8,7 @@
 //! Run against a live Postgres (sqlx spins up a per-test database):
 //! `DATABASE_URL=... cargo test -p db --test payment_management_tests`.
 
+use crate::common::seed_org;
 use db::repositories::FinancialRepository;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
@@ -15,22 +16,6 @@ use uuid::Uuid;
 
 fn money(units: i64) -> Decimal {
     Decimal::new(units * 100, 2) // whole-euro helper: money(100) == 100.00
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("PayMgmt {slug}"))
-    .bind(format!("pay-mgmt-{slug}"))
-    .bind(format!("{slug}@pay-mgmt.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
 }
 
 async fn seed_unit(pool: &PgPool, org: Uuid) -> Uuid {

--- a/backend/crates/db/tests/suites/payment_reminder_dedup_tests.rs
+++ b/backend/crates/db/tests/suites/payment_reminder_dedup_tests.rs
@@ -21,6 +21,7 @@
 //! Run against a live Postgres (sqlx spins up a per-test database):
 //! `DATABASE_URL=... cargo test -p db --test payment_reminder_dedup_tests`.
 
+use crate::common::seed_org;
 use db::models::financial::InvoiceStatus;
 use db::repositories::FinancialRepository;
 use rust_decimal::Decimal;
@@ -29,22 +30,6 @@ use uuid::Uuid;
 
 fn money(units: i64) -> Decimal {
     Decimal::new(units * 100, 2) // whole-euro helper: money(100) == 100.00
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Reminder {slug}"))
-    .bind(format!("reminder-{slug}"))
-    .bind(format!("{slug}@reminder.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
 }
 
 async fn seed_unit(pool: &PgPool, org: Uuid) -> Uuid {

--- a/backend/crates/db/tests/suites/predictive_maintenance_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/predictive_maintenance_rls_repo_tests.rs
@@ -34,36 +34,11 @@
 //! `vendor_rls_repo_tests.rs` / `work_order_rls_repo_tests.rs` (the PAP-67/-70
 //! precedent this follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::predictive_maintenance::EquipmentQuery;
 use db::repositories::PredictiveMaintenanceRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("PM {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@pm.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/predictive_maintenance_sort_injection_tests.rs
+++ b/backend/crates/db/tests/suites/predictive_maintenance_sort_injection_tests.rs
@@ -15,26 +15,11 @@
 //! silently treated as the default and the query returns normal results
 //! without error.
 
+use crate::common::seed_org;
 use db::models::predictive_maintenance::{CreateEquipment, EquipmentQuery};
 use db::repositories::PredictiveMaintenanceRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("PM Sort {slug}"))
-    .bind(format!("pm-sort-{slug}"))
-    .bind(format!("{slug}@pm-sort.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/rag_similarity_search_tests.rs
+++ b/backend/crates/db/tests/suites/rag_similarity_search_tests.rs
@@ -43,6 +43,7 @@
 //! (BIT-352); prefer consolidating new assertions into an existing function over
 //! adding a fresh migrator run unless a guard genuinely warrants its own case.
 
+use crate::common::seed_org;
 use db::repositories::LlmDocumentRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
@@ -55,22 +56,6 @@ async fn set_super_ctx(pool: &PgPool) {
         .execute(pool)
         .await
         .expect("set super-admin context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Rag {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@rag.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
 }
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {

--- a/backend/crates/db/tests/suites/record_payment_atomicity_tests.rs
+++ b/backend/crates/db/tests/suites/record_payment_atomicity_tests.rs
@@ -40,6 +40,7 @@
 //! Run against a superuser pool (CI default) so the assertions exercise the
 //! application-level read-modify-write rather than any RLS layer.
 
+use crate::common::seed_org;
 use chrono::Utc;
 use db::models::violations::{
     CreateEnforcementAction, CreateViolation, EnforcementActionType, EnforcementStatus,
@@ -53,22 +54,6 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 // Fixtures (mirrors violations_cross_org_idor_tests.rs)
 // ---------------------------------------------------------------------------
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("PayAtomicity {slug}"))
-    .bind(format!("pay-atomicity-{slug}"))
-    .bind(format!("{slug}@pay-atomicity.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/registry_enum_decode_tests.rs
+++ b/backend/crates/db/tests/suites/registry_enum_decode_tests.rs
@@ -18,6 +18,7 @@
 //! the missing column); post-fix they resolve cleanly. A second test pins the
 //! defense-in-depth tenant scope added to the vehicle-list `parking_spots` join.
 
+use crate::common::seed_org;
 use db::models::{
     registry_status, CreatePetRegistration, CreateVehicleRegistration, PetRegistrationQuery,
     ReviewRegistration, UpdatePetRegistration, VehicleRegistrationQuery,
@@ -25,22 +26,6 @@ use db::models::{
 use db::repositories::RegistryRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Registry {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@registry.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/registry_parking_spot_cross_tenant_tests.rs
+++ b/backend/crates/db/tests/suites/registry_parking_spot_cross_tenant_tests.rs
@@ -14,25 +14,10 @@
 //! FORCE RLS, so the SQL predicate (not RLS) is what this test exercises:
 //! pre-fix this returns the foreign spot number, post-fix it resolves to `None`.
 
+use crate::common::seed_org;
 use db::repositories::RegistryRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Registry {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@registry.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/registry_rules_enum_decode_tests.rs
+++ b/backend/crates/db/tests/suites/registry_rules_enum_decode_tests.rs
@@ -1,26 +1,11 @@
 //! Regression tests for PAP-159 — allowed_pet_types pet_type[] decode+bind fix
 //! in [`db::repositories::RegistryRepository`].
 
+use crate::common::seed_org;
 use db::models::UpdateRegistryRules;
 use db::repositories::RegistryRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Rules {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@rules.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_building(pool: &PgPool, org_id: Uuid, slug: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/rental_cross_tenant_upsert_tests.rs
+++ b/backend/crates/db/tests/suites/rental_cross_tenant_upsert_tests.rs
@@ -11,28 +11,9 @@
 //!
 //! These tests must PASS on the patched branch and would FAIL on original dev.
 
+use crate::common::seed_org;
 use db::repositories::RentalRepository;
 use sqlx::PgPool;
-use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Cross-Tenant Test {slug}"))
-    .bind(format!(
-        "cross-tenant-test-{slug}-{}",
-        Uuid::new_v4().simple()
-    ))
-    .bind(format!("{slug}@cross-tenant.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 // ---------------------------------------------------------------------------
 // Airbnb cross-tenant upsert

--- a/backend/crates/db/tests/suites/report_schedule_scheduler_rls_tests.rs
+++ b/backend/crates/db/tests/suites/report_schedule_scheduler_rls_tests.rs
@@ -33,35 +33,10 @@
 //!      creates a `pending` row and `advance_after_run(id, None)` parks the
 //!      schedule (NULL `next_run_at`), after which it stops appearing as due.
 
+use crate::common::{seed_org, set_ctx};
 use db::repositories::ReportScheduleRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Reports {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@reports.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 /// Seed a due schedule directly (as superuser, RLS-exempt): active, with a
 /// `next_run_at` one hour in the past so `get_due_schedules` should return it.

--- a/backend/crates/db/tests/suites/reserve_atomicity_tests.rs
+++ b/backend/crates/db/tests/suites/reserve_atomicity_tests.rs
@@ -1,3 +1,4 @@
+use crate::common::{seed_org, set_ctx};
 use db::models::reserve_funds::{
     CreateReserveFund, FundTransactionType, FundType, RecordFundTransaction,
 };
@@ -5,32 +6,6 @@ use db::repositories::ReserveFundRepository;
 use rust_decimal_macros::dec;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Atomicity {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@atomicity.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/reserve_funds_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/reserve_funds_rls_repo_tests.rs
@@ -37,6 +37,7 @@
 //! policy the way the production owner role experiences it. Mirrors
 //! `work_order_rls_repo_tests.rs` (the PAP-67 precedent this follows).
 
+use crate::common::{seed_org, set_ctx};
 use chrono::NaiveDate;
 use db::models::reserve_funds::{
     ContributionFrequency, CreateContributionSchedule, CreateReserveFund, FundType,
@@ -45,32 +46,6 @@ use db::repositories::ReserveFundRepository;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("RF {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@rf.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/sentiment_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/sentiment_rls_repo_tests.rs
@@ -37,36 +37,11 @@
 //! `emergency_rls_repo_tests.rs` / `vendor_rls_repo_tests.rs` (the PAP-67
 //! precedent PAP-80 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{CreateSentimentAlert, UpsertSentimentTrend};
 use db::repositories::SentimentRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Sentiment {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@sentiment.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/subscription_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/subscription_rls_repo_tests.rs
@@ -46,36 +46,11 @@
 //! it. Mirrors `integration_rls_repo_tests.rs` / `emergency_rls_repo_tests.rs`
 //! (the PAP-67 precedent PAP-80 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::CreateOrganizationSubscription;
 use db::repositories::SubscriptionRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Subscription {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@subscription.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/user_invite_tests.rs
+++ b/backend/crates/db/tests/suites/user_invite_tests.rs
@@ -4,27 +4,12 @@
 //! membership → join any org"). Every invite is single-use, expiring, and
 //! email-bound; tokens are stored only as SHA-256 hashes.
 
+use crate::common::seed_org;
 use chrono::Duration;
 use db::repositories::user_invite::ConsumeInviteOutcome;
 use db::repositories::UserInviteRepository;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Phase2 Inv {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@invite.phase2.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     let row = sqlx::query(

--- a/backend/crates/db/tests/suites/vendor_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/vendor_rls_repo_tests.rs
@@ -34,36 +34,11 @@
 //! the policy the way the production owner role experiences it. Mirrors
 //! `work_order_rls_repo_tests.rs` (the PAP-67 precedent PAP-70 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{CreateVendor, VendorQuery};
 use db::repositories::VendorRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("Vendor {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@vendor.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/violations_cross_org_idor_tests.rs
+++ b/backend/crates/db/tests/suites/violations_cross_org_idor_tests.rs
@@ -18,6 +18,7 @@
 //! Each test seeds two orgs (A, B) and asserts that an Org B caller cannot
 //! touch Org A's rows, while the legitimate Org A caller still can.
 
+use crate::common::seed_org;
 use chrono::Utc;
 use db::models::violations::{
     AppealStatus, CreateCommunityRule, CreateEnforcementAction, CreateViolation,
@@ -33,22 +34,6 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("ViolationsIDOR {slug}"))
-    .bind(format!("violations-idor-{slug}"))
-    .bind(format!("{slug}@violations-idor.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/vote_cast_regression_tests.rs
+++ b/backend/crates/db/tests/suites/vote_cast_regression_tests.rs
@@ -20,6 +20,7 @@
 //! tenant GUC (`app.current_org_id`) in scope, so each test sets the request
 //! context on the connection it hands to `cast_vote_rls`.
 
+use crate::common::seed_org;
 use db::models::vote::{audit_action, vote_status, CastVote, CreateVote, CreateVoteQuestion};
 use db::repositories::VoteRepository;
 use rust_decimal::Decimal;
@@ -29,22 +30,6 @@ use uuid::Uuid;
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("VoteCast {slug}"))
-    .bind(format!("vote-cast-{slug}"))
-    .bind(format!("{slug}@vote-cast.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/work_order_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/work_order_rls_repo_tests.rs
@@ -21,25 +21,10 @@
 //! it. `FORCE` binds that role, so the org-scoped policy is enforced. The org
 //! context (`app.current_org_id`) is a session GUC and survives `SET ROLE`.
 
+use crate::common::seed_org;
 use db::repositories::WorkOrderRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("WorkOrders {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@work-orders.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(

--- a/backend/crates/db/tests/suites/workflow_rls_repo_tests.rs
+++ b/backend/crates/db/tests/suites/workflow_rls_repo_tests.rs
@@ -38,36 +38,11 @@
 //! experiences it. Mirrors `legal_rls_repo_tests.rs` /
 //! `vendor_rls_repo_tests.rs` (the PAP-67 precedent PAP-77 follows).
 
+use crate::common::{seed_org, set_ctx};
 use db::models::{CreateWorkflow, CreateWorkflowAction, TriggerWorkflow, WorkflowQuery};
 use db::repositories::WorkflowRepository;
 use sqlx::PgPool;
 use uuid::Uuid;
-
-async fn set_ctx(pool: &PgPool, org_id: Option<Uuid>, user_id: Option<Uuid>, is_super_admin: bool) {
-    sqlx::query("SELECT set_request_context($1, $2, $3)")
-        .bind(org_id)
-        .bind(user_id)
-        .bind(is_super_admin)
-        .execute(pool)
-        .await
-        .expect("set_request_context");
-}
-
-async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
-    sqlx::query_scalar::<_, Uuid>(
-        r#"
-        INSERT INTO organizations (name, slug, contact_email, status)
-        VALUES ($1, $2, $3, 'active')
-        RETURNING id
-        "#,
-    )
-    .bind(format!("WORKFLOW {slug}"))
-    .bind(slug)
-    .bind(format!("{slug}@workflow.test"))
-    .fetch_one(pool)
-    .await
-    .expect("seed org")
-}
 
 async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
     sqlx::query_scalar::<_, Uuid>(


### PR DESCRIPTION
## Task
test(backend): follow-ups from dev-team review of test-binary consolidation (#2487) (Closes #2557)

## Owner
pm-backend  (specialist: rust-backend)

## What changed (Part 1 — SIMP-003, the primary win)
Swept **51** `db` RLS suite files under `backend/crates/db/tests/suites/` off their private, near-identical `seed_org`/`set_ctx` copies and onto the canonical `crate::common::{seed_org, set_ctx}` helpers established in #2487.

- **+51 / −1040 lines** (net ~−989 of duplicated test scaffolding).
- Two files (`auth_policy_tests.rs`, `rental_cross_tenant_upsert_tests.rs`) also drop a now-unused `use uuid::Uuid;` (Uuid was only referenced by the removed helper's return type).
- Consolidated imports normalized with `cargo fmt`.

### Deliberately NOT swept (behaviour would change / different contract)
- `announcement_targeting_visibility_tests.rs`, `vote_delegation_eligibility_tests.rs` — their `set_ctx` takes `&mut PgConnection`, not `&PgPool`; canonical helper signature is incompatible. Local copy kept.
- `api_ecosystem_developer_force_rls_tests.rs` — 3-arg `set_ctx(pool, user_id, is_super_admin)` (no org param). Local copy kept.
- `rls_smoke_tests.rs`, `rls_penetration_tests.rs` — standalone-by-CI-name binaries, out of scope per the issue.

### Behaviour preservation
The canonical `seed_org` differs from the old private copies only in the cosmetic org `name` / `contact_email` prefix (`Org {slug}` / `{slug}@orgs.test` vs per-file prefixes). Verified that **none of the 51 swept files assert on the seeded org name or contact_email** — the files that read those columns back (`repository_tests`, `announcement_tests`, `announcement_comments_rls_tests`, `rls_listings_global_context_tests`) are all outside this sweep. `set_ctx` bodies were byte-identical GUC calls. So the change is behaviour-preserving.

## Deferred (out of scope for this PR)
- **PERF-003 (Part 2)** — folding the standalone `api-core` (7), `admin-core` (4), and `deploy-server` (2) test binaries into the suite-harness pattern is a larger, riskier restructure (new suite driver binaries per crate). Deferred to a follow-up so this mechanical, high-value dedupe lands clean and reviewable on its own. Recommend a separate task per crate.
- **CI-003 (Part 3)** — running the branch-protection `workflow_dispatch` with `GH_ADMIN_TOKEN` is an **operator action**, not code. **Deferred-to-operator**; not attempted here.

## Verification
Change is **test-only inside `backend/crates/db/tests/`** — the `db` *library* output is unchanged, so the only crate whose compiled artifact changed is `db` (its test binaries).

- `cd backend && cargo fmt --all -- --check` → **exit 0 (green)**
- `cd backend && SQLX_OFFLINE=true cargo clippy -p db --all-targets -- -D warnings` → **exit 0 (green)** — compiles all four `suite_*` binaries + `rls_smoke`/`rls_penetration`; caught & fixed the two unused-`Uuid` imports.

The impact-scoped `just verify` plan (`VERIFY-PLAN base=959e048 files=51`) additionally lists clippy/`cargo test` for `db`'s reverse-dependents (accounting/admin/api/reality servers). Those steps are **not runnable in this sandbox** for two reasons unrelated to the diff, both covered by CI `backend.yml`:
1. `utoipa-swagger-ui v9.0.2`'s build script fails (exit 101 — network fetch of Swagger UI assets is blocked here), breaking clippy for the server crates. `db` has no such dependency.
2. `cargo test -p db` needs a live Postgres for its `#[sqlx::test]` cases; no database is available in this environment (no docker daemon, no pg binaries).

Reverse-dependent crates don't recompile from a test-only change in `db/tests/`, so `db`'s green `clippy --all-targets` is the authoritative local signal. **CI (`backend.yml`, which provisions network + Postgres) is the gate for the DB-backed test run** — hence this PR is a draft.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (pure test-scaffolding refactor; no security/auth/billing/data-integrity change).

## Remote-tested
skipped (ppt-bridge MCP not connected in this session).

## Notes
- Pre-flight: scope-check (owner=pm-backend) → **scope_drift=false**; reuse-grep (rust-backend) → **no warnings** (this PR *removes* helpers rather than adding any).
- All 51 swept files verified to end with exactly one consolidated `use crate::common::{…}` import and zero leftover private helper definitions.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZGPLJXavEjEqELEp2JfGY)_