### PR TITLE
dx-stale-todo-security-comments-faults-critical-notifications: remove stale TODO(security) gate comments

### DIFF
--- a/backend/servers/api-server/src/routes/critical_notifications.rs
+++ b/backend/servers/api-server/src/routes/critical_notifications.rs
@@ -475,11 +475,10 @@ pub async fn get_stats(
 // deleted; every handler now goes through `RequestPrincipal` (verified
 // bearer JWT + host-resolved tenant).
 //
-// TODO(security): the `is_admin` branches below previously trusted the
-// client-supplied role and gated `create_notification` / `get_stats` on it.
-// They have been replaced with `false` (least privilege), which makes those
-// endpoints unreachable until a real role lookup is wired up (see
-// `routes/organizations.rs` for the canonical membership-role pattern).
+// The `is_admin` branches gating `create_notification` / `get_stats` now
+// perform a real admin role lookup — platform principals always pass, others
+// go through `MembershipRepository::is_manager_in_org` (P0-07); no
+// client-supplied role is trusted.
 
 /// Resolve the effective tenant id from a verified [`RequestPrincipal`].
 fn require_tenant_id(

--- a/backend/servers/api-server/src/routes/faults.rs
+++ b/backend/servers/api-server/src/routes/faults.rs
@@ -130,11 +130,9 @@ pub fn manager_recipients(
 // forge tenancy. That helper has been deleted; every handler now goes
 // through `RequestPrincipal` (verified bearer JWT + host-resolved tenant).
 //
-// TODO(security): the `is_manager` branches below previously trusted the
-// client-supplied role. They have been replaced with `false` (least
-// privilege) and need a real role lookup against the `memberships` table —
-// see `routes/organizations.rs` for the canonical pattern. Closing the
-// auth-bypass takes priority over reinstating the role distinction.
+// The `is_manager` branches below now perform a real role lookup against
+// `user_memberships` via `MembershipRepository::is_manager_in_org` (P0-07);
+// no client-supplied role is trusted.
 
 /// Resolve the effective tenant id from a verified [`RequestPrincipal`].
 fn require_tenant_id(


### PR DESCRIPTION
## Task
Stale TODO(security) headers in faults.rs / critical_notifications.rs describe a hardcoded-false gate that no longer exists. Locate the stale TODO(security) comment blocks in these files, verify against current code that the described hardcoded-false gate is gone, and remove/update the misleading comments to reflect reality. Comment/doc-only cleanup — do not change runtime behavior.

## Owner
pm-devops

## What changed
Comment-only. Two stale `TODO(security)` header blocks claimed the `is_manager` / `is_admin` role branches had been "replaced with `false` (least privilege)" and needed a real membership lookup wired up. That is no longer true — both files already perform real role lookups:

- `backend/servers/api-server/src/routes/faults.rs`: `is_manager` is resolved via `MembershipRepository::is_manager_in_org` in `require_manager` (L192-195), `get_fault` (L690-693), `list_comments` (L1419-1422) and `add_comment` (L1467-1470). The `get_fault` body even carries an inline `P0-07: real role lookup. Previously this was hardcoded false...` note.
- `backend/servers/api-server/src/routes/critical_notifications.rs`: `create_notification` (L59-63) and `get_stats` (L399-403) gate on `principal.is_platform() || MembershipRepository::is_manager_in_org(...)` (P0-07).

The stale `TODO(security)` paragraph in each header block is replaced with a short accurate note describing the current real-role-lookup behavior. The accurate `SECURITY:` paragraph above each (documenting the deleted `extract_tenant_context` helper) is preserved. No code, signatures, or control flow changed — `git diff` is 7 insertions / 10 deletions, all comment lines.

## Verification
```
VERIFY-PLAN base=1653d28392ac5fd09f79aea27c51f506988284ce files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` — **passed** (exit 0).
- `cargo clippy -p api-server` / `cargo test -p api-server` — **could not run in this sandbox**: `api-server` transitively builds `utoipa-swagger-ui`, whose build script downloads the Swagger UI archive from `github.com` / `codeload.github.com`, both of which are 403-denied by the sandbox egress policy (the "download" is a 378-byte JSON error page → `InvalidArchive("Could not find EOCD")`). This blocks ALL backend compilation in this environment and is unrelated to this comment-only diff. The authoritative clippy + test run happens in CI (`backend.yml`), which runs on a network-enabled runner. This PR is left as a draft until that CI is green.

This change is textually incapable of affecting compilation or test outcomes (comments only).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (comment/doc-only cleanup — no security/auth/billing/data-integrity behavior change)

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-devops` reports the two touched backend route files as outside pm-devops's owned areas (exit 2). This is expected: `owner_role=pm-devops` was a dispatcher hint for a stale-comment DX-cleanup task; the actual edit is a comment-only cleanup inside `backend/servers/api-server/src/routes/`. No runtime code touched. Reviewer to confirm the drift is acceptable for a doc-only change.
- `backend/servers/api-server/src/routes/faults.rs`
- `backend/servers/api-server/src/routes/critical_notifications.rs`

## Code-reuse review
`reuse-grep.sh` clean (no added helpers).

## Notes
Comment/doc-only. Kept the still-accurate `SECURITY:` paragraph documenting the removed `extract_tenant_context` header-trust vuln; only the obsolete `TODO(security)` "replaced with false / needs a real lookup" paragraphs were rewritten to reflect the shipped P0-07 real-role-lookup behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LQ8X9bVCnPtW6VQPTHWns3)_