### PR TITLE
gh-issue-2598: fix pre-existing frontend test failures blocking the verify gate (admin-web / reality-web)

### DIFF
--- a/frontend/apps/admin-web/src/pages/CapabilitiesAdminPage.test.tsx
+++ b/frontend/apps/admin-web/src/pages/CapabilitiesAdminPage.test.tsx
@@ -115,22 +115,39 @@ describe('CapabilitiesAdminPage', () => {
   });
 
   // ------------------------------------------------------------------
-  // 3. Registry view (default) → renders all 17 capability cards
+  // 3. Registry view (default) → renders a card for every capability
   // ------------------------------------------------------------------
 
-  it('renders all 17 capability cards in registry view', async () => {
-    renderPage({ initialEntries: ['/identity/capabilities'] });
+  it('renders a registry card for every capability', async () => {
+    // The registry mirrors the `admin_core::Capability` enum. Derive the
+    // expected cards from CAPABILITIES itself so the test can't drift when a
+    // capability is added on the backend (e.g. `oauth_client_write`).
+    expect(CAPABILITIES.length).toBeGreaterThan(0);
+    expect(new Set(CAPABILITIES).size).toBe(CAPABILITIES.length);
 
-    // The registry view renders CAPABILITIES.length cards
-    expect(CAPABILITIES.length).toBe(17);
+    // The registry view fetches GET /admin/capabilities/registry — return one
+    // entry per capability so the card grid renders.
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () =>
+        CAPABILITIES.map((capability) => ({
+          capability,
+          description: `desc for ${capability}`,
+          risk_level: 'low' as const,
+          holder_count: 0,
+        })),
+    } as Response);
+
+    renderPage({ initialEntries: ['/identity/capabilities'] });
 
     await waitFor(() => expect(screen.getByText('Capabilities registry')).toBeDefined());
 
-    // Check a sample of capability names
-    expect(screen.getByText('agencies_read')).toBeDefined();
-    expect(screen.getByText('tenant_purge')).toBeDefined();
-    expect(screen.getByText('audit_read')).toBeDefined();
-    expect(screen.getByText('principal_kind_escalate')).toBeDefined();
+    // Every capability in the registry enum must render a card.
+    await waitFor(() => expect(screen.getByText('agencies_read')).toBeDefined());
+    for (const capability of CAPABILITIES) {
+      expect(screen.getByText(capability)).toBeDefined();
+    }
   });
 
   // ------------------------------------------------------------------

--- a/frontend/apps/admin-web/vitest.config.ts
+++ b/frontend/apps/admin-web/vitest.config.ts
@@ -1,5 +1,5 @@
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
@@ -7,5 +7,11 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
+    // Only collect unit/component tests under src/. The Playwright e2e specs
+    // under e2e/ use `@playwright/test` (test.describe/registerNavigationSpecs)
+    // and must NOT be picked up by Vitest's default `**/*.spec.ts` glob —
+    // otherwise they fail collection and structurally red the verify gate.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 });

--- a/frontend/apps/reality-web/src/components/agency/RealtorManagement.test.tsx
+++ b/frontend/apps/reality-web/src/components/agency/RealtorManagement.test.tsx
@@ -39,14 +39,14 @@ describe('InviteRealtorModal — error handling', () => {
 
     render(<InviteRealtorModal agencyId={agencyId} onClose={onClose} />);
 
-    fireEvent.change(screen.getByLabelText(/email \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelEmail/i), {
       target: { value: 'test@example.com' },
     });
-    fireEvent.change(screen.getByLabelText(/full name \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelName/i), {
       target: { value: 'Jane Doe' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /buttonSendInvitation/i }));
 
     // Error alert should appear (mock useTranslations returns the key: "inviteError")
     await waitFor(() => {
@@ -63,14 +63,14 @@ describe('InviteRealtorModal — error handling', () => {
 
     render(<InviteRealtorModal agencyId={agencyId} onClose={onClose} />);
 
-    fireEvent.change(screen.getByLabelText(/email \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelEmail/i), {
       target: { value: 'test@example.com' },
     });
-    fireEvent.change(screen.getByLabelText(/full name \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelName/i), {
       target: { value: 'Jane Doe' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /buttonSendInvitation/i }));
 
     await waitFor(() => {
       expect(screen.getByRole('alert')).toBeInTheDocument();
@@ -88,14 +88,14 @@ describe('InviteRealtorModal — error handling', () => {
 
     render(<InviteRealtorModal agencyId={agencyId} onClose={onClose} />);
 
-    fireEvent.change(screen.getByLabelText(/email \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelEmail/i), {
       target: { value: 'test@example.com' },
     });
-    fireEvent.change(screen.getByLabelText(/full name \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelName/i), {
       target: { value: 'Jane Doe' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /buttonSendInvitation/i }));
 
     await waitFor(() => {
       expect(onClose).toHaveBeenCalledOnce();
@@ -116,21 +116,21 @@ describe('InviteRealtorModal — error handling', () => {
 
     render(<InviteRealtorModal agencyId={agencyId} onClose={onClose} />);
 
-    fireEvent.change(screen.getByLabelText(/email \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelEmail/i), {
       target: { value: 'test@example.com' },
     });
-    fireEvent.change(screen.getByLabelText(/full name \*/i), {
+    fireEvent.change(screen.getByLabelText(/formLabelName/i), {
       target: { value: 'Jane Doe' },
     });
 
     // First submit — should fail and show error
-    fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /buttonSendInvitation/i }));
     await waitFor(() => {
       expect(screen.getByRole('alert')).toBeInTheDocument();
     });
 
     // Second submit — succeeds, modal closes
-    fireEvent.click(screen.getByRole('button', { name: /send invitation/i }));
+    fireEvent.click(screen.getByRole('button', { name: /buttonSendInvitation/i }));
     await waitFor(() => {
       expect(onClose).toHaveBeenCalledOnce();
     });


### PR DESCRIPTION
## Task
Pre-existing frontend test failures on `dev` block the verify gate for admin-web / reality-web PRs (Closes #2598).

Investigated which admin-web / reality-web tests fail on a clean `origin/dev`, fixed them at the root, and proved the fix.

## Owner
pm-frontend

## Root causes fixed

1. **admin-web — Playwright e2e specs mis-collected by Vitest.** `apps/admin-web/vitest.config.ts` had no `include`/`exclude`, so Vitest's default `**/*.spec.ts` glob collected the 4 Playwright specs under `e2e/` (`flows`, `platform-health`, `login`, `smoke`), which use `@playwright/test`'s `test.describe` and fail collection under Vitest → **5 failed test files**. Fix: restrict collection to `src/**` and exclude `e2e/**` (mirrors the existing `reality-web` vitest config).

2. **admin-web — `CapabilitiesAdminPage.test.tsx` capability-count drift.** `expect(CAPABILITIES.length).toBe(17)` while `@ppt/admin-ui`'s `CAPABILITIES` now exports 18 (`oauth_client_write` was added). This hardcoded assertion also *masked* latent `getByText('agencies_read')` assertions that never ran (the registry view fetch was unmocked → error state, no cards). Fix (drift-proof): derive the expectation from `CAPABILITIES` itself — assert non-empty + no-dupes, mock `GET /admin/capabilities/registry` to return one entry per capability, and assert a rendered card for every capability. Can't drift again.

3. **reality-web — `RealtorManagement.test.tsx` stale label queries.** The `next-intl` test mock returns i18n keys verbatim, so the component renders `formLabelEmail` / `formLabelName` / `buttonSendInvitation`, but the test queried `/email \*/i`, `/full name \*/i`, `/send invitation/i` → 4 failures. Fix: query the i18n keys the mock returns (consistent with the test's existing `inviteError` alert assertion).

## Proof (before → after, clean worktree off `origin/dev`)
- **admin-web:** `5 failed | 27 passed (32 files)` → `28 passed (274 tests)`.
- **reality-web:** `RealtorManagement.test.tsx 4 failed` → `23 passed (220 tests)`.

## Verification
```
VERIFY-PLAN base=ef15adb0e9007c38ca69b2e7d3ddf82f7990ab75 files=3
  cd frontend && pnpm exec biome check apps/admin-web/src/pages/CapabilitiesAdminPage.test.tsx apps/admin-web/vitest.config.ts apps/reality-web/src/components/agency/RealtorManagement.test.tsx
  cd frontend && pnpm --filter "...[ef15adb0e9007c38ca69b2e7d3ddf82f7990ab75]" typecheck
  cd frontend && pnpm --filter "...[ef15adb0e9007c38ca69b2e7d3ddf82f7990ab75]" test
```
```
VERIFY OK d3e989806cae9c604da9e0dd9c91536971b6281d
```
biome clean, admin-web + reality-web typecheck Done, admin-web 274 passed + reality-web 220 passed.

## Scope drift
`scope-check.sh --owner pm-frontend` → exit 0 (`scope_drift=false`). All 3 files are frontend test/config.

## Code-reuse review
`reuse-grep.sh --specialist react-web` → empty (`code_reuse_warn=none`).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only fix, no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- IG goal-check (Step 3.5) reports IG1/IG2/IG3/IG4/IG5/IG6 as fails **by task shape**, not by defect: this is a GitHub-issue test-repair on the dispatcher-mandated `auto-impl/...` branch, not a `.research/plans/<slug>.md` plan-driven task with an `impl/<slug>` branch. IG3's "failing-on-main test" is inherently satisfied — the failing tests already live on `dev` (the entire premise of #2598) and this change turns them green; a separate `test:` commit would be redundant. The hard gate **IG7 (`just verify`) passed**.


---
_Generated by [Claude Code](https://claude.ai/code/session_016RgmDvDpkpsDXChXAtf7HZ)_