### PR TITLE
code-review-api-core-idempotency-client-tenant: scope idempotency cache by server-side tenant, not client header

### DIFF
--- a/backend/crates/api-core/src/middleware/idempotency.rs
+++ b/backend/crates/api-core/src/middleware/idempotency.rs
@@ -164,22 +164,26 @@ pub async fn handle_idempotent_request(
     response
 }
 
+/// Derive the idempotency cache-scope tenant.
+///
+/// SECURITY: the scope MUST come from the server-side [`ResolvedTenant`]
+/// injected by `host_tenant_middleware` — the exact same source RLS/tenant
+/// extraction uses — and NEVER from a client-supplied header. The middleware
+/// previously fell back to the raw `X-Tenant-ID` request header when no
+/// `ResolvedTenant` was present; a caller could set that header to another
+/// organization's id and land in its cache scope, enabling cross-tenant
+/// idempotency-key collision (poisoning another tenant's replay) or bypass.
+/// This function no longer reads any request header.
 fn tenant_scope(request: &Request<Body>) -> String {
-    if let Some(resolved) = request.extensions().get::<ResolvedTenant>() {
-        if resolved.is_platform_host() {
-            return "platform-host".to_string();
-        }
-        return resolved.organization_id.to_string();
+    match request.extensions().get::<ResolvedTenant>() {
+        Some(resolved) if resolved.is_platform_host() => "platform-host".to_string(),
+        Some(resolved) => resolved.organization_id.to_string(),
+        // No resolved tenant means the request reached us without
+        // `host_tenant_middleware` running (e.g. a public/allowlisted path).
+        // Fall back to a fixed server-side sentinel that no client input can
+        // influence — deliberately NOT the `X-Tenant-ID` header.
+        None => "global".to_string(),
     }
-
-    request
-        .headers()
-        .get("X-Tenant-ID")
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("global")
-        .to_string()
 }
 
 fn request_hash(method: &str, path: &str, body: &[u8]) -> String {

--- a/backend/crates/api-core/tests/idempotency_middleware_tests.rs
+++ b/backend/crates/api-core/tests/idempotency_middleware_tests.rs
@@ -24,6 +24,7 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 use api_core::extractors::TenantMembershipProvider;
+use api_core::middleware::{ResolvedTenant, TenantSource};
 
 #[derive(Clone)]
 struct TestState {
@@ -77,6 +78,41 @@ fn post_demo(key: &str, tenant_id: Uuid, body: Value) -> Request<Body> {
         .header("idempotency-key", key)
         .body(Body::from(body.to_string()))
         .expect("build request")
+}
+
+/// Build a request that carries a **server-side** `ResolvedTenant` in its
+/// extensions (as `host_tenant_middleware` would inject it), optionally
+/// alongside a *spoofed* client-supplied `X-Tenant-ID` header. The idempotency
+/// scope must derive from the extension, never from the header.
+fn post_demo_resolved(
+    key: &str,
+    resolved_org: Uuid,
+    spoofed_header: Option<Uuid>,
+    body: Value,
+) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/demo")
+        .header("content-type", "application/json")
+        .header("idempotency-key", key);
+    if let Some(spoof) = spoofed_header {
+        builder = builder.header("x-tenant-id", spoof.to_string());
+    }
+    builder
+        .extension(ResolvedTenant {
+            organization_id: resolved_org,
+            source: TenantSource::Subdomain,
+        })
+        .body(Body::from(body.to_string()))
+        .expect("build request")
+}
+
+fn is_replayed(response: &Response) -> bool {
+    response
+        .headers()
+        .get("x-idempotency-replayed")
+        .and_then(|value| value.to_str().ok())
+        == Some("true")
 }
 
 async fn read_json(response: Response) -> Value {
@@ -181,7 +217,9 @@ async fn expired_cached_row_is_recomputed(pool: db::DbPool) {
           AND idempotency_key = 'idem-expired'
         "#,
     )
-    .bind(tenant_id.to_string())
+    // No `ResolvedTenant` is injected on these legacy requests, so the scope is
+    // the server-side "global" sentinel — NOT the client-supplied header value.
+    .bind("global")
     .bind(path)
     .execute(&pool)
     .await
@@ -206,5 +244,153 @@ async fn expired_cached_row_is_recomputed(pool: db::DbPool) {
         hits.load(Ordering::SeqCst),
         2,
         "handler must execute again after TTL expiry"
+    );
+}
+
+/// Two *different authenticated tenants* sending the SAME idempotency key must
+/// NOT collide — each tenant gets its own scope, so the second tenant's request
+/// executes the handler fresh rather than replaying tenant A's cached response.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn different_authenticated_tenants_do_not_collide(pool: db::DbPool) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let app = build_app(pool, hits.clone());
+    let org_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+
+    // Tenant A, key "shared-key" -> handler runs (call 1).
+    let first = app
+        .clone()
+        .oneshot(post_demo_resolved(
+            "shared-key",
+            org_a,
+            None,
+            json!({"value": 1}),
+        ))
+        .await
+        .expect("tenant A response");
+    assert_eq!(first.status(), StatusCode::CREATED);
+    assert!(!is_replayed(&first));
+    let first_body = read_json(first).await;
+    assert_eq!(first_body["call"], 1);
+
+    // Tenant B, SAME key, SAME payload -> must NOT be served from A's cache.
+    let second = app
+        .clone()
+        .oneshot(post_demo_resolved(
+            "shared-key",
+            org_b,
+            None,
+            json!({"value": 1}),
+        ))
+        .await
+        .expect("tenant B response");
+    assert_eq!(second.status(), StatusCode::CREATED);
+    assert!(
+        !is_replayed(&second),
+        "tenant B must not replay tenant A's cached response for the same key"
+    );
+    let second_body = read_json(second).await;
+    assert_eq!(
+        second_body["call"], 2,
+        "a different authenticated tenant must execute the handler fresh"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "each tenant's identical key must run the handler once — no cross-tenant collision"
+    );
+}
+
+/// A spoofed client-supplied `X-Tenant-ID` header must NOT influence the
+/// idempotency cache scope — only the server-side `ResolvedTenant` counts.
+///
+/// Proven two ways:
+///   1. Same resolved tenant + *different* spoofed headers still replays
+///      (the header is ignored, so the scope is stable).
+///   2. Different resolved tenants + the *same* spoofed header do NOT collide
+///      (the header cannot force two tenants into one scope — the exact bypass
+///      the old header fallback allowed).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn spoofed_tenant_header_cannot_change_scope(pool: db::DbPool) {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let app = build_app(pool, hits.clone());
+    let org_a = Uuid::new_v4();
+    let org_b = Uuid::new_v4();
+    let spoof_x = Uuid::new_v4();
+    let spoof_y = Uuid::new_v4();
+
+    // (1) Tenant A, spoofed header X, key "spoof-key" -> handler runs (call 1).
+    let first = app
+        .clone()
+        .oneshot(post_demo_resolved(
+            "spoof-key",
+            org_a,
+            Some(spoof_x),
+            json!({"value": 1}),
+        ))
+        .await
+        .expect("first response");
+    assert_eq!(first.status(), StatusCode::CREATED);
+    assert!(!is_replayed(&first));
+    let first_body = read_json(first).await;
+    assert_eq!(first_body["call"], 1);
+
+    // (1) Same resolved tenant A, but a DIFFERENT spoofed header Y, same key +
+    //     payload -> must REPLAY. The header does not participate in the scope,
+    //     so changing it must not change the outcome.
+    let second = app
+        .clone()
+        .oneshot(post_demo_resolved(
+            "spoof-key",
+            org_a,
+            Some(spoof_y),
+            json!({"value": 1}),
+        ))
+        .await
+        .expect("second response");
+    assert_eq!(second.status(), StatusCode::CREATED);
+    assert!(
+        is_replayed(&second),
+        "changing the spoofed X-Tenant-ID header must not change the cache scope"
+    );
+    let second_body = read_json(second).await;
+    assert_eq!(
+        second_body, first_body,
+        "must replay tenant A's cached body"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        1,
+        "same resolved tenant replays regardless of the spoofed header"
+    );
+
+    // (2) DIFFERENT resolved tenant B, but the SAME spoofed header X as the
+    //     first request. Under the old header-trusting scope this would collide
+    //     with tenant A and wrongly replay A's response. With the fix it must
+    //     run the handler fresh under tenant B's own scope.
+    let third = app
+        .clone()
+        .oneshot(post_demo_resolved(
+            "spoof-key",
+            org_b,
+            Some(spoof_x),
+            json!({"value": 1}),
+        ))
+        .await
+        .expect("third response");
+    assert_eq!(third.status(), StatusCode::CREATED);
+    assert!(
+        !is_replayed(&third),
+        "a spoofed header matching another tenant must not grant that tenant's cache scope"
+    );
+    let third_body = read_json(third).await;
+    assert_eq!(
+        third_body["call"], 2,
+        "tenant B must execute the handler under its own scope"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        2,
+        "the spoofed X-Tenant-ID header must never merge two tenants into one scope"
     );
 }


### PR DESCRIPTION
## Task
Idempotency middleware trusts the client-supplied `X-Tenant-ID` header for the cache-scope key, enabling cross-tenant idempotency-key collision or bypass. Change the idempotency cache-scope key to derive the tenant from the authenticated/server-side tenant context (the same source RLS/tenant extraction uses) instead of the raw client header. Add a test proving two different authenticated tenants sending the same idempotency key do not collide, and that a spoofed `X-Tenant-ID` header cannot change the scope.

## Owner
pm-security

## Change
`backend/crates/api-core/src/middleware/idempotency.rs` — `tenant_scope()` previously fell back to the raw `X-Tenant-ID` request header whenever no `ResolvedTenant` extension was present. A caller could set that header to another organization's id and be placed in its idempotency cache scope (poisoning another tenant's replay, or bypassing their key). The function now derives the scope **solely** from the server-side `ResolvedTenant` injected by `host_tenant_middleware` — the exact same source RLS/tenant extraction uses — and never reads any request header. When no `ResolvedTenant` is present (public/allowlisted paths that never ran host resolution) it falls back to a fixed server-side `"global"` sentinel that no client input can influence.

### Tests added (`tests/idempotency_middleware_tests.rs`)
- `different_authenticated_tenants_do_not_collide` — two distinct `ResolvedTenant` orgs sending the SAME idempotency key each run the handler once (no cross-tenant replay).
- `spoofed_tenant_header_cannot_change_scope` — proves both directions: (1) same resolved tenant + *different* spoofed `X-Tenant-ID` headers still replays (header ignored → stable scope); (2) *different* resolved tenants + the *same* spoofed header do NOT collide (the exact bypass the old fallback allowed).
- Updated the pre-existing `expired_cached_row_is_recomputed` fixture: its manual `UPDATE ... WHERE tenant_scope = $1` now binds the server-side `"global"` sentinel instead of the (now-ignored) header value.

## Verification
```
VERIFY-PLAN base=892f6e0154152de104d0b6e1d12f81261756eb4b files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-core --all-targets -- -D warnings
  cd backend && cargo test -p api-core   (+ reverse-dependent crates)
```
- `cargo fmt --all -- --check` — PASS (exit 0)
- `cargo clippy -p api-core --all-targets -- -D warnings` — PASS (exit 0); `--all-targets` compiles the new integration-test file clean.
- `cargo test -p api-core` — the idempotency tests are `#[sqlx::test]` and require a live Postgres, which is **not available in this sandbox** (no local Postgres, no Docker daemon, no ppt-bridge MCP). They will run in CI (`backend.yml`). The change is a private-fn body + doc-comment + test file with **zero public API-surface change** to `api-core`, so the reverse-dependent crates (api-server, reality-server, admin-core, accounting-server) are unaffected and were not recompiled.

## CI parity (Band C — hot-path)
This is a hot-path tenant-isolation security change. Local `act`/DB replication of `backend.yml` was not possible (no Docker/Postgres in-sandbox); CI `backend.yml` on this draft PR is the parity run for the DB-backed tests.

## Remote-tested
skipped — ppt-bridge MCP not connected in this session.

## Scope drift
`scope-check` (owner `pm-security`) flags both changed files: pm-security's mapped areas include `backend/crates/api-core/src/extractors/**` but not `.../src/middleware/**`. The drift is justified — the vulnerability lives in the idempotency **middleware**, and its test file sits under `api-core/tests/`. No files outside `api-core` were touched. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep` (rust-backend) — no warnings. No new auth/crypto/http helpers introduced; reuses the existing `ResolvedTenant` / `TenantSource` from `host_tenant`.

## Notes
`code_reuse_warn=none`. Draft pending CI green on the DB-backed `sqlx::test` cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_016hThjqRnH88MKWTUf6qbyL)_