### PR TITLE
code-review-ppt-web-ui-sessions-double-cast: type SessionsPage against generated SessionInfo

### DIFF
--- a/frontend/apps/ppt-web/src/features/settings/pages/SessionsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/settings/pages/SessionsPage.tsx
@@ -9,6 +9,7 @@
  * `POST /auth/sessions/revoke-all`) exposed through `getAuthApi()`.
  */
 
+import type { SessionInfo } from '@ppt/api-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,19 +19,8 @@ import '../styles/sessions.css';
 /** Query key for the active-sessions list. */
 const SESSIONS_QUERY_KEY = ['auth', 'sessions'] as const;
 
-/** Minimal session shape consumed here (mirrors the backend SessionInfo DTO). */
-interface SessionRow {
-  id: string;
-  deviceInfo?: string | null;
-  ipAddress?: string | null;
-  userAgent?: string | null;
-  createdAt: string;
-  lastUsedAt: string;
-  isCurrent: boolean;
-}
-
 /** Derive a friendly device/browser label from a user-agent string. */
-function deviceLabel(session: SessionRow, unknownLabel: string): string {
+function deviceLabel(session: SessionInfo, unknownLabel: string): string {
   if (session.deviceInfo) return session.deviceInfo;
   const ua = session.userAgent;
   if (!ua) return unknownLabel;
@@ -81,7 +71,7 @@ export const SessionsPage: React.FC = () => {
     },
   });
 
-  const sessions = (sessionsQuery.data?.sessions ?? []) as unknown as SessionRow[];
+  const sessions = sessionsQuery.data?.sessions ?? [];
   const hasOtherSessions = sessions.some((s) => !s.isCurrent);
 
   return (


### PR DESCRIPTION
## Task
SessionsPage double-casts through unknown to a hand-maintained interface — defeats the API-boundary type-check. Replace the `as unknown as <HandMaintainedInterface>` double-cast in ppt-web SessionsPage with the generated @ppt/api-client type for the sessions response, so the API boundary is type-checked. If the generated client lacks the shape, narrow with a proper type guard instead of a double-cast.

## Owner
pm-backend (task is frontend-only in practice — see Scope drift)

## What changed
`frontend/apps/ppt-web/src/features/settings/pages/SessionsPage.tsx`:
- Removed the local hand-maintained `SessionRow` interface (a duplicate of the client's `SessionInfo`).
- Imported `SessionInfo` from `@ppt/api-client` and used it as the `deviceLabel` parameter type.
- Dropped the `(sessionsQuery.data?.sessions ?? []) as unknown as SessionRow[]` double-cast — `getAuthApi().listSessions()` already returns `ListSessionsResponse` (`{ sessions: SessionInfo[] }`), so `sessions` is now inferred as `SessionInfo[]` and the API boundary is type-checked with no cast.

The generated client already exposes the exact shape, so no type guard was needed. Net: +3 / -13 lines.

## Verification
```
VERIFY-PLAN base=19bf2d5cc2d3790e98a112f8d0739f6d0561506f files=1
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/settings/pages/SessionsPage.tsx
  cd frontend && pnpm --filter "...[19bf2d5cc2d3790e98a112f8d0739f6d0561506f]" typecheck
  cd frontend && pnpm --filter "...[19bf2d5cc2d3790e98a112f8d0739f6d0561506f]" test
```
```
VERIFY OK ae32026ce32f4fdcdc15e9e312ba9cbd3f5b9af8
```
biome clean, typecheck clean, 1616 tests passed (106 files).

## Scope drift
`owner_role=pm-backend` maps to `backend/**` only, but this task is inherently a frontend type-safety fix. The single changed file is:
- `frontend/apps/ppt-web/src/features/settings/pages/SessionsPage.tsx`

`scope-check.sh` flags this (exit 2). The drift is the task label, not the change — the action text explicitly targets ppt-web SessionsPage. react-web was the correctly-selected specialist.

## Code-reuse review
`reuse-grep.sh` clean (no new helpers introduced — the change removes a duplicate type in favor of the existing generated one).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity behavior change — type-only refactor).

## Remote-tested
skipped

## Notes
- Pure type-level refactor; no runtime behavior change. IG3 (failing-on-main regression test) legitimately does not apply.
- The repo's `goal-check.sh` targets the `.research/plans/` flow (plan file, `impl/<slug>` branch, TDD commit pair); this dispatcher micro-task uses the pre-assigned `auto-impl/` branch with no plan file, so those structural IG checks are N/A. The binding correctness gate (impact-scoped verify) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNTKT4DcimVUfrGgEpzxES

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNTKT4DcimVUfrGgEpzxES)_