### PR TITLE
code-review-ppt-web-core-ws-token-rotation-stale: re-auth WebSocket on token rotation instead of leaving a stale socket

### DIFF
--- a/frontend/apps/ppt-web/src/lib/websocket.delivery.test.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.delivery.test.ts
@@ -163,3 +163,90 @@ describe('WebSocketService — message:new delivery', () => {
     expect(service.getLastEventTimestamp()).not.toBeNull();
   });
 });
+
+/**
+ * Token-rotation re-auth (regression).
+ *
+ * The auth layer rotates the access token periodically. `WebSocketContext`
+ * reacts to the new token by calling `service.connect()` again. Before the fix,
+ * `connect()` early-returned whenever a socket was already OPEN — regardless of
+ * the token — leaving a live connection bound to the *stale* token. The server
+ * can drop that socket on its next auth check (silent realtime outage) or keep
+ * honouring a rotated-out token.
+ *
+ * The contract asserted here: a `connect()` whose token differs from the live
+ * socket's token tears the stale socket down and opens a fresh one carrying the
+ * new token — while a `connect()` with the unchanged token still no-ops.
+ */
+describe('WebSocketService — token rotation re-auth', () => {
+  function tokenParam(socket: FakeWebSocket): string | null {
+    return new URL(socket.url).searchParams.get('token');
+  }
+
+  it('tears down the stale socket and reconnects with the rotated token', () => {
+    let token = 'token-old';
+    const service = new WebSocketService({
+      url: 'ws://localhost:8080',
+      getToken: () => token,
+    });
+
+    service.connect();
+    const first = FakeWebSocket.lastInstance;
+    if (!first) throw new Error('expected the first WebSocket to be constructed');
+    first.simulateOpen();
+    expect(tokenParam(first)).toBe('token-old');
+
+    // Auth layer rotates the token, then the context re-invokes connect().
+    token = 'token-new';
+    service.connect();
+
+    const second = FakeWebSocket.lastInstance;
+    if (!second) throw new Error('expected a second WebSocket to be constructed');
+
+    // A brand-new socket carrying the rotated token must have been opened...
+    expect(second).not.toBe(first);
+    expect(tokenParam(second)).toBe('token-new');
+    // ...and the stale socket bound to the old token must have been closed.
+    expect(first.readyState).toBe(FakeWebSocket.CLOSED);
+  });
+
+  it('no-ops when connect() is called again with the unchanged token', () => {
+    const service = new WebSocketService({
+      url: 'ws://localhost:8080',
+      getToken: () => 'token-stable',
+    });
+
+    service.connect();
+    const first = FakeWebSocket.lastInstance;
+    if (!first) throw new Error('expected the first WebSocket to be constructed');
+    first.simulateOpen();
+
+    // Same token → the existing live socket is reused, no new socket created.
+    service.connect();
+    expect(FakeWebSocket.lastInstance).toBe(first);
+    expect(first.readyState).toBe(FakeWebSocket.OPEN);
+  });
+
+  it('detaches stale-socket handlers so its close does not trigger a reconnect', () => {
+    let token = 'rot-a';
+    const service = new WebSocketService({
+      url: 'ws://localhost:8080',
+      getToken: () => token,
+      minReconnectDelay: 1,
+    });
+
+    service.connect();
+    const first = FakeWebSocket.lastInstance;
+    if (!first) throw new Error('expected the first WebSocket to be constructed');
+    first.simulateOpen();
+    const firstOnClose = first.onclose;
+
+    token = 'rot-b';
+    service.connect();
+
+    // The stale socket's handlers were detached during teardown, so a late
+    // close event on it is inert and cannot drive the service's reconnect path.
+    expect(first.onclose).toBeNull();
+    expect(firstOnClose).not.toBeNull();
+  });
+});

--- a/frontend/apps/ppt-web/src/lib/websocket.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.ts
@@ -221,6 +221,17 @@ export class WebSocketService {
   private connectionState: ConnectionState = 'disconnected';
   private lastError: Error | null = null;
 
+  /**
+   * The auth token the current (open or in-flight) socket was opened with.
+   *
+   * Used by {@link connect} to detect token rotation: if `connect()` is called
+   * again while a socket is already live but the token has since changed, the
+   * stale socket must be torn down and re-opened with the new token — otherwise
+   * the early-return would leave a live connection authenticated with a
+   * rotated-out token, and the server may close it on the next validation.
+   */
+  private currentToken: string | null = null;
+
   // Configuration
   private readonly url: string;
   private readonly getToken: () => string | null;
@@ -289,16 +300,33 @@ export class WebSocketService {
    * Connect to the WebSocket server.
    */
   connect(): void {
-    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-      return; // Already connected
-    }
-
     const token = this.getToken();
     if (!token) {
       this.setConnectionState('error', new Error('No auth token available'));
       return;
     }
 
+    // Only keep the existing socket if it is live (open or still handshaking)
+    // AND was opened with the same token. If the token has rotated we must
+    // fall through and re-establish the connection with the new token — a bare
+    // `readyState === OPEN` early-return would leave a live socket bound to the
+    // stale token (the server can then drop it on the next auth check, or worse
+    // keep honouring a token that should no longer be valid).
+    if (
+      this.socket &&
+      (this.socket.readyState === WebSocket.OPEN ||
+        this.socket.readyState === WebSocket.CONNECTING) &&
+      token === this.currentToken
+    ) {
+      return; // Already connected/connecting with the current token
+    }
+
+    // Any pre-existing socket here is either bound to a rotated-out token or
+    // already closed/closing. Tear it down cleanly before opening a new one so
+    // we never run two sockets in parallel or leak the stale connection.
+    this.teardownStaleSocket();
+
+    this.currentToken = token;
     this.shouldReconnect = true;
     this.clearReconnectTimeout();
 
@@ -333,7 +361,40 @@ export class WebSocketService {
       this.socket = null;
     }
 
+    this.currentToken = null;
     this.setConnectionState('disconnected');
+  }
+
+  /**
+   * Tear down the current socket without touching reconnect intent.
+   *
+   * Unlike {@link disconnect}, this does NOT flip `shouldReconnect` or emit a
+   * `disconnected` state — it is an internal replace step used by
+   * {@link connect} when re-establishing the connection (e.g. after a token
+   * rotation) or when the previous socket is already closed. The stale socket's
+   * handlers are detached first so its imminent `close` event cannot drive a
+   * spurious reconnect or state transition on the service that is about to own
+   * a fresh socket.
+   */
+  private teardownStaleSocket(): void {
+    if (!this.socket) return;
+
+    this.stopHeartbeat();
+
+    const stale = this.socket;
+    stale.onopen = null;
+    stale.onclose = null;
+    stale.onerror = null;
+    stale.onmessage = null;
+
+    try {
+      stale.close(1000, 'Reconnecting with a new token');
+    } catch {
+      // Closing an already-closed/closing socket can throw in some engines;
+      // the socket is being discarded regardless, so the error is irrelevant.
+    }
+
+    this.socket = null;
   }
 
   /**


### PR DESCRIPTION
## Task
WebSocket not re-authed on token rotation — connect() early-return leaves live socket on old token. Fix so that when the auth token rotates, the existing WebSocket connection is torn down and re-established (or re-authenticated) with the new token instead of the connect() early-return leaving a live socket bound to the stale token.

## Owner
pm-backend (hint) — actual fix lives in `frontend/apps/ppt-web/` (the WebSocket client is frontend code). See Scope drift below.

## Root cause
`WebSocketService.connect()` (`frontend/apps/ppt-web/src/lib/websocket.ts`) early-returned whenever a socket was `readyState === OPEN`, without checking the token. `WebSocketContext`'s auth effect re-invokes `service.connect()` whenever `auth.accessToken` changes, so on token rotation the call hit the early-return and the live socket stayed bound to the rotated-out token — a silent realtime outage the moment the server re-validates the JWT.

## Fix
- `connect()` now tracks `currentToken` (the token the live/in-flight socket was opened with). It reuses an existing `OPEN`/`CONNECTING` socket **only when the token is unchanged**; otherwise it tears the stale socket down and re-establishes with the new token.
- New private `teardownStaleSocket()` closes the stale socket and **detaches its handlers first**, so the stale socket's imminent `close` cannot drive a spurious reconnect/state transition on the service that's about to own a fresh socket. It intentionally does not flip `shouldReconnect` (unlike `disconnect()`).
- `disconnect()` clears `currentToken`.

## Test plan
Regression tests added to `frontend/apps/ppt-web/src/lib/websocket.delivery.test.ts` (new `token rotation re-auth` describe block):
- rotated token tears down the stale socket and opens a fresh one carrying the new token;
- unchanged token still no-ops (reuses the live socket);
- stale-socket handlers are detached so a late close is inert.

Confirmed 2 of the 3 new tests fail on `dev` (pre-fix) and pass with the fix (TDD evidence — separate `test:` + `fix:` commits).

## Scope drift
owner_role hint was `pm-backend`, but the bug and fix are entirely in frontend WebSocket-client code. `scope-check.sh --owner pm-backend` flags (exit 2):
- `frontend/apps/ppt-web/src/lib/websocket.ts`
- `frontend/apps/ppt-web/src/lib/websocket.delivery.test.ts`

This is expected — the "ppt-web core WS" client is React/TS code; no backend change is required or made. Reviewer to confirm the owner hint mislabel.

## Code-reuse review
`reuse-grep.sh --specialist react-web` — no warnings.

## Verification
```
VERIFY-PLAN base=d11186011f490c8df263305d0012991cd083134c files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/lib/websocket.delivery.test.ts apps/ppt-web/src/lib/websocket.ts
  cd frontend && pnpm --filter "...[d11186011f490c8df263305d0012991cd083134c]" typecheck
  cd frontend && pnpm --filter "...[d11186011f490c8df263305d0012991cd083134c]" test
```
`VERIFY OK 91410d5f61d50f6a7d469f532b6460e8f2cbab60`
(biome + typecheck clean; 1612 ppt-web tests pass.)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (client-side transport re-auth; no server auth/billing/data-integrity change).

## Remote-tested
skipped: ppt-bridge MCP not connected.

## Notes
- IG goal-check: IG3 (TDD test:/fix: commits) and IG7 (verify) pass. IG1/IG2/IG4/IG5/IG6 are N/A for this dispatcher `code-review-*` task — there is no `.research/plans/` file and the branch name (`auto-impl/…`) is dispatcher-mandated, not `impl/…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WExxvsznsZ6z9fLG3faoCK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WExxvsznsZ6z9fLG3faoCK)_