### PR TITLE
code-review-ppt-web-core-api-retry-nonidempotent: gate axios auto-retry to idempotent methods

### DIFF
--- a/frontend/apps/ppt-web/src/lib/api.test.tsx
+++ b/frontend/apps/ppt-web/src/lib/api.test.tsx
@@ -148,6 +148,35 @@ async function advanceUntil(predicate: () => boolean): Promise<void> {
   }
 }
 
+/**
+ * Await a raw promise (not driven by useQuery) that goes through the retry
+ * backoff, under fake timers. Mirrors {@link advanceUntil}: it fast-forwards
+ * the fake clock past each backoff sleep until the promise settles, then
+ * returns the outcome so the caller can assert on it.
+ */
+async function settleUnderFakeTimers<T>(
+  promise: Promise<T>
+): Promise<{ status: 'resolved'; value: T } | { status: 'rejected'; reason: unknown }> {
+  let outcome:
+    | { status: 'resolved'; value: T }
+    | { status: 'rejected'; reason: unknown }
+    | undefined;
+  const tracked = promise.then(
+    (value) => {
+      outcome = { status: 'resolved', value };
+    },
+    (reason) => {
+      outcome = { status: 'rejected', reason };
+    }
+  );
+  await advanceUntil(() => outcome !== undefined);
+  await tracked;
+  if (outcome === undefined) {
+    throw new Error('settleUnderFakeTimers: promise never settled within budget');
+  }
+  return outcome;
+}
+
 beforeEach(() => {
   resetApiClient();
   vi.useFakeTimers();
@@ -369,6 +398,20 @@ describe('api client — 5xx surfacing through useQuery', () => {
     expect(attempts()).toBe(2);
   });
 
+  it('retries an idempotent DELETE on a 503 (safe method)', async () => {
+    const instance = configureApiClient({});
+    const { adapter, attempts } = scriptedAdapter([
+      { kind: 'status', status: 503, data: { error: 'SERVICE_UNAVAILABLE', message: 'down' } },
+    ]);
+    installAdapter(instance, adapter);
+
+    const outcome = await settleUnderFakeTimers(getApiClient().delete('/widgets/1'));
+    expect(outcome.status).toBe('rejected');
+    expect((outcome as { reason: ApiError }).reason.status).toBe(503);
+    // DELETE is idempotent -> 1 initial + 3 retries.
+    expect(attempts()).toBe(4);
+  });
+
   it('does NOT retry a non-retryable 4xx and surfaces it immediately', async () => {
     const instance = configureApiClient({});
     const { adapter, attempts } = scriptedAdapter([
@@ -395,5 +438,100 @@ describe('api client — 5xx surfacing through useQuery', () => {
     expect(apiError.isRetryable).toBe(false);
     // No retries for a 400.
     expect(attempts()).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Method-based retry gating (idempotency) — regression for
+//    duplicate-write risk on non-idempotent requests.
+// ---------------------------------------------------------------------------
+
+describe('api client — non-idempotent requests are never auto-retried', () => {
+  it('does NOT retry a POST on a 5xx (avoids duplicate server-side writes)', async () => {
+    const instance = configureApiClient({});
+    const { adapter, attempts } = scriptedAdapter([
+      { kind: 'status', status: 503, data: { error: 'SERVICE_UNAVAILABLE', message: 'down' } },
+    ]);
+    installAdapter(instance, adapter);
+
+    // POST must surface the 5xx immediately, with no retry loop.
+    await expect(getApiClient().post('/widgets', { name: 'x' })).rejects.toMatchObject({
+      status: 503,
+    });
+    expect(attempts()).toBe(1);
+  });
+
+  it('does NOT retry a POST on a network error', async () => {
+    const instance = configureApiClient({});
+    const { adapter, attempts } = scriptedAdapter([{ kind: 'network' }]);
+    installAdapter(instance, adapter);
+
+    await expect(getApiClient().post('/widgets', { name: 'x' })).rejects.toMatchObject({
+      status: 0,
+    });
+    // Exactly one attempt — the network error is NOT replayed for a POST.
+    expect(attempts()).toBe(1);
+  });
+
+  it('does NOT retry a PUT or PATCH on a 5xx', async () => {
+    for (const call of [
+      (i: AxiosInstance) => i.put('/widgets/1', { name: 'x' }),
+      (i: AxiosInstance) => i.patch('/widgets/1', { name: 'x' }),
+    ]) {
+      resetApiClient();
+      const instance = configureApiClient({});
+      const { adapter, attempts } = scriptedAdapter([
+        { kind: 'status', status: 500, data: { error: 'INTERNAL', message: 'boom' } },
+      ]);
+      installAdapter(instance, adapter);
+
+      await expect(call(getApiClient())).rejects.toMatchObject({ status: 500 });
+      expect(attempts()).toBe(1);
+    }
+  });
+
+  it('DOES retry a GET on the same 5xx (safe method is still retried)', async () => {
+    const instance = configureApiClient({});
+    const { adapter, attempts } = scriptedAdapter([
+      { kind: 'status', status: 503, data: { error: 'SERVICE_UNAVAILABLE', message: 'down' } },
+    ]);
+    installAdapter(instance, adapter);
+
+    const { result } = renderHook(
+      () =>
+        useQuery({
+          queryKey: ['get-still-retries'],
+          queryFn: async () => {
+            const res = await getApiClient().get('/widgets');
+            return res.data;
+          },
+        }),
+      { wrapper: createWrapper() }
+    );
+
+    await advanceUntil(() => result.current.isError);
+
+    // GET is idempotent -> 1 initial + 3 retries, in contrast to the POST above.
+    expect(attempts()).toBe(4);
+  });
+
+  it('DOES retry a POST that explicitly opts in via `idempotent: true`', async () => {
+    const instance = configureApiClient({});
+    const { adapter, attempts } = scriptedAdapter([
+      { kind: 'status', status: 503, data: { error: 'SERVICE_UNAVAILABLE', message: 'down' } },
+    ]);
+    installAdapter(instance, adapter);
+
+    const outcome = await settleUnderFakeTimers(
+      getApiClient().post('/widgets', { name: 'x' }, {
+        // Caller asserts this write is safe to replay (e.g. carries an
+        // idempotency key).
+        idempotent: true,
+      } as never)
+    );
+    expect(outcome.status).toBe('rejected');
+    expect((outcome as { reason: ApiError }).reason.status).toBe(503);
+    // Opt-in restores the retry budget: 1 initial + 3 retries.
+    expect(attempts()).toBe(4);
   });
 });

--- a/frontend/apps/ppt-web/src/lib/api.ts
+++ b/frontend/apps/ppt-web/src/lib/api.ts
@@ -75,12 +75,35 @@ const INITIAL_RETRY_DELAY = 1000;
 /** HTTP status codes that should trigger a retry */
 const RETRYABLE_STATUS_CODES = [408, 429, 500, 502, 503, 504];
 
+/**
+ * HTTP methods that are safe to auto-retry.
+ *
+ * Only safe / idempotent methods are retried automatically. POST, PUT and
+ * PATCH are intentionally excluded: replaying them after a 5xx or a network
+ * error (where the server may already have applied the write but the response
+ * was lost) risks duplicate server-side writes. A request that is genuinely
+ * idempotent may still opt in explicitly via `idempotent: true` on its axios
+ * config — see {@link isMethodRetryable}.
+ */
+const RETRYABLE_METHODS = ['get', 'head', 'options', 'delete'];
+
 // ============================================================================
 // Helpers
 // ============================================================================
 
+/** Axios request config extended with our opt-in idempotency flag. */
+type RetryableRequestConfig = InternalAxiosRequestConfig & {
+  __retryCount?: number;
+  /** Opt-in: mark a non-safe request (e.g. POST/PUT/PATCH) as safe to retry. */
+  idempotent?: boolean;
+};
+
 /**
  * Check if an error is retryable based on status code or network error.
+ *
+ * Note: this only classifies the *error* (transient vs. permanent). Whether a
+ * request may actually be replayed also depends on its HTTP method — see
+ * {@link isMethodRetryable}. The auto-retry loop requires both.
  */
 function isRetryableError(error: AxiosError): boolean {
   // Network errors (no response) are retryable
@@ -90,6 +113,22 @@ function isRetryableError(error: AxiosError): boolean {
 
   // Check if status code is in retryable list
   return RETRYABLE_STATUS_CODES.includes(error.response.status);
+}
+
+/**
+ * Check whether a request may be auto-retried based on its HTTP method.
+ *
+ * Safe/idempotent methods (GET/HEAD/OPTIONS/DELETE) are retryable by default.
+ * Non-safe methods (POST/PUT/PATCH) are only retried when the caller has
+ * explicitly opted in with `idempotent: true` on the request config. This
+ * guards against duplicate server-side writes on transient failures.
+ */
+function isMethodRetryable(config: InternalAxiosRequestConfig): boolean {
+  if ((config as RetryableRequestConfig).idempotent) {
+    return true;
+  }
+  const method = (config.method ?? 'get').toLowerCase();
+  return RETRYABLE_METHODS.includes(method);
 }
 
 /**
@@ -181,16 +220,17 @@ function createAxiosInstance(config: ApiClientConfig = {}): AxiosInstance {
         onUnauthorizedCallback();
       }
 
-      // Check if we should retry
-      if (config && isRetryableError(error)) {
+      // Check if we should retry.
+      // Both the error (transient) AND the method (safe/idempotent) must permit
+      // it — never auto-retry a non-idempotent POST/PUT/PATCH, to avoid
+      // duplicate server-side writes on 5xx / network failures.
+      if (config && isRetryableError(error) && isMethodRetryable(config)) {
         // Initialize retry count
-        const retryCount =
-          (config as InternalAxiosRequestConfig & { __retryCount?: number }).__retryCount || 0;
+        const retryCount = (config as RetryableRequestConfig).__retryCount || 0;
 
         if (retryCount < MAX_RETRIES) {
           // Update retry count
-          (config as InternalAxiosRequestConfig & { __retryCount?: number }).__retryCount =
-            retryCount + 1;
+          (config as RetryableRequestConfig).__retryCount = retryCount + 1;
 
           // Calculate delay with exponential backoff
           const delay = calculateRetryDelay(retryCount);


### PR DESCRIPTION
## Task
ppt-web axios retry interceptor retries non-idempotent POST/PUT on 5xx / network errors — risk of duplicate server-side writes. Fix the axios retry interceptor so it only retries idempotent/safe methods (GET/HEAD/OPTIONS/DELETE per config, plus explicitly-idempotent requests), and never auto-retries POST/PUT/PATCH on 5xx or network errors, to avoid duplicate server-side writes. Add a regression test that a POST is not retried on a 5xx/network error while a GET is.

## Owner
pm-backend (backlog tag). The code actually lives in the ppt-web frontend api-client, so the `react-web` specialist implemented it.

## What changed
`frontend/apps/ppt-web/src/lib/api.ts` — the axios response interceptor previously retried **any** request whenever `isRetryableError(error)` was true (network error or 5xx/408/429), regardless of HTTP method. A POST/PUT/PATCH that reached the server but lost its response would be silently replayed, causing duplicate writes.

The retry decision is now gated on the method as well:

```ts
if (config && isRetryableError(error) && isMethodRetryable(config)) { ... }
```

- `RETRYABLE_METHODS = ['get', 'head', 'options', 'delete']` are auto-retried by default.
- POST/PUT/PATCH are **never** auto-retried unless the caller explicitly sets `idempotent: true` on the request config (opt-in for writes that carry an idempotency key).
- `isRetryableError` (error/status classification) is unchanged, so the public `ApiError.isRetryable` field keeps its existing meaning — only the auto-retry *action* is gated.

## Regression coverage (IG3)
`frontend/apps/ppt-web/src/lib/api.test.tsx` adds a `non-idempotent requests are never auto-retried` suite plus a DELETE case:
- POST on 5xx → 1 attempt (no retry)
- POST on network error → 1 attempt (no retry)
- PUT and PATCH on 5xx → 1 attempt (no retry)
- GET on the same 5xx → 4 attempts (still retried) — the "while a GET is" contrast
- POST with `idempotent: true` → 4 attempts (opt-in restores retry)
- DELETE on 5xx → 4 attempts (safe method)

Confirmed failing-on-`dev`: with `api.ts` reverted to the base version, the three POST/PUT/PATCH not-retried tests FAIL (the old code retried them); with the fix they pass. All 13 tests in the file pass with the fix.

## Verification
```
VERIFY-PLAN base=dc7e0edfb2e13901685c254e9b2e1650a378863d files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/lib/api.test.tsx apps/ppt-web/src/lib/api.ts
  cd frontend && pnpm --filter "...[dc7e0edfb2e13901685c254e9b2e1650a378863d]" typecheck
  cd frontend && pnpm --filter "...[dc7e0edfb2e13901685c254e9b2e1650a378863d]" test
```
```
VERIFY OK 0dae74606552d542f886931217993f3ffe23ff92
```
Gate ran green: biome clean on both files, typecheck clean, 107 test files / 2129 tests passed across the impact-scoped set.

## CI parity (Band C — hot-path only)
skipped: not flagged hot-path. (Note: this does touch data-integrity by preventing duplicate writes; the impact-scoped `frontend.yml`-equivalent — biome + typecheck + vitest — was fully replicated by the verify gate above.)

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Scope drift
`owner_role=pm-backend` maps to backend areas, but the fix is correctly in `frontend/apps/ppt-web/src/lib/` (the api-client is a frontend module — the task text itself notes this). Diff is exactly two files, both in ppt-web:
- `frontend/apps/ppt-web/src/lib/api.ts`
- `frontend/apps/ppt-web/src/lib/api.test.tsx`

The advisory `scope-check.sh` also reported unrelated paths because the worktree's local `dev` ref was stale; against `origin/dev` the diff is only the two files above.

## Code-reuse review
None. The change adds one small local helper (`isMethodRetryable`) and a `RETRYABLE_METHODS` constant beside the existing `RETRYABLE_STATUS_CODES` / `isRetryableError`; no existing helper was duplicated.

## Notes
- `idempotent: true` is a new opt-in escape hatch on the axios request config for writes that are genuinely safe to replay (e.g. carry an idempotency key). No existing call site uses it; behavior for all current POST/PUT/PATCH callers is now "surface the error immediately" instead of "retry up to 3x".

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFxxFmwdkY8WSt1QzEJyJQ)_