### PR TITLE
dx-fixme-admin-web-ui-kit-primitives-missing: consolidate admin-web inline primitives onto @ppt/ui-kit

### DIFF
--- a/frontend/apps/admin-web/src/main.tsx
+++ b/frontend/apps/admin-web/src/main.tsx
@@ -1,4 +1,5 @@
-import '@ppt/ui-kit/tokens.css'; // Design system tokens — admin Toast/CSS uses --ppt-* vars.
+import '@ppt/ui-kit/tokens.css'; // Legacy tokens — admin Toast/CSS uses --ppt-* vars.
+import '@ppt/ui-kit/tokens/tokens.css'; // Design-system tokens (--accent/--bg-surface/…) used by @ppt/ui-kit primitives (Stepper, FileUpload, …).
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ReactDOM from 'react-dom/client';

--- a/frontend/apps/admin-web/src/pages/TenantLifecyclePage.tsx
+++ b/frontend/apps/admin-web/src/pages/TenantLifecyclePage.tsx
@@ -12,6 +12,7 @@
  */
 
 import { useCapability } from '@ppt/admin-ui';
+import { FileUpload, Stepper } from '@ppt/ui-kit';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAdminAuth } from '../auth/AdminAuthContext';
@@ -171,23 +172,8 @@ function ensureStyles() {
     /* Countdown hint */
     .lc-btn-hint { font-size: 12px; color: var(--ppt-fg-muted, #6b7280); margin: 0; }
 
-    /* File restore */
-    .lc-file-label {
-      display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      padding: 8px 14px;
-      border-radius: var(--ppt-radius-md, 8px);
-      font-size: 13px;
-      font-weight: 500;
-      cursor: pointer;
-      background: var(--ppt-bg-surface, #fff);
-      border: 1px solid var(--ppt-border-default, #e5e7eb);
-      color: var(--ppt-fg-secondary, #374151);
-      transition: background 120ms ease;
-    }
-    .lc-file-label:hover { background: var(--ppt-bg-hover, #f3f4f6); }
-    .lc-file-selected { font-size: 12px; color: var(--ppt-fg-muted, #6b7280); margin: 0; }
+    /* File restore — dropzone provided by @ppt/ui-kit <FileUpload>; only the submit button margin remains */
+    .lc-restore-actions { margin-top: 12px; }
 
     /* ──── Purge wizard ──── */
     .lc-wizard {
@@ -199,30 +185,8 @@ function ensureStyles() {
     }
     .lc-wizard-title { font-size: 14px; font-weight: 600; color: var(--ppt-danger-800, #991b1b); margin: 0 0 16px; }
 
-    /* Step indicator */
-    .lc-steps { display: flex; align-items: center; gap: 8px; margin-bottom: 24px; flex-wrap: wrap; }
-    .lc-step-arrow { color: var(--ppt-fg-muted, #9ca3af); font-size: 14px; }
-    .lc-pill {
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      padding: 4px 12px;
-      border-radius: 999px;
-      font-size: 12px;
-      font-weight: 600;
-    }
-    .lc-pill--done {
-      background: var(--ppt-success-100, #dcfce7);
-      color: var(--ppt-success-800, #166534);
-    }
-    .lc-pill--current {
-      background: var(--ppt-brand-100, #dbeafe);
-      color: var(--ppt-brand-800, #1e40af);
-    }
-    .lc-pill--pending {
-      background: var(--ppt-neutral-100, #f3f4f6);
-      color: var(--ppt-neutral-600, #4b5563);
-    }
+    /* Step indicator — rendered by @ppt/ui-kit <Stepper>; only spacing remains here */
+    .lc-stepper { margin-bottom: 24px; }
 
     /* Step body */
     .lc-step-body { display: flex; flex-direction: column; gap: 14px; }
@@ -281,21 +245,6 @@ function ensureStyles() {
 }
 
 // ---------------------------------------------------------------------------
-// Step pill component
-// ---------------------------------------------------------------------------
-
-type PillState = 'done' | 'current' | 'pending';
-
-function StepPill({ label, state }: { label: string; state: PillState }) {
-  return (
-    <span className={`lc-pill lc-pill--${state}`}>
-      {state === 'done' && '✓ '}
-      {label}
-    </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Purge wizard (inline, below the grid)
 // ---------------------------------------------------------------------------
 
@@ -335,12 +284,6 @@ export function PurgeWizard({ tenant, onCancel }: PurgeWizardProps) {
       setStep(2);
     }
   }, [step, exportOk]);
-
-  const pillState = (forStep: 1 | 2 | 3): PillState => {
-    if (forStep < step) return 'done';
-    if (forStep === step) return 'current';
-    return 'pending';
-  };
 
   // TOTP digit input handler with auto-advance
   const handleTotpChange = (idx: number, val: string) => {
@@ -407,18 +350,12 @@ export function PurgeWizard({ tenant, onCancel }: PurgeWizardProps) {
     <div className="lc-wizard" role="region" aria-label="Purge wizard">
       <p className="lc-wizard-title">Purge wizard — proceed carefully</p>
 
-      {/* Step indicator */}
-      <div className="lc-steps" aria-label="Wizard steps">
-        <StepPill label="1. Confirm export" state={pillState(1)} />
-        <span className="lc-step-arrow" aria-hidden="true">
-          →
-        </span>
-        <StepPill label="2. Type slug" state={pillState(2)} />
-        <span className="lc-step-arrow" aria-hidden="true">
-          →
-        </span>
-        <StepPill label="3. MFA + reason" state={pillState(3)} />
-      </div>
+      {/* Step indicator — shared @ppt/ui-kit primitive (step is 1-based, Stepper is 0-based) */}
+      <Stepper
+        className="lc-stepper"
+        steps={['Confirm export', 'Type slug', 'MFA + reason']}
+        current={step - 1}
+      />
 
       <div className="lc-step-body">
         {/* Step 1 */}
@@ -818,22 +755,26 @@ export default function TenantLifecyclePage() {
           </p>
           {canRestore && (
             <>
-              <label className="lc-file-label" htmlFor="lc-restore-file">
-                Choose file…
-              </label>
-              <input
-                id="lc-restore-file"
-                type="file"
+              <FileUpload
                 accept=".tar.gz"
-                style={{ display: 'none' }}
-                onChange={(e) => setRestoreFile(e.target.files?.[0] ?? null)}
+                multiple={false}
+                onFiles={(files) => setRestoreFile(files[0] ?? null)}
+                onRemove={() => setRestoreFile(null)}
+                files={
+                  restoreFile
+                    ? [
+                        {
+                          id: restoreFile.name,
+                          file: restoreFile,
+                          progress: isUploading ? 50 : 0,
+                          status: isUploading ? 'uploading' : 'idle',
+                        },
+                      ]
+                    : []
+                }
               />
               {restoreFile && (
-                <>
-                  <p className="lc-file-selected">
-                    Selected: {restoreFile.name} ({(restoreFile.size / 1_073_741_824).toFixed(1)}{' '}
-                    GB)
-                  </p>
+                <div className="lc-restore-actions">
                   <button
                     type="button"
                     className="lc-btn lc-btn--primary"
@@ -843,7 +784,7 @@ export default function TenantLifecyclePage() {
                     {isUploading && <span className="lc-spinner" aria-hidden="true" />}
                     {isUploading ? 'Uploading…' : 'Upload'}
                   </button>
-                </>
+                </div>
               )}
             </>
           )}

--- a/frontend/apps/admin-web/src/vite-env.d.ts
+++ b/frontend/apps/admin-web/src/vite-env.d.ts
@@ -1,0 +1,14 @@
+/// <reference types="vite/client" />
+
+/**
+ * CSS Modules type declaration.
+ *
+ * admin-web consumes @ppt/ui-kit source directly (its `main`/`types` point at
+ * `src/index.ts`), so tsc compiles ui-kit component files under admin-web's
+ * program. Those components import `*.module.css`; ui-kit's own ambient
+ * declaration lives outside admin-web's `include`, so declare it here too.
+ */
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}


### PR DESCRIPTION
## Task
@ppt/ui-kit missing primitives (Stepper, FileUpload, RadioCards, StatusPill) — admin-web ships inline duplicates

## Owner
pm-devops (hint only — see **Scope drift** below; this is a frontend/admin-web change)

## What this actually is
The four primitives are **no longer missing** — `Stepper`, `FileUpload`, `RadioCards`, and `StatusPill` already exist under `frontend/packages/ui-kit/src/components/*` and are exported from `@ppt/ui-kit`. The remaining actionable work is the second half of the FIXME: **admin-web still ships inline duplicates** instead of consuming the shared primitives.

`admin-web` imported **zero** ui-kit components before this PR. The canonical duplicate lives in `TenantLifecyclePage` whose own header docstring calls out an "inline purge wizard" (a Stepper) and a "file upload stub" (a FileUpload). This PR consolidates those two onto the shared primitives:

- **Stepper** — replaced the inline `StepPill` component + `.lc-pill`/`.lc-steps`/`.lc-step-arrow` CSS with `<Stepper steps={…} current={step-1} />`.
- **FileUpload** — replaced the raw `<input type="file">` restore picker + `.lc-file-*` CSS with `<FileUpload accept=".tar.gz" multiple={false} … />` (the restore flow was already a non-functional stub, so no behavioral change).
- **Token wiring** — admin-web is the first consumer of ui-kit's design-system-token-based components, so `@ppt/ui-kit/tokens/tokens.css` (the `--accent`/`--bg-surface`/… set) is now imported in `main.tsx`; without it the primitives render with unresolved CSS vars.
- **CSS-module types** — added `apps/admin-web/src/vite-env.d.ts` declaring `*.module.css`. admin-web compiles ui-kit source directly (`main`/`types` → `src/index.ts`); ui-kit's own ambient decl sits outside admin-web's `include`, so tsc needs its own.

**Not in this PR (deliberate, follow-ups):**
- `RadioCards` — admin-web has **no** radio/radiogroup duplicate at all (verified: zero `type="radio"` in the app), so nothing to consolidate.
- `StatusPill` — admin-web has many bespoke inline pills (Dashboard capability pills, CapabilitiesAdminPage risk/status pills, audit CapabilityPill/OutcomePill, MfaWindowChip, SeverityBadge). Each carries custom color logic that doesn't map 1:1 to StatusPill's 7 semantic variants; migrating them is a larger, visually-sensitive change best done as its own focused PR rather than bundled into a low-priority DX cleanup.

## Verification
```
VERIFY-PLAN base=41b4e5a60ea9a6a85c4e5d319984cea1dea01e8b files=3
  cd frontend && pnpm exec biome check apps/admin-web/src/main.tsx apps/admin-web/src/pages/TenantLifecyclePage.tsx apps/admin-web/src/vite-env.d.ts
  cd frontend && pnpm --filter "...[41b4e5a60ea9a6a85c4e5d319984cea1dea01e8b]" typecheck
  cd frontend && pnpm --filter "...[41b4e5a60ea9a6a85c4e5d319984cea1dea01e8b]" test
```
```
VERIFY OK 11cfd41a95b83d003b1b69192137ae3fe8f799bd
```
biome clean · admin-web `tsc --noEmit` clean · vitest 274/274 passed (incl. the 7 TenantLifecyclePage/PurgeWizard tests, unchanged).

## Scope drift
`scope-check.sh --owner pm-devops` → exit 2. All three touched paths are `frontend/apps/admin-web/src/**`, which fall outside pm-devops's owner areas (`.github/**`, `scripts/**`, `docker/**`, `*.yml`). This is a **mislabeled `owner_role`** on the dispatcher task — the work is inherently `pm-frontend` (admin-web app code). No off-area/opportunistic edits: the diff is entirely the admin-web consolidation described above.

Drifting paths:
- `frontend/apps/admin-web/src/main.tsx`
- `frontend/apps/admin-web/src/pages/TenantLifecyclePage.tsx`
- `frontend/apps/admin-web/src/vite-env.d.ts`

## Code-reuse review
`reuse-grep.sh --specialist react-web` → empty (no duplicated helper symbols). This PR is itself a de-duplication (inline components → shared @ppt/ui-kit primitives).

## Goal-check (IG1–IG8)
This is a **dispatcher action-list task**, not a `ppt-research-flow` plan task, so the plan-file IG checks are N/A: IG1 (no `.research/plans/<slug>.md`), IG2 (branch is dispatcher-assigned `auto-impl/…`), IG8 (archive move + backlog flip — `.research/**` is explicitly off-limits for this run). IG3 skipped — pure refactor, behavior covered by existing tests. **IG7 (verify gate) passed** — see Verification above.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — admin dashboard UI refactor only)

## Remote-tested
skipped (no ppt-bridge MCP in this session)

## Notes
- No behavior change: the purge wizard's step semantics (`step` 1→2→3) map directly to `Stepper current={step-1}`; the restore upload was and remains a stub that toasts "not yet implemented".
- Follow-up candidate: migrate the remaining bespoke admin-web pills to `StatusPill` where the 7-variant palette fits (separate PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KNBno6TLDwquZnRxYeHiqK)_