### PR TITLE
code-review-ppt-web-core-ws-ungated-console: gate WebSocket console diagnostics behind import.meta.env.DEV

### DIFF
--- a/frontend/apps/ppt-web/src/lib/websocket.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.ts
@@ -214,6 +214,28 @@ function defaultWebSocketUrl(): string {
 }
 
 /**
+ * Dev-only diagnostic logging for the WebSocket client.
+ *
+ * The connection diagnostics below (send failures, handler errors, pong
+ * timeouts, reconnect give-up) are valuable while developing but must not
+ * leak to the browser console in production builds: they surface internal
+ * connection state and add noise for end users. Gating on `import.meta.env.DEV`
+ * — the same convention `lib/api.ts` uses for its retry logging — lets Vite
+ * dead-code-eliminate these calls from the production bundle entirely.
+ */
+function wsWarn(...args: unknown[]): void {
+  if (import.meta.env.DEV) {
+    console.warn(...args);
+  }
+}
+
+function wsError(...args: unknown[]): void {
+  if (import.meta.env.DEV) {
+    console.error(...args);
+  }
+}
+
+/**
  * WebSocket service that manages connection, reconnection, and message handling.
  */
 export class WebSocketService {
@@ -402,7 +424,7 @@ export class WebSocketService {
    */
   send(message: WebSocketMessage): boolean {
     if (!this.isConnected()) {
-      console.warn('[WebSocket] Cannot send message: not connected');
+      wsWarn('[WebSocket] Cannot send message: not connected');
       return false;
     }
 
@@ -410,7 +432,7 @@ export class WebSocketService {
       this.socket!.send(JSON.stringify(message));
       return true;
     } catch (error) {
-      console.error('[WebSocket] Failed to send message:', error);
+      wsError('[WebSocket] Failed to send message:', error);
       return false;
     }
   }
@@ -530,7 +552,7 @@ export class WebSocketService {
           try {
             handler(message);
           } catch (handlerError) {
-            console.error(`[WebSocket] Handler error for ${message.type}:`, handlerError);
+            wsError(`[WebSocket] Handler error for ${message.type}:`, handlerError);
           }
         }
       }
@@ -542,12 +564,12 @@ export class WebSocketService {
           try {
             handler(message);
           } catch (handlerError) {
-            console.error('[WebSocket] Wildcard handler error:', handlerError);
+            wsError('[WebSocket] Wildcard handler error:', handlerError);
           }
         }
       }
     } catch (error) {
-      console.error('[WebSocket] Failed to parse message:', error);
+      wsError('[WebSocket] Failed to parse message:', error);
     }
   }
 
@@ -562,7 +584,7 @@ export class WebSocketService {
       try {
         handler(state, error);
       } catch (handlerError) {
-        console.error('[WebSocket] Connection state handler error:', handlerError);
+        wsError('[WebSocket] Connection state handler error:', handlerError);
       }
     }
   }
@@ -577,7 +599,7 @@ export class WebSocketService {
     // acting as a small DoS amplifier in dev.
     if (this.reconnectAttempts >= this.maxReconnectAttempts) {
       this.shouldReconnect = false;
-      console.warn(
+      wsWarn(
         `[WebSocket] Giving up after ${this.reconnectAttempts} reconnect attempts. ` +
           'Call connect() to resume.'
       );
@@ -617,7 +639,7 @@ export class WebSocketService {
         try {
           handler(message);
         } catch (handlerError) {
-          console.error('[WebSocket] max-retries handler error:', handlerError);
+          wsError('[WebSocket] max-retries handler error:', handlerError);
         }
       }
     }
@@ -628,7 +650,7 @@ export class WebSocketService {
         try {
           handler(message);
         } catch (handlerError) {
-          console.error('[WebSocket] Wildcard handler error:', handlerError);
+          wsError('[WebSocket] Wildcard handler error:', handlerError);
         }
       }
     }
@@ -679,7 +701,7 @@ export class WebSocketService {
 
       this.pongTimeoutId = setTimeout(() => {
         if (this.awaitingPong) {
-          console.warn('[WebSocket] Pong timeout - closing connection');
+          wsWarn('[WebSocket] Pong timeout - closing connection');
           this.socket?.close(4000, 'Pong timeout');
         }
       }, this.pongTimeout);


### PR DESCRIPTION
## Task
10 ungated console.warn/error in ppt-web websocket.ts leak diagnostics in prod

## Owner
pm-tech-lead

## Change
`frontend/apps/ppt-web/src/lib/websocket.ts` had 10 `console.warn`/`console.error`
calls that fired unconditionally — leaking internal WebSocket connection
diagnostics (send failures, per-handler errors, parse failures, pong timeout,
reconnect give-up) to the browser console in production. They are now routed
through two dev-only helpers, `wsWarn` / `wsError`, gated on
`import.meta.env.DEV` — the same convention `lib/api.ts` already uses for its
retry logging — so Vite dead-code-eliminates them from the production bundle.
Behaviour in dev is unchanged; no public API change.

Call sites gated (3 warn + 7 error = 10): `send()` (2), `handleMessage()` (3),
`setConnectionState()` (1), `scheduleReconnect()` (1), `notifyMaxRetriesExceeded()` (2),
`sendPing()` (1).

## Verification
```
VERIFY-PLAN base=a1ea2b6d6bdcd457fa54cdb6d579a4160afc16a7 files=1
  cd frontend && pnpm exec biome check apps/ppt-web/src/lib/websocket.ts
  cd frontend && pnpm --filter "...[a1ea2b6d6bdcd457fa54cdb6d579a4160afc16a7]" typecheck
  cd frontend && pnpm --filter "...[a1ea2b6d6bdcd457fa54cdb6d579a4160afc16a7]" test
```
VERIFY OK ac9280a282a25953ec6a3bab9f5cf196dfc4c01d

(biome clean, typecheck clean, 104 test files / 1612 tests passed.)

## Scope drift
`scope-check.sh --owner pm-tech-lead` flags the one changed file
(`frontend/apps/ppt-web/src/lib/websocket.ts`) as outside `pm-tech-lead`'s
mapped areas (`docs/**`, `.research/**`, `_bmad-output/**`). This is expected:
`owner_role` is a dispatcher hint, and the actual work is a `react-web`/ppt-web
code fix. The diff is a single, in-scope ppt-web file. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist react-web` returned no warnings. No existing logger
utility exists in ppt-web; the added `wsWarn`/`wsError` are module-local and
follow the established `import.meta.env.DEV` gating pattern rather than
introducing a shared abstraction.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- Pure refactor: no behavioural change, no new/changed tests required (existing
  1612 tests still green; none asserted on console output). IG3 regression-test
  requirement is N/A for this diagnostics-gating refactor.
- Goal-check IG1/IG2 report structural mismatches only (no
  `.research/plans/<slug>.md` for this code-review task; dispatcher-chosen
  `auto-impl/...` branch vs the script's assumed `impl/<slug>`), not correctness
  issues. The correctness gate (verify) is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_015oa3YXBELrYsZH4UoZeL2q)_