### PR TITLE
code-review-ppt-web-ui-accounting-invoice-silent-fail: surface create/delete invoice mutation failures

### DIFF
--- a/frontend/apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Regression test for AccountingInvoiceManagementPage error surfacing.
+ *
+ * The create and delete invoice mutations previously had no `onError`, so a
+ * failed create/delete failed silently — the user saw nothing. This test pins
+ * the fix: both mutations now surface the failure through the toast system
+ * (via `parseApiError` + `useToast`). It fails on `dev` (no `onError` handler
+ * ⇒ `showToast` is never called) and passes with the handlers wired in.
+ */
+
+/// <reference types="vitest/globals" />
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { AccountingInvoiceManagementPage } from './AccountingInvoiceManagementPage';
+
+const invoicesApiList = vi.fn();
+const contactsApiList = vi.fn();
+const invoicesApiCreate = vi.fn();
+const invoicesApiDelete = vi.fn();
+
+vi.mock('@ppt/api-client', () => ({
+  invoicesApiList: () => invoicesApiList(),
+  contactsApiList: () => contactsApiList(),
+  invoicesApiCreate: (args: unknown) => invoicesApiCreate(args),
+  invoicesApiDelete: (args: unknown) => invoicesApiDelete(args),
+}));
+
+const mockShowToast = vi.fn();
+vi.mock('../../../components', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const invoice = {
+  id: 'inv-1',
+  number: 'INV-001',
+  dueDate: '2026-09-01',
+  issueDate: '2026-08-01',
+  currency: 'CZK',
+  totalAmount: 121,
+  vatAmount: 21,
+  status: 'issued',
+};
+
+const contact = { id: 'contact-1', name: 'Acme s.r.o.' };
+
+function renderPage(): ReactElement {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AccountingInvoiceManagementPage />
+    </QueryClientProvider>
+  );
+}
+
+describe('AccountingInvoiceManagementPage — error surfacing', () => {
+  beforeEach(() => {
+    invoicesApiList.mockResolvedValue({ data: [invoice] });
+    contactsApiList.mockResolvedValue({ data: [contact] });
+    invoicesApiCreate.mockReset();
+    invoicesApiDelete.mockReset();
+    mockShowToast.mockClear();
+  });
+
+  it('shows an error toast when deleting an invoice fails', async () => {
+    invoicesApiDelete.mockRejectedValue(new Error('Delete exploded'));
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    try {
+      render(renderPage());
+
+      // Wait for the list to render the invoice row, then click its delete icon.
+      await screen.findByText('INV-001');
+      const list = screen.getByRole('list');
+      await userEvent.click(within(list).getByRole('button'));
+
+      await waitFor(() =>
+        expect(mockShowToast).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'error',
+            title: 'Failed to delete invoice',
+            message: 'Delete exploded',
+          })
+        )
+      );
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it('shows an error toast when creating an invoice fails', async () => {
+    invoicesApiCreate.mockRejectedValue(new Error('Create exploded'));
+    const { container } = render(renderPage());
+
+    // Open the create form (header "Create Invoice" button).
+    await userEvent.click(screen.getByRole('button', { name: /create invoice/i }));
+    await screen.findByText('New Invoice');
+
+    // The form labels are not associated with their inputs, so target the
+    // required controls by DOM position (contact select, number input, due date).
+    const contactSelect = container.querySelector('select') as HTMLSelectElement;
+    await userEvent.selectOptions(contactSelect, 'contact-1');
+
+    const numberInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    fireEvent.change(numberInput, { target: { value: 'INV-002' } });
+
+    const dateInputs = Array.from(
+      container.querySelectorAll('input[type="date"]')
+    ) as HTMLInputElement[];
+    const dueDate = dateInputs.find((d) => d.value === '') ?? dateInputs[dateInputs.length - 1];
+    fireEvent.change(dueDate, { target: { value: '2026-12-31' } });
+
+    // Submit — the in-form submit button is the one with type="submit".
+    const submit = screen
+      .getAllByRole('button', { name: /create invoice/i })
+      .find((b) => (b as HTMLButtonElement).type === 'submit') as HTMLButtonElement;
+    await userEvent.click(submit);
+
+    await waitFor(() =>
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Failed to create invoice',
+          message: 'Create exploded',
+        })
+      )
+    );
+  });
+});

--- a/frontend/apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.tsx
+++ b/frontend/apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.tsx
@@ -11,6 +11,8 @@ import {
 } from '@ppt/api-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useToast } from '../../../components';
+import { parseApiError } from '../../../lib/errorHandler';
 import { queryKeys } from '../../../lib/queryKeys';
 import { AccountingInvoiceForm } from '../components/AccountingInvoiceForm';
 import { AccountingInvoiceList } from '../components/AccountingInvoiceList';
@@ -18,6 +20,7 @@ import { AccountingInvoiceList } from '../components/AccountingInvoiceList';
 export function AccountingInvoiceManagementPage() {
   const [isCreating, setIsCreating] = useState(false);
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
 
   // Auth (Authorization + X-Tenant-ID) is injected centrally by the api-client
   // request interceptor (#1522) — no per-call headers / casts needed here.
@@ -39,12 +42,28 @@ export function AccountingInvoiceManagementPage() {
       queryClient.invalidateQueries({ queryKey: queryKeys.accounting.invoices() });
       setIsCreating(false);
     },
+    onError: (error) => {
+      const parsed = parseApiError(error);
+      showToast({
+        type: 'error',
+        title: 'Failed to create invoice',
+        message: parsed.message,
+      });
+    },
   });
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => invoicesApiDelete({ path: { id } }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.accounting.invoices() });
+    },
+    onError: (error) => {
+      const parsed = parseApiError(error);
+      showToast({
+        type: 'error',
+        title: 'Failed to delete invoice',
+        message: parsed.message,
+      });
     },
   });
 


### PR DESCRIPTION
## Task
AccountingInvoiceManagementPage: create/delete mutations have no onError — silent invoice failures. Add proper onError handling (user-visible error surfacing, e.g. toast/error state) to the create and delete invoice mutations so failures are no longer silent. Follow the existing error-handling patterns used elsewhere in ppt-web.

## Owner
owner_role hint was `pm-backend`, but this is genuinely a ppt-web frontend change (React + TanStack Query, `frontend/apps/ppt-web/`). Specialist: **react-web**.

## What changed
`frontend/apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.tsx`:
- Added `onError` to both the create and delete invoice `useMutation` calls.
- Each handler runs the failure through `parseApiError` (`lib/errorHandler.ts`) and raises an error toast via `useToast` — the same error-surfacing idiom used elsewhere in ppt-web (e.g. `IntegrationsPage`). Previously both mutations had only `onSuccess`, so backend failures were completely silent.

Titles: "Failed to create invoice" / "Failed to delete invoice"; message = the parsed, user-friendly API error message.

## Verification
```
VERIFY-PLAN base=c24259be0399b617d89b80b2c7e7eefc61c47e04 files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.test.tsx apps/ppt-web/src/features/accounting/pages/AccountingInvoiceManagementPage.tsx
  cd frontend && pnpm --filter "...[c24259be0399b617d89b80b2c7e7eefc61c47e04]" typecheck
  cd frontend && pnpm --filter "...[c24259be0399b617d89b80b2c7e7eefc61c47e04]" test
```
```
VERIFY OK bd65354c205beefa01651ba94aaf290c4935e596
```
All 1616 ppt-web tests pass (106 files), including the 2 new regression tests.

## IG3 evidence (failing-on-main test)
Added `AccountingInvoiceManagementPage.test.tsx` with two tests:
- "shows an error toast when deleting an invoice fails"
- "shows an error toast when creating an invoice fails"

Committed test-first (`test:` commit) then fix (`fix:` commit). Verified both tests **fail on `dev`** (no `onError` ⇒ `showToast` never called) and **pass with the fix**.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- Scope-drift: clean under the real owner area (pm-frontend → exit 0). The deterministic `scope-check.sh` flags drift only against the mislabeled `pm-backend` owner_role; the task inputs explicitly note this is a frontend change, so `scope_drift=false`.
- Code-reuse pre-flight: no warnings (reuses existing `parseApiError` + `useToast`; adds no new helper).
- goal-check IG1/IG2 are N/A for this code-review dispatch mode (no `.research/plans/<slug>.md` file — which is dispatcher-owned and must not be touched — and the branch name is the dispatcher-chosen `auto-impl/…`). IG3 and IG7 (verify gate) pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGqXakdHJNnJuxBeqM5SaJ)_