### PR TITLE
code-review-api-core-scheduler-rs-silent-target-err: surface DB errors on scheduler notification-target lookups

### DIFF
--- a/backend/servers/api-server/src/services/scheduler.rs
+++ b/backend/servers/api-server/src/services/scheduler.rs
@@ -378,11 +378,24 @@ impl Scheduler {
 
             // Send notifications for each published announcement
             for announcement in &published {
-                // Get target users based on target_type and target_ids
-                let target_user_ids = self
-                    .get_announcement_target_users(announcement)
-                    .await
-                    .unwrap_or_default();
+                // Get target users based on target_type and target_ids.
+                // A DB error here must be surfaced (not coerced into an empty
+                // target set) so a failed dispatch is observable instead of
+                // silently sending zero notifications — mirrors the
+                // log-and-fall-back treatment in `send_vote_reminders`.
+                let target_user_ids = match self.get_announcement_target_users(announcement).await {
+                    Ok(ids) => ids,
+                    Err(e) => {
+                        tracing::error!(
+                            announcement_id = %announcement.id,
+                            target_type = %announcement.target_type,
+                            error = %e,
+                            "Failed to resolve announcement notification targets; \
+                             skipping dispatch for this announcement"
+                        );
+                        Vec::new()
+                    }
+                };
 
                 if !target_user_ids.is_empty() {
                     match self
@@ -594,10 +607,22 @@ impl Scheduler {
 
             // Send notifications for each activated vote
             for vote in &activated {
-                let eligible_user_ids = self
-                    .get_vote_eligible_users(vote.building_id)
-                    .await
-                    .unwrap_or_default();
+                // A DB error resolving the eligible voters must be surfaced
+                // (not coerced into an empty target set) so a failed dispatch
+                // is observable — mirrors `send_vote_reminders`.
+                let eligible_user_ids = match self.get_vote_eligible_users(vote.building_id).await {
+                    Ok(ids) => ids,
+                    Err(e) => {
+                        tracing::error!(
+                            vote_id = %vote.id,
+                            building_id = %vote.building_id,
+                            error = %e,
+                            "Failed to resolve vote-started notification targets; \
+                             skipping dispatch for this vote"
+                        );
+                        Vec::new()
+                    }
+                };
 
                 if !eligible_user_ids.is_empty() {
                     match self
@@ -667,6 +692,26 @@ impl Scheduler {
                 let vote_result = self.vote_repo.find_by_id(*vote_id).await;
                 #[allow(deprecated)]
                 let results_result = self.vote_repo.get_results(*vote_id).await;
+                // Surface DB errors on the vote/result lookups instead of
+                // letting `if let Ok(Some(..))` silently drop the `Err` arm —
+                // otherwise a failed closed-vote dispatch is invisible.
+                // `Ok(None)` (vote genuinely gone) stays a silent skip.
+                if let Err(e) = &vote_result {
+                    tracing::error!(
+                        vote_id = %vote_id,
+                        error = %e,
+                        "Failed to load closed vote for result notification; \
+                         skipping dispatch for this vote"
+                    );
+                }
+                if let Err(e) = &results_result {
+                    tracing::error!(
+                        vote_id = %vote_id,
+                        error = %e,
+                        "Failed to load vote results for result notification; \
+                         skipping dispatch for this vote"
+                    );
+                }
                 if let Ok(Some(vote)) = vote_result {
                     if let Ok(Some(results)) = results_result {
                         // Participants pre-fetched by batch query above.


### PR DESCRIPTION
## Task
scheduler.rs silently swallows DB errors on notification target lookups at 3 sites — failed dispatches show as empty target sets, no log/metric. Make each of the 3 target-lookup sites surface the DB error: log it (tracing::error!/warn! with context) instead of coercing a query error into an empty target set, so failed dispatches are observable rather than silently dropped. Do NOT change the happy-path behavior.

## Owner
pm-backend

## Sites fixed (from the code-review finding)
`backend/servers/api-server/src/services/scheduler.rs`

1. **`publish_scheduled_announcements`** (was line 385) — `get_announcement_target_users(...).await.unwrap_or_default()` silently produced an empty target set on a DB error. Now `match`ed: `Err` logs `tracing::error!` with `announcement_id` + `target_type` + `error`, then falls back to empty.
2. **`activate_scheduled_votes`** (was line 600) — `get_vote_eligible_users(...).await.unwrap_or_default()` same pattern. Now logs with `vote_id` + `building_id` + `error` before falling back.
3. **`close_expired_votes`** (was lines 667–671) — `if let Ok(Some(vote)) = vote_result { if let Ok(Some(results)) = results_result {` dropped the `Err` arm of both `find_by_id` / `get_results`. Added explicit `if let Err(e) = &vote_result` / `&results_result` logging before the existing `if let Ok(Some(..))`, so a failed closed-vote dispatch is visible. `Ok(None)` (vote genuinely gone) stays a silent skip.

All three mirror the pre-existing log-and-fall-back treatment in `send_vote_reminders` (lines 885–894) referenced by the finding. Happy-path values and control flow are unchanged — only the previously-silent error arms now emit a log.

## Verification
`just verify` / full `cargo clippy -p api-server` could not complete locally: `api-server` transitively builds `utoipa-swagger-ui`, whose Swagger-UI zip download is 403-blocked in this sandbox (`InvalidArchive("Could not find EOCD")` from its build.rs). This is the established limitation on this repo.

Static verification performed:
- `cd backend && cargo fmt --all -- --check` → exit 0 (clean).
- Scope-drift check (`scope-check.sh --owner pm-backend`) → exit 0, `scope_drift=false`.
- Change is a pure logging addition using tracing field idioms already present in the file (`%announcement.id`, `%vote.id`, `%vote_id`, `error = %e`); no new symbols/helpers introduced.

CI `backend.yml` (`cargo fmt`, `clippy`, `cargo test`) is authoritative for the full compile/clippy/test gate.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (observability-only logging change; no security/auth/billing/data-integrity behavior change).

## Remote-tested
skipped.

## Notes
Single-file diff (`services/scheduler.rs`). No behavior change on success; the fallback-to-empty-set behavior is retained so the scheduler loop never panics — the only difference is that a DB error is now logged with context instead of being swallowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJdCmzP3VBt6Rt7ykwDMvC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJdCmzP3VBt6Rt7ykwDMvC)_