### PR TITLE
code-review-api-core-admin-rs-swallowed-serialize: return 500 on failed layout serialize instead of null body

### DIFF
--- a/backend/servers/api-server/src/routes/layout/admin.rs
+++ b/backend/servers/api-server/src/routes/layout/admin.rs
@@ -91,7 +91,7 @@ pub async fn list_screens(
         .list_configs(&mut **conn)
         .await
         .map_err(internal_error)?;
-    Ok(Json(serde_json::to_value(rows).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(rows).map_err(internal_error)?))
 }
 
 #[utoipa::path(get, path = "/api/v1/platform-admin/layout/config", tag = "Layout Admin",
@@ -168,7 +168,7 @@ pub async fn put_draft(
         .upsert_draft(&mut **conn, &req.screen, &req.config, Some(admin_id))
         .await
         .map_err(internal_error)?;
-    Ok(Json(serde_json::to_value(row).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(row).map_err(internal_error)?))
 }
 
 #[utoipa::path(put, path = "/api/v1/platform-admin/layout/rails", tag = "Layout Admin",
@@ -199,7 +199,7 @@ pub async fn put_rails(
         .set_rails(&mut **conn, &req.screen, &req.rails, Some(admin_id))
         .await
         .map_err(internal_error)?;
-    Ok(Json(serde_json::to_value(row).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(row).map_err(internal_error)?))
 }
 
 #[utoipa::path(get, path = "/api/v1/platform-admin/layout/manifests", tag = "Layout Admin",
@@ -226,7 +226,7 @@ pub async fn list_manifests(
         .list_manifests(&mut **conn)
         .await
         .map_err(internal_error)?;
-    Ok(Json(serde_json::to_value(rows).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(rows).map_err(internal_error)?))
 }
 
 #[utoipa::path(put, path = "/api/v1/platform-admin/layout/manifests", tag = "Layout Admin",
@@ -266,7 +266,7 @@ pub async fn put_manifest(
         .upsert_manifest(&mut **conn, &req.platform, &req.manifest, Some(admin_id))
         .await
         .map_err(internal_error)?;
-    Ok(Json(serde_json::to_value(row).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(row).map_err(internal_error)?))
 }
 
 #[utoipa::path(post, path = "/api/v1/platform-admin/layout/publish", tag = "Layout Admin",
@@ -386,7 +386,7 @@ pub async fn publish(
         Some(row.published_version),
         delivery_id,
     );
-    Ok(Json(serde_json::to_value(row).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(row).map_err(internal_error)?))
 }
 
 #[utoipa::path(post, path = "/api/v1/platform-admin/layout/rollback", tag = "Layout Admin",
@@ -450,7 +450,7 @@ pub async fn rollback(
         Some(row.published_version),
         delivery_id,
     );
-    Ok(Json(serde_json::to_value(row).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(row).map_err(internal_error)?))
 }
 
 #[utoipa::path(post, path = "/api/v1/platform-admin/layout/kill", tag = "Layout Admin",

--- a/backend/servers/api-server/src/routes/layout/tenant.rs
+++ b/backend/servers/api-server/src/routes/layout/tenant.rs
@@ -199,5 +199,5 @@ pub async fn put_tenant_override(
         .await;
     guard.release().await;
     let saved = saved.map_err(internal_error)?;
-    Ok(Json(serde_json::to_value(saved).unwrap_or_default()))
+    Ok(Json(serde_json::to_value(saved).map_err(internal_error)?))
 }


### PR DESCRIPTION
## Task
layout/admin.rs (+ tenant.rs) mutation handlers end with `unwrap_or_default()` serialize — a failed serialize returns 200 OK / body null instead of 500. Make failed serialization return a proper 500 error (with server-side log) rather than swallowing it into a 200/null body.

## Owner
pm-backend

## Change
Replaced the 8 `serde_json::to_value(row).unwrap_or_default()` success-path tails (7 in `admin.rs`, 1 in `tenant.rs`) with `serde_json::to_value(row).map_err(internal_error)?`. `internal_error` is the pre-existing helper in each file that logs the real error via `tracing::error!` and returns a generic `500 INTERNAL_SERVER_ERROR` (no raw serde text leaked). This is the same pattern already used elsewhere in both files (e.g. `tenant.rs` line 143). Previously a serialization failure was coerced to `Value::Null`, so the client got `200 OK` with a `null` body.

## Verification
```
VERIFY-PLAN base=639bce69edd38b7e5e787d697b339fb5c36b2552 files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```
- `cargo fmt --all -- --check` — exit 0 (clean).
- `cargo clippy -p api-server` / `cargo test -p api-server` — could NOT run in this sandbox: `api-server` transitively builds `utoipa-swagger-ui`, whose build script downloads `swagger-ui` from github.com and is 403-blocked here (fails with `InvalidArchive("Could not find EOCD")`). CI `backend.yml` is authoritative for clippy+test. The change is a mechanical, type-safe `Result::map_err(...)?` substitution using an existing helper with a matching error type (`serde_json::Error: Display`), and the identical pattern already compiles in these files.

No `VERIFY OK` line — the gate could not complete locally due to the sandbox network block noted above.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change) — this is defensive error-handling hardening on the platform-admin layout endpoints.

## Remote-tested
skipped

## Notes
- No regression test added (IG3): the affected concrete types (`LayoutRepository` rows, `TenantOverride` canonical value) always serialize successfully via `serde_json::to_value`, so there is no in-process way to force `to_value` to fail for a meaningful failing-on-`dev` test. The fix is a defensive/refactor vector — behavior only diverges on a hypothetical `Serialize` failure. The correctness is carried by the type system + existing identical pattern.
- Scope: backend-only (`backend/servers/api-server/src/routes/layout/`), matches `pm-backend`. No drift. No new helpers added (reused `internal_error`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJdCmzP3VBt6Rt7ykwDMvC)_