### PR TITLE
gh-issue-2528: harden booking_push_notification webhook + Airbnb replay parity

### DIFF
--- a/backend/crates/integrations/src/lib.rs
+++ b/backend/crates/integrations/src/lib.rs
@@ -73,11 +73,12 @@ pub use booking::{
 
 // Story 83.3: Portal Webhooks
 pub use portals::{
-    compute_hmac_sha256, get_parser, parse_webhook, verify_webhook_signature,
-    BezrealitkyInquiryData, BezrealitkyParser, BezrealitkyWebhook, GenericParser, GenericWebhook,
-    ImmoweltContact, ImmoweltParser, ImmoweltWebhook, InquiryStatus, ParseError, ParsedInquiry,
-    PortalClient, PortalConnection, PortalError, PortalInquiry, PortalParser, PortalType,
-    SrealityContact, SrealityParser, SrealityWebhook,
+    compute_hmac_sha256, get_parser, parse_webhook, verify_timestamped_signature,
+    verify_webhook_signature, BezrealitkyInquiryData, BezrealitkyParser, BezrealitkyWebhook,
+    GenericParser, GenericWebhook, ImmoweltContact, ImmoweltParser, ImmoweltWebhook, InquiryStatus,
+    ParseError, ParsedInquiry, PortalClient, PortalConnection, PortalError, PortalInquiry,
+    PortalParser, PortalType, SrealityContact, SrealityParser, SrealityWebhook,
+    TimestampedSignatureError,
 };
 
 // Story 61.2: Accounting System Export

--- a/backend/crates/integrations/src/portals.rs
+++ b/backend/crates/integrations/src/portals.rs
@@ -585,6 +585,75 @@ pub fn timestamp_within_tolerance(now_unix: i64, timestamp: i64, tolerance_secs:
     }
 }
 
+/// Why an inbound timestamped webhook signature failed to verify.
+///
+/// Both variants fail closed. Receivers map every variant to an opaque
+/// `401 INVALID_SIGNATURE` (the discriminant is logged, never leaked to the
+/// caller) so an attacker cannot distinguish "stale" from "bad key".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimestampedSignatureError {
+    /// The signed timestamp is outside the freshness window — a stale capture
+    /// being replayed, or an absurd future-dated delivery.
+    StaleTimestamp,
+    /// The HMAC over `"{timestamp}.{body}"` did not match, the signature was
+    /// malformed, or the signing secret was empty.
+    BadSignature,
+}
+
+/// Verify an inbound webhook that binds a unix-seconds `timestamp` into its
+/// HMAC-SHA256 signature as `"{timestamp}.{body}"`, enforcing **authenticity**
+/// (the shared `secret` produced `signature`) and **freshness** (`timestamp`
+/// within `tolerance_secs` of `now_unix`).
+///
+/// This is the single reviewed implementation of the `"{ts}.{body}"` inbound
+/// scheme shared by the hex-signature receivers (the connection-scoped portal,
+/// Airbnb, and Booking.com push receivers in `api-server`) — the R4 follow-up
+/// of the 2026-07 webhook-hardening audit. It mirrors, in one place, the
+/// construction the Stripe receiver (`services::stripe::verify_signature`) and
+/// the per-portal base64 receiver implement in their provider-specific
+/// encodings (those keep bespoke verifiers because their signature encodings —
+/// Stripe's compound `t=/v1=` header, per-portal base64 — differ from the plain
+/// hex handled here).
+///
+/// Fail-closed properties:
+/// * an empty `secret` is rejected (`verify_webhook_signature` would otherwise
+///   compute a valid HMAC under the empty key, so an unset secret must never
+///   verify);
+/// * a `timestamp` outside the window is rejected before the HMAC is checked,
+///   using the overflow-proof [`timestamp_within_tolerance`] (an adversarial
+///   `i64::MIN`/`MAX` cannot panic or wrap the gate);
+/// * folding the timestamp into the signed material means a captured signature
+///   cannot be re-presented with a refreshed timestamp header — the swap
+///   invalidates the HMAC.
+///
+/// An optional `sha256=` prefix on `signature` is tolerated. The HMAC compare
+/// is constant-time (delegated to [`verify_webhook_signature`]).
+///
+/// `now_unix` / `tolerance_secs` are injected so the freshness window is
+/// unit-testable without wall-clock dependence.
+pub fn verify_timestamped_signature(
+    secret: &str,
+    timestamp: i64,
+    body: &str,
+    signature: &str,
+    now_unix: i64,
+    tolerance_secs: i64,
+) -> Result<(), TimestampedSignatureError> {
+    if secret.is_empty() {
+        return Err(TimestampedSignatureError::BadSignature);
+    }
+    if !timestamp_within_tolerance(now_unix, timestamp, tolerance_secs) {
+        return Err(TimestampedSignatureError::StaleTimestamp);
+    }
+    let signature = signature.trim_start_matches("sha256=");
+    let signed_payload = format!("{timestamp}.{body}");
+    if verify_webhook_signature(secret, &signed_payload, signature) {
+        Ok(())
+    } else {
+        Err(TimestampedSignatureError::BadSignature)
+    }
+}
+
 /// Compute HMAC-SHA256 signature for a payload.
 ///
 /// # Arguments
@@ -892,6 +961,113 @@ mod tests {
         assert_eq!(
             url,
             "https://api.example.com/api/v1/webhooks/portal/550e8400-e29b-41d4-a716-446655440000"
+        );
+    }
+
+    // ---- verify_timestamped_signature (audit R4 shared helper) ----
+
+    const TS_SECRET: &str = "shared_ts_secret";
+    const TS_BODY: &str = r#"{"event":"reservation.created","id":"r1"}"#;
+    const TS_NOW: i64 = 1_700_000_000;
+    const TS_TOL: i64 = 300;
+
+    fn ts_sign(secret: &str, ts: i64, body: &str) -> String {
+        compute_hmac_sha256(secret, &format!("{ts}.{body}"))
+    }
+
+    #[test]
+    fn timestamped_sig_accepts_valid() {
+        let sig = ts_sign(TS_SECRET, TS_NOW, TS_BODY);
+        assert_eq!(
+            verify_timestamped_signature(TS_SECRET, TS_NOW, TS_BODY, &sig, TS_NOW, TS_TOL),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn timestamped_sig_accepts_sha256_prefix() {
+        let sig = format!("sha256={}", ts_sign(TS_SECRET, TS_NOW, TS_BODY));
+        assert_eq!(
+            verify_timestamped_signature(TS_SECRET, TS_NOW, TS_BODY, &sig, TS_NOW, TS_TOL),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn timestamped_sig_rejects_empty_secret() {
+        // An unset secret must never verify, even under a syntactically valid
+        // signature computed with the empty key.
+        let sig = ts_sign("", TS_NOW, TS_BODY);
+        assert_eq!(
+            verify_timestamped_signature("", TS_NOW, TS_BODY, &sig, TS_NOW, TS_TOL),
+            Err(TimestampedSignatureError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn timestamped_sig_rejects_wrong_secret() {
+        let sig = ts_sign("attacker", TS_NOW, TS_BODY);
+        assert_eq!(
+            verify_timestamped_signature(TS_SECRET, TS_NOW, TS_BODY, &sig, TS_NOW, TS_TOL),
+            Err(TimestampedSignatureError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn timestamped_sig_rejects_tampered_body() {
+        let sig = ts_sign(TS_SECRET, TS_NOW, TS_BODY);
+        let tampered = r#"{"event":"reservation.created","id":"evil"}"#;
+        assert_eq!(
+            verify_timestamped_signature(TS_SECRET, TS_NOW, tampered, &sig, TS_NOW, TS_TOL),
+            Err(TimestampedSignatureError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn timestamped_sig_rejects_stale_and_future() {
+        for ts in [TS_NOW - TS_TOL - 1, TS_NOW + TS_TOL + 1] {
+            let sig = ts_sign(TS_SECRET, ts, TS_BODY);
+            assert_eq!(
+                verify_timestamped_signature(TS_SECRET, ts, TS_BODY, &sig, TS_NOW, TS_TOL),
+                Err(TimestampedSignatureError::StaleTimestamp),
+                "timestamp {ts} must be rejected as stale"
+            );
+        }
+    }
+
+    #[test]
+    fn timestamped_sig_accepts_exact_boundary() {
+        for ts in [TS_NOW - TS_TOL, TS_NOW + TS_TOL] {
+            let sig = ts_sign(TS_SECRET, ts, TS_BODY);
+            assert_eq!(
+                verify_timestamped_signature(TS_SECRET, ts, TS_BODY, &sig, TS_NOW, TS_TOL),
+                Ok(())
+            );
+        }
+    }
+
+    #[test]
+    fn timestamped_sig_rejects_adversarial_overflow_without_panic() {
+        // Regression for issue #2330: an adversarial timestamp near i64::MIN/MAX
+        // must reject as stale, never panic under overflow-checks builds.
+        for ts in [i64::MIN, i64::MIN + 1, i64::MAX, i64::MAX - 1] {
+            let sig = ts_sign(TS_SECRET, ts, TS_BODY);
+            assert_eq!(
+                verify_timestamped_signature(TS_SECRET, ts, TS_BODY, &sig, TS_NOW, TS_TOL),
+                Err(TimestampedSignatureError::StaleTimestamp)
+            );
+        }
+    }
+
+    #[test]
+    fn timestamped_sig_rejects_timestamp_swap_on_captured_signature() {
+        // Core replay defense: a captured (old_ts, sig) pair re-presented with a
+        // fresh timestamp is rejected because ts is folded into the HMAC.
+        let old_ts = TS_NOW - 10_000;
+        let sig = ts_sign(TS_SECRET, old_ts, TS_BODY);
+        assert_eq!(
+            verify_timestamped_signature(TS_SECRET, TS_NOW, TS_BODY, &sig, TS_NOW, TS_TOL),
+            Err(TimestampedSignatureError::BadSignature)
         );
     }
 }

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -973,24 +973,198 @@ pub async fn esignature_webhook(
 
 // ==================== Inbound: Booking.com Push ====================
 
+/// Maximum accepted skew (seconds) between a Booking.com push's signed
+/// timestamp and the receiver's clock. Mirrors the portal/Stripe receivers'
+/// 5-minute replay-protection window.
+const BOOKING_WEBHOOK_TOLERANCE_SECS: i64 = 300;
+
+/// In-process, TTL-bounded replay ledger for the Booking.com push receiver
+/// (audit R1 dedup leg).
+///
+/// The signed-timestamp window bounds the replay *duration* (±tolerance) but not
+/// the *count*: within the window a captured valid delivery could still be
+/// replayed N times. Booking.com guarantees at-least-once delivery, so a genuine
+/// retry is byte-identical and yields the same dedup key. This guard suppresses
+/// both — a duplicate key seen inside the retention window is treated as
+/// already-processed and acked idempotently.
+///
+/// It is deliberately in-process (no migration): the receiver has no state
+/// mutation today (audit F1 — it only parses OTA XML and acks), so a persistent,
+/// cross-replica ledger (the `airbnb_webhook_events` pattern) is only *required*
+/// before this receiver is wired to persist reservations (audit R1 blocking
+/// condition). Retention is pinned to the freshness window so an entry never
+/// outlives the timestamp tolerance that would let the same delivery back in
+/// anyway, which also bounds the map size.
+///
+/// The decision logic ([`BookingReplayGuard::check_and_record`]) takes an
+/// injected `now`, so it is unit-testable without wall-clock dependence.
+#[derive(Default)]
+struct BookingReplayGuard {
+    seen: std::sync::Mutex<std::collections::HashMap<String, i64>>,
+}
+
+impl BookingReplayGuard {
+    /// Record `key` as seen at `now_unix`. Returns `true` when the key is
+    /// first-seen (caller should process), `false` when it is a duplicate still
+    /// inside the `retention_secs` window (caller should ack idempotently).
+    /// Expired entries are opportunistically evicted on each call so the map
+    /// cannot grow without bound.
+    fn check_and_record(&self, key: &str, now_unix: i64, retention_secs: i64) -> bool {
+        let mut seen = match self.seen.lock() {
+            Ok(g) => g,
+            // A poisoned lock must not wedge the receiver. The dedup layer is
+            // defense-in-depth (signature + freshness already gate authenticity),
+            // so recover the guard and continue rather than fail the request.
+            Err(p) => p.into_inner(),
+        };
+        // Evict entries older than the retention window (overflow-proof).
+        seen.retain(|_, &mut ts| {
+            now_unix
+                .checked_sub(ts)
+                .map(|skew| skew <= retention_secs)
+                .unwrap_or(false)
+        });
+        if seen.contains_key(key) {
+            return false;
+        }
+        seen.insert(key.to_string(), now_unix);
+        true
+    }
+}
+
+/// Process-global Booking.com replay ledger (see [`BookingReplayGuard`]).
+static BOOKING_REPLAY_GUARD: std::sync::OnceLock<BookingReplayGuard> = std::sync::OnceLock::new();
+
+fn booking_replay_guard() -> &'static BookingReplayGuard {
+    BOOKING_REPLAY_GUARD.get_or_init(BookingReplayGuard::default)
+}
+
+/// Compute the idempotency/dedup key for an inbound Booking.com push delivery.
+///
+/// Booking.com redelivers the byte-identical signed body on an at-least-once
+/// retry, so a SHA-256 over the raw body is a stable key across redeliveries
+/// while differing for any distinct notification. Reservation ids parsed from
+/// the OTA payload are folded in first (for observability and stability against
+/// insignificant reordering), with the body hash as the collision-proof tail.
+/// Mirrors the Airbnb synthetic-key derivation ([`airbnb_dedup_key`]).
+fn booking_dedup_key(body: &str, res_ids: &[String]) -> String {
+    use sha2::Digest;
+    let mut hasher = Sha256::new();
+    for id in res_ids {
+        hasher.update(id.as_bytes());
+        hasher.update(b"|");
+    }
+    hasher.update(body.as_bytes());
+    format!("booking:{}", hex::encode(hasher.finalize()))
+}
+
 /// Handle Booking.com push notification.
+///
+/// Fail-closed inbound receiver (audit F1/R1). The endpoint has no request
+/// principal — Booking.com POSTs OTA `OTA_HotelResNotifRQ` XML to the URL handed
+/// to them at connection time — so authenticity is established by verifying an
+/// HMAC-SHA256 `X-Booking-Signature` over `"{X-Booking-Timestamp}.{raw_body}"`
+/// against the shared `BOOKING_WEBHOOK_SECRET`, exactly like the sibling portal
+/// ([`handle_portal_webhook`]) / Airbnb ([`handle_airbnb_webhook`]) / Stripe
+/// ([`handle_payment_webhook`]) receivers, **before** the payload is parsed.
+///
+/// The receiver fails closed: an unset secret is `503 NOT_CONFIGURED`; a
+/// missing/malformed timestamp, a stale/future timestamp, or an invalid/absent
+/// signature are all `401 INVALID_SIGNATURE`. Timestamp freshness closes the
+/// replay window and an in-process dedup ledger ([`BookingReplayGuard`])
+/// suppresses at-least-once redeliveries within that window; both are idempotent
+/// (a duplicate is acked with the same OTA `<Success/>`).
+///
+/// Raw `Bytes` are taken so the HMAC is computed over the exact bytes signed —
+/// UTF-8 decoding happens after signature verification.
 #[utoipa::path(
     post,
     path = "/api/v1/integrations/booking/push",
+    params(
+        ("X-Booking-Timestamp" = String, Header,
+         description = "Unix-seconds timestamp of the delivery. Signed as part of \"{timestamp}.{body}\"; deliveries outside ±300s of server time are rejected 401 (replay defense)."),
+        ("X-Booking-Signature" = String, Header,
+         description = "Hex HMAC-SHA256 (optionally `sha256=`-prefixed) over \"{X-Booking-Timestamp}.{raw_body}\" keyed by BOOKING_WEBHOOK_SECRET."),
+    ),
     responses(
         (status = 200, description = "Push notification processed"),
         (status = 400, description = "Invalid notification"),
-        (status = 500, description = "Internal server error")
+        (status = 401, description = "Invalid signature or stale timestamp"),
+        (status = 500, description = "Internal server error"),
+        (status = 503, description = "Webhook signature verification not configured")
     ),
     tag = "Integrations - Booking.com"
 )]
 pub async fn booking_push_notification(
-    State(_state): State<AppState>,
-    body: String,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: Bytes,
 ) -> Result<Response<Body>, (StatusCode, Json<ErrorResponse>)> {
     tracing::info!("Received Booking.com push notification");
 
-    let _notifications = ota_xml::parse_res_notif_rq_raw(&body).map_err(|e| {
+    // Fail closed when the signing secret is not configured — never accept an
+    // unverified OTA push (audit F1/R1).
+    let secret = state.booking_config.webhook_secret.as_str();
+    if secret.is_empty() {
+        tracing::error!("BOOKING_WEBHOOK_SECRET is not configured — refusing Booking.com push");
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse::new(
+                "NOT_CONFIGURED",
+                "Booking.com push signature verification is not configured",
+            )),
+        ));
+    }
+
+    // Decode for signing over the exact received bytes (HMAC is over the raw
+    // body; a non-UTF-8 body can never be a valid OTA XML push anyway).
+    let body_str = std::str::from_utf8(&body).map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "INVALID_ENCODING",
+                "Request body is not valid UTF-8",
+            )),
+        )
+    })?;
+
+    // Verify HMAC signature AND timestamp freshness over the raw body BEFORE
+    // parsing or acting. A missing/malformed timestamp fails closed (an attacker
+    // cannot strip the header to defeat replay protection).
+    let timestamp = headers
+        .get("X-Booking-Timestamp")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|t| t.trim().parse::<i64>().ok());
+    let signature = headers
+        .get("X-Booking-Signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default();
+
+    let now_unix = chrono::Utc::now().timestamp();
+    let verified = match timestamp {
+        Some(ts) => integrations::verify_timestamped_signature(
+            secret,
+            ts,
+            body_str,
+            signature,
+            now_unix,
+            BOOKING_WEBHOOK_TOLERANCE_SECS,
+        ),
+        None => Err(integrations::TimestampedSignatureError::BadSignature),
+    };
+    if let Err(reason) = verified {
+        tracing::warn!(?reason, "Booking.com push rejected (signature/freshness)");
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse::new(
+                "INVALID_SIGNATURE",
+                "Webhook signature or freshness verification failed",
+            )),
+        ));
+    }
+
+    // Parse only AFTER authenticity + freshness are established.
+    let notifications = ota_xml::parse_res_notif_rq_raw(body_str).map_err(|e| {
         tracing::error!(error = %e, "Failed to parse Booking.com notification");
         (
             StatusCode::BAD_REQUEST,
@@ -1000,6 +1174,30 @@ pub async fn booking_push_notification(
             )),
         )
     })?;
+
+    // Dedup / replay-count defense: suppress an at-least-once redelivery within
+    // the freshness window. Harmless-but-first-class today (no side effects);
+    // becomes load-bearing the moment this receiver mutates state (audit R1).
+    let res_ids: Vec<String> = notifications.iter().map(|(id, _, _)| id.clone()).collect();
+    let dedup_key = booking_dedup_key(body_str, &res_ids);
+    let first_seen = booking_replay_guard().check_and_record(
+        &dedup_key,
+        now_unix,
+        BOOKING_WEBHOOK_TOLERANCE_SECS,
+    );
+    if first_seen {
+        tracing::debug!(
+            dedup_key = %dedup_key,
+            reservation_count = notifications.len(),
+            "Booking.com push: first-seen delivery recorded in replay guard"
+        );
+    } else {
+        // Idempotent ack — no reprocessing, same OTA <Success/> response.
+        tracing::info!(
+            dedup_key = %dedup_key,
+            "Booking.com push: duplicate delivery suppressed by replay guard, acking idempotently"
+        );
+    }
 
     let response_xml = ota_xml::build_res_notif_rs(true, None).map_err(|e| {
         tracing::error!(error = %e, "Failed to build Booking.com response");
@@ -1073,9 +1271,12 @@ enum PortalWebhookError {
 ///
 /// `now_unix`/`tolerance_secs` are injected so the window is unit-testable
 /// without wall-clock dependence, matching
-/// [`crate::services::stripe::verify_signature`]. The HMAC comparison is
-/// constant-time (delegated to [`integrations::verify_webhook_signature`]) so
-/// it cannot leak the expected signature through timing.
+/// [`crate::services::stripe::verify_signature`]. The freshness + constant-time
+/// HMAC check is delegated to the shared
+/// [`integrations::verify_timestamped_signature`] helper (the 2026-07 audit R4
+/// consolidation) so every `"{ts}.{body}"` hex receiver runs one reviewed
+/// implementation; this wrapper only adapts header parsing and the opaque
+/// error taxonomy.
 fn verify_portal_webhook(
     secret: &str,
     body: &str,
@@ -1084,10 +1285,11 @@ fn verify_portal_webhook(
     now_unix: i64,
     tolerance_secs: i64,
 ) -> Result<(), PortalWebhookError> {
-    // Defense-in-depth: `integrations::verify_webhook_signature` computes a valid
-    // HMAC even for an empty key, so an unset secret must be rejected here too and
-    // not only in the handler's up-front `500 CONFIG_ERROR` guard — otherwise a
-    // caller signing with the empty key would verify.
+    // Defense-in-depth: the shared helper computes a valid HMAC even for an empty
+    // key, so an unset secret must be rejected here too and not only in the
+    // handler's up-front `500 CONFIG_ERROR` guard — otherwise a caller signing
+    // with the empty key would verify. (The helper also rejects it, but keeping
+    // the guard preserves the original error ordering pinned by the unit tests.)
     if secret.is_empty() {
         return Err(PortalWebhookError::BadSignature);
     }
@@ -1096,26 +1298,26 @@ fn verify_portal_webhook(
         .and_then(|t| t.trim().parse::<i64>().ok())
         .ok_or(PortalWebhookError::MalformedTimestamp)?;
 
-    // Replay defense: reject deliveries whose signed timestamp is too far from
-    // now — a stale capture being replayed, or an absurd future-dated delivery.
-    // Overflow-proof (issue #2330): the skew is computed with a checked
-    // subtraction in the shared helper, so an adversarial timestamp near
-    // i64::MIN cannot panic (debug) or wrap the freshness gate (release).
-    if !integrations::portals::timestamp_within_tolerance(now_unix, timestamp, tolerance_secs) {
-        return Err(PortalWebhookError::StaleTimestamp);
-    }
+    let signature = signature_header.ok_or(PortalWebhookError::BadSignature)?;
 
-    let signature = signature_header
-        .map(|s| s.trim_start_matches("sha256="))
-        .ok_or(PortalWebhookError::BadSignature)?;
-
-    // signed_payload = "{timestamp}.{raw_body}" — same construction as the
-    // Stripe receiver, so the timestamp cannot be tampered with independently.
-    let signed_payload = format!("{timestamp}.{body}");
-    if integrations::verify_webhook_signature(secret, &signed_payload, signature) {
-        Ok(())
-    } else {
-        Err(PortalWebhookError::BadSignature)
+    // Freshness + authenticity over "{timestamp}.{raw_body}" — same construction
+    // as the Stripe receiver — via the shared helper (overflow-proof window,
+    // constant-time compare). Map its opaque error variants onto this receiver's.
+    match integrations::verify_timestamped_signature(
+        secret,
+        timestamp,
+        body,
+        signature,
+        now_unix,
+        tolerance_secs,
+    ) {
+        Ok(()) => Ok(()),
+        Err(integrations::TimestampedSignatureError::StaleTimestamp) => {
+            Err(PortalWebhookError::StaleTimestamp)
+        }
+        Err(integrations::TimestampedSignatureError::BadSignature) => {
+            Err(PortalWebhookError::BadSignature)
+        }
     }
 }
 
@@ -1266,11 +1468,66 @@ fn airbnb_dedup_key(event: &integrations::AirbnbWebhookEvent) -> String {
     format!("synthetic:{}", hex::encode(hasher.finalize()))
 }
 
+/// Maximum accepted skew (seconds) between an inbound Airbnb webhook's signed
+/// timestamp and the receiver's clock, when the delivery carries an
+/// `X-Airbnb-Timestamp` header. Mirrors the portal/Stripe receivers' 5-minute
+/// replay-protection window (audit R2).
+const AIRBNB_WEBHOOK_TOLERANCE_SECS: i64 = 300;
+
+/// Establish the authenticity (and, when timestamped, freshness) of an inbound
+/// Airbnb delivery — the staged accept-both decision (audit R2), extracted so it
+/// is unit-testable without wall-clock dependence (`now_unix` is injected).
+///
+/// * `X-Airbnb-Timestamp` **present** ⇒ verify the signature over
+///   `"{timestamp}.{body}"` and require the timestamp within `tolerance_secs`
+///   (shared [`integrations::verify_timestamped_signature`]). A present-but-
+///   malformed timestamp fails closed, so an attacker cannot send a garbage
+///   header to fall back to the no-freshness path.
+/// * **absent** ⇒ accept a legacy body-only signature (migration window); replay
+///   for those deliveries stays neutralized by the persistent dedup ledger.
+///
+/// Returns `true` when the delivery is authentic (and fresh, if timestamped).
+fn verify_airbnb_delivery(
+    secret: &str,
+    timestamp_header: Option<&str>,
+    signature: &str,
+    body: &str,
+    now_unix: i64,
+    tolerance_secs: i64,
+) -> bool {
+    match timestamp_header {
+        Some(ts_raw) => match ts_raw.trim().parse::<i64>() {
+            Ok(ts) => integrations::verify_timestamped_signature(
+                secret,
+                ts,
+                body,
+                signature,
+                now_unix,
+                tolerance_secs,
+            )
+            .is_ok(),
+            Err(_) => false,
+        },
+        None => AirbnbClient::verify_webhook_signature(signature, body, secret),
+    }
+}
+
 /// Receive and dispatch an inbound Airbnb webhook event.
 ///
-/// Airbnb signs every delivery with HMAC-SHA256 over the raw body using the
-/// shared secret from `AIRBNB_WEBHOOK_SECRET`. The signature is verified
+/// Airbnb signs every delivery with HMAC-SHA256 keyed by the shared secret from
+/// `AIRBNB_WEBHOOK_SECRET`; the signature (`X-Airbnb-Signature`) is verified
 /// before the payload is parsed to reject unauthenticated callers.
+///
+/// Replay freshness (audit R2, staged accept-both): when the delivery carries an
+/// `X-Airbnb-Timestamp` header the signature is verified over the timestamped
+/// payload `"{timestamp}.{body}"` (via the shared
+/// [`integrations::verify_timestamped_signature`]) and the timestamp must fall
+/// within [`AIRBNB_WEBHOOK_TOLERANCE_SECS`] of server time, giving the same
+/// replay posture as the portal/Stripe receivers. Until Airbnb senders are
+/// migrated to send that header, a legacy **body-only** signature is still
+/// accepted (with a deprecation warning); replay for those deliveries remains
+/// neutralized by the persistent dedup ledger in step 4. Once every sender sends
+/// the header the legacy branch should be removed so freshness is mandatory.
 ///
 /// Raw `Bytes` are used so the HMAC is computed over the exact bytes Airbnb
 /// signed — UTF-8 decoding happens after signature verification.
@@ -1278,9 +1535,13 @@ fn airbnb_dedup_key(event: &integrations::AirbnbWebhookEvent) -> String {
     post,
     path = "/api/v1/integrations/airbnb/webhook",
     request_body(content = String, content_type = "application/json", description = "Airbnb webhook event payload"),
+    params(
+        ("X-Airbnb-Timestamp" = Option<String>, Header,
+         description = "Optional unix-seconds timestamp. When present the signature covers \"{timestamp}.{body}\" and deliveries outside ±300s of server time are rejected 401 (replay defense, audit R2). Absent ⇒ legacy body-only signature (accepted during the accept-both rollout)."),
+    ),
     responses(
         (status = 200, description = "Webhook processed"),
-        (status = 401, description = "Invalid signature"),
+        (status = 401, description = "Invalid signature or stale timestamp"),
         (status = 500, description = "Internal server error")
     ),
     tag = "Integrations - Airbnb"
@@ -1322,7 +1583,35 @@ pub async fn handle_airbnb_webhook(
         )
     })?;
 
-    if !AirbnbClient::verify_webhook_signature(signature, body_str, secret) {
+    // Staged accept-both (audit R2): when the delivery carries an
+    // `X-Airbnb-Timestamp` header, enforce the same `"{timestamp}.{body}"`
+    // freshness window as the portal/Stripe receivers (folding the timestamp
+    // into the signed material so it cannot be swapped without invalidating the
+    // signature). Absent header ⇒ legacy body-only signature is still accepted
+    // during the migration; replay for those is already neutralized by the
+    // dedup ledger in step 4.
+    let ts_header = headers
+        .get("X-Airbnb-Timestamp")
+        .and_then(|v| v.to_str().ok());
+    let now_unix = chrono::Utc::now().timestamp();
+    let authentic = verify_airbnb_delivery(
+        secret,
+        ts_header,
+        signature,
+        body_str,
+        now_unix,
+        AIRBNB_WEBHOOK_TOLERANCE_SECS,
+    );
+    if authentic && ts_header.is_none() {
+        tracing::warn!(
+            "Airbnb webhook accepted with a legacy body-only signature and no \
+             X-Airbnb-Timestamp — replay freshness is NOT in effect for this delivery \
+             (dedup ledger still applies). Migrate this sender to sign \
+             \"{{timestamp}}.{{body}}\" and send X-Airbnb-Timestamp (audit R2)."
+        );
+    }
+
+    if !authentic {
         tracing::warn!("Airbnb webhook signature verification failed");
         return Err((
             StatusCode::UNAUTHORIZED,
@@ -2236,5 +2525,274 @@ mod portal_webhook_signature_tests {
             ),
             Err(PortalWebhookError::BadSignature)
         );
+    }
+}
+
+// ==================== Booking.com push: auth + freshness + dedup tests ====================
+//
+// Regression cover for the audit F1/R1 fix: the Booking.com push receiver used
+// to perform NO signature, timestamp, or dedup check — any caller could POST OTA
+// XML and receive a `<Success/>` ack. These pin the three properties it now
+// enforces before parsing/acting:
+//   1. authenticity + freshness over "{X-Booking-Timestamp}.{body}" (shared
+//      `verify_timestamped_signature` at BOOKING_WEBHOOK_TOLERANCE_SECS);
+//   2. a stable dedup key across at-least-once redeliveries;
+//   3. an in-process replay guard that suppresses a duplicate within the window.
+#[cfg(test)]
+mod booking_webhook_tests {
+    use super::{booking_dedup_key, BookingReplayGuard, BOOKING_WEBHOOK_TOLERANCE_SECS};
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    const SECRET: &str = "booking_webhook_secret";
+    const BODY: &str = r#"<OTA_HotelResNotifRQ><HotelReservation ResStatus="Commit"><HotelReservationID ResID_Value="R1"/></HotelReservation></OTA_HotelResNotifRQ>"#;
+    const NOW: i64 = 1_700_000_000;
+
+    fn sign_ts(secret: &str, ts: i64, body: &str) -> String {
+        let mut mac =
+            HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+        mac.update(format!("{ts}.{body}").as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    // ---- authenticity + freshness (the F1 auth-bypass fix) ----
+
+    #[test]
+    fn accepts_valid_signed_and_fresh_delivery() {
+        let sig = sign_ts(SECRET, NOW, BODY);
+        assert_eq!(
+            integrations::verify_timestamped_signature(
+                SECRET,
+                NOW,
+                BODY,
+                &sig,
+                NOW,
+                BOOKING_WEBHOOK_TOLERANCE_SECS,
+            ),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn rejects_forged_or_unsigned_delivery() {
+        // The pre-fix bypass: an arbitrary/forged signature must not verify.
+        assert_eq!(
+            integrations::verify_timestamped_signature(
+                SECRET,
+                NOW,
+                BODY,
+                "deadbeef",
+                NOW,
+                BOOKING_WEBHOOK_TOLERANCE_SECS,
+            ),
+            Err(integrations::TimestampedSignatureError::BadSignature)
+        );
+    }
+
+    #[test]
+    fn rejects_stale_replay_and_timestamp_swap() {
+        // Stale capture outside the window.
+        let stale = NOW - BOOKING_WEBHOOK_TOLERANCE_SECS - 1;
+        let stale_sig = sign_ts(SECRET, stale, BODY);
+        assert_eq!(
+            integrations::verify_timestamped_signature(
+                SECRET,
+                stale,
+                BODY,
+                &stale_sig,
+                NOW,
+                BOOKING_WEBHOOK_TOLERANCE_SECS,
+            ),
+            Err(integrations::TimestampedSignatureError::StaleTimestamp)
+        );
+        // Captured old signature re-presented with a fresh timestamp: the
+        // folded timestamp invalidates the HMAC.
+        let old_sig = sign_ts(SECRET, NOW - 10_000, BODY);
+        assert_eq!(
+            integrations::verify_timestamped_signature(
+                SECRET,
+                NOW,
+                BODY,
+                &old_sig,
+                NOW,
+                BOOKING_WEBHOOK_TOLERANCE_SECS,
+            ),
+            Err(integrations::TimestampedSignatureError::BadSignature)
+        );
+    }
+
+    // ---- dedup key ----
+
+    #[test]
+    fn dedup_key_is_stable_across_byte_identical_redelivery() {
+        let a = booking_dedup_key(BODY, &["R1".to_string()]);
+        let b = booking_dedup_key(BODY, &["R1".to_string()]);
+        assert_eq!(a, b);
+        assert!(a.starts_with("booking:"), "unexpected key: {a}");
+    }
+
+    #[test]
+    fn dedup_key_differs_for_distinct_deliveries() {
+        let a = booking_dedup_key(BODY, &["R1".to_string()]);
+        let other_body = BODY.replace("R1", "R2");
+        let b = booking_dedup_key(&other_body, &["R2".to_string()]);
+        assert_ne!(a, b);
+    }
+
+    // ---- in-process replay guard ----
+
+    #[test]
+    fn replay_guard_first_seen_then_duplicate_suppressed() {
+        let guard = BookingReplayGuard::default();
+        let key = "booking:abc";
+        // First delivery is processed; an immediate redelivery is suppressed.
+        assert!(guard.check_and_record(key, NOW, BOOKING_WEBHOOK_TOLERANCE_SECS));
+        assert!(!guard.check_and_record(key, NOW + 1, BOOKING_WEBHOOK_TOLERANCE_SECS));
+    }
+
+    #[test]
+    fn replay_guard_reaccepts_after_retention_window() {
+        let guard = BookingReplayGuard::default();
+        let key = "booking:abc";
+        assert!(guard.check_and_record(key, NOW, BOOKING_WEBHOOK_TOLERANCE_SECS));
+        // Once the entry ages past the retention window it is evicted; a delivery
+        // that far in the future would itself be stale at the signature gate, so
+        // re-accepting here does not widen the replay window.
+        assert!(guard.check_and_record(
+            key,
+            NOW + BOOKING_WEBHOOK_TOLERANCE_SECS + 1,
+            BOOKING_WEBHOOK_TOLERANCE_SECS,
+        ));
+    }
+
+    #[test]
+    fn replay_guard_distinct_keys_are_independent() {
+        let guard = BookingReplayGuard::default();
+        assert!(guard.check_and_record("booking:a", NOW, BOOKING_WEBHOOK_TOLERANCE_SECS));
+        assert!(guard.check_and_record("booking:b", NOW, BOOKING_WEBHOOK_TOLERANCE_SECS));
+    }
+}
+
+// ==================== Airbnb timestamp-parity (staged accept-both) tests ====================
+//
+// Regression cover for the audit R2 fix: the Airbnb receiver verified a body-only
+// HMAC with no freshness window. It now enforces "{timestamp}.{body}" freshness
+// when the delivery carries `X-Airbnb-Timestamp`, while still accepting a legacy
+// body-only signature during the migration. These pin `verify_airbnb_delivery`.
+#[cfg(test)]
+mod airbnb_timestamp_parity_tests {
+    use super::{verify_airbnb_delivery, AIRBNB_WEBHOOK_TOLERANCE_SECS};
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    const SECRET: &str = "airbnb_webhook_secret";
+    const BODY: &str = r#"{"event_type":"reservation_created","listing_id":"L1","timestamp":"2026-01-01T00:00:00Z","payload":{}}"#;
+    const NOW: i64 = 1_700_000_000;
+
+    fn sign_ts(secret: &str, ts: i64, body: &str) -> String {
+        let mut mac =
+            HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+        mac.update(format!("{ts}.{body}").as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    fn sign_body(secret: &str, body: &str) -> String {
+        let mut mac =
+            HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+        mac.update(body.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    #[test]
+    fn timestamped_delivery_within_window_is_accepted() {
+        let sig = sign_ts(SECRET, NOW, BODY);
+        assert!(verify_airbnb_delivery(
+            SECRET,
+            Some(&NOW.to_string()),
+            &sig,
+            BODY,
+            NOW,
+            AIRBNB_WEBHOOK_TOLERANCE_SECS,
+        ));
+    }
+
+    #[test]
+    fn timestamped_delivery_outside_window_is_rejected() {
+        let stale = NOW - AIRBNB_WEBHOOK_TOLERANCE_SECS - 1;
+        let sig = sign_ts(SECRET, stale, BODY);
+        assert!(!verify_airbnb_delivery(
+            SECRET,
+            Some(&stale.to_string()),
+            &sig,
+            BODY,
+            NOW,
+            AIRBNB_WEBHOOK_TOLERANCE_SECS,
+        ));
+    }
+
+    #[test]
+    fn timestamp_swap_on_captured_signature_is_rejected() {
+        let sig = sign_ts(SECRET, NOW - 10_000, BODY);
+        assert!(!verify_airbnb_delivery(
+            SECRET,
+            Some(&NOW.to_string()),
+            &sig,
+            BODY,
+            NOW,
+            AIRBNB_WEBHOOK_TOLERANCE_SECS,
+        ));
+    }
+
+    #[test]
+    fn present_but_malformed_timestamp_fails_closed() {
+        // A body-only signature paired with a garbage timestamp header must not
+        // fall back to the no-freshness path.
+        let sig = sign_body(SECRET, BODY);
+        assert!(!verify_airbnb_delivery(
+            SECRET,
+            Some("not-a-number"),
+            &sig,
+            BODY,
+            NOW,
+            AIRBNB_WEBHOOK_TOLERANCE_SECS,
+        ));
+    }
+
+    #[test]
+    fn legacy_body_only_signature_accepted_when_no_timestamp() {
+        // Accept-both migration window: no header ⇒ legacy body-only signature.
+        let sig = sign_body(SECRET, BODY);
+        assert!(verify_airbnb_delivery(
+            SECRET,
+            None,
+            &sig,
+            BODY,
+            NOW,
+            AIRBNB_WEBHOOK_TOLERANCE_SECS,
+        ));
+    }
+
+    #[test]
+    fn forged_signature_rejected_on_both_paths() {
+        assert!(!verify_airbnb_delivery(
+            SECRET,
+            None,
+            "deadbeef",
+            BODY,
+            NOW,
+            AIRBNB_WEBHOOK_TOLERANCE_SECS,
+        ));
+        assert!(!verify_airbnb_delivery(
+            SECRET,
+            Some(&NOW.to_string()),
+            "deadbeef",
+            BODY,
+            NOW,
+            AIRBNB_WEBHOOK_TOLERANCE_SECS,
+        ));
     }
 }

--- a/backend/servers/api-server/src/routes/integrations/webhook.rs
+++ b/backend/servers/api-server/src/routes/integrations/webhook.rs
@@ -1080,6 +1080,7 @@ fn booking_dedup_key(body: &str, res_ids: &[String]) -> String {
 #[utoipa::path(
     post,
     path = "/api/v1/integrations/booking/push",
+    request_body(content = String, content_type = "application/xml", description = "Raw signed OTA_HotelResNotifRQ webhook payload (HMAC-SHA256 verified over \"{X-Booking-Timestamp}.{body}\" before parsing)"),
     params(
         ("X-Booking-Timestamp" = String, Header,
          description = "Unix-seconds timestamp of the delivery. Signed as part of \"{timestamp}.{body}\"; deliveries outside ±300s of server time are rejected 401 (replay defense)."),

--- a/backend/servers/api-server/src/state.rs
+++ b/backend/servers/api-server/src/state.rs
@@ -112,6 +112,12 @@ pub struct BookingOAuthAppConfig {
     pub client_secret: String,
     /// `BOOKING_REDIRECT_URI` — the registered OAuth callback URI.
     pub redirect_uri: String,
+    /// `BOOKING_WEBHOOK_SECRET` — HMAC-SHA256 signing secret for the inbound
+    /// push receiver (`X-Booking-Signature` over `"{X-Booking-Timestamp}.{body}"`).
+    /// Required to accept a Booking.com push (audit F1/R1); empty ⇒ the receiver
+    /// fails closed with `503 NOT_CONFIGURED` so an unverified, attacker-forged
+    /// OTA payload is never processed.
+    pub webhook_secret: String,
 }
 
 impl BookingOAuthAppConfig {
@@ -122,6 +128,7 @@ impl BookingOAuthAppConfig {
             client_id: std::env::var("BOOKING_CLIENT_ID").unwrap_or_default(),
             client_secret: std::env::var("BOOKING_CLIENT_SECRET").unwrap_or_default(),
             redirect_uri: std::env::var("BOOKING_REDIRECT_URI").unwrap_or_default(),
+            webhook_secret: std::env::var("BOOKING_WEBHOOK_SECRET").unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
## Task
Follow-up: harden `booking_push_notification` webhook + Airbnb replay parity (PR #2499). Add fail-closed HMAC signature + timestamp + dedup verification to `booking_push_notification` at `/api/v1/integrations/booking/push` (mirror the Airbnb/Stripe receiver pattern); bring the Airbnb inbound receiver (`handle_airbnb_webhook`) to `{timestamp}.{body}` timestamped-signature parity with a freshness window; extract a shared `verify_timestamped_signature(secret, ts, body, sig, now, tol)` helper into `backend/crates/integrations/`. Add security/regression tests.

Closes #2528

## Owner
pm-tech-lead (security / rust-backend)

## What changed
Implements the four follow-ups from `docs/integrations/webhook-hardening-audit-2026-07.md`:

- **F1/R1 — Booking.com push was fully unauthenticated.** `booking_push_notification` now:
  - fails closed on unset `BOOKING_WEBHOOK_SECRET` → `503 NOT_CONFIGURED`;
  - verifies an HMAC-SHA256 `X-Booking-Signature` over `"{X-Booking-Timestamp}.{raw_body}"` **before** parsing the OTA XML → `401 INVALID_SIGNATURE` on missing/malformed/stale timestamp or bad signature;
  - dedups at-least-once redeliveries within the freshness window via an in-process `BookingReplayGuard` (idempotent `<Success/>` ack). In-process (not a DB ledger) is deliberate: the receiver has no state mutation today; a persistent `airbnb_webhook_events`-style ledger is the documented precondition (R1) for wiring it to persist reservations — noted in code.
- **R2 — Airbnb lacked a freshness window.** `handle_airbnb_webhook` now uses `verify_airbnb_delivery` (extracted, unit-testable): when `X-Airbnb-Timestamp` is present it enforces `"{ts}.{body}"` + a ±300 s window (shared helper); absent, it accepts a legacy body-only signature during the accept-both migration (replay still neutralized by the existing dedup ledger). A present-but-malformed timestamp fails closed.
- **R4 — Shared helper.** New `integrations::verify_timestamped_signature` + `TimestampedSignatureError` in `crates/integrations/src/portals.rs`; `verify_portal_webhook` refactored to delegate to it so all `"{ts}.{body}"` hex receivers (portal / Airbnb / Booking) run one reviewed, overflow-proof, constant-time implementation. (Stripe's compound `t=/v1=` header and the per-portal base64 encoding intentionally keep bespoke verifiers.)
- `BOOKING_WEBHOOK_SECRET` added to `BookingOAuthAppConfig`.

## IG3 — failing-on-main security/regression tests
All reference symbols that do not exist on `dev`, so they fail on `dev` and pass on this branch:
- `crates/integrations` (`portals::tests`): `timestamped_sig_*` — valid/prefix/empty-secret/wrong-secret/tampered/stale/future/boundary/overflow/timestamp-swap.
- `api-server` (`booking_webhook_tests`): rejects forged/unsigned + stale replay + timestamp-swap (the F1 auth-bypass fix), dedup-key stability/distinctness, replay-guard first-seen/duplicate/expiry.
- `api-server` (`airbnb_timestamp_parity_tests`): timestamped accept/reject, timestamp-swap reject, malformed-ts fail-closed, legacy body-only accept, forged reject on both paths.

## Verification
`crates/integrations` — fully green locally:
```
cargo fmt --all -- --check          # exit 0
cargo clippy -p integrations --all-targets -- -D warnings   # Finished, exit 0
cargo test -p integrations timestamped_sig  # 9 passed; 0 failed
```

`api-server` crate band — **BLOCKED by a documented environment egress policy**, not by the diff:
```
cargo clippy -p api-server --all-targets -- -D warnings
# error: failed to run custom build command for `utoipa-swagger-ui v9.0.2`
#   SWAGGER_UI_DOWNLOAD_URL: https://github.com/swagger-api/swagger-ui/.../v5.17.14.zip
#   InvalidArchive("Could not find EOCD")   ← github.com archive blocked by org egress policy
```
`github.com` is not on the session egress allowlist, so the `utoipa-swagger-ui` build script cannot fetch its Swagger-UI zip; this blocks compiling **any** api-server-binary target locally (clippy or test). Per repo convention this was **not** routed around (proxy `403`/policy deny — reported, not bypassed), same env-block prior PRs (e.g. #2620) hit. The api-server changes were instead reviewed by hand and rely on CI `backend.yml` (which has github access) as the authoritative build/test — this is why the PR is a **draft**.

## CI parity (Band C — hot-path)
Hot-path (security/auth). Authoritative `cargo fmt` + `clippy` + `cargo test` for the api-server crate run in `backend.yml` on this PR; local run blocked as above.

## Remote-tested
skipped (no ppt-bridge MCP)

## Notes
- **Deployment:** `BOOKING_WEBHOOK_SECRET` must now be set for the Booking.com push receiver to accept deliveries (fail-closed). Safe today — the receiver has no side effects (audit F1); until the secret is configured it returns 503 and Booking.com retries.
- Airbnb change is backward compatible (accept-both): existing body-only senders keep working; add `X-Airbnb-Timestamp` to opt into the freshness window.
- scope-check: clean (`scope_drift=false`). reuse-grep: clean (`code_reuse_warn=none`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SNZsYck3M5KmrfQSi6aGuq)_