### PR TITLE
sec-ammonia-supply-chain-audit-2026-07-23-retry1: bump quinn-proto 0.11.14->0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5163,9 +5163,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Task

Post-#2446 (RUSTSEC-2026-0213 ammonia bump) — run a cargo-audit sweep against the workspace to catch any other pinned crates with open advisories [retry 1/2 of failed sec-ammonia-supply-chain-audit-2026-07-23].

## Owner

pm-security (specialist: rust-backend)

## Sweep results (`cargo audit`, advisory-db loaded 1177 advisories, `backend/Cargo.lock`, 763 crate deps)

**Vulnerabilities before this PR (6):**

| RUSTSEC ID | Crate | Ver | Sev | Status |
|---|---|---|---|---|
| **2026-0185** | **quinn-proto** | 0.11.14 | 7.5 high | **NEW — fixed by this PR (→0.11.15)** |
| 2026-0187 | lopdf | 0.26.0 | 7.5 high | already ignored in `deny.toml` (BIT-279) |
| 2023-0071 | rsa | 0.9.10 | 5.9 med | already ignored in `deny.toml` (HMAC-only JWT, unreachable) |
| 2026-0098 | rustls-webpki | 0.101.7 | — | already ignored in `deny.toml` (AWS SDK rustls 0.21 pin) |
| 2026-0099 | rustls-webpki | 0.101.7 | — | already ignored in `deny.toml` |
| 2026-0104 | rustls-webpki | 0.101.7 | — | already ignored in `deny.toml` |

After the bump, `cargo audit` reports 5 vulnerabilities — **exactly** the five already carried on `backend/deny.toml`'s `[advisories].ignore` list with written reachability justifications. The only advisory not previously accounted for (quinn-proto RUSTSEC-2026-0185) is resolved here.

**Warnings (7, unchanged): unmaintained / unsound transitive** — `encoding`, `lzw`, `proc-macro-error2`, `rusttype`, `stb_truetype`, `stdweb` (unmaintained) and `event-listener` 5.4.1 (unsound, RUSTSEC-2026-0221). These are transitive and covered by `deny.toml`'s `unmaintained = "workspace"` scope; they are notices, not vulnerabilities, and were already present on `dev` before this change.

## Fix

`RUSTSEC-2026-0185` — remote memory exhaustion (DoS) from unbounded out-of-order QUIC stream reassembly in `quinn-proto` < 0.11.15. `quinn-proto` is transitive: `reqwest 0.13 → quinn → quinn-proto`. The fix is a patch bump within 0.11.x, applied as a **lockfile-only precise update** (`cargo update -p quinn-proto --precise 0.11.15`) — no `Cargo.toml` change, no manifest pin touched. Diff is `backend/Cargo.lock` only (2 lines).

Reachability note: our `reqwest` is configured with `http2` (not `http3`/QUIC) features, so the QUIC reassembly path is not exercised in practice; the bump clears the advisory outright regardless and keeps `cargo deny check advisories` green.

## Scope drift

`scope-check.sh --owner pm-security` flags `backend/Cargo.lock` as outside the pm-security owner areas (exit 2). This is expected and justified: the task IS a dependency-security remediation, whose deliverable is by definition a lockfile bump. No source/handler code touched.

## Verification

```
VERIFY-PLAN base=fb495a07058577c455faafac2759e3262402690c files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```

**Local verify BLOCKED BY EGRESS — not by this change.** `cargo clippy --workspace` failed inside the `utoipa-swagger-ui` v9.0.2 **build script**, which downloads `swagger-ui v5.17.14.zip` from `github.com` at build time. The sandbox egress proxy returns **HTTP 403** (a 378-byte denial page, not a zip), so the build script panics: `InvalidArchive("Could not find EOCD")`. This is the same egress policy that 403s github.com noted in the task brief; it is unrelated to the one-line lockfile bump (clippy died before reaching any workspace crate; there were zero quinn/sqlx/first-party errors). Reproduced directly:

```
curl -sS -w 'HTTP=%{http_code} size=%{size_download}' \
  https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
# HTTP=403 size=378
```

Per the task's documented convention (report, don't bypass), **CI is authoritative** — `.github/workflows/backend.yml` runs `cargo fmt` / `clippy` / `cargo test` with a real Postgres service and reaches github.com normally, and its `cargo-deny` job runs `cargo deny check --workspace` (the authoritative advisories gate). The `cargo audit` sweep above was itself run successfully against a freshly-cloned advisory-db (egress to the RustSec advisory-db clone did succeed).

## CI parity (Band C — hot-path only)

Security/supply-chain change. The authoritative advisory validation is CI's existing `cargo-deny` job (`cargo deny check --workspace` in `backend.yml`) plus the standalone `deny-toml-ban-gate.yml`. No `deny.toml` edit is required (the bump removes the advisory rather than ignoring it), so both gates should stay green.

## Remote-tested

skipped (ppt-bridge MCP not connected)

## Notes

- Deliverable = 1 dependency bump clearing 1 new high-severity advisory; all other graph advisories were already triaged in `backend/deny.toml`. No new `ignore` entries added.
- `cargo-audit` v0.22.2 was installed in-session; advisory-db cloned from RustSec/advisory-db (1177 advisories).


---
_Generated by [Claude Code](https://claude.ai/code/session_016cGwy9mN5cEytXr21LRKup)_