### PR TITLE
code-review-reality-web-inline-tenant-json-xss: escape inlined tenant-config JSON

### DIFF
--- a/frontend/apps/reality-web/src/app/[locale]/layout.tsx
+++ b/frontend/apps/reality-web/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from '@/lib/auth-context';
 import { ComparisonProvider } from '@/lib/comparison-context';
 import { FeatureFlags } from '@/lib/feature-flags';
 import { QueryProvider } from '@/lib/query-provider';
+import { serializeForScript } from '@/lib/serialize-script';
 import { brandingToStyleObject, getTenantConfig } from '@/lib/tenant-config';
 import { TenantProvider } from '@/providers/TenantProvider';
 import { CookieConsentBanner } from '../../components/CookieConsentBanner';
@@ -42,7 +43,11 @@ const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.rlt.sk').repl
 // the JSON.stringify out of the render path so we don't re-serialize on
 // every request. (Inline `<script>` injection means no React reconcile
 // either way, but this keeps the layout render hot path clean.)
-const ORGANIZATION_LD = JSON.stringify({
+// serializeForScript (not bare JSON.stringify) so `<`/`>`/`&`/U+2028/U+2029
+// are escaped before this lands inside <script>. Values here are static, but
+// routing every inline-script payload through the same hardened primitive
+// keeps the invariant local — no reviewer has to re-audit the data source.
+const ORGANIZATION_LD = serializeForScript({
   '@context': 'https://schema.org',
   '@type': 'Organization',
   name: 'Reality Portal',
@@ -168,7 +173,12 @@ export default async function LocaleLayout({ children, params }: Props) {
     tenant_id: tenantConfig.tenant_id,
     feature_flags: tenantConfig.feature_flags,
   };
-  const tenantBootstrap = JSON.stringify(tenantBootstrapObj);
+  // MUST be serializeForScript, not JSON.stringify: `tenant_id` and the
+  // feature-flag keys are per-request, host-derived values. A bare
+  // JSON.stringify would let a `</script>` (or U+2028/U+2029) inside any of
+  // them break out of the inline bootstrap <script> below — an HTML-injection
+  // window on every request. serializeForScript escapes those to `\uXXXX`.
+  const tenantBootstrap = serializeForScript(tenantBootstrapObj);
 
   return (
     <html

--- a/frontend/apps/reality-web/src/app/env.js/route.ts
+++ b/frontend/apps/reality-web/src/app/env.js/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { serializeForScript } from '@/lib/serialize-script';
 
 // Always dynamic — this route's whole purpose is to expose runtime env vars.
 export const dynamic = 'force-dynamic';
@@ -50,9 +51,11 @@ export function GET(req: NextRequest) {
     env.NEXT_PUBLIC_SITE_URL = inferred.siteUrl;
   }
 
-  // Escape '<' to prevent '</script>' injection in case a value is embedded
-  // inside another script context (defence-in-depth; content is env vars).
-  const safeJson = JSON.stringify(env).replace(/</g, '\\u003c');
+  // Escape '<'/'>'/'&'/U+2028/U+2029 so no value can break out of the script
+  // context (defence-in-depth; content is env vars). Shares the same hardened
+  // primitive as the layout tenant bootstrap — a bare `.replace(/</g, ...)`
+  // here previously missed the two Unicode line/paragraph separators.
+  const safeJson = serializeForScript(env);
 
   return new NextResponse(`window.__ENV__=${safeJson};`, {
     headers: {

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.test.tsx
@@ -134,6 +134,32 @@ describe('ListingDetailContent', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
+  it('escapes user-supplied jsonLd before inlining it into the <script> (XSS)', () => {
+    // jsonLd is derived from listing data an attacker can influence. A raw
+    // `</script>` (plus U+2028/U+2029) in any string must be escaped to its
+    // `\uXXXX` form so it cannot break out of the inline JSON-LD script.
+    // The separators are built from code points so this source stays ASCII.
+    const LS = String.fromCharCode(0x2028); // U+2028 LINE SEPARATOR
+    const PS = String.fromCharCode(0x2029); // U+2029 PARAGRAPH SEPARATOR
+    const jsonLd = {
+      '@type': 'Product',
+      name: '</script><script>alert(1)</script>',
+      sep: `${LS}${PS}`,
+    };
+    const { container } = render(<ListingDetailContent listing={validListing} jsonLd={jsonLd} />);
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script).not.toBeNull();
+    const html = script?.innerHTML ?? '';
+    // The break-out sequences must not appear raw...
+    expect(html).not.toContain('</script>');
+    expect(html).not.toContain(LS);
+    expect(html).not.toContain(PS);
+    // ...but the escaped forms must, and the JSON must still round-trip.
+    expect(html).toContain('\\u003c');
+    expect(html).toContain('\\u2028');
+    expect(JSON.parse(html)).toEqual(jsonLd);
+  });
+
   it('pushed preview layout overrides the layout prop', () => {
     // The prop has agent-contact visible; the pushed layout makes gallery a placeholder.
     // This proves previewLayout ?? layout prop is used for both mainLayout and sidebar.

--- a/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
+++ b/frontend/apps/reality-web/src/components/listings/ListingDetailContent.tsx
@@ -13,6 +13,7 @@ import { useEffect } from 'react';
 import { Footer, Header } from '@/components/ui';
 import type { ResolvedScreen } from '@/lib/layout';
 import { DEFAULT_LISTING_DETAIL_LAYOUT } from '@/lib/layout';
+import { serializeForScript } from '@/lib/serialize-script';
 import { ContactForm } from './ContactForm';
 import { LayoutSections, Placeholder } from './LayoutSections';
 import { trackListingViewed } from './listingAnalytics';
@@ -128,8 +129,12 @@ export function ListingDetailContent({ listing, jsonLd, layout }: ListingDetailC
       {jsonLd && (
         <script
           type="application/ld+json"
+          // serializeForScript (not bare JSON.stringify): jsonLd is built from
+          // user-supplied listing data, so `</script>`/U+2028/U+2029 in any
+          // string would break out of this inline script context (XSS). The
+          // helper escapes those to `\uXXXX` while keeping the JSON-LD valid.
           // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD for SEO requires dangerouslySetInnerHTML
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeForScript(jsonLd) }}
         />
       )}
       <Header />

--- a/frontend/apps/reality-web/src/lib/serialize-script.test.ts
+++ b/frontend/apps/reality-web/src/lib/serialize-script.test.ts
@@ -1,0 +1,53 @@
+/**
+ * XSS-hardening tests for serializeForScript.
+ *
+ * Pins the exact escapes that stop attacker-influenced data (per-request
+ * tenant config, /env.js runtime config) from breaking out of an inline
+ * <script> element. A regression here reopens an HTML-injection window,
+ * so these assertions are deliberately literal.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { serializeForScript } from './serialize-script';
+
+describe('serializeForScript', () => {
+  it('escapes a </script> breakout attempt so the tag cannot close early', () => {
+    const out = serializeForScript({ tenant_id: '</script><script>alert(1)</script>' });
+    // The raw closing tag must not survive anywhere in the output.
+    expect(out).not.toContain('</script>');
+    expect(out).not.toContain('<script>');
+    // '<' and '>' are escaped to their unicode forms.
+    expect(out).toContain('\\u003c');
+    expect(out).toContain('\\u003e');
+  });
+
+  it('escapes angle brackets and ampersand', () => {
+    const out = serializeForScript({ a: '<', b: '>', c: '&' });
+    expect(out).not.toMatch(/[<>&]/);
+    expect(out).toContain('\\u003c');
+    expect(out).toContain('\\u003e');
+    expect(out).toContain('\\u0026');
+  });
+
+  it('escapes U+2028 and U+2029 line/paragraph separators', () => {
+    const LS = String.fromCharCode(0x2028);
+    const PS = String.fromCharCode(0x2029);
+    const out = serializeForScript({ a: LS, b: PS });
+    // Raw separators would be a SyntaxError inside a pre-ES2019 JS string.
+    expect(out).not.toContain(LS);
+    expect(out).not.toContain(PS);
+    expect(out).toContain('\\u2028');
+    expect(out).toContain('\\u2029');
+  });
+
+  it('leaves safe payloads byte-for-byte equal to JSON.stringify', () => {
+    const value = { tenant_id: 'acme', feature_flags: { building_disabled: { enabled: false } } };
+    expect(serializeForScript(value)).toBe(JSON.stringify(value));
+  });
+
+  it('produces output that still parses back to the original value', () => {
+    const value = { tenant_id: '</script>', nested: ['<', '>', '&'] };
+    // The escapes are valid JSON escapes, so JSON.parse round-trips them.
+    expect(JSON.parse(serializeForScript(value))).toEqual(value);
+  });
+});

--- a/frontend/apps/reality-web/src/lib/serialize-script.ts
+++ b/frontend/apps/reality-web/src/lib/serialize-script.ts
@@ -1,0 +1,53 @@
+/**
+ * XSS-safe serialization of a value that is about to be inlined into an
+ * HTML `<script>` element (e.g. `window.__X__=<here>;`).
+ *
+ * `JSON.stringify` alone is NOT safe in this position: the JSON grammar
+ * happily emits the literal characters `<`, `>`, `&`, U+2028 and U+2029,
+ * every one of which is meaningful to the surrounding HTML/JS context:
+ *
+ *   - `</script>` inside any string value closes the script element early,
+ *     handing the rest of the payload to the HTML parser as markup -- a full
+ *     HTML-injection / XSS window whenever the serialized data contains a
+ *     single attacker-influenced string (per-request tenant config, env
+ *     vars, user content, ...).
+ *   - U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) are valid
+ *     inside a JSON string but were, until ES2019, illegal *unescaped* in a
+ *     JavaScript string literal -- an old engine throws a SyntaxError and
+ *     the whole bootstrap script fails to parse.
+ *
+ * Escaping these to their `\uXXXX` forms keeps the output valid JSON *and*
+ * valid JS while making it impossible to break out of the script context.
+ * The result is byte-for-byte equal to the input for the common case (no
+ * special chars), so there is no behavioural change for well-formed data.
+ *
+ * This is the single hardened primitive; callers that inline JSON into a
+ * `<script>` (layout tenant bootstrap, `/env.js` runtime config) MUST route
+ * through it rather than hand-rolling a partial `.replace(/</g, ...)`.
+ */
+
+// The five characters that must not appear raw inside an inline <script>,
+// mapped to their `\uXXXX` escapes. Keys for the two Unicode separators are
+// computed from code points so this source file never contains the invisible
+// U+2028 / U+2029 characters themselves.
+const SCRIPT_ESCAPES: Record<string, string> = {
+  '<': '\\u003c',
+  '>': '\\u003e',
+  '&': '\\u0026',
+  [String.fromCharCode(0x2028)]: '\\u2028',
+  [String.fromCharCode(0x2029)]: '\\u2029',
+};
+
+// Matches exactly the keys of SCRIPT_ESCAPES. The two Unicode separators are
+// written as `\u2028` / `\u2029` escape sequences (not raw characters), so
+// this regex literal -- and the whole source file -- stays pure ASCII.
+const SCRIPT_UNSAFE = /[<>&\u2028\u2029]/g;
+
+/**
+ * Serialize `value` to JSON safe for direct inlining inside `<script>`.
+ * Returns a string; throws the same errors as `JSON.stringify` for cyclic
+ * or otherwise non-serializable input.
+ */
+export function serializeForScript(value: unknown): string {
+  return JSON.stringify(value).replace(SCRIPT_UNSAFE, (ch) => SCRIPT_ESCAPES[ch] ?? ch);
+}


### PR DESCRIPTION
Auto: SECURITY: reality-web layout.tsx inlines tenant-config JSON into <script> without </script>/U+2028/U+2029 escaping — HTML injection window per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016RgmDvDpkpsDXChXAtf7HZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016RgmDvDpkpsDXChXAtf7HZ)_