### PR TITLE
code-review-api-core-resolved-rs-leaks-db-error: stop leaking raw sqlx/serde error text on public GET /layout/resolved

### DIFF
--- a/backend/servers/api-server/src/routes/layout/resolved.rs
+++ b/backend/servers/api-server/src/routes/layout/resolved.rs
@@ -18,6 +18,19 @@ pub fn parse_platform(s: Option<&str>) -> Result<layout_core::Platform, String> 
     }
 }
 
+/// 500 — infra failures (pool acquire, query errors, corrupt stored data).
+/// Logs the real error server-side; the public client gets a generic message so
+/// raw sqlx/serde error text never leaks. Mirrors `admin.rs::internal_error`.
+fn internal_error(err: impl std::fmt::Display) -> (StatusCode, Json<ValidationErrorsResponse>) {
+    tracing::error!(error = %err, "layout resolved: internal error");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ValidationErrorsResponse {
+            errors: vec!["internal server error".into()],
+        }),
+    )
+}
+
 #[utoipa::path(get, path = "/api/v1/layout/resolved/{screen}", tag = "Layout",
     security(("bearer_auth" = [])),
     params(("screen" = String, Path, description = "Screen id, e.g. ppt/dashboard"),
@@ -33,12 +46,6 @@ pub async fn get_resolved(
     Path(screen): Path<String>,
     Query(q): Query<ResolvedQuery>,
 ) -> Result<Json<layout_core::ResolvedScreen>, (StatusCode, Json<ValidationErrorsResponse>)> {
-    let err500 = |msg: String| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ValidationErrorsResponse { errors: vec![msg] }),
-        )
-    };
     let err404 = |msg: &str| {
         (
             StatusCode::NOT_FOUND,
@@ -79,23 +86,23 @@ pub async fn get_resolved(
         .get_tenant_override(&mut **rls.conn(), org_id, &screen)
         .await;
     rls.release().await;
-    let tenant_ov_row = tenant_ov_row.map_err(|e| err500(format!("db error: {e}")))?;
+    let tenant_ov_row = tenant_ov_row.map_err(|e| internal_error(format!("db error: {e}")))?;
 
     // Global no-RLS layout tables — sanctioned public connection (clears stale context).
     let mut pub_conn = RlsPool::new(state.db.clone())
         .acquire_public()
         .await
-        .map_err(|e| err500(format!("db error: {e}")))?;
+        .map_err(|e| internal_error(format!("db error: {e}")))?;
     let cfg = repo
         .get_config(&mut **pub_conn, &screen)
         .await
-        .map_err(|e| err500(format!("db error: {e}")))?
+        .map_err(|e| internal_error(format!("db error: {e}")))?
         .ok_or_else(|| err404("unknown screen"))?;
     let Some(published) = cfg.published else {
         return Err(err404("screen has no published config"));
     };
     let base: layout_core::ScreenConfig = serde_json::from_value(published)
-        .map_err(|e| err500(format!("stored published config invalid: {e}")))?;
+        .map_err(|e| internal_error(format!("stored published config invalid: {e}")))?;
 
     let platform_key = match platform {
         layout_core::Platform::Web => "web",
@@ -104,15 +111,15 @@ pub async fn get_resolved(
     let manifest_row = repo
         .get_manifest(&mut **pub_conn, platform_key)
         .await
-        .map_err(|e| err500(format!("db error: {e}")))?
+        .map_err(|e| internal_error(format!("db error: {e}")))?
         .ok_or_else(|| err404("no registry manifest for platform"))?;
     let manifest: layout_core::RegistryManifest = serde_json::from_value(manifest_row.manifest)
-        .map_err(|e| err500(format!("stored manifest invalid: {e}")))?;
+        .map_err(|e| internal_error(format!("stored manifest invalid: {e}")))?;
 
     let kills: BTreeSet<layout_core::SectionType> = repo
         .list_kills(&mut **pub_conn, &screen)
         .await
-        .map_err(|e| err500(format!("db error: {e}")))?
+        .map_err(|e| internal_error(format!("db error: {e}")))?
         .into_iter()
         .map(|k| layout_core::SectionType(k.section_type))
         .collect();
@@ -120,11 +127,35 @@ pub async fn get_resolved(
     let tenant_ov: Option<layout_core::TenantOverride> = match tenant_ov_row {
         Some(row) => Some(
             serde_json::from_value(row.override_config)
-                .map_err(|e| err500(format!("stored tenant override invalid: {e}")))?,
+                .map_err(|e| internal_error(format!("stored tenant override invalid: {e}")))?,
         ),
         None => None,
     };
 
     let resolved = layout_core::resolve(&base, platform, tenant_ov.as_ref(), &kills, &manifest);
     Ok(Json(resolved))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression: the public GET /layout/resolved/{screen} 500 path must map raw
+    // sqlx/serde error text to a generic message. Before this fix `err500` echoed
+    // the raw tail (e.g. "db error: relation ... does not exist") to the client.
+    #[test]
+    fn internal_error_hides_raw_detail_from_client() {
+        let raw = "db error: relation \"layout_config\" does not exist; \
+                   connection to 10.0.0.5:5432 refused";
+        let (status, Json(body)) = internal_error(raw);
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body.errors, vec!["internal server error".to_string()]);
+        // No fragment of the raw sqlx/serde detail may reach the client body.
+        for e in &body.errors {
+            assert!(!e.contains("db error"), "leaked raw prefix: {e}");
+            assert!(!e.contains("does not exist"), "leaked sqlx detail: {e}");
+            assert!(!e.contains("10.0.0.5"), "leaked host detail: {e}");
+        }
+    }
 }


### PR DESCRIPTION
## Task
SECURITY-LITE: layout/resolved.rs err500 handler leaks raw sqlx/serde error text on public GET /layout/resolved/{screen} — 8 sites, no server-side log. Map the error tails to an internal_error / 500 without echoing raw sqlx/serde text to the client, and add a server-side log line at each site. Mirror the pattern already merged for admin.rs (PR #2606).

## Owner
pm-backend

## What changed
`backend/servers/api-server/src/routes/layout/resolved.rs`:
- Replaced the per-handler `err500` closure — which put the raw error tail (`format!("db error: {e}")`, `format!("stored manifest invalid: {e}")`, etc.) straight into the client-facing 500 body — with a module-level `internal_error(err: impl std::fmt::Display)` helper.
- `internal_error` logs the real error server-side via `tracing::error!(error = %err, "layout resolved: internal error")` and returns a generic `"internal server error"` 500 body. The raw sqlx/serde detail is preserved in the log (each of the 8 sites still passes its context string, so the log keeps `db error: …` / `stored manifest invalid: …`) but never reaches the public client.
- All 8 leak sites now route through `internal_error`. The `err404` closure (404, no leak) is unchanged.
- This mirrors the `internal_error` helper merged for `admin.rs` in PR #2606.
- Added a DB-free regression test (`internal_error_hides_raw_detail_from_client`) asserting the client body is exactly `["internal server error"]` and contains no fragment of the raw sqlx/serde/host detail.

## Verification
```
VERIFY-PLAN base=3020d4e21c1b0b15052f9c9055cc1c45cfdfcc60 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```
- `cargo fmt --all -- --check` — exit 0 (clean).
- `cargo clippy -p api-server` / `cargo test -p api-server` — **blocked by a known env limitation**: the `utoipa-swagger-ui v9.0.2` build script downloads swagger-ui from GitHub, which the sandbox proxy blocks (`InvalidArchive("Could not find EOCD")`). This failure is in a build dependency and occurs *before* any of api-server's own code compiles — it is independent of this change. Per the task's guidance (and as PR #2606 did under the same limitation), CI is authoritative for clippy + test.

## CI parity (Band C — hot-path only)
skipped: not replicated locally (env blocks the api-server build dep). CI `backend.yml` will run fmt + clippy + test on a runner with network access.

## Remote-tested
skipped

## Notes
- Scope: only `resolved.rs`. `tenant.rs` has the same leaky pattern but is out of scope for this task and left untouched (a separate follow-up).
- No SQL changed → no sqlx offline regeneration needed.
- scope_drift=false, code_reuse_warn=none (pre-flight checks clean).


---
_Generated by [Claude Code](https://claude.ai/code/session_01C5buvRevp3RFr39ce32LqM)_