### PR TITLE
code-review-reality-web-protectedroute-i18n: translate ProtectedRoute auth gate

### DIFF
--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -47,6 +47,12 @@
       "submitting": "Přihlašuji…",
       "subtitle": "Vítejte zpět v Reality Portálu.",
       "title": "Přihlášení"
+    },
+    "protected": {
+      "description": "Chcete-li zobrazit tuto stránku, přihlaste se.",
+      "loading": "Načítá se…",
+      "signIn": "Přihlásit se",
+      "title": "Vyžaduje se přihlášení"
     }
   },
   "common": {

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -47,6 +47,12 @@
       "submitting": "Anmelden…",
       "subtitle": "Willkommen zurück bei Reality Portal.",
       "title": "Anmelden"
+    },
+    "protected": {
+      "description": "Bitte melden Sie sich an, um auf diese Seite zuzugreifen.",
+      "loading": "Wird geladen…",
+      "signIn": "Anmelden",
+      "title": "Anmeldung erforderlich"
     }
   },
   "common": {

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -47,6 +47,12 @@
       "submitting": "Signing in…",
       "subtitle": "Welcome back to Reality Portal.",
       "title": "Sign in"
+    },
+    "protected": {
+      "description": "Please sign in to access this page.",
+      "loading": "Loading…",
+      "signIn": "Sign in",
+      "title": "Sign in required"
     }
   },
   "common": {

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -47,6 +47,12 @@
       "submitting": "Bejelentkezés…",
       "subtitle": "Üdvözöljük újra a Reality Portálon.",
       "title": "Bejelentkezés"
+    },
+    "protected": {
+      "description": "Az oldal megtekintéséhez jelentkezzen be.",
+      "loading": "Betöltés…",
+      "signIn": "Bejelentkezés",
+      "title": "Bejelentkezés szükséges"
     }
   },
   "common": {

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -47,6 +47,12 @@
       "submitting": "Logowanie…",
       "subtitle": "Witamy ponownie w Reality Portal.",
       "title": "Logowanie"
+    },
+    "protected": {
+      "description": "Zaloguj się, aby uzyskać dostęp do tej strony.",
+      "loading": "Ładowanie…",
+      "signIn": "Zaloguj się",
+      "title": "Wymagane logowanie"
     }
   },
   "common": {

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -47,6 +47,12 @@
       "submitting": "Prihlasujem…",
       "subtitle": "Vitajte späť v Reality Portáli.",
       "title": "Prihlásenie"
+    },
+    "protected": {
+      "description": "Ak chcete zobraziť túto stránku, prihláste sa.",
+      "loading": "Načítava sa…",
+      "signIn": "Prihlásiť sa",
+      "title": "Vyžaduje sa prihlásenie"
     }
   },
   "common": {

--- a/frontend/apps/reality-web/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/apps/reality-web/src/components/auth/ProtectedRoute.tsx
@@ -7,6 +7,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import type { ReactNode } from 'react';
 import { useAuth } from '@/lib/auth-context';
 
@@ -18,12 +19,13 @@ interface ProtectedRouteProps {
 export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
   const { isLoading, isAuthenticated, login } = useAuth();
   const pathname = usePathname();
+  const t = useTranslations('auth.protected');
 
   if (isLoading) {
     return (
       <div className="loading-container">
         <div className="spinner" />
-        <p>Loading...</p>
+        <p>{t('loading')}</p>
         <style jsx>{`
           .loading-container {
             display: flex;
@@ -71,10 +73,10 @@ export function ProtectedRoute({ children, fallback }: ProtectedRouteProps) {
           <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
           <path d="M7 11V7a5 5 0 0 1 10 0v4" />
         </svg>
-        <h2 className="title">Sign in required</h2>
-        <p className="text">Please sign in to access this page.</p>
+        <h2 className="title">{t('title')}</h2>
+        <p className="text">{t('description')}</p>
         <button type="button" className="sign-in-button" onClick={() => login(pathname)}>
-          Sign In
+          {t('signIn')}
         </button>
         <style jsx>{`
           .auth-required {


### PR DESCRIPTION
## Task
reality-web ProtectedRoute renders an untranslated English auth-required gate for sk/cs/de users. Convert the hardcoded English strings in the reality-web ProtectedRoute (the auth-required gate / redirect messaging) to next-intl translation lookups, adding message keys to all supported locales (sk, cs, de, en).

## Owner
pm-backend (hint) — actual work is frontend/reality-web; specialist selected: `nextjs-web`

## What changed
- `frontend/apps/reality-web/src/components/auth/ProtectedRoute.tsx`: replaced 4 hardcoded English strings (`Loading...`, `Sign in required`, `Please sign in to access this page.`, `Sign In`) with `useTranslations('auth.protected')` lookups.
- Added the `auth.protected` namespace (`loading`, `title`, `description`, `signIn`) to all six locale files: `en`, `sk`, `cs`, `de`, `pl`, `hu`. Real translated copy for every locale (not stubs).

## Verification
```
VERIFY-PLAN base=19bf2d5cc2d3790e98a112f8d0739f6d0561506f files=7
  cd frontend && pnpm exec biome check apps/reality-web/messages/cs.json apps/reality-web/messages/de.json apps/reality-web/messages/en.json apps/reality-web/messages/hu.json apps/reality-web/messages/pl.json apps/reality-web/messages/sk.json apps/reality-web/src/components/auth/ProtectedRoute.tsx
  cd frontend && pnpm --filter "...[19bf2d5cc2d3790e98a112f8d0739f6d0561506f]" typecheck
  cd frontend && pnpm --filter "...[19bf2d5cc2d3790e98a112f8d0739f6d0561506f]" test
```
```
VERIFY OK 1e9b1de5005ed582245f90abb388adf1c0b43a7f
```
biome: clean · typecheck: clean · reality-web tests: 235 passed (24 files).

## Scope drift
`scope-check.sh --owner pm-backend` returns exit 2 because the `owner_role` hint is `pm-backend` while the task is genuinely frontend (reality-web i18n). Not real cross-area drift — every touched path is inside `frontend/apps/reality-web/` (component + `messages/`), which is the `nextjs-web` specialist's owned area. Reviewer to adjudicate the hint mismatch.

## Code-reuse review
`reuse-grep.sh` clean — no duplicated helpers.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity logic change — string extraction only).

## Remote-tested
skipped.

## Notes
- Locale key parity: the new `auth.protected.*` keys are present in all six locales. `pl`/`hu` still have 5 pre-existing missing keys (`pages.compare.*`, `pages.security.description`) unrelated to this change — left untouched.
- IG goal-check: IG7 (verify gate) passed; IG1/IG2/IG4-6/IG8 are plan-flow/`.research/**` artifact checks that don't apply to this directly-dispatched task (no plan file, dispatcher-chosen branch name, archive move is the dispatcher's domain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNTKT4DcimVUfrGgEpzxES

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNTKT4DcimVUfrGgEpzxES)_