### PR TITLE
data-pgvector-rag-observability-2026-07-23-retry1: observe pgvector RAG retrieval quality (latency, top-k relevance, empty-result rate)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2039,6 +2039,7 @@ dependencies = [
  "genpdf",
  "hex",
  "integrations",
+ "metrics 0.24.6",
  "password-hash",
  "rand 0.10.2",
  "rust_decimal",

--- a/backend/crates/db/Cargo.toml
+++ b/backend/crates/db/Cargo.toml
@@ -13,6 +13,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+metrics = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true }

--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -27,6 +27,7 @@ use crate::models::llm_document::{
     ProviderStats, RagStatistics, RequestTypeStats, UpdateEscalationConfig, VoiceAssistantDevice,
     VoiceCommandHistory,
 };
+use crate::repositories::rag_metrics;
 use chrono::{DateTime, Utc};
 use sqlx::{Error as SqlxError, Executor, PgConnection, PgPool, Postgres};
 use uuid::Uuid;
@@ -1036,6 +1037,11 @@ impl LlmDocumentRepository {
         min_similarity: Option<f64>,
         model_filter: Option<&str>,
     ) -> Result<Vec<(DocumentEmbedding, f64)>, SqlxError> {
+        // Story 84.5: observe retrieval quality (latency, top-k relevance,
+        // empty-result rate). Timed from here so the histogram covers the whole
+        // retrieval — including the pgvector-availability probe and the
+        // provenance post-filter — not just the SQL round-trip.
+        let started = std::time::Instant::now();
         let min_sim = min_similarity.unwrap_or(0.5);
         // Over-fetch when a provenance filter is active so post-filtering still
         // returns up to `limit` compatible rows (capped to avoid unbounded scans).
@@ -1093,11 +1099,9 @@ impl LlmDocumentRepository {
                 embeddings.push((emb, similarity));
             }
 
-            return Ok(Self::filter_by_embedding_model(
-                embeddings,
-                model_filter,
-                limit,
-            ));
+            let out = Self::filter_by_embedding_model(embeddings, model_filter, limit);
+            Self::observe_retrieval(rag_metrics::BACKEND_PGVECTOR, started.elapsed(), &out);
+            return Ok(out);
         }
 
         // Fallback to the existing application-level search
@@ -1110,11 +1114,19 @@ impl LlmDocumentRepository {
                 min_similarity,
             )
             .await?;
-        Ok(Self::filter_by_embedding_model(
-            fallback,
-            model_filter,
-            limit,
-        ))
+        let out = Self::filter_by_embedding_model(fallback, model_filter, limit);
+        Self::observe_retrieval(rag_metrics::BACKEND_FALLBACK, started.elapsed(), &out);
+        Ok(out)
+    }
+
+    /// Emit RAG retrieval-quality metrics for one search (Story 84.5).
+    fn observe_retrieval(
+        backend: &'static str,
+        elapsed: std::time::Duration,
+        results: &[(DocumentEmbedding, f64)],
+    ) {
+        let scores: Vec<f64> = results.iter().map(|(_, score)| *score).collect();
+        rag_metrics::record_retrieval(backend, elapsed, &scores);
     }
 
     /// Drop rows whose stored `metadata.embedding_model` is known to differ from

--- a/backend/crates/db/src/repositories/mod.rs
+++ b/backend/crates/db/src/repositories/mod.rs
@@ -264,6 +264,8 @@ pub use energy::EnergyRepository;
 
 // Epic 64: Advanced AI & LLM Capabilities
 pub mod llm_document;
+// Story 84.5: pgvector RAG retrieval-quality observability.
+pub mod rag_metrics;
 
 pub use llm_document::LlmDocumentRepository;
 

--- a/backend/crates/db/src/repositories/rag_metrics.rs
+++ b/backend/crates/db/src/repositories/rag_metrics.rs
@@ -1,0 +1,165 @@
+//! Observability for pgvector RAG retrieval quality (Story 84.5).
+//!
+//! The pgvector RAG store (`document_embeddings`) is the retrieval half of the
+//! Enhanced-Chat RAG flow. Before feature adoption grows we want to see how
+//! healthy retrieval is in production without shipping the whole answer through
+//! a log line. This module emits three quality signals per retrieval:
+//!
+//! * **retrieval latency** — `rag_retrieval_duration_seconds` (histogram),
+//!   labelled by `backend` (`pgvector` native index vs `fallback` app-level
+//!   cosine scan) so a slow fallback path is visible.
+//! * **top-k relevance** — `rag_retrieval_relevance_score` (histogram): the
+//!   cosine similarity of every returned chunk, giving the relevance
+//!   distribution of what actually reached the model.
+//! * **empty-result rate** — `rag_retrieval_total` and
+//!   `rag_retrieval_empty_total` (counters): the ratio
+//!   `empty / total` is the empty-result rate. `rag_retrieval_results`
+//!   (histogram) records the per-call result count for finer analysis.
+//!
+//! Metrics are emitted through the `metrics` facade rather than a concrete
+//! exporter, so the db crate stays exporter-agnostic: any binary that installs
+//! a recorder (api-server's Prometheus exporter) captures them, and when no
+//! recorder is installed (unit tests, one-off tooling) the macros are cheap
+//! no-ops.
+
+use std::sync::Once;
+use std::time::Duration;
+
+/// Histogram: pgvector RAG retrieval latency, in seconds.
+pub const METRIC_DURATION: &str = "rag_retrieval_duration_seconds";
+/// Histogram: cosine similarity of each returned chunk (top-k relevance).
+pub const METRIC_RELEVANCE: &str = "rag_retrieval_relevance_score";
+/// Histogram: number of chunks returned per retrieval.
+pub const METRIC_RESULTS: &str = "rag_retrieval_results";
+/// Counter: total RAG retrievals.
+pub const METRIC_TOTAL: &str = "rag_retrieval_total";
+/// Counter: RAG retrievals that returned zero chunks (empty-result numerator).
+pub const METRIC_EMPTY: &str = "rag_retrieval_empty_total";
+
+/// Label value: native pgvector index path (`search_similar_documents`).
+pub const BACKEND_PGVECTOR: &str = "pgvector";
+/// Label value: application-level cosine-similarity fallback scan.
+pub const BACKEND_FALLBACK: &str = "fallback";
+
+static DESCRIBE: Once = Once::new();
+
+/// Register metric descriptions once per process. Idempotent and safe to call
+/// on every retrieval; the `Once` guard makes all but the first call a no-op.
+fn describe_once() {
+    DESCRIBE.call_once(|| {
+        metrics::describe_histogram!(
+            METRIC_DURATION,
+            "pgvector RAG retrieval latency in seconds, labelled by backend (pgvector|fallback)"
+        );
+        metrics::describe_histogram!(
+            METRIC_RELEVANCE,
+            "Cosine similarity of each returned RAG chunk (top-k relevance distribution)"
+        );
+        metrics::describe_histogram!(
+            METRIC_RESULTS,
+            "Number of chunks returned per RAG retrieval"
+        );
+        metrics::describe_counter!(
+            METRIC_TOTAL,
+            "Total pgvector RAG retrievals, labelled by backend"
+        );
+        metrics::describe_counter!(
+            METRIC_EMPTY,
+            "RAG retrievals that returned zero chunks (empty-result rate numerator)"
+        );
+    });
+}
+
+/// A recorder-free summary of one retrieval's outcome.
+///
+/// Split out from metric emission so the classification logic (empty vs
+/// non-empty, top score) can be unit-tested without installing a global
+/// `metrics` recorder.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RetrievalObservation {
+    /// Which retrieval path served the query.
+    pub backend: &'static str,
+    /// Number of chunks returned.
+    pub result_count: usize,
+    /// True when no chunk cleared the similarity threshold.
+    pub is_empty: bool,
+    /// Highest similarity among returned chunks, if any.
+    pub top_score: Option<f64>,
+}
+
+impl RetrievalObservation {
+    /// Summarise a set of returned similarity scores.
+    pub fn new(backend: &'static str, scores: &[f64]) -> Self {
+        let top_score = scores.iter().copied().fold(None, |acc, s| match acc {
+            Some(m) if m >= s => Some(m),
+            _ => Some(s),
+        });
+        Self {
+            backend,
+            result_count: scores.len(),
+            is_empty: scores.is_empty(),
+            top_score,
+        }
+    }
+}
+
+/// Record one RAG retrieval's latency and relevance outcome.
+///
+/// `backend` should be [`BACKEND_PGVECTOR`] or [`BACKEND_FALLBACK`].
+/// `scores` are the cosine similarities of the returned chunks (empty slice ==
+/// empty result).
+pub fn record_retrieval(backend: &'static str, elapsed: Duration, scores: &[f64]) {
+    describe_once();
+    let obs = RetrievalObservation::new(backend, scores);
+
+    metrics::histogram!(METRIC_DURATION, "backend" => backend).record(elapsed.as_secs_f64());
+    metrics::counter!(METRIC_TOTAL, "backend" => backend).increment(1);
+    metrics::histogram!(METRIC_RESULTS, "backend" => backend).record(obs.result_count as f64);
+
+    if obs.is_empty {
+        metrics::counter!(METRIC_EMPTY, "backend" => backend).increment(1);
+    } else {
+        for &score in scores {
+            metrics::histogram!(METRIC_RELEVANCE, "backend" => backend).record(score);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn observation_empty_scores() {
+        let obs = RetrievalObservation::new(BACKEND_PGVECTOR, &[]);
+        assert_eq!(obs.backend, "pgvector");
+        assert_eq!(obs.result_count, 0);
+        assert!(obs.is_empty);
+        assert_eq!(obs.top_score, None);
+    }
+
+    #[test]
+    fn observation_tracks_count_and_top_score() {
+        let obs = RetrievalObservation::new(BACKEND_FALLBACK, &[0.62, 0.91, 0.75]);
+        assert_eq!(obs.backend, "fallback");
+        assert_eq!(obs.result_count, 3);
+        assert!(!obs.is_empty);
+        assert_eq!(obs.top_score, Some(0.91));
+    }
+
+    #[test]
+    fn observation_single_score_is_top() {
+        let obs = RetrievalObservation::new(BACKEND_PGVECTOR, &[0.5]);
+        assert!(!obs.is_empty);
+        assert_eq!(obs.top_score, Some(0.5));
+    }
+
+    #[test]
+    fn record_retrieval_is_noop_without_recorder() {
+        // No global recorder is installed in unit tests; the facade macros must
+        // remain cheap no-ops and never panic on either the empty or populated
+        // path.
+        record_retrieval(BACKEND_PGVECTOR, Duration::from_millis(12), &[0.8, 0.7]);
+        record_retrieval(BACKEND_FALLBACK, Duration::from_millis(40), &[]);
+    }
+}


### PR DESCRIPTION
## Task
Add observability for pgvector RAG retrieval quality (84-5 shipped) — retrieval latency, top-k relevance, empty-result rate — before feature adoption grows

## Owner
pm-data

## Summary
Instruments the pgvector RAG retrieval choke point — `LlmDocumentRepository::search_documents_pgvector` (the function `ai/sessions.rs` Enhanced-Chat calls, Story 84.5 / 103.5) — with three retrieval-quality signals emitted through the `metrics` facade:

- **`rag_retrieval_duration_seconds`** (histogram, label `backend=pgvector|fallback`) — retrieval latency, timed to cover the pgvector-availability probe and the provenance post-filter, not just the SQL round-trip.
- **`rag_retrieval_relevance_score`** (histogram) — cosine similarity of every returned chunk, i.e. the top-k relevance distribution of what actually reached the model.
- **`rag_retrieval_total`** + **`rag_retrieval_empty_total`** (counters) — empty-result rate = `empty / total`. **`rag_retrieval_results`** (histogram) records the per-call result count.

Emission lives in the `db` crate (pm-data area) behind the exporter-agnostic `metrics` facade, so api-server's existing Prometheus recorder (`/metrics`) picks the series up automatically, and processes without a recorder (unit tests, tooling) see cheap no-ops. Classification logic is factored into a recorder-free `RetrievalObservation` for unit testing.

## Type of Change
- [x] New feature (non-breaking change adding functionality) — observability only, no behavior change to retrieval results.

## Epic/Story Context
- Epic: 84
- Story: 84.5 (pgvector RAG) / observability follow-up

## Changes Made
- `backend/crates/db/src/repositories/rag_metrics.rs` (new) — metric names, `RetrievalObservation`, `record_retrieval`, one-time `describe_*` registration, 4 unit tests.
- `backend/crates/db/src/repositories/llm_document.rs` — time `search_documents_pgvector`; record on both the pgvector-native and fallback return paths via a small `observe_retrieval` helper.
- `backend/crates/db/src/repositories/mod.rs` — declare `pub mod rag_metrics`.
- `backend/crates/db/Cargo.toml` — add `metrics` (workspace) dependency.
- `backend/Cargo.lock` — lockfile update from the dependency add (mechanical).

## Testing
- [x] Unit tests added (`rag_metrics` — 4 tests: empty scores, count+top-score, single score, recorder-free no-op path)

## Verification
```
VERIFY-PLAN base=913b936f705c9a30560e79d48008c6702fd0d933 files=5
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```

The impact gate escalated to full-workspace because the diff touches `Cargo.lock`. In this sandbox the full-workspace band **cannot complete**: `cargo fmt` passed, but `cargo clippy --workspace` aborts in the build script of an unrelated, untouched dependency — `utoipa-swagger-ui v9.0.2` (used only by the server crates for Swagger UI) — which downloads `swagger-ui/…/v5.17.14.zip` from github.com at build time. The org egress policy returns **HTTP 403** for that host (confirmed via `curl` + `$HTTPS_PROXY/__agentproxy/status`), so the download yields a corrupt archive (`InvalidArchive("Could not find EOCD")`). Per the proxy policy this 403 must be reported, not routed around; it does not exist in CI, where the download succeeds.

**This entire change is contained in the `db` crate** (every changed path is under `backend/crates/db/` except the one mechanical `Cargo.lock` line), and the `db` crate does **not** depend on `utoipa-swagger-ui`. It was therefore verified in full at the containing-crate band:

```
cd backend && cargo fmt --all -- --check                         # PASS
cd backend && cargo clippy -p db --all-targets -- -D warnings    # PASS (Finished, 0 warnings)
cd backend && cargo test -p db --lib rag_metrics                 # ok. 4 passed; 0 failed
```

CI (`backend.yml`) runs the true `cargo clippy --workspace` + `cargo test --workspace` with working network and must be green before merge — this PR is kept **draft** until then.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — observability instrumentation only).

## Remote-tested
skipped (no ppt-bridge MCP in this session).

## Scope drift
`scope_drift=true` — one path outside the pm-data areas (`backend/crates/db/**`, `backend/crates/analytics/**`, `docs/data/**`):
- `backend/Cargo.lock` — mechanical lockfile update produced by adding the `metrics` dependency to the `db` crate. No source drift; all `.rs`/`Cargo.toml` changes are in the pm-data area.

## Code-reuse review
`code_reuse_warn=none` — reuse-grep clean. Reuses the existing workspace `metrics` facade (already used by `api-core`/api-server observability) rather than introducing a new metrics mechanism; no new auth/crypto/http helpers.

## Notes
- No change to retrieval results, ordering, thresholds, or RLS behavior — purely additive instrumentation.
- Metric HELP text is registered once per process via a `std::sync::Once` guard inside the db crate, so the series are self-describing wherever a recorder is installed without touching api-server's `observability.rs`.
- `backend` label is deliberately low-cardinality (`pgvector` | `fallback`) — no per-org/per-tenant labels, to keep Prometheus cardinality bounded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01S2UdTbbshDp2Ct2ZyXqagp)_