### PR TITLE
gh-issue-2621: don't record untrusted Host as target_tenant on pre-auth layout-revalidate paths

### DIFF
--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
@@ -8,7 +8,13 @@ vi.mock('next/cache', () => ({
 
 import { revalidateTag } from 'next/cache';
 import { __clearAnalyticsSinks, type AnalyticsEvent, registerAnalyticsSink } from '@/lib/analytics';
-import { isTimestampFresh, layoutTagsFor, POST, parseWebhookTimestamp } from './route';
+import {
+  authenticatedTargetTenant,
+  isTimestampFresh,
+  layoutTagsFor,
+  POST,
+  parseWebhookTimestamp,
+} from './route';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -110,6 +116,37 @@ describe('isTimestampFresh', () => {
   it('rejects just outside the window in the past and future', () => {
     expect(isTimestampFresh(NOW - 301, NOW)).toBe(false);
     expect(isTimestampFresh(NOW + 301, NOW)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authenticatedTargetTenant helper (issue #2621)
+// ---------------------------------------------------------------------------
+
+describe('authenticatedTargetTenant', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('normalizes host: trims, lowercases, strips port', () => {
+    expect(authenticatedTargetTenant('  Tenant.RLT.sk:3001 ')).toBe('tenant.rlt.sk');
+  });
+
+  it('maps an absent/empty host to the * sentinel', () => {
+    expect(authenticatedTargetTenant(null)).toBe('*');
+    expect(authenticatedTargetTenant('   ')).toBe('*');
+  });
+
+  it('records the host verbatim when no allow-list is configured', () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_ALLOWED_HOSTS', '');
+    expect(authenticatedTargetTenant('unknown.example.com')).toBe('unknown.example.com');
+  });
+
+  it('collapses an unknown host to * when an allow-list is configured', () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_ALLOWED_HOSTS', 'a.rlt.sk, b.rlt.sk');
+    expect(authenticatedTargetTenant('a.rlt.sk')).toBe('a.rlt.sk');
+    expect(authenticatedTargetTenant('B.RLT.sk:443')).toBe('b.rlt.sk');
+    expect(authenticatedTargetTenant('evil.example.com')).toBe('*');
   });
 });
 
@@ -368,6 +405,48 @@ describe('layout_revalidate_received emission', () => {
       revalidate_outcome: 'invalid_signature',
       http_status: 401,
     });
+  });
+
+  // --- issue #2621: pre-auth paths must NOT record an attacker-chosen Host ---
+
+  it('records the * sentinel (not the injected Host) on the pre-auth disabled path', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', '');
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    // Unauthenticated caller injects an arbitrary Host header.
+    const req = makeRequest(body, { host: 'attacker-controlled.evil.example.com' });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+    expect(events).toHaveLength(1);
+    expect(events[0].properties.target_tenant).toBe('*');
+    expect(events[0].properties.target_tenant).not.toBe('attacker-controlled.evil.example.com');
+  });
+
+  it('records the * sentinel (not the injected Host) on the pre-auth invalid_signature path', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail' });
+    const req = makeRequest(body, {
+      host: 'attacker-controlled.evil.example.com',
+      'X-Webhook-Timestamp': String(nowTs()),
+      'X-Webhook-Signature': 'sha256=invalidsignature==',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(events).toHaveLength(1);
+    expect(events[0].properties.target_tenant).toBe('*');
+    expect(events[0].properties.target_tenant).not.toBe('attacker-controlled.evil.example.com');
+  });
+
+  it('records the (normalized) Host on the authenticated revalidated path', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    const body = JSON.stringify({ screen: 'reality/listing-detail', event: 'published' });
+    // Authenticated (correctly signed) delivery — the host is trusted here.
+    const req = signedRequest(SECRET, body, {
+      extraHeaders: { host: 'Tenant-A.RLT.sk:443' },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(events).toHaveLength(1);
+    expect(events[0].properties.target_tenant).toBe('tenant-a.rlt.sk');
   });
 
   it('emits invalid_screen (422) when the screen has no slash', async () => {

--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts
@@ -102,18 +102,78 @@ export function isTimestampFresh(
 }
 
 // ---------------------------------------------------------------------------
+// target_tenant derivation (issue #2621, hardening follow-up to #2532).
+//
+// The request `Host` header is client-controlled and is NOT validated against
+// any known-tenant set. Recording it verbatim as the `target_tenant` analytics
+// dimension is only safe *after* the HMAC signature has been verified — i.e. on
+// deliveries proven to come from the trusted webhook sender.
+//
+// On the two pre-authentication emit paths (`disabled`, `invalid_signature`)
+// the caller has NOT proven possession of the shared secret, so an
+// unauthenticated attacker could otherwise drive unbounded, high-cardinality
+// `layout_revalidate_received` events carrying an arbitrary attacker-chosen
+// host. Those paths record the `'*'` sentinel instead — the same global
+// sentinel api-server writes for `target_tenant` — so pre-auth callers cannot
+// inject cardinality into the dimension. See the events doc §4.3 and, once the
+// append-only cross-service sink lands, gate the persisted write on successful
+// signature verification too (issue #2621, improvement 3).
+// ---------------------------------------------------------------------------
+
+/** Global sentinel recorded when the tenant is unknown / not authenticated. */
+const GLOBAL_TENANT = '*';
+
+/** Normalize a host for comparison/recording: trim, lowercase, drop any port. */
+function normalizeHost(host: string): string {
+  return host.trim().toLowerCase().replace(/:\d+$/, '');
+}
+
+/**
+ * Optional comma-separated allow-list of known tenant hosts
+ * (`LAYOUT_WEBHOOK_ALLOWED_HOSTS`). When configured, an authenticated
+ * delivery's host must appear here to be recorded verbatim; otherwise it
+ * collapses to the `'*'` sentinel. When unset, the normalized host is recorded
+ * as-is (legacy behaviour) — the delivery is already HMAC-authenticated.
+ */
+function allowedTenantHosts(): Set<string> | null {
+  const raw = process.env.LAYOUT_WEBHOOK_ALLOWED_HOSTS;
+  if (!raw) return null;
+  const hosts = raw
+    .split(',')
+    .map(normalizeHost)
+    .filter((h) => h.length > 0);
+  return hosts.length > 0 ? new Set(hosts) : null;
+}
+
+/**
+ * The `target_tenant` to record on an authenticated (post-HMAC) path. The host
+ * is normalized; when an allow-list is configured, an unknown host collapses to
+ * the `'*'` sentinel so even a trusted-but-misbehaving sender cannot inflate
+ * cardinality. An absent host also maps to the sentinel.
+ */
+export function authenticatedTargetTenant(rawHost: string | null): string {
+  const host = normalizeHost(rawHost ?? '');
+  if (!host) return GLOBAL_TENANT;
+  const allow = allowedTenantHosts();
+  if (allow && !allow.has(host)) return GLOBAL_TENANT;
+  return host;
+}
+
+// ---------------------------------------------------------------------------
 // POST /api/layout-revalidate
 // ---------------------------------------------------------------------------
 
 export async function POST(request: Request): Promise<NextResponse> {
   // Tenant scope on the receiver is expressed as the request host (events doc
-  // §4.3); fall back to the global sentinel when absent.
-  const targetTenant = request.headers.get('host') ?? '*';
+  // §4.3), but the host is client-controlled: it is only trusted AFTER the HMAC
+  // signature is verified. Every pre-authentication emit path records the '*'
+  // sentinel so an unauthenticated caller cannot inject arbitrary cardinality
+  // into the `target_tenant` dimension (issue #2621).
 
-  // 1. Secret must be configured
+  // 1. Secret must be configured (pre-auth — record the sentinel, not the host).
   const secret = process.env.LAYOUT_WEBHOOK_SECRET;
   if (!secret) {
-    emitRevalidateReceived({ outcome: 'disabled', httpStatus: 503, targetTenant });
+    emitRevalidateReceived({ outcome: 'disabled', httpStatus: 503, targetTenant: GLOBAL_TENANT });
     return NextResponse.json({ error: 'disabled' }, { status: 503 });
   }
 
@@ -131,12 +191,20 @@ export async function POST(request: Request): Promise<NextResponse> {
   // These auth rejections fold into the `invalid_signature` analytics outcome.
   const timestamp = parseWebhookTimestamp(request.headers.get('X-Webhook-Timestamp'));
   if (timestamp === null) {
-    emitRevalidateReceived({ outcome: 'invalid_signature', httpStatus: 401, targetTenant });
+    emitRevalidateReceived({
+      outcome: 'invalid_signature',
+      httpStatus: 401,
+      targetTenant: GLOBAL_TENANT,
+    });
     return NextResponse.json({ error: 'missing timestamp' }, { status: 401 });
   }
   const nowSecs = Math.floor(Date.now() / 1000);
   if (!isTimestampFresh(timestamp, nowSecs)) {
-    emitRevalidateReceived({ outcome: 'invalid_signature', httpStatus: 401, targetTenant });
+    emitRevalidateReceived({
+      outcome: 'invalid_signature',
+      httpStatus: 401,
+      targetTenant: GLOBAL_TENANT,
+    });
     return NextResponse.json({ error: 'stale timestamp' }, { status: 401 });
   }
 
@@ -151,9 +219,18 @@ export async function POST(request: Request): Promise<NextResponse> {
 
   // Guard unequal lengths before timingSafeEqual (it throws on length mismatch)
   if (headerBuf.length !== expectedBuf.length || !timingSafeEqual(headerBuf, expectedBuf)) {
-    emitRevalidateReceived({ outcome: 'invalid_signature', httpStatus: 401, targetTenant });
+    emitRevalidateReceived({
+      outcome: 'invalid_signature',
+      httpStatus: 401,
+      targetTenant: GLOBAL_TENANT,
+    });
     return NextResponse.json({ error: 'invalid signature' }, { status: 401 });
   }
+
+  // Signature verified — the delivery is proven to come from the trusted
+  // webhook sender, so the host may now be recorded (normalized + optionally
+  // allow-list validated) as the tenant on the remaining emit paths.
+  const targetTenant = authenticatedTargetTenant(request.headers.get('host'));
 
   // 5. Parse body and validate shape
   let body: unknown;


### PR DESCRIPTION
## Task
Follow-up: reality-web layout-revalidate receiver records untrusted Host as `target_tenant` on pre-auth paths (PR #2549). Closes #2621.

Security/correctness hardening of the `POST /api/layout-revalidate` receiver added in PR #2549 (#2532). The handler derived the `target_tenant` analytics dimension from the client-controlled `Host` header and emitted a `layout_revalidate_received` event on **every** return path — including the two that run **before** HMAC verification:
- `disabled` (503) — `LAYOUT_WEBHOOK_SECRET` unset.
- `invalid_signature` (401) — missing/stale timestamp or HMAC mismatch.

An unauthenticated caller could therefore drive unbounded, high-cardinality events carrying an attacker-chosen `Host` as `target_tenant` (a dimension used for tenant attribution), which becomes a write-amplification / cardinality-poisoning vector once the planned append-only cross-service sink lands.

## Owner
pm-tech-lead (pm-frontend / reality-web, with a pm-security lens)

## What changed
`frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts`
1. **Pre-auth emit paths** (`disabled`, `invalid_signature`) now record the `'*'` global sentinel instead of the raw `Host` — matching api-server's `target_tenant="*"`. An unauthenticated caller can no longer inject cardinality (improvement 1).
2. **Post-HMAC paths** derive the tenant via a new exported `authenticatedTargetTenant(host)` helper that normalizes the host (trim / lowercase / strip port) and, when the optional `LAYOUT_WEBHOOK_ALLOWED_HOSTS` allow-list is configured, collapses unknown hosts to `'*'` (improvement 2). Unset ⇒ legacy behaviour (record the normalized, already-HMAC-authenticated host).
3. Improvement 3 (gate the persisted sink write on signature verification) is documented in a code comment for when cross-service persistence lands — no persistence exists yet, so nothing to gate here.

Tests (`route.test.ts`): focused regression tests asserting the pre-auth `disabled`/`invalid_signature` events carry the `'*'` sentinel rather than an injected `Host`, the authenticated path records the normalized host, plus `authenticatedTargetTenant` unit tests (normalization + allow-list). These fail on `dev` (committed as a separate `test:` commit for IG3 TDD evidence).

## Verification
```
VERIFY-PLAN base=fb495a07058577c455faafac2759e3262402690c files=2
  cd frontend && pnpm exec biome check apps/reality-web/src/app/api/layout-revalidate/route.test.ts apps/reality-web/src/app/api/layout-revalidate/route.ts
  cd frontend && pnpm --filter "...[fb495a07058577c455faafac2759e3262402690c]" typecheck
  cd frontend && pnpm --filter "...[fb495a07058577c455faafac2759e3262402690c]" test
```
```
VERIFY OK d5e5f539edf78ab0ed7f241ed5fd7f0671090ba7
```
- reality-web: typecheck clean, biome clean (exit 0 — 4 pre-existing style *infos* on untouched lines), 235 tests pass (42 in the touched suite).
- scope-check (owner `pm-tech-lead`): exit 0 → `scope_drift=false`.
- reuse-grep (`nextjs-web`): clean → `code_reuse_warn=none`.

## CI parity (Band C — hot-path only)
Skipped: not a build/data-integrity hot path (analytics-dimension hardening; no auth/billing/DB write path changed — the receiver already fails closed on signature). `frontend.yml` runs biome + typecheck + tests on this diff.

## Remote-tested
skipped (ppt-bridge MCP not connected).

## Notes
- Sentinel choice is `'*'` (the established global sentinel across api-server and this file) rather than a new `'unauthenticated'` label — keeps the dimension's cardinality bounded and consistent. The issue offered either.
- IG goal-check: IG3 (separate test:/fix: commits) and IG7 (verify) pass. IG1/IG2 report FAIL only because this is a GitHub-issue-driven task on the dispatcher-assigned `auto-impl/*` branch (no `.research/plans/` file, non-`impl/*` branch name) — inapplicable to this flow, not real failures.


---
_Generated by [Claude Code](https://claude.ai/code/session_016cGwy9mN5cEytXr21LRKup)_