### PR TITLE
gh-issue-2564: org-scoped DELETE-by-file_key route for direct-upload orphan cleanup

### DIFF
--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -384,6 +384,18 @@ pub struct CreateUploadUrlResponse {
     pub expires_at: DateTime<Utc>,
 }
 
+/// Query parameters for deleting a storage object by its `file_key` (#2564).
+///
+/// Used by the direct-to-S3 orphan-cleanup route. The `file_key` is carried as
+/// a query parameter (not a body) so the request stays a plain `DELETE` that
+/// intermediaries don't strip a body from.
+#[derive(Debug, Deserialize, ToSchema, utoipa::IntoParams)]
+pub struct DeleteByFileKeyQuery {
+    /// Storage key of the object to delete. MUST lie inside the caller's own
+    /// org namespace (`{org_id}/…`) — enforced by `validate_file_key_org_scope`.
+    pub file_key: String,
+}
+
 /// Query for listing documents.
 #[derive(Debug, Serialize, Deserialize, ToSchema, Default, utoipa::IntoParams)]
 pub struct ListDocumentsQuery {
@@ -460,6 +472,10 @@ pub fn router() -> Router<AppState> {
         // needed — only a small JSON request/response crosses the api-server;
         // the file bytes go straight to S3.
         .route("/upload-url", post(create_upload_url))
+        // Best-effort orphan cleanup for the direct-to-S3 path (#2564): delete a
+        // bucket object by file_key when registration (step 3) failed after the
+        // bytes were already PUT (step 2). Org-scoped, no body needed.
+        .route("/by-file-key", delete(delete_by_file_key))
         // Multipart upload (Story 7A.1)
         .merge(upload_router)
 }
@@ -1739,6 +1755,88 @@ async fn create_upload_url(
         method: "PUT".to_string(),
         expires_at: presigned.expires_at,
     }))
+}
+
+/// Delete a storage object by `file_key` — direct-upload orphan cleanup (#2564).
+///
+/// Compensating action for the direct-to-S3 upload flow (gap-84-1). That flow
+/// PUTs the bytes straight to S3 (step 2) *before* registering the document
+/// record via `POST /api/v1/documents` (step 3). If registration fails, the
+/// object is left in the bucket with no `documents` row referencing it — a
+/// leaked orphan. The client calls this route best-effort in its catch block to
+/// reap the orphan immediately, rather than depending solely on the ~1-day
+/// bucket lifecycle sweep (the authorised alternative in #2534).
+///
+/// Authorization mirrors the rest of the direct-upload flow: any authenticated
+/// org member (`AuthUser` + tenant context, no extra capability gate — same
+/// posture as `create_upload_url` / `create_document`). The `file_key` MUST lie
+/// inside the caller's own org namespace: `validate_file_key_org_scope` rejects
+/// cross-org keys, `messages/…` attachments, and `..` traversal with 400, so
+/// this route cannot be used to delete another tenant's objects (the same guard
+/// `create_document` applies to a client-supplied key, #2320).
+///
+/// Returns 204 No Content on success. S3 `DeleteObject` is idempotent, so
+/// deleting an already-absent key is a no-op that still returns 204. 503 if
+/// storage is not configured.
+#[utoipa::path(
+    delete,
+    path = "/api/v1/documents/by-file-key",
+    params(DeleteByFileKeyQuery),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 204, description = "Object deleted (or already absent)"),
+        (status = 400, description = "Invalid file_key", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 503, description = "Storage unavailable", body = ErrorResponse),
+    ),
+    tag = "Documents"
+)]
+async fn delete_by_file_key(
+    State(state): State<AppState>,
+    _auth: AuthUser,
+    tenant: TenantExtractor,
+    Query(query): Query<DeleteByFileKeyQuery>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    let org_id = tenant.tenant_id;
+
+    // Org-scope guard: the caller may only delete objects under its own
+    // `{org_id}/` prefix. Rejects cross-org keys, message attachments, and `..`
+    // traversal (400) — same guard create_document applies (#2320).
+    validate_file_key_org_scope(&query.file_key, org_id)?;
+
+    let storage = state.storage_service.as_ref().ok_or_else(|| {
+        tracing::error!("Storage service not configured — orphan cleanup unavailable");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "STORAGE_NOT_CONFIGURED",
+                "Document storage is not configured. Please contact support.",
+            )),
+        )
+    })?;
+
+    storage.delete(&query.file_key).await.map_err(|e| {
+        tracing::error!(
+            error = %e,
+            file_key = %query.file_key,
+            "Failed to delete object from storage (direct-upload orphan cleanup)"
+        );
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "STORAGE_ERROR",
+                "Unable to delete object. Please try again later.",
+            )),
+        )
+    })?;
+
+    tracing::info!(
+        file_key = %query.file_key,
+        org_id = %org_id,
+        "Deleted object by file_key (direct-upload orphan cleanup)"
+    );
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // ============================================================================

--- a/frontend/packages/api-client/src/documents/api.test.ts
+++ b/frontend/packages/api-client/src/documents/api.test.ts
@@ -273,9 +273,7 @@ describe('documents api client', () => {
     // The compensating delete (step 3b) fired: DELETE to the by-file-key route
     // with the URL-encoded file_key.
     const [delUrl, delInit] = vi.mocked(fetch).mock.calls[2];
-    expect(delUrl).toBe(
-      '/api/v1/documents/by-file-key?file_key=org%2F2026%2F07%2Fuuid_report.pdf'
-    );
+    expect(delUrl).toBe('/api/v1/documents/by-file-key?file_key=org%2F2026%2F07%2Fuuid_report.pdf');
     expect((delInit as RequestInit).method).toBe('DELETE');
     // Cleanup succeeded, so no orphan warning was logged.
     expect(warnSpy).not.toHaveBeenCalled();

--- a/frontend/packages/api-client/src/documents/api.test.ts
+++ b/frontend/packages/api-client/src/documents/api.test.ts
@@ -214,11 +214,8 @@ describe('documents api client', () => {
     vi.unstubAllGlobals();
   });
 
-  it('uploadDocumentDirect surfaces the orphaned file_key when registration fails (#2534)', async () => {
-    // Regression for the orphaned-S3-object leak: after the bytes are PUT to S3
-    // (step 2), a failing register (step 3) must NOT be swallowed — the caller
-    // still sees the real registration error — and the orphaned `file_key`
-    // must be logged so the lifecycle-rule sweep / ops can correlate it.
+  // Shared XHR mock that resolves the S3 PUT (step 2) successfully.
+  function stubSuccessfulS3Put(): { open: ReturnType<typeof vi.fn> } {
     const listeners: Record<string, () => void> = {};
     const xhrMock = {
       upload: { addEventListener: vi.fn() },
@@ -238,9 +235,18 @@ describe('documents api client', () => {
     vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestMock() {
       return xhrMock;
     });
+    return { open: xhrMock.open };
+  }
+
+  it('uploadDocumentDirect best-effort deletes the orphan when registration fails (#2564)', async () => {
+    // Deterministic compensating delete: after the bytes are PUT to S3 (step 2),
+    // a failing register (step 3) must NOT be swallowed — the caller still sees
+    // the real registration error — and the client must fire the auth+org-scoped
+    // DELETE-by-file_key route to reap the orphan immediately.
+    const { open } = stubSuccessfulS3Put();
 
     const registrationError = new Error('registration boom (HTTP 422)');
-    // 1) upload-url succeeds  2) register document rejects
+    // 1) upload-url ok  2) register rejects  3) compensating delete → 204
     vi.mocked(fetch)
       .mockResolvedValueOnce(
         mockOkResponse({
@@ -251,7 +257,8 @@ describe('documents api client', () => {
           expires_at: '2026-07-15T00:05:00Z',
         })
       )
-      .mockRejectedValueOnce(registrationError);
+      .mockRejectedValueOnce(registrationError)
+      .mockResolvedValueOnce(mock204Response());
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -262,7 +269,48 @@ describe('documents api client', () => {
     ).rejects.toBe(registrationError);
 
     // The S3 PUT (step 2) did happen — this is why the object is now orphaned.
-    expect(xhrMock.open).toHaveBeenCalledWith('PUT', 'https://s3.example/bucket/key?sig=abc');
+    expect(open).toHaveBeenCalledWith('PUT', 'https://s3.example/bucket/key?sig=abc');
+    // The compensating delete (step 3b) fired: DELETE to the by-file-key route
+    // with the URL-encoded file_key.
+    const [delUrl, delInit] = vi.mocked(fetch).mock.calls[2];
+    expect(delUrl).toBe(
+      '/api/v1/documents/by-file-key?file_key=org%2F2026%2F07%2Fuuid_report.pdf'
+    );
+    expect((delInit as RequestInit).method).toBe('DELETE');
+    // Cleanup succeeded, so no orphan warning was logged.
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('uploadDocumentDirect logs the orphan when the compensating delete also fails (#2564)', async () => {
+    // If the best-effort delete itself fails, the orphan must be made observable
+    // (greppable file_key) for the lifecycle-rule sweep to reconcile, and the
+    // ORIGINAL registration error must still surface.
+    stubSuccessfulS3Put();
+
+    const registrationError = new Error('registration boom (HTTP 422)');
+    // 1) upload-url ok  2) register rejects  3) compensating delete rejects
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockOkResponse({
+          url: 'https://s3.example/bucket/key?sig=abc',
+          file_key: 'org/2026/07/uuid_report.pdf',
+          content_type: 'application/pdf',
+          method: 'PUT',
+          expires_at: '2026-07-15T00:05:00Z',
+        })
+      )
+      .mockRejectedValueOnce(registrationError)
+      .mockRejectedValueOnce(new Error('storage unavailable (HTTP 503)'));
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+    await expect(
+      uploadDocumentDirect({ file, title: 'Report', category: 'report', organizationId: 'org-1' })
+    ).rejects.toBe(registrationError);
+
     // The orphan is observable: the warning names the exact orphaned file_key.
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain('org/2026/07/uuid_report.pdf');

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -324,6 +324,25 @@ export async function createUploadUrl(
 }
 
 /**
+ * Best-effort delete of a directly-uploaded S3 object by its `file_key` (#2564).
+ *
+ * Compensating action for {@link uploadDocumentDirect}: after the bytes are PUT
+ * straight to S3 but registration (`POST /api/v1/documents`) fails, the object
+ * is orphaned in the bucket. This calls the auth+org-scoped
+ * `DELETE /api/v1/documents/by-file-key` route (which wraps `StorageService`
+ * behind `validate_file_key_org_scope`) to reap it immediately.
+ *
+ * The `file_key` is passed as a URL-encoded query parameter (it contains `/`).
+ * The route replies `204 No Content`, so the shared transport resolves to
+ * `undefined`.
+ */
+export async function deleteUploadedFile(fileKey: string): Promise<void> {
+  await fetchApi(`${API_BASE}/by-file-key?file_key=${encodeURIComponent(fileKey)}`, {
+    method: 'DELETE',
+  });
+}
+
+/**
  * PUT raw file bytes to a presigned S3 URL (gap-84-1).
  *
  * Uses `XMLHttpRequest` for upload-progress events. The request goes directly
@@ -425,43 +444,41 @@ export async function uploadDocumentDirect(
     size_bytes: params.file.size,
   };
 
-  // ORPHANED-OBJECT CLEANUP (#2534): by this point step 2 has already PUT the
-  // bytes into S3. If registration (step 3) throws — validation, auth, or a
+  // ORPHANED-OBJECT CLEANUP (#2534, #2564): by this point step 2 has already PUT
+  // the bytes into S3. If registration (step 3) throws — validation, auth, or a
   // dropped connection — the object is left in the bucket with no `documents`
   // row referencing it, so every failed/abandoned upload would leak storage.
   //
-  // There is NO client-reachable compensating delete today:
-  //   - `deleteDocument` operates on a document *id*, which does not exist yet
-  //     (registration is exactly what failed), and
-  //   - there is no `DELETE`-by-`file_key` endpoint on the api-server. Adding
-  //     one is a backend (pm-backend) change: it would wrap the existing
-  //     `StorageService::delete` behind an auth+org-scoped route
-  //     (`validate_file_key_org_scope` already exists) and pull the live-infra
-  //     api-server test suite into scope — out of scope for this pm-frontend
-  //     follow-up.
+  // Deterministic compensating delete (#2564): call the auth+org-scoped
+  // `DELETE /api/v1/documents/by-file-key` route (wraps `StorageService::delete`
+  // behind `validate_file_key_org_scope`) to reap the orphan immediately. This
+  // is best-effort — if the delete itself fails (network, storage unavailable,
+  // race), we fall back to making the orphan observable in logs so it is
+  // greppable and correlatable with the durable backstop below. Either way we
+  // re-throw the ORIGINAL registration error unchanged so callers still see the
+  // real failure.
   //
-  // Compensating mechanism (the authorised alternative in #2534): reap these
-  // unreferenced keys with an S3 bucket LIFECYCLE RULE on the storage bucket
-  // used by `StorageService` (the `generate_storage_key` upload namespace):
-  //
-  //   Expire objects under the org upload prefix after 1 day. This is safe
-  //   because a successful upload registers within seconds and the presigned
-  //   PUT URL itself lives only ~5 min, so any object older than a day with no
-  //   matching `documents.file_key` is a presigned-but-never-registered
-  //   orphan. Configure this once on the S3/MinIO bucket (infra/DevOps) — it is
-  //   the durable backstop for the leak described above.
-  //
-  // Client-side we can only make the orphan observable so it is greppable in
-  // logs/telemetry and correlatable with the lifecycle sweep; we re-throw the
-  // ORIGINAL registration error unchanged so callers still see the real
-  // failure.
+  // Durable backstop (the authorised alternative in #2534): an S3 bucket
+  // LIFECYCLE RULE that expires objects under the org upload prefix after ~1
+  // day still catches anything the best-effort delete misses (e.g. the client
+  // process died before the catch ran). Safe because a successful upload
+  // registers within seconds and the presigned PUT URL lives only ~5 min, so
+  // any object older than a day with no matching `documents.file_key` is a
+  // presigned-but-never-registered orphan. Configure once on the S3/MinIO
+  // bucket (infra/DevOps).
   try {
     return await createDocument(registration);
   } catch (err) {
-    console.warn(
-      `[documents] registration failed after direct-to-S3 upload; orphaned object left at file_key="${presigned.file_key}" — it will be reaped by the bucket lifecycle rule (see #2534)`,
-      err
-    );
+    try {
+      await deleteUploadedFile(presigned.file_key);
+    } catch (cleanupErr) {
+      // Best-effort delete failed — leave a greppable trail for the lifecycle
+      // sweep to reconcile. Do not mask the original registration error.
+      console.warn(
+        `[documents] registration failed after direct-to-S3 upload AND the compensating delete failed; orphaned object left at file_key="${presigned.file_key}" — it will be reaped by the bucket lifecycle rule (see #2534, #2564)`,
+        cleanupErr
+      );
+    }
     throw err;
   }
 }


### PR DESCRIPTION
## Task
Follow-up: actually implement/track the direct-upload orphan mitigation (PR #2546). The issue authorizes one of two options; this implements the **Backend** option: add the auth+org-scoped `DELETE`-by-`file_key` route wrapping `StorageService::delete` (using existing `validate_file_key_org_scope`), and have `uploadDocumentDirect` best-effort call it in the catch block.

Closes #2564

## Owner
pm-tech-lead (specialist: rust-backend + small react-web/api-client wire)

## What changed
**Backend** (`backend/servers/api-server/src/routes/documents/core.rs`)
- New route `DELETE /api/v1/documents/by-file-key?file_key=<key>` → handler `delete_by_file_key`.
- Authorization mirrors the rest of the direct-upload flow: `AuthUser` + tenant context, no extra capability gate.
- Reuses the existing `validate_file_key_org_scope` guard so a caller can only delete objects under its own `{org_id}/` prefix (rejects cross-org keys, `messages/…` attachments, and `..` traversal with 400 — the same guard `create_document` applies, #2320).
- Wraps `StorageService::delete`; returns 204 (idempotent — S3 DeleteObject on a missing key is a no-op), 503 if storage is unconfigured. No new SQL (no `.sqlx` regeneration needed).

**Frontend** (`frontend/packages/api-client/src/documents/`)
- `api.ts`: new `deleteUploadedFile(fileKey)` client (URL-encoded query param, 204 → void). `uploadDocumentDirect` now best-effort calls it in the catch block before re-throwing the ORIGINAL registration error; if the compensating delete itself fails, it falls back to the observable-orphan `console.warn` (so the ~1-day bucket lifecycle rule — the alternative in #2534 — remains the durable backstop). Updated the large inline comment accordingly.
- `api.test.ts`: replaced the #2534 "surfaces orphan" test with two #2564 tests — (a) compensating delete fires (`DELETE` to the by-file-key route with the encoded `file_key`) and no warning is logged on success; (b) when the delete also fails, the orphaned `file_key` is still logged and the original error still surfaces.

## Verification
Local environment is a **DB-less sandbox** (no Postgres, `DATABASE_URL` unset). Every check that exercises the changed code is green; the only red is DB-dependent tests that cannot run here and are deferred to CI (`backend.yml` provisions Postgres).

`VERIFY-PLAN base=ce6d5bc40e1a129393bec44b1b97e5c0978e3908 files=3`
```
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
  cd frontend && pnpm exec biome check packages/api-client/src/documents/api.test.ts packages/api-client/src/documents/api.ts
  cd frontend && pnpm --filter "...[<base>]" typecheck
  cd frontend && pnpm --filter "...[<base>]" test
```
Results:
- `cargo fmt --all -- --check` — **PASS** (exit 0)
- `cargo clippy -p api-server --all-targets -D warnings` — **PASS** (exit 0) — compiles all code incl. integration-test targets
- `cargo test -p api-server --lib` (SQLX_OFFLINE) — **479 passed, 3 failed**; the 3 failures are `#[sqlx::test]` scheduler tests panicking with `DATABASE_URL must be set: EnvVar(NotPresent)` — unrelated to this diff (announcement-fanout / report-schedule), fail purely on missing Postgres. The document `validate_file_key_org_scope` guard tests are pure `#[test]`s and are among the 479 passing. Full integration suite (`tests/`) also needs Postgres → deferred to CI.
- `biome check` (changed files) — **PASS** (exit 0)
- `pnpm typecheck` (impacted) — **PASS** (exit 0)
- `pnpm --filter "...[origin/dev]" test` — api-client (this change): **143 passed**. One unrelated failure in `apps/mobile` `DocumentUploadScreen.test.tsx` (a success-path double-submit-guard test using the screen's own `uploadDocumentMultipart`, not touched here) — a known parallel-load teardown flake that **passes 28/28 in isolation**.

Note: `just`/`verify-impact.sh` local swagger-ui build was blocked by a truncated `utoipa-swagger-ui` download through the agent proxy (GitHub access-denial JSON, 378 B); worked around by copying the valid cached zip. This is infra-only and does not affect the diff.

## CI parity (Band C — hot-path only)
This touches an auth+org-scoped storage-delete route (data-integrity adjacent). The org-scope guard is fully unit-tested (pure `#[test]`s pass locally); CI `backend.yml` (with DB) is the authoritative gate for the DB-backed + integration suites, which the DB-less sandbox cannot run.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Scope drift
`scope-check --owner pm-tech-lead` reports the 3 changed files as drift because `pm-tech-lead` maps only to `docs/** .research/** _bmad-output/**` in owner-areas.json. This is an artifact of the lead-role hint, not an unexpected touch: the diff is exactly the backend route + frontend wire the issue authorizes. Files: `backend/servers/api-server/src/routes/documents/core.rs`, `frontend/packages/api-client/src/documents/api.ts`, `frontend/packages/api-client/src/documents/api.test.ts`.

## Code-reuse review
`reuse-grep --specialist rust-backend` — clean (no warnings). Deliberately reuses `validate_file_key_org_scope` and `StorageService::delete` rather than adding new helpers, per the issue proposal.

## Notes
- Draft: authoritative full verify (with DB) runs in CI.
- No TypeSpec/OpenAPI change: the direct-upload client (`@ppt/api-client/src/documents/api.ts`) is hand-written (same as `createUploadUrl`), and the route carries a `#[utoipa::path]` mirroring the sibling `create_upload_url` handler.
- Authorization posture matches `create_upload_url`/`create_document` (any authenticated org member). Deleting a raw orphan key is strictly less privileged than the existing `delete_document`, and the org-scope guard prevents cross-tenant deletion.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgGRT6LaMeT9e1LNKx2LGz)_