### PR TITLE
gh-issue-2574: fix(mobile-native) wire Android SSO initiation leg (mint CSRF nonce)

### DIFF
--- a/mobile-native/CLAUDE.md
+++ b/mobile-native/CLAUDE.md
@@ -154,9 +154,11 @@ intent-filter, so any app/browser/notification can hand it to us. **Both platfor
 per-flow `state` nonce before validating the token** — skipping it allows session fixation / account
 takeover (an attacker's token silently signs the victim in).
 
-- **Android** — `SsoStateStore` (commonMain): `mint()` before opening the SSO hop (append
-  `&state=<nonce>`); `MainActivity.handleDeepLink` calls `consume(target.state)` and validates the
-  token only on a match. Default-reject: an unsolicited callback with no pending flow is dropped.
+- **Android** — `SsoStateStore` (commonMain): `SsoInitiation.begin()` mints the nonce and builds the
+  outbound `propertymanagement://sso?callback=reality://sso&state=<nonce>` hop (wired to the
+  `LoginScreen` "Sign in via PM App" button in `Navigation.kt`); `MainActivity.handleDeepLink` calls
+  `consume(target.state)` and validates the token only on a match. Default-reject: an unsolicited
+  callback with no pending flow is dropped.
 - **iOS** — `AuthManager.beginSsoFlow()` / `consumeSsoState(_:)` (owns its own nonce; does not use
   the KMP store).
 

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/navigation/Navigation.kt
@@ -1,5 +1,6 @@
 package three.two.bit.ppt.reality.navigation
 
+import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -21,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -31,6 +33,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import kotlinx.coroutines.launch
 import three.two.bit.ppt.reality.R
+import three.two.bit.ppt.reality.auth.SsoInitiation
 import three.two.bit.ppt.reality.auth.SsoService
 import three.two.bit.ppt.reality.favorites.FavoritesRepository
 import three.two.bit.ppt.reality.favorites.SavedSearch as ApiSavedSearch
@@ -276,6 +279,7 @@ fun RealityNavHost(
 
             // Auth & profile (UC-47).
             composable(Screen.Login.route) {
+                val context = LocalContext.current
                 LoginScreen(
                     onBackClick = { navController.popBackStack() },
                     onSubmit = { email, password ->
@@ -283,6 +287,19 @@ fun RealityNavHost(
                     },
                     onForgotPasswordClick = { navController.navigate(Screen.ForgotPassword.route) },
                     onRegisterClick = { navController.navigate(Screen.Register.route) },
+                    // SSO initiation leg (parity with iOS `LoginView.loginWithSso`): mint the
+                    // per-flow CSRF nonce and hand off to the PM app. `SsoStateStore` now has a
+                    // pending nonce, so the `reality://sso` callback `MainActivity` receives passes
+                    // `consume()` instead of being default-rejected. `ACTION_VIEW` fails only when
+                    // the PM app isn't installed — swallow that so the email/password fallback
+                    // remains usable.
+                    onSsoLoginClick = {
+                        runCatching {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, Uri.parse(SsoInitiation.begin()))
+                            )
+                        }
+                    },
                     // On success, drop the whole auth stack and land on Home. Home (and
                     // every top-level screen) collects authState, so it re-renders signed in.
                     onLoginSuccess = {

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.*
@@ -34,10 +35,16 @@ import three.two.bit.ppt.reality.util.isNetworkError
  * 4. Primary "Sign in" button (filled).
  * 5. "OR" divider + footer "Don't have an account? Sign up".
  *
- * Social-login (Google / Apple) buttons in the mock are not wired here — the Reality Portal SSO is
- * delegated to the PPT app per UC-47, and the separate social-login flow isn't on the roadmap yet.
+ * The primary "Sign in via PM App" action mirrors iOS `LoginView.loginWithSso()`: it hands the flow
+ * to the Property Management app over the `propertymanagement://sso` deep link after minting the
+ * per-flow CSRF nonce (see [onSsoLoginClick] / `SsoInitiation.begin`). Google / Apple social-login
+ * buttons from the mock stay unwired — that flow isn't on the roadmap yet.
  *
  * UC-47.2 — Email/password login.
+ *
+ * @param onSsoLoginClick launches the SSO hop to the PM app. The caller mints the CSRF nonce via
+ *   `SsoInitiation.begin()` and fires the outbound `ACTION_VIEW` intent; this screen only surfaces
+ *   the affordance.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -47,6 +54,7 @@ fun LoginScreen(
     onForgotPasswordClick: () -> Unit,
     onRegisterClick: () -> Unit,
     onLoginSuccess: () -> Unit,
+    onSsoLoginClick: () -> Unit = {},
 ) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
@@ -71,6 +79,33 @@ fun LoginScreen(
                     ErrorBanner(it)
                     Spacer(modifier = Modifier.height(14.dp))
                 }
+
+                // Primary SSO affordance — parity with iOS `LoginView.ssoLoginSection`. Tapping this
+                // mints a CSRF nonce and opens the Property Management app; the email/password form
+                // below is the fallback.
+                Button(
+                    onClick = onSsoLoginClick,
+                    modifier = Modifier.fillMaxWidth().height(52.dp),
+                    shape = RoundedCornerShape(14.dp),
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.Login,
+                        contentDescription = null,
+                        modifier = Modifier.padding(end = 8.dp).size(18.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.sign_in_pm_app),
+                        style = MaterialTheme.typography.titleSmall,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = stringResource(R.string.sign_in_redirect_notice),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                OrDivider(stringResource(R.string.auth_or))
 
                 AuthFieldLabel(stringResource(R.string.email))
                 Spacer(modifier = Modifier.height(6.dp))

--- a/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
+++ b/mobile-native/androidApp/src/main/java/three/two/bit/ppt/reality/ui/auth/LoginScreen.kt
@@ -80,7 +80,8 @@ fun LoginScreen(
                     Spacer(modifier = Modifier.height(14.dp))
                 }
 
-                // Primary SSO affordance — parity with iOS `LoginView.ssoLoginSection`. Tapping this
+                // Primary SSO affordance — parity with iOS `LoginView.ssoLoginSection`. Tapping
+                // this
                 // mints a CSRF nonce and opens the Property Management app; the email/password form
                 // below is the fallback.
                 Button(

--- a/mobile-native/androidApp/src/main/res/values-cs/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-cs/strings.xml
@@ -134,6 +134,7 @@
     <string name="sign_in_benefits">Uložte si oblíbené, sledujte dotazy a dostávejte upozornění na nové nabídky</string>
     <string name="sign_in_pm_app">Přihlásit se přes PM aplikaci</string>
     <string name="sign_in_redirect_notice">Budete přesměrováni do aplikace Property Management pro bezpečné přihlášení.</string>
+    <string name="auth_or">NEBO</string>
     <string name="confirm_sign_out_message">Opravdu se chcete odhlásit?</string>
 
     <!-- Notification preferences -->

--- a/mobile-native/androidApp/src/main/res/values-de/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-de/strings.xml
@@ -134,6 +134,7 @@
     <string name="sign_in_benefits">Speichern Sie Favoriten, verfolgen Sie Anfragen und erhalten Sie Benachrichtigungen über neue Angebote</string>
     <string name="sign_in_pm_app">Über PM-App anmelden</string>
     <string name="sign_in_redirect_notice">Sie werden zur Property Management App weitergeleitet, um sich sicher anzumelden.</string>
+    <string name="auth_or">ODER</string>
     <string name="confirm_sign_out_message">Möchten Sie sich wirklich abmelden?</string>
 
     <!-- Notification preferences -->

--- a/mobile-native/androidApp/src/main/res/values-hu/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-hu/strings.xml
@@ -134,6 +134,7 @@
     <string name="sign_in_benefits">Mentse el kedvenceit, kövesse érdeklődéseit és kapjon értesítéseket új ajánlatokról</string>
     <string name="sign_in_pm_app">Bejelentkezés PM alkalmazással</string>
     <string name="sign_in_redirect_notice">Átirányítjuk a Property Management alkalmazásba a biztonságos bejelentkezéshez.</string>
+    <string name="auth_or">VAGY</string>
     <string name="confirm_sign_out_message">Biztosan ki szeretne jelentkezni?</string>
 
     <!-- Notification preferences -->

--- a/mobile-native/androidApp/src/main/res/values-pl/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-pl/strings.xml
@@ -134,6 +134,7 @@
     <string name="sign_in_benefits">Zapisuj ulubione, śledź zapytania i otrzymuj powiadomienia o nowych ofertach</string>
     <string name="sign_in_pm_app">Zaloguj przez aplikację PM</string>
     <string name="sign_in_redirect_notice">Zostaniesz przekierowany do aplikacji Property Management, aby bezpiecznie się zalogować.</string>
+    <string name="auth_or">LUB</string>
     <string name="confirm_sign_out_message">Czy na pewno chcesz się wylogować?</string>
 
     <!-- Notification preferences -->

--- a/mobile-native/androidApp/src/main/res/values-sk/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values-sk/strings.xml
@@ -231,6 +231,7 @@
     <string name="sign_in_benefits">Uložte si obľúbené, sledujte dopyty a dostávajte upozornenia na nové ponuky</string>
     <string name="sign_in_pm_app">Prihlásiť sa cez PM aplikáciu</string>
     <string name="sign_in_redirect_notice">Budete presmerovaný do aplikácie Property Management pre bezpečné prihlásenie.</string>
+    <string name="auth_or">ALEBO</string>
     <string name="confirm_sign_out_message">Naozaj sa chcete odhlásiť?</string>
 
     <!-- Notification preferences -->

--- a/mobile-native/androidApp/src/main/res/values/strings.xml
+++ b/mobile-native/androidApp/src/main/res/values/strings.xml
@@ -236,6 +236,7 @@
     <string name="sign_in_benefits">Save favorites, track inquiries, and get notified about new listings</string>
     <string name="sign_in_pm_app">Sign In via PM App</string>
     <string name="sign_in_redirect_notice">You\'ll be redirected to the Property Management app to sign in securely.</string>
+    <string name="auth_or">OR</string>
     <string name="confirm_sign_out_message">Are you sure you want to sign out?</string>
 
     <!-- Notification preferences -->

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoInitiation.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoInitiation.kt
@@ -1,0 +1,50 @@
+package three.two.bit.ppt.reality.auth
+
+import three.two.bit.ppt.reality.navigation.DeepLinkRouter
+
+/**
+ * Builds the outbound SSO hop that hands the login flow to the Property Management app, and — as its
+ * one and only responsibility — is the production call site for [SsoStateStore.mint].
+ *
+ * This is the Android/KMP mirror of iOS `LoginView.loginWithSso()`:
+ * ```swift
+ * let state = authManager.beginSsoFlow()
+ * "propertymanagement://sso?callback=realityportal://sso&state=\(state)"
+ * ```
+ * The two platforms differ only in the callback scheme — iOS re-enters through
+ * `realityportal://sso`, Android through `reality://sso` ([DeepLinkRouter.SCHEME]).
+ *
+ * The CSRF contract (see `mobile-native/CLAUDE.md` → "SSO deep-link CSRF contract"): before opening
+ * the hop the app [mint][SsoStateStore.mint]s a single-use nonce and appends it as `&state=`; the PM
+ * app round-trips it back on the `reality://sso?token=…&state=…` callback, where
+ * `MainActivity.handleDeepLink` calls [SsoStateStore.consume] and validates the token only on a
+ * match. Without this initiation leg no nonce is ever pending, so the default-reject `consume` drops
+ * every callback — which is exactly the half-wired gap this closes.
+ */
+object SsoInitiation {
+
+    /** Custom URL scheme of the Property Management app that owns the SSO login. */
+    const val PM_APP_SCHEME: String = "propertymanagement"
+
+    /**
+     * The callback URL the PM app must redirect back to after authenticating. Derived from
+     * [DeepLinkRouter.SCHEME] so it stays in lockstep with the `reality://sso` intent-filter and the
+     * shared deep-link parser.
+     */
+    val CALLBACK: String = "${DeepLinkRouter.SCHEME}://sso"
+
+    /**
+     * Pure URL builder — assembles the outbound SSO URL for a given CSRF [state] nonce. Kept
+     * separate from [begin] so the URL shape is unit-testable without touching the process-global
+     * [SsoStateStore].
+     */
+    fun buildUrl(state: String): String = "$PM_APP_SCHEME://sso?callback=$CALLBACK&state=$state"
+
+    /**
+     * Mint a fresh single-use CSRF nonce, register it as the pending value in [SsoStateStore], and
+     * return the outbound SSO URL carrying it as `state`. The caller launches the returned URL (on
+     * Android via an `ACTION_VIEW` intent); the echoed `state` is later verified by
+     * [SsoStateStore.consume] on the callback.
+     */
+    fun begin(): String = buildUrl(SsoStateStore.mint())
+}

--- a/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoInitiation.kt
+++ b/mobile-native/shared/src/commonMain/kotlin/three/two/bit/ppt/reality/auth/SsoInitiation.kt
@@ -3,23 +3,24 @@ package three.two.bit.ppt.reality.auth
 import three.two.bit.ppt.reality.navigation.DeepLinkRouter
 
 /**
- * Builds the outbound SSO hop that hands the login flow to the Property Management app, and — as its
- * one and only responsibility — is the production call site for [SsoStateStore.mint].
+ * Builds the outbound SSO hop that hands the login flow to the Property Management app, and — as
+ * its one and only responsibility — is the production call site for [SsoStateStore.mint].
  *
  * This is the Android/KMP mirror of iOS `LoginView.loginWithSso()`:
  * ```swift
  * let state = authManager.beginSsoFlow()
  * "propertymanagement://sso?callback=realityportal://sso&state=\(state)"
  * ```
+ *
  * The two platforms differ only in the callback scheme — iOS re-enters through
  * `realityportal://sso`, Android through `reality://sso` ([DeepLinkRouter.SCHEME]).
  *
  * The CSRF contract (see `mobile-native/CLAUDE.md` → "SSO deep-link CSRF contract"): before opening
- * the hop the app [mint][SsoStateStore.mint]s a single-use nonce and appends it as `&state=`; the PM
- * app round-trips it back on the `reality://sso?token=…&state=…` callback, where
+ * the hop the app [mint][SsoStateStore.mint]s a single-use nonce and appends it as `&state=`; the
+ * PM app round-trips it back on the `reality://sso?token=…&state=…` callback, where
  * `MainActivity.handleDeepLink` calls [SsoStateStore.consume] and validates the token only on a
- * match. Without this initiation leg no nonce is ever pending, so the default-reject `consume` drops
- * every callback — which is exactly the half-wired gap this closes.
+ * match. Without this initiation leg no nonce is ever pending, so the default-reject `consume`
+ * drops every callback — which is exactly the half-wired gap this closes.
  */
 object SsoInitiation {
 
@@ -28,8 +29,8 @@ object SsoInitiation {
 
     /**
      * The callback URL the PM app must redirect back to after authenticating. Derived from
-     * [DeepLinkRouter.SCHEME] so it stays in lockstep with the `reality://sso` intent-filter and the
-     * shared deep-link parser.
+     * [DeepLinkRouter.SCHEME] so it stays in lockstep with the `reality://sso` intent-filter and
+     * the shared deep-link parser.
      */
     val CALLBACK: String = "${DeepLinkRouter.SCHEME}://sso"
 

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoInitiationTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoInitiationTest.kt
@@ -1,0 +1,79 @@
+package three.two.bit.ppt.reality.auth
+
+import three.two.bit.ppt.reality.navigation.DeepLinkRouter
+import three.two.bit.ppt.reality.navigation.DeepLinkTarget
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Contract for the SSO initiation leg — the production call site for [SsoStateStore.mint] that was
+ * missing after PR #2568 (issue #2574), leaving every `reality://sso` callback default-rejected.
+ *
+ * The key case is [mint_then_callback_consume_round_trips]: it exercises the full loop the two
+ * halves of the CSRF guard form — [SsoInitiation.begin] mints + emits `&state=`, and a matching
+ * callback parsed by [DeepLinkRouter] is accepted by [SsoStateStore.consume]. On `dev` (no
+ * `SsoInitiation`) this file does not compile — the regression guard for the missing-call-site fix.
+ */
+class SsoInitiationTest {
+
+    @BeforeTest fun clear() = SsoStateStore.reset()
+
+    @AfterTest fun cleanup() = SsoStateStore.reset()
+
+    @Test
+    fun build_url_targets_pm_app_with_reality_callback_and_state() {
+        val url = SsoInitiation.buildUrl("abc123")
+        assertEquals("propertymanagement://sso?callback=reality://sso&state=abc123", url)
+    }
+
+    @Test
+    fun callback_scheme_matches_the_reality_deep_link_scheme() {
+        // The callback must re-enter through the same scheme the exported intent-filter listens on,
+        // otherwise the PM app would redirect into a dead URL.
+        assertEquals("${DeepLinkRouter.SCHEME}://sso", SsoInitiation.CALLBACK)
+    }
+
+    @Test
+    fun begin_leaves_a_pending_nonce_matching_the_url_state() {
+        val url = SsoInitiation.begin()
+        assertTrue(SsoStateStore.hasPending(), "begin() must mint a pending nonce")
+        val state = url.substringAfter("&state=")
+        assertTrue(state.isNotEmpty(), "the outbound URL must carry a state nonce")
+    }
+
+    @Test
+    fun mint_then_callback_consume_round_trips() {
+        // 1. App initiates SSO: mint + build the outbound hop.
+        val outbound = SsoInitiation.begin()
+        val state = outbound.substringAfter("&state=")
+
+        // 2. PM app authenticates and redirects back to the reality:// callback echoing the state.
+        val callback = "reality://sso?token=session-token-xyz&state=$state"
+        val target = DeepLinkRouter.parse(callback)
+        assertTrue(target is DeepLinkTarget.Sso, "the callback must parse as an SSO target")
+        assertEquals("session-token-xyz", target.token)
+        assertEquals(state, target.state)
+
+        // 3. The receiver accepts the token only because the state matches the minted nonce.
+        assertTrue(
+            SsoStateStore.consume(target.state),
+            "a callback echoing the minted state must be accepted",
+        )
+    }
+
+    @Test
+    fun callback_with_forged_state_is_rejected_after_begin() {
+        SsoInitiation.begin()
+        val forged = "reality://sso?token=attacker-token&state=forged-nonce"
+        val target = DeepLinkRouter.parse(forged)
+        assertTrue(target is DeepLinkTarget.Sso)
+        assertFalse(
+            SsoStateStore.consume(target.state),
+            "a callback whose state does not match the minted nonce must be rejected",
+        )
+    }
+}

--- a/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoInitiationTest.kt
+++ b/mobile-native/shared/src/commonTest/kotlin/three/two/bit/ppt/reality/auth/SsoInitiationTest.kt
@@ -1,13 +1,13 @@
 package three.two.bit.ppt.reality.auth
 
-import three.two.bit.ppt.reality.navigation.DeepLinkRouter
-import three.two.bit.ppt.reality.navigation.DeepLinkTarget
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import three.two.bit.ppt.reality.navigation.DeepLinkRouter
+import three.two.bit.ppt.reality.navigation.DeepLinkTarget
 
 /**
  * Contract for the SSO initiation leg — the production call site for [SsoStateStore.mint] that was


### PR DESCRIPTION
Auto-created by the research dispatcher (Phase 2 reconciliation): the implementer pushed commits to this branch but the run ended before opening the PR.

**Task:** `gh-issue-2574` — Follow-up: Android SSO CSRF guard was only half-wired — `SsoStateStore.mint()` had no call site (PR #2568).

Wires the Android SSO initiation leg so the CSRF nonce is minted at login, plus a `SsoInitiationTest` regression.

Closes #2574

---
_Generated by [Claude Code](https://claude.ai/code/session_014wJcBpLKGREe6G48jn5REf)_