### PR TITLE
pm-backend-scheduler-rs-refactor-extract-jobs: extract scheduler retention/prune jobs to a dedicated module

### DIFF
--- a/backend/servers/api-server/src/services/scheduler/mod.rs
+++ b/backend/servers/api-server/src/services/scheduler/mod.rs
@@ -18,23 +18,17 @@ use tracing::Instrument;
 use super::notification::{NotificationService, NotificationServiceConfig};
 use super::EmailService;
 
+/// Retention/prune scheduled jobs (`support_tooling_events`,
+/// `layout_change_events`) extracted into their own module to keep this file
+/// focused on the core tick loop. The submodule attaches its jobs to
+/// `Scheduler` via a dedicated `impl Scheduler` block; behaviour is identical
+/// to the previous inline implementation.
+mod retention;
+
 /// Per-signer minimum interval between reminder emails sent by the
 /// background scheduler. Prevents the every-60s scheduler tick from
 /// spamming the same signer for the entire reminder window.
 const SIGNATURE_REMINDER_MIN_INTERVAL_HOURS: i64 = 12;
-
-/// Minimum interval between successive `support_tooling_events` retention
-/// prunes (issue #2531). The scheduler ticks every ~60s, but the append-only
-/// admin-audit prune only needs a daily cadence — this gate skips the prune
-/// until 24h have elapsed since the last successful run.
-const SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS: i64 = 24;
-
-/// Minimum interval between successive `layout_change_events` retention prunes
-/// (issue #2563). Mirrors the `support_tooling_events` cadence: the scheduler
-/// ticks every ~60s, but the append-only layout-publish trail only needs a
-/// daily prune — this gate skips the prune until 24h have elapsed since the
-/// last successful run.
-const LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS: i64 = 24;
 
 /// Scheduler service configuration.
 #[derive(Clone)]
@@ -1003,137 +997,6 @@ impl Scheduler {
     }
 
     // ========================================================================
-    // Issue #2531: support_tooling_events retention prune (daily cadence)
-    // ========================================================================
-
-    /// Prune aged rows from the append-only `support_tooling_events` admin-audit
-    /// trail past the configured retention window (issue #2531).
-    ///
-    /// The prune calls `PlatformAdminRepository::cleanup_old_support_tooling_events`,
-    /// which routes through the sanctioned `app.retention_prune` GUC path so the
-    /// table's immutability trigger permits these — and only these — deletes
-    /// (migration `00222_support_tooling_events_retention.sql`). The repository
-    /// method existed but nothing invoked it, so the audit trail grew without
-    /// bound; this tick wires it into the scheduler, mirroring `cleanup_sessions`.
-    ///
-    /// Cadence: the scheduler ticks every ~60s, but retention only needs to run
-    /// once per day. A stored last-run timestamp gates the prune to at most one
-    /// run per [`SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS`] window. The stamp is
-    /// written only after a successful prune, so a failed run retries next tick.
-    async fn prune_support_tooling_events(&self) -> Result<(), sqlx::Error> {
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
-
-        // Daily gate — skip until 24h have elapsed since the last prune.
-        {
-            let last = self
-                .last_support_tooling_prune_at
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            if !support_tooling_prune_due(*last, now, min_interval) {
-                return Ok(());
-            }
-        }
-
-        // Note: Scheduler runs in background without user context. This prune is
-        // a privileged/admin-level retention job and does not need RLS context.
-        let deleted = self
-            .platform_admin_repo
-            .cleanup_old_support_tooling_events(self.config.support_tooling_retention_days as i32)
-            .await?;
-
-        // Stamp only after a successful prune so a transient DB error retries on
-        // the next tick instead of being suppressed for a full day.
-        {
-            let mut last = self
-                .last_support_tooling_prune_at
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            *last = Some(now);
-        }
-
-        if deleted > 0 {
-            tracing::info!(
-                deleted = deleted,
-                retention_days = self.config.support_tooling_retention_days,
-                "Pruned aged support_tooling_events"
-            );
-            let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
-            metrics.support_tooling_events_pruned += deleted as u64;
-        }
-
-        Ok(())
-    }
-
-    // ========================================================================
-    // Issue #2563: layout_change_events retention prune (daily cadence)
-    // ========================================================================
-
-    /// Prune aged rows from the append-only `layout_change_events` layout-publish
-    /// trail past the configured retention window (issue #2563).
-    ///
-    /// The prune calls `LayoutRepository::cleanup_old_layout_change_events`,
-    /// which routes through the sanctioned SQL `cleanup_old_layout_change_events`
-    /// function so the table's immutability trigger permits these — and only
-    /// these — deletes (migration `00225_create_layout_change_events.sql`). The
-    /// repository method existed but nothing invoked it, so the audit trail grew
-    /// without bound; this tick wires it into the scheduler, mirroring
-    /// [`Scheduler::prune_support_tooling_events`] (issue #2531).
-    ///
-    /// Cadence: the scheduler ticks every ~60s, but retention only needs to run
-    /// once per day. A stored last-run timestamp gates the prune to at most one
-    /// run per [`LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS`] window. The
-    /// stamp is written only after a successful prune, so a failed run retries
-    /// next tick.
-    async fn prune_layout_change_events(&self) -> Result<(), sqlx::Error> {
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
-
-        // Daily gate — skip until 24h have elapsed since the last prune.
-        {
-            let last = self
-                .last_layout_change_events_prune_at
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            if !layout_change_events_prune_due(*last, now, min_interval) {
-                return Ok(());
-            }
-        }
-
-        // Note: Scheduler runs in background without user context. This prune is
-        // a privileged retention job and does not need RLS context.
-        let deleted = self
-            .layout_repo
-            .cleanup_old_layout_change_events(
-                &self.pool,
-                self.config.layout_change_events_retention_days as i32,
-            )
-            .await?;
-
-        // Stamp only after a successful prune so a transient DB error retries on
-        // the next tick instead of being suppressed for a full day.
-        {
-            let mut last = self
-                .last_layout_change_events_prune_at
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            *last = Some(now);
-        }
-
-        if deleted > 0 {
-            tracing::info!(
-                deleted = deleted,
-                retention_days = self.config.layout_change_events_retention_days,
-                "Pruned aged layout_change_events"
-            );
-            let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
-            metrics.layout_change_events_pruned += deleted as u64;
-        }
-
-        Ok(())
-    }
-
-    // ========================================================================
     // Story 84.2: E-Signature Reminder & Expiry Tasks
     // ========================================================================
 
@@ -1854,38 +1717,6 @@ fn parse_announcement_target_ids(
     }
 }
 
-/// Decide whether the daily `support_tooling_events` retention prune is due
-/// (issue #2531). Returns `true` on the first run (`last` is `None`) or once at
-/// least `min_interval` has elapsed since the last successful prune. Extracted
-/// as a pure function so the daily-cadence gate is testable without a DB or a
-/// live clock.
-fn support_tooling_prune_due(
-    last: Option<chrono::DateTime<chrono::Utc>>,
-    now: chrono::DateTime<chrono::Utc>,
-    min_interval: chrono::Duration,
-) -> bool {
-    match last {
-        None => true,
-        Some(t) => now.signed_duration_since(t) >= min_interval,
-    }
-}
-
-/// Decide whether the daily `layout_change_events` retention prune is due
-/// (issue #2563). Returns `true` on the first run (`last` is `None`) or once at
-/// least `min_interval` has elapsed since the last successful prune. Extracted
-/// as a pure function so the daily-cadence gate is testable without a DB or a
-/// live clock.
-fn layout_change_events_prune_due(
-    last: Option<chrono::DateTime<chrono::Utc>>,
-    now: chrono::DateTime<chrono::Utc>,
-    min_interval: chrono::Duration,
-) -> bool {
-    match last {
-        None => true,
-        Some(t) => now.signed_duration_since(t) >= min_interval,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2363,7 +2194,8 @@ mod tests {
     // advance its metric, and honour the daily-cadence gate — against a real
     // database.
     //
-    // The pure-function tests above (`support_tooling_prune_due`) only pin the
+    // The pure-function tests in the `retention` submodule
+    // (`support_tooling_prune_due`) only pin the
     // in-Rust daily-gate arithmetic; like `org_scoped_target_users` they are a
     // re-model, so they still pass if the prune is un-wired from the tick loop,
     // the sanctioned `app.retention_prune` GUC path breaks, or the metric never
@@ -2554,51 +2386,6 @@ mod tests {
         assert_eq!(config.support_tooling_retention_days, 730);
     }
 
-    // ------------------------------------------------------------------
-    // Issue #2531: daily-cadence gate for the support_tooling_events prune.
-    //
-    // The scheduler ticks every ~60s but the retention prune must run at
-    // most once per day. These pin the gate that stops the ~60s tick loop
-    // from re-pruning on every tick — the behaviour that distinguishes the
-    // fix (bounded daily prune) from a naive "prune every tick" wiring.
-    // ------------------------------------------------------------------
-
-    #[test]
-    fn test_support_tooling_prune_due_on_first_run() {
-        // Never pruned before → due immediately.
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
-        assert!(support_tooling_prune_due(None, now, min_interval));
-    }
-
-    #[test]
-    fn test_support_tooling_prune_skipped_within_interval() {
-        // Pruned 1h ago, interval is 24h → NOT due (the every-60s tick must
-        // not re-prune).
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
-        let last = now - chrono::Duration::hours(1);
-        assert!(!support_tooling_prune_due(Some(last), now, min_interval));
-    }
-
-    #[test]
-    fn test_support_tooling_prune_due_after_interval() {
-        // Pruned 25h ago, interval is 24h → due again.
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
-        let last = now - chrono::Duration::hours(25);
-        assert!(support_tooling_prune_due(Some(last), now, min_interval));
-    }
-
-    #[test]
-    fn test_support_tooling_prune_due_at_exact_boundary() {
-        // Exactly at the interval boundary → due (>= comparison).
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
-        let last = now - min_interval;
-        assert!(support_tooling_prune_due(Some(last), now, min_interval));
-    }
-
     #[test]
     fn test_scheduler_config_layout_change_events_retention_default() {
         // Issue #2563: the append-only layout_change_events trail is pruned
@@ -2606,63 +2393,6 @@ mod tests {
         // of cleanup_old_layout_change_events().
         let config = SchedulerConfig::default();
         assert_eq!(config.layout_change_events_retention_days, 730);
-    }
-
-    // ------------------------------------------------------------------
-    // Issue #2563: daily-cadence gate for the layout_change_events prune.
-    //
-    // The scheduler ticks every ~60s but the retention prune must run at
-    // most once per day. These pin the gate that stops the ~60s tick loop
-    // from re-pruning on every tick — the behaviour that distinguishes the
-    // fix (bounded daily prune) from a naive "prune every tick" wiring.
-    // ------------------------------------------------------------------
-
-    #[test]
-    fn test_layout_change_events_prune_due_on_first_run() {
-        // Never pruned before → due immediately.
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
-        assert!(layout_change_events_prune_due(None, now, min_interval));
-    }
-
-    #[test]
-    fn test_layout_change_events_prune_skipped_within_interval() {
-        // Pruned 1h ago, interval is 24h → NOT due (the every-60s tick must
-        // not re-prune).
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
-        let last = now - chrono::Duration::hours(1);
-        assert!(!layout_change_events_prune_due(
-            Some(last),
-            now,
-            min_interval
-        ));
-    }
-
-    #[test]
-    fn test_layout_change_events_prune_due_after_interval() {
-        // Pruned 25h ago, interval is 24h → due again.
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
-        let last = now - chrono::Duration::hours(25);
-        assert!(layout_change_events_prune_due(
-            Some(last),
-            now,
-            min_interval
-        ));
-    }
-
-    #[test]
-    fn test_layout_change_events_prune_due_at_exact_boundary() {
-        // Exactly at the interval boundary → due (>= comparison).
-        let now = chrono::Utc::now();
-        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
-        let last = now - min_interval;
-        assert!(layout_change_events_prune_due(
-            Some(last),
-            now,
-            min_interval
-        ));
     }
 
     #[test]

--- a/backend/servers/api-server/src/services/scheduler/retention.rs
+++ b/backend/servers/api-server/src/services/scheduler/retention.rs
@@ -1,0 +1,299 @@
+//! Retention/prune scheduled jobs for the background [`Scheduler`].
+//!
+//! Extracted verbatim from `scheduler/mod.rs` to keep the core tick loop
+//! readable (churn-reduction refactor — no behaviour change). Holds the daily
+//! append-only audit-trail prunes:
+//!
+//! - `support_tooling_events` retention prune (issue #2531)
+//! - `layout_change_events` retention prune (issue #2563)
+//!
+//! Each prune is gated to a daily cadence even though the scheduler ticks every
+//! ~60s. The jobs are attached to `Scheduler` via the `impl` block below and
+//! are invoked from `Scheduler::run_scheduled_tasks` in the parent module.
+
+use super::Scheduler;
+
+/// Minimum interval between successive `support_tooling_events` retention
+/// prunes (issue #2531). The scheduler ticks every ~60s, but the append-only
+/// admin-audit prune only needs a daily cadence — this gate skips the prune
+/// until 24h have elapsed since the last successful run.
+const SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS: i64 = 24;
+
+/// Minimum interval between successive `layout_change_events` retention prunes
+/// (issue #2563). Mirrors the `support_tooling_events` cadence: the scheduler
+/// ticks every ~60s, but the append-only layout-publish trail only needs a
+/// daily prune — this gate skips the prune until 24h have elapsed since the
+/// last successful run.
+const LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS: i64 = 24;
+
+impl Scheduler {
+    // ========================================================================
+    // Issue #2531: support_tooling_events retention prune (daily cadence)
+    // ========================================================================
+
+    /// Prune aged rows from the append-only `support_tooling_events` admin-audit
+    /// trail past the configured retention window (issue #2531).
+    ///
+    /// The prune calls `PlatformAdminRepository::cleanup_old_support_tooling_events`,
+    /// which routes through the sanctioned `app.retention_prune` GUC path so the
+    /// table's immutability trigger permits these — and only these — deletes
+    /// (migration `00222_support_tooling_events_retention.sql`). The repository
+    /// method existed but nothing invoked it, so the audit trail grew without
+    /// bound; this tick wires it into the scheduler, mirroring `cleanup_sessions`.
+    ///
+    /// Cadence: the scheduler ticks every ~60s, but retention only needs to run
+    /// once per day. A stored last-run timestamp gates the prune to at most one
+    /// run per [`SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS`] window. The stamp is
+    /// written only after a successful prune, so a failed run retries next tick.
+    pub(super) async fn prune_support_tooling_events(&self) -> Result<(), sqlx::Error> {
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
+
+        // Daily gate — skip until 24h have elapsed since the last prune.
+        {
+            let last = self
+                .last_support_tooling_prune_at
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if !support_tooling_prune_due(*last, now, min_interval) {
+                return Ok(());
+            }
+        }
+
+        // Note: Scheduler runs in background without user context. This prune is
+        // a privileged/admin-level retention job and does not need RLS context.
+        let deleted = self
+            .platform_admin_repo
+            .cleanup_old_support_tooling_events(self.config.support_tooling_retention_days as i32)
+            .await?;
+
+        // Stamp only after a successful prune so a transient DB error retries on
+        // the next tick instead of being suppressed for a full day.
+        {
+            let mut last = self
+                .last_support_tooling_prune_at
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            *last = Some(now);
+        }
+
+        if deleted > 0 {
+            tracing::info!(
+                deleted = deleted,
+                retention_days = self.config.support_tooling_retention_days,
+                "Pruned aged support_tooling_events"
+            );
+            let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
+            metrics.support_tooling_events_pruned += deleted as u64;
+        }
+
+        Ok(())
+    }
+
+    // ========================================================================
+    // Issue #2563: layout_change_events retention prune (daily cadence)
+    // ========================================================================
+
+    /// Prune aged rows from the append-only `layout_change_events` layout-publish
+    /// trail past the configured retention window (issue #2563).
+    ///
+    /// The prune calls `LayoutRepository::cleanup_old_layout_change_events`,
+    /// which routes through the sanctioned SQL `cleanup_old_layout_change_events`
+    /// function so the table's immutability trigger permits these — and only
+    /// these — deletes (migration `00225_create_layout_change_events.sql`). The
+    /// repository method existed but nothing invoked it, so the audit trail grew
+    /// without bound; this tick wires it into the scheduler, mirroring
+    /// [`Scheduler::prune_support_tooling_events`] (issue #2531).
+    ///
+    /// Cadence: the scheduler ticks every ~60s, but retention only needs to run
+    /// once per day. A stored last-run timestamp gates the prune to at most one
+    /// run per [`LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS`] window. The
+    /// stamp is written only after a successful prune, so a failed run retries
+    /// next tick.
+    pub(super) async fn prune_layout_change_events(&self) -> Result<(), sqlx::Error> {
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
+
+        // Daily gate — skip until 24h have elapsed since the last prune.
+        {
+            let last = self
+                .last_layout_change_events_prune_at
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            if !layout_change_events_prune_due(*last, now, min_interval) {
+                return Ok(());
+            }
+        }
+
+        // Note: Scheduler runs in background without user context. This prune is
+        // a privileged retention job and does not need RLS context.
+        let deleted = self
+            .layout_repo
+            .cleanup_old_layout_change_events(
+                &self.pool,
+                self.config.layout_change_events_retention_days as i32,
+            )
+            .await?;
+
+        // Stamp only after a successful prune so a transient DB error retries on
+        // the next tick instead of being suppressed for a full day.
+        {
+            let mut last = self
+                .last_layout_change_events_prune_at
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            *last = Some(now);
+        }
+
+        if deleted > 0 {
+            tracing::info!(
+                deleted = deleted,
+                retention_days = self.config.layout_change_events_retention_days,
+                "Pruned aged layout_change_events"
+            );
+            let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
+            metrics.layout_change_events_pruned += deleted as u64;
+        }
+
+        Ok(())
+    }
+}
+
+/// Decide whether the daily `support_tooling_events` retention prune is due
+/// (issue #2531). Returns `true` on the first run (`last` is `None`) or once at
+/// least `min_interval` has elapsed since the last successful prune. Extracted
+/// as a pure function so the daily-cadence gate is testable without a DB or a
+/// live clock.
+fn support_tooling_prune_due(
+    last: Option<chrono::DateTime<chrono::Utc>>,
+    now: chrono::DateTime<chrono::Utc>,
+    min_interval: chrono::Duration,
+) -> bool {
+    match last {
+        None => true,
+        Some(t) => now.signed_duration_since(t) >= min_interval,
+    }
+}
+
+/// Decide whether the daily `layout_change_events` retention prune is due
+/// (issue #2563). Returns `true` on the first run (`last` is `None`) or once at
+/// least `min_interval` has elapsed since the last successful prune. Extracted
+/// as a pure function so the daily-cadence gate is testable without a DB or a
+/// live clock.
+fn layout_change_events_prune_due(
+    last: Option<chrono::DateTime<chrono::Utc>>,
+    now: chrono::DateTime<chrono::Utc>,
+    min_interval: chrono::Duration,
+) -> bool {
+    match last {
+        None => true,
+        Some(t) => now.signed_duration_since(t) >= min_interval,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // Issue #2531: daily-cadence gate for the support_tooling_events prune.
+    //
+    // The scheduler ticks every ~60s but the retention prune must run at
+    // most once per day. These pin the gate that stops the ~60s tick loop
+    // from re-pruning on every tick — the behaviour that distinguishes the
+    // fix (bounded daily prune) from a naive "prune every tick" wiring.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_support_tooling_prune_due_on_first_run() {
+        // Never pruned before → due immediately.
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
+        assert!(support_tooling_prune_due(None, now, min_interval));
+    }
+
+    #[test]
+    fn test_support_tooling_prune_skipped_within_interval() {
+        // Pruned 1h ago, interval is 24h → NOT due (the every-60s tick must
+        // not re-prune).
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
+        let last = now - chrono::Duration::hours(1);
+        assert!(!support_tooling_prune_due(Some(last), now, min_interval));
+    }
+
+    #[test]
+    fn test_support_tooling_prune_due_after_interval() {
+        // Pruned 25h ago, interval is 24h → due again.
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
+        let last = now - chrono::Duration::hours(25);
+        assert!(support_tooling_prune_due(Some(last), now, min_interval));
+    }
+
+    #[test]
+    fn test_support_tooling_prune_due_at_exact_boundary() {
+        // Exactly at the interval boundary → due (>= comparison).
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS);
+        let last = now - min_interval;
+        assert!(support_tooling_prune_due(Some(last), now, min_interval));
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #2563: daily-cadence gate for the layout_change_events prune.
+    //
+    // The scheduler ticks every ~60s but the retention prune must run at
+    // most once per day. These pin the gate that stops the ~60s tick loop
+    // from re-pruning on every tick — the behaviour that distinguishes the
+    // fix (bounded daily prune) from a naive "prune every tick" wiring.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_layout_change_events_prune_due_on_first_run() {
+        // Never pruned before → due immediately.
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
+        assert!(layout_change_events_prune_due(None, now, min_interval));
+    }
+
+    #[test]
+    fn test_layout_change_events_prune_skipped_within_interval() {
+        // Pruned 1h ago, interval is 24h → NOT due (the every-60s tick must
+        // not re-prune).
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
+        let last = now - chrono::Duration::hours(1);
+        assert!(!layout_change_events_prune_due(
+            Some(last),
+            now,
+            min_interval
+        ));
+    }
+
+    #[test]
+    fn test_layout_change_events_prune_due_after_interval() {
+        // Pruned 25h ago, interval is 24h → due again.
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
+        let last = now - chrono::Duration::hours(25);
+        assert!(layout_change_events_prune_due(
+            Some(last),
+            now,
+            min_interval
+        ));
+    }
+
+    #[test]
+    fn test_layout_change_events_prune_due_at_exact_boundary() {
+        // Exactly at the interval boundary → due (>= comparison).
+        let now = chrono::Utc::now();
+        let min_interval = chrono::Duration::hours(LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS);
+        let last = now - min_interval;
+        assert!(layout_change_events_prune_due(
+            Some(last),
+            now,
+            min_interval
+        ));
+    }
+}


### PR DESCRIPTION
## Task
Investigate repeated churn on `backend/servers/api-server/src/services/scheduler.rs` (top-churn 2 windows running) — propose extraction of retention/prune jobs to a dedicated module.

## Owner
pm-backend

## What changed (pure move/extract — no behaviour change)
`scheduler.rs` (2795 lines, a repeat top-churn hot file) is split so the retention/prune scheduled jobs live in their own submodule:

- `services/scheduler.rs` → `services/scheduler/mod.rs` (the core tick loop, unchanged).
- New `services/scheduler/retention.rs` holds the two daily append-only retention prunes and everything only they use:
  - the two cadence constants `SUPPORT_TOOLING_PRUNE_MIN_INTERVAL_HOURS` / `LAYOUT_CHANGE_EVENTS_PRUNE_MIN_INTERVAL_HOURS` (issues #2531 / #2563),
  - the two `Scheduler` methods `prune_support_tooling_events` / `prune_layout_change_events` (moved verbatim into an `impl Scheduler` block in the child module),
  - the two pure daily-gate helpers `support_tooling_prune_due` / `layout_change_events_prune_due`,
  - the 8 pure gate unit tests for those helpers.

The prunes stay wired into `Scheduler::run_scheduled_tasks` in the parent module. `mod.rs` shrinks by ~280 lines.

The **only** non-move change is bumping the two prune methods' visibility from private to `pub(super)`, the minimum needed so the parent tick loop and the DB integration test can still call them across the new module boundary (a child module can already see the parent struct's private fields, so no field/config visibility changed). The DB integration test and config-default / meter-dedup tests stay in `mod.rs` and are untouched.

## Scope drift
None. Diff is confined to `backend/servers/api-server/src/services/scheduler/` (two files). `scope-check.sh --owner pm-backend --base origin/dev` → exit 0 (in-area).

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. No new helpers introduced; existing symbols were relocated, not duplicated.

## Verification
```
VERIFY-PLAN base=1f9646b7a0071651a310740e8cabd2b82a3d0946 files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` → **exit 0**.
- `cargo clippy -p api-server --all-targets -- -D warnings` → **exit 0** (full crate + all test targets compile and lint clean — the type/compile gate is green).
- `cargo test -p api-server` (pure, no-DB tests) → **green**: the 8 relocated `services::scheduler::retention::tests` gate tests pass, plus the config-default and meter-dedup unit tests.

### Environment notes for the reviewer / CI
Two parts of the local gate could not be exercised in this sandbox and are deferred to CI (`backend.yml`), which has both:

1. **Build-time asset:** `utoipa-swagger-ui`'s build script downloads Swagger UI from `github.com/swagger-api/swagger-ui`, which this session's egress policy 403s (repo not allow-listed). To get a real `clippy`/compile pass locally I vendored a local Swagger UI dist zip and pointed `SWAGGER_UI_DOWNLOAD_URL=file://…` at it — the crate's sanctioned local-asset path, no proxy/TLS bypass. CI downloads the real asset.
2. **`#[sqlx::test]` integration tests** (incl. `test_scheduler_prunes_aged_support_tooling_events_and_gates_daily`) need Postgres; no DB is reachable here (port 5432 closed, `DATABASE_URL` unset). They **compile** clean (proven by `clippy --all-targets` + the test-binary build) but can't run locally. CI runs them against a live database. This change does not touch their logic — it is a pure relocation of already-passing code.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — pure refactor).

## Remote-tested
skipped: ppt-bridge MCP not connected this session.

## Notes
Draft: opened as draft so CI runs the full backend gate (real Swagger asset + Postgres) before this is marked ready. Behaviour is byte-for-byte identical to the pre-split code; the goal is purely to reduce churn concentration on the `scheduler` hot file by giving the retention jobs their own home.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HCRy6DxgxYbcC5C8YEbjqX)_