### PR TITLE
code-review-ppt-web-aml-review-decision-untrusted-cast: fix(ppt-web) validate AML review decision before submit

### DIFF
--- a/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.test.tsx
@@ -1,0 +1,87 @@
+/// <reference types="vitest/globals" />
+/**
+ * AmlDashboardPage review-decision validation tests.
+ *
+ * Regression: the Phase-1 review flow reads the decision from window.prompt and
+ * previously cast the raw string straight into the `approve | reject | escalate`
+ * union (`decision as ...`). A typo ("aprove") therefore reached the API as an
+ * invalid AML decision. The page now validates the free-text input against the
+ * allowed union before calling the mutation.
+ */
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AmlDashboardPage } from './AmlDashboardPage';
+
+const reviewMutate = vi.fn();
+
+const assessment = {
+  id: 'assess-1',
+  subject_id: 'party-1',
+  subject_type: 'tenant',
+  risk_score: 80,
+  risk_level: 'high',
+  status: 'requires_review',
+  risk_factors: [],
+  flagged_for_review: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+};
+
+vi.mock('@ppt/api-client', () => ({
+  useAmlAssessments: vi.fn(() => ({
+    data: { assessments: [assessment] },
+    isLoading: false,
+    error: null,
+  })),
+  useAmlThresholds: vi.fn(() => ({ data: undefined })),
+  useCountryRisks: vi.fn(() => ({ data: undefined })),
+  useInitiateEdd: vi.fn(() => ({ mutate: vi.fn() })),
+  useReviewAmlAssessment: vi.fn(() => ({ mutate: reviewMutate })),
+}));
+
+function clickReview() {
+  const button = screen.getByRole('button', { name: /review assessment/i });
+  button.click();
+}
+
+describe('AmlDashboardPage review-decision validation', () => {
+  const promptSpy = vi.spyOn(window, 'prompt');
+  const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+
+  beforeEach(() => {
+    reviewMutate.mockClear();
+    promptSpy.mockReset();
+    alertSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not submit when the decision prompt contains an invalid value', () => {
+    // First prompt = decision (typo). Notes are also supplied so that the old
+    // `decision as ...` cast path would have reached the mutation — the guard is
+    // what keeps it from being called.
+    promptSpy.mockReturnValueOnce('aprove').mockReturnValueOnce('some notes');
+    render(<AmlDashboardPage />);
+    clickReview();
+
+    expect(reviewMutate).not.toHaveBeenCalled();
+    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid decision'));
+  });
+
+  it('submits a valid decision (case/whitespace tolerant) as the typed union value', () => {
+    promptSpy
+      .mockReturnValueOnce('  Escalate ') // decision — normalised to 'escalate'
+      .mockReturnValueOnce('needs more docs'); // notes
+    render(<AmlDashboardPage />);
+    clickReview();
+
+    expect(reviewMutate).toHaveBeenCalledTimes(1);
+    const [payload] = reviewMutate.mock.calls[0];
+    expect(payload).toMatchObject({
+      assessmentId: 'assess-1',
+      request: { decision: 'escalate', notes: 'needs more docs' },
+    });
+  });
+});

--- a/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.tsx
@@ -32,6 +32,13 @@ interface CountryRiskDisplay {
   fatf_status?: string;
 }
 
+type AmlReviewDecision = 'approve' | 'reject' | 'escalate';
+
+const AML_REVIEW_DECISIONS: readonly AmlReviewDecision[] = ['approve', 'reject', 'escalate'];
+
+const isAmlReviewDecision = (value: string): value is AmlReviewDecision =>
+  (AML_REVIEW_DECISIONS as readonly string[]).includes(value);
+
 export const AmlDashboardPage: React.FC = () => {
   // Filters
   const [statusFilter, setStatusFilter] = useState<string>('');
@@ -133,8 +140,18 @@ export const AmlDashboardPage: React.FC = () => {
     (assessmentId: string) => {
       // TODO(Phase-2): Replace window.prompt with proper modal form with validation
       // Phase 1: Basic prompts for collecting decision and notes
-      const decision = window.prompt('Enter decision (approve, reject, escalate):', 'approve');
-      if (!decision) return;
+      const decisionInput = window.prompt('Enter decision (approve, reject, escalate):', 'approve');
+      if (!decisionInput) return;
+
+      // Validate the free-text prompt against the allowed decision union before
+      // submitting — a typo (e.g. "aprove") must not reach the API as a decision.
+      const decision = decisionInput.trim().toLowerCase();
+      if (!isAmlReviewDecision(decision)) {
+        alert(
+          `Invalid decision "${decisionInput}". Please enter one of: approve, reject, escalate.`
+        );
+        return;
+      }
 
       const notes = window.prompt('Enter review notes:');
       if (!notes) return;
@@ -143,7 +160,7 @@ export const AmlDashboardPage: React.FC = () => {
         {
           assessmentId,
           request: {
-            decision: decision as 'approve' | 'reject' | 'escalate',
+            decision,
             notes,
           },
         },


### PR DESCRIPTION
Auto-created by the research dispatcher (Phase 2 reconciliation): the implementer pushed commits to this branch but the run ended before opening the PR.

**Task:** `code-review-ppt-web-aml-review-decision-untrusted-cast` — `AmlDashboardPage` cast raw `window.prompt` text into the review-decision union, so a typo could submit an invalid AML decision.

Validates the decision against the allowed union before submit, plus a failing-first regression test.

---
_Generated by [Claude Code](https://claude.ai/code/session_014wJcBpLKGREe6G48jn5REf)_