### PR TITLE
dx-fixme-api-client-generator-typescript-error-types: harden openapi-ts drift-gate generator steps

### DIFF
--- a/.github/workflows/api-validation.yml
+++ b/.github/workflows/api-validation.yml
@@ -65,6 +65,17 @@ jobs:
           name: openapi-spec
           path: docs/api/generated/openapi.yaml
 
+  # Regenerates the committed TypeScript SDKs over their in-tree copies and
+  # fails on drift. The generator steps below are hardened so a generation
+  # failure or silent no-op can't slip past the drift gates as a false green.
+  #
+  # NOTE (weak error types): the generated request wrapper in each
+  # */src/generated/client/client.gen.ts returns `{ error: unknown }` on a
+  # non-throwing failure ("TODO: we probably want to return error and improve
+  # types"). That surface is emitted from the upstream @hey-api/openapi-ts
+  # template and is byte-compared by the drift gates, so it cannot be hardened
+  # by hand here — improving it needs a custom openapi-ts template/plugin in the
+  # frontend client packages, tracked separately.
   generate-sdks:
     needs: validate
     runs-on: ubuntu-latest
@@ -85,6 +96,7 @@ jobs:
 
       - name: Generate TypeScript SDK
         run: |
+          set -euo pipefail
           # Pin @hey-api/openapi-ts and co-install its `typescript` peer so the
           # generator can initialize. An unpinned `npm install -g` pulled a
           # newer release without typescript present, crashing at init with
@@ -92,7 +104,24 @@ jobs:
           # Versions mirror frontend/packages/api-client (openapi-ts ^0.99.0,
           # typescript ^5.3 -> resolved 5.9.3 in pnpm-lock).
           npm install --no-save @hey-api/openapi-ts@0.99.0 typescript@5.9.3
-          npx openapi-ts -i docs/api/generated/openapi.yaml -o frontend/packages/api-client/src/generated
+
+          # Wrapper hardening (#dx-fixme-api-client-generator): don't swallow
+          # generator failures. Surface a clear ::error:: annotation instead of
+          # a bare non-zero exit, and — critically — guard against a SILENT
+          # no-op. If openapi-ts exits 0 but writes nothing (an ignored flag, an
+          # empty spec, output landing in the wrong dir), the committed tree is
+          # unchanged and the drift gate below would pass as a FALSE GREEN over
+          # stale output. Asserting the client entrypoint exists closes that hole.
+          sdk_path=frontend/packages/api-client/src/generated
+          if ! npx openapi-ts -i docs/api/generated/openapi.yaml -o "$sdk_path"; then
+            echo "::error::openapi-ts failed to generate the TypeScript SDK ($sdk_path). See generator output above."
+            exit 1
+          fi
+          entrypoint="$sdk_path/client/client.gen.ts"
+          if [ ! -s "$entrypoint" ]; then
+            echo "::error::openapi-ts exited 0 but produced no client entrypoint ($entrypoint) — generation was a no-op. Refusing to let the drift gate pass on stale output."
+            exit 1
+          fi
 
       # Drift gate (2026-07-22): the step above regenerates the SDK directly
       # over the COMMITTED tree (frontend/packages/api-client/src/generated),
@@ -127,11 +156,25 @@ jobs:
 
       - name: Generate Reality TypeScript SDK
         run: |
+          set -euo pipefail
           # @ppt/reality-api-client is generated from the SAME openapi.yaml with
           # the SAME `openapi-ts` invocation as @ppt/api-client (see each
           # package's `generate` script), so we reuse the generator installed
           # above and regenerate directly over the committed reality tree.
-          npx openapi-ts -i docs/api/generated/openapi.yaml -o frontend/packages/reality-api-client/src/generated
+          #
+          # Same wrapper hardening as the @ppt/api-client step above: fail loudly
+          # on generator error and refuse a silent no-op so the reality drift
+          # gate below can't return a FALSE GREEN over a stale committed tree.
+          sdk_path=frontend/packages/reality-api-client/src/generated
+          if ! npx openapi-ts -i docs/api/generated/openapi.yaml -o "$sdk_path"; then
+            echo "::error::openapi-ts failed to generate the Reality TypeScript SDK ($sdk_path). See generator output above."
+            exit 1
+          fi
+          entrypoint="$sdk_path/client/client.gen.ts"
+          if [ ! -s "$entrypoint" ]; then
+            echo "::error::openapi-ts exited 0 but produced no Reality client entrypoint ($entrypoint) — generation was a no-op. Refusing to let the drift gate pass on stale output."
+            exit 1
+          fi
 
       # Drift gate (#2556): mirror of the @ppt/api-client gate above. The step
       # above regenerates over the COMMITTED reality tree, so a plain `git diff`


### PR DESCRIPTION
## Task
openapi-ts generator wrapper swallows errors and emits weak error types

## Owner
pm-devops

## What this changes (and why this scope)
The FIXME originates from PR #2607 (commit `5c604d5`), which added the reality-api-client drift gate in `.github/workflows/api-validation.yml`. Two distinct concerns were conflated in the backlog note:

1. **"swallows errors" / weak failure diagnostics** in the generator wrapper — this is the CI generate steps (`npx openapi-ts …`). **Fixed here (in-scope for pm-devops: `.github/**`).**
2. **"weak error types"** — this is the `TODO: we probably want to return error and improve types` at `*/src/generated/client/client.gen.ts:214`, where the request wrapper returns `{ error: unknown }` on a non-throwing failure. That file is **auto-generated by the upstream @hey-api/openapi-ts template** and is **byte-compared by the drift gate** — hand-editing it would break the gate, and it lives under `frontend/packages/**` (pm-frontend, not pm-devops). Improving it needs a custom openapi-ts template/plugin in the client packages and is out of reach of this workflow. Documented as a NOTE in the workflow so it isn't silently assumed fixed.

### The real bug fixed
The `Generate TypeScript SDK` / `Generate Reality TypeScript SDK` steps ran `npx openapi-ts` with no guard against a **silent no-op**: if the generator exits 0 but writes nothing (ignored flag, empty spec, output landing in the wrong dir), the committed tree is unchanged, so the subsequent drift-gate `git diff` passes as a **FALSE GREEN** over stale output. The steps also emitted no diagnostic on a bare generator failure.

Hardening applied to both steps:
- `set -euo pipefail` (explicit, matching the drift-gate steps' hygiene).
- A clear `::error::` annotation when `openapi-ts` fails.
- A post-generation assertion that the client entrypoint (`client/client.gen.ts`) was actually produced — closing the false-green hole.

## Verification
```
VERIFY-PLAN base=41b4e5a60ea9a6a85c4e5d319984cea1dea01e8b files=1
VERIFY OK 14da9c23f2130e2c3840e7ffad8482bcc2e23b30
```
Additionally: YAML parses (`yaml.safe_load`), and both generate-step bodies pass `bash -n`.

Goal-check (`goal-check.sh`): PASS with `--skip IG1,IG2,IG3,IG7,IG8`. IG1/IG2 are premised on the plan-driven `ppt-research-flow` (a `.research/plans/<slug>.md` file + `impl/<slug>` branch); this is a dispatcher `ppt-implement` task with a mandated `auto-impl/…` branch and no plan file, so they're structurally N/A. IG3 is skipped: a GitHub Actions shell-step change has no unit-test harness (the added assertion is itself the guard). IG7 already ran in Verification above.

## Scope drift
None — `scope-check.sh --owner pm-devops` exits 0. Only `.github/workflows/api-validation.yml` changed.

## Code-reuse review
None — no new auth/crypto/http helpers added (YAML-only change).

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
Skipped.

## Notes
The reality-api-client generated tree is documented in #2607 as unused/dead code (its barrel export is commented out), but the gate still guards it against drift — the false-green hardening applies equally to both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNBno6TLDwquZnRxYeHiqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNBno6TLDwquZnRxYeHiqK)_