### PR TITLE
gh-issue-2573: guard DELETE /documents/by-file-key against reaping a still-referenced object (Closes #2573)

### DIFF
--- a/backend/crates/db/src/repositories/document/documents.rs
+++ b/backend/crates/db/src/repositories/document/documents.rs
@@ -84,6 +84,41 @@ impl DocumentRepository {
         .await
     }
 
+    /// Check whether a live (non-deleted) document row references `file_key`
+    /// within the given org, with RLS context (#2573).
+    ///
+    /// Used by the direct-upload orphan-cleanup route to refuse deleting a
+    /// storage object whose bytes are still referenced by a registered
+    /// document. Soft-deleted rows (`deleted_at IS NOT NULL`) do not count as
+    /// live references.
+    pub async fn exists_by_file_key_rls<'e, E>(
+        &self,
+        executor: E,
+        org_id: Uuid,
+        file_key: &str,
+    ) -> Result<bool, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let row = sqlx::query(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM documents
+                WHERE organization_id = $1
+                  AND file_key = $2
+                  AND deleted_at IS NULL
+            ) AS "exists"
+            "#,
+        )
+        .bind(org_id)
+        .bind(file_key)
+        .fetch_one(executor)
+        .await?;
+
+        Ok(row.get("exists"))
+    }
+
     /// Find document by ID with RLS context.
     pub async fn find_by_id_rls<'e, E>(
         &self,

--- a/backend/servers/api-server/src/routes/documents/core.rs
+++ b/backend/servers/api-server/src/routes/documents/core.rs
@@ -1775,9 +1775,16 @@ async fn create_upload_url(
 /// this route cannot be used to delete another tenant's objects (the same guard
 /// `create_document` applies to a client-supplied key, #2320).
 ///
+/// The route reaps *orphaned* (never-registered) keys only. Before touching
+/// storage it asserts that no live `documents` row references the key within
+/// the caller's org and rejects with 409 `FILE_KEY_IN_USE` otherwise (#2573):
+/// without this guard any authenticated org member could pass another member's
+/// registered `file_key` (same `{org_id}/…` prefix) and delete the underlying
+/// object out from under a live document row, leaving a dangling reference.
+///
 /// Returns 204 No Content on success. S3 `DeleteObject` is idempotent, so
-/// deleting an already-absent key is a no-op that still returns 204. 503 if
-/// storage is not configured.
+/// deleting an already-absent key is a no-op that still returns 204. 409 if the
+/// key is still referenced by a live document. 503 if storage is not configured.
 #[utoipa::path(
     delete,
     path = "/api/v1/documents/by-file-key",
@@ -1787,6 +1794,7 @@ async fn create_upload_url(
         (status = 204, description = "Object deleted (or already absent)"),
         (status = 400, description = "Invalid file_key", body = ErrorResponse),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 409, description = "file_key still referenced by a document", body = ErrorResponse),
         (status = 503, description = "Storage unavailable", body = ErrorResponse),
     ),
     tag = "Documents"
@@ -1795,6 +1803,7 @@ async fn delete_by_file_key(
     State(state): State<AppState>,
     _auth: AuthUser,
     tenant: TenantExtractor,
+    mut rls: RlsConnection,
     Query(query): Query<DeleteByFileKeyQuery>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     let org_id = tenant.tenant_id;
@@ -1803,6 +1812,38 @@ async fn delete_by_file_key(
     // `{org_id}/` prefix. Rejects cross-org keys, message attachments, and `..`
     // traversal (400) — same guard create_document applies (#2320).
     validate_file_key_org_scope(&query.file_key, org_id)?;
+
+    // Referenced-object guard (#2573): this route reaps *orphaned* keys only.
+    // Refuse to delete an object whose bytes are still referenced by a live
+    // `documents` row — otherwise any authenticated org member could delete a
+    // registered document's underlying object and leave a dangling reference.
+    let in_use = state
+        .document_repo
+        .exists_by_file_key_rls(&mut **rls.conn(), org_id, &query.file_key)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                error = %e,
+                file_key = %query.file_key,
+                "Failed to check whether file_key is still referenced"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new(
+                    "INTERNAL_ERROR",
+                    "Unable to verify file_key state. Please try again later.",
+                )),
+            )
+        })?;
+    if in_use {
+        return Err((
+            StatusCode::CONFLICT,
+            Json(ErrorResponse::new(
+                "FILE_KEY_IN_USE",
+                "Refusing to delete a file_key still referenced by a document",
+            )),
+        ));
+    }
 
     let storage = state.storage_service.as_ref().ok_or_else(|| {
         tracing::error!("Storage service not configured — orphan cleanup unavailable");

--- a/backend/servers/api-server/tests/suites/documents_core_crud_tests.rs
+++ b/backend/servers/api-server/tests/suites/documents_core_crud_tests.rs
@@ -203,6 +203,121 @@ async fn delete_document_succeeds(pool: PgPool) {
 }
 
 // ---------------------------------------------------------------------------
+// documents/core.rs — DELETE /api/v1/documents/by-file-key (#2564, #2573)
+// ---------------------------------------------------------------------------
+
+/// Seed a document whose `file_key` lies inside the org namespace
+/// (`{org_id}/…`), so it satisfies `validate_file_key_org_scope`.
+async fn seed_document_with_file_key(
+    pool: &PgPool,
+    org_id: Uuid,
+    user_id: Uuid,
+    file_key: &str,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO documents \
+         (organization_id, title, category, file_key, file_name, mime_type, size_bytes, created_by) \
+         VALUES ($1, 'Registered Doc', 'other', $2, 'report.pdf', 'application/pdf', 1024, $3) \
+         RETURNING id",
+    )
+    .bind(org_id)
+    .bind(file_key)
+    .bind(user_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed document with file_key")
+}
+
+/// #2573 regression: the orphan-cleanup route must REFUSE to delete a
+/// `file_key` still referenced by a live `documents` row (409 FILE_KEY_IN_USE).
+/// Without the guard, any authenticated org member could delete a registered
+/// document's underlying object and leave a dangling reference.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_by_file_key_rejects_referenced_key(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "doc-reap-inuse").await;
+    let user_id = user_id_for(&pool, &user.email).await;
+
+    let file_key = format!("{org_id}/2026/07/registered_report.pdf");
+    let doc_id = seed_document_with_file_key(&pool, org_id, user_id, &file_key).await;
+
+    let resp = app
+        .execute(
+            app.session(token, org_id)
+                .delete(&format!(
+                    "/api/v1/documents/by-file-key?file_key={}",
+                    urlencoding::encode(&file_key)
+                ))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::CONFLICT,
+        "referenced file_key must not be reapable; body: {}",
+        resp.text()
+    );
+    assert!(
+        resp.text().contains("FILE_KEY_IN_USE"),
+        "body should carry FILE_KEY_IN_USE code: {}",
+        resp.text()
+    );
+
+    // The document row (and thus the storage reference) must survive.
+    let exists: bool = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM documents WHERE id = $1 AND deleted_at IS NULL)",
+    )
+    .bind(doc_id)
+    .fetch_one(&pool)
+    .await
+    .expect("check doc still present");
+    assert!(
+        exists,
+        "referenced document must remain intact after refused reap"
+    );
+}
+
+/// An unreferenced (orphan) org-scoped `file_key` passes the referenced-object
+/// guard and proceeds to the storage stage. The test `AppState` has no storage
+/// service configured, so it surfaces 503 there — the point is that it is NOT
+/// 409: the guard only blocks keys backed by a live document row.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn delete_by_file_key_allows_unreferenced_key(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "doc-reap-orphan").await;
+
+    // No documents row references this key — it is a genuine orphan.
+    let file_key = format!("{org_id}/2026/07/orphan_never_registered.pdf");
+
+    let resp = app
+        .execute(
+            app.session(token, org_id)
+                .delete(&format!(
+                    "/api/v1/documents/by-file-key?file_key={}",
+                    urlencoding::encode(&file_key)
+                ))
+                .build(),
+        )
+        .await;
+
+    assert_ne!(
+        resp.status,
+        StatusCode::CONFLICT,
+        "an unreferenced orphan key must NOT be blocked by the in-use guard; body: {}",
+        resp.text()
+    );
+    assert_eq!(
+        resp.status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "guard passed; storage is unconfigured in tests so the storage stage returns 503; body: {}",
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
 // documents/core.rs — PUT /api/v1/documents/{id}/access
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Task
Follow-up: DELETE /documents/by-file-key can delete a still-referenced object within the same org (PR #2571) (Closes #2573)

`delete_by_file_key` authorized purely on org scope (`validate_file_key_org_scope`) and then unconditionally called `storage.delete`, without checking whether the `file_key` is still referenced by a live `documents` row. Any authenticated org member could pass another member's *registered* `file_key` (same `{org_id}/…` prefix) and delete the underlying S3 object, leaving a dangling reference (intra-tenant data-integrity / minor-DoS gap). The route is meant to reap only *orphaned* (never-registered) keys.

## Change
- `backend/crates/db/src/repositories/document/documents.rs`: added `exists_by_file_key_rls(executor, org_id, file_key)` — an org-scoped, non-deleted-only `EXISTS` lookup on `documents`.
- `backend/servers/api-server/src/routes/documents/core.rs`: `delete_by_file_key` now takes an `RlsConnection` and, after the org-scope guard, rejects with **409 `FILE_KEY_IN_USE`** when a live `documents` row still references the key. Only genuinely unreferenced keys proceed to `storage.delete`. Added the 409 response to the OpenAPI annotation and doc comments.
- `backend/servers/api-server/tests/suites/documents_core_crud_tests.rs`: two integration tests —
  - `delete_by_file_key_rejects_referenced_key` (IG3 regression): a registered document's `file_key` returns 409 and the row survives.
  - `delete_by_file_key_allows_unreferenced_key`: an orphan key is NOT blocked by the guard (passes through to the storage stage).

## Owner
pm-tech-lead

## Scope drift
`scripts/scope-check.sh --owner pm-tech-lead` reports drift (exit 2): `pm-tech-lead` maps only to `docs/**`, `.research/**`, `_bmad-output/**` in `owner-areas.json`, but this is a backend security fix. All three changed files are within the `documents` domain the issue names (backend `documents/core.rs` + document repo + its test suite). No files outside the documents area were touched.

## Code-reuse review
`scripts/reuse-grep.sh --specialist rust-backend` — no warnings. The new `exists_by_file_key_rls` follows the existing `*_rls(executor, …)` repository pattern (mirrors `find_by_id_rls` / `list_rls`); no duplicated helper.

## Verification
```
VERIFY-PLAN base=a1ea2b6d6bdcd457fa54cdb6d579a4160afc16a7 files=3
```
`just verify` (`scripts/verify-impact.sh --base origin/dev`) was run against a local Postgres 16. Results:
- `cargo fmt --all -- --check` — **pass**
- `cargo clippy -p {accounting-core, accounting-server, admin-core, api-core, api-server, db, reality-server, tenant-ops} --all-targets -- -D warnings` — **all 8 pass** (includes the modified `api-server` handler + tests and the `db` repo method).
- `cargo test -p {accounting-core, accounting-server, admin-core, api-core}` — **pass**.
- `cargo test -p api-server` — 989 tests pass, **1 fails**: `airbnb_oauth_routes_tests::token_exchange_returns_503_when_not_configured` → **VERIFY FAIL**.

### The single failure is a pre-existing, unrelated test-isolation flake (not this change)
- The failing test lives in the **airbnb** OAuth suite; this PR only touches **documents** code. No code path connects them.
- Root cause: `tests/suites/airbnb_install_routes_tests.rs:81` does `std::env::set_var("AIRBNB_CLIENT_ID", …)` (process-global), and `AppState::new` reads `std::env::var("AIRBNB_CLIENT_ID")` (`src/state.rs:95`). When the aggregated `suite_1` binary runs both modules in parallel, the install test pollutes the env for `token_exchange_returns_503_when_not_configured`, which asserts the var is *unset* → it observes "configured" and doesn't return 503.
- **Proven pre-existing:** run in isolation from the compiled binary, the test passes:
  `suite_1 airbnb_oauth_routes_tests::token_exchange_returns_503_when_not_configured` → `test result: ok. 1 passed`.

### This change's own tests pass (direct run of the compiled `suite_3` binary against Postgres)
```
running 2 tests
test documents_core_crud_tests::delete_by_file_key_allows_unreferenced_key ... ok
test documents_core_crud_tests::delete_by_file_key_rejects_referenced_key ... ok
test result: ok. 2 passed; 0 failed; 279 filtered out
```

## CI parity (Band C — hot-path)
This is a data-integrity fix. CI runs `cargo test -p api-server` in a clean environment; the local flake above is environment/parallelism-specific to this sandbox. Left for the `backend.yml` job on this PR to confirm.

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- Fix uses the minimal "no referencing row" guard proposed in #2573 (409 `FILE_KEY_IN_USE`), not the presign-ledger alternative.
- Reviewer decision needed on: (a) the scope-drift tag (pm-tech-lead owner-area mapping vs. a backend fix), and (b) whether to also file/fix the pre-existing `airbnb_install`↔`airbnb_oauth` env-var pollution in `suite_1` (out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015oa3YXBELrYsZH4UoZeL2q

---
_Generated by [Claude Code](https://claude.ai/code/session_015oa3YXBELrYsZH4UoZeL2q)_