### PR TITLE
code-review-mobile-rn-offline-sync-false-complete: processQueue must not report isComplete after a halted cycle

### DIFF
--- a/frontend/apps/mobile/src/hooks/useOfflineSupport.test.ts
+++ b/frontend/apps/mobile/src/hooks/useOfflineSupport.test.ts
@@ -11,6 +11,9 @@
  *       earlier CREATE that failed and is being retried.
  *   (d) offline-edit linkage — after a CREATE returns its server id, a queued
  *       UPDATE that targeted the temp id is replayed against the real id.
+ *   (e) halted-cycle honesty (issue #2637) — a cycle that stops early on a
+ *       retryable head-of-line failure reports isComplete:false with pending>0,
+ *       never a false completion.
  *
  * The hook is a real React hook (useState/useRef/useEffect), so it is driven
  * through a tiny `react-test-renderer` harness. We deliberately do NOT import
@@ -89,6 +92,7 @@ const store = TEST_GLOBAL.__offlineStore;
 
 import {
   type QueuedAction,
+  type SyncProgress,
   type UseOfflineSupportReturn,
   useOfflineSupport,
 } from './useOfflineSupport';
@@ -306,6 +310,73 @@ describe('useOfflineSupport.processQueue — issue #1767', () => {
     expect(updateCall?.body).toContain('srv-1');
     expect(updateCall?.body).not.toContain(TEMP);
     // Queue fully drained.
+    expect(readQueue()).toHaveLength(0);
+  });
+
+  it('(e) does NOT report isComplete after a head-of-line-blocked (halted) cycle', async () => {
+    // issue #2637: a retryable failure halts the flush mid-cycle. The final
+    // progress must NOT claim the queue is complete while items are still
+    // pending — the old code unconditionally overwrote the halted state with
+    // { isComplete: true } after the loop.
+    seedQueue([
+      makeAction({ id: 'create', type: 'CREATE', endpoint: '/api/v1/faults', body: { t: 'c' } }),
+      makeAction({
+        id: 'update',
+        type: 'UPDATE',
+        method: 'PUT',
+        endpoint: '/api/v1/faults/known-id',
+        body: { t: 'u' },
+      }),
+    ]);
+    const fetchMock = globalThis.fetch as jest.Mock;
+    // The head-of-line CREATE fails with a retryable 5xx, halting the cycle.
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/api/v1/faults')) return serverError(503);
+      return ok({});
+    });
+
+    await mountHook();
+
+    const events: SyncProgress[] = [];
+    let result!: { success: number; failed: number };
+    await act(async () => {
+      result = await api.processQueue((p) => events.push({ ...p }));
+    });
+
+    // The CREATE blocked the UPDATE, so nothing succeeded and nothing was
+    // terminally dropped (503 is retryable) — one attempt, then halt.
+    expect(result).toEqual({ success: 0, failed: 0 });
+
+    // The FINAL progress tick must reflect a halt, not a completion.
+    const last = events.at(-1);
+    expect(last).toBeDefined();
+    expect(last?.isComplete).toBe(false);
+    expect(last?.pending).toBeGreaterThan(0);
+
+    // The exposed syncProgress state agrees with the callback's last tick.
+    expect(api.syncProgress?.isComplete).toBe(false);
+    expect(api.syncProgress?.pending).toBeGreaterThan(0);
+
+    // Both actions survive in the queue for the next reconnect (strict FIFO).
+    expect(readQueue().map((a) => a.id)).toEqual(['create', 'update']);
+  });
+
+  it('reports isComplete with pending:0 when the queue fully drains', async () => {
+    // Positive counterpart to (e): a clean drain must still report completion.
+    seedQueue([makeAction({ id: 'a1' }), makeAction({ id: 'a2' })]);
+    const fetchMock = globalThis.fetch as jest.Mock;
+    fetchMock.mockResolvedValue(ok({ id: 'srv' }));
+
+    await mountHook();
+
+    const events: SyncProgress[] = [];
+    await act(async () => {
+      await api.processQueue((p) => events.push({ ...p }));
+    });
+
+    const last = events.at(-1);
+    expect(last?.isComplete).toBe(true);
+    expect(last?.pending).toBe(0);
     expect(readQueue()).toHaveLength(0);
   });
 });

--- a/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
+++ b/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
@@ -122,6 +122,18 @@ export interface SyncProgress {
   total: number;
   current: number;
   failed: number;
+  /**
+   * Actions still awaiting a successful (or terminal) outcome. Zero only when
+   * the queue is fully drained; > 0 whenever the cycle halted early on a
+   * head-of-line-blocking retryable failure with work still carried forward
+   * (issue #2637).
+   */
+  pending: number;
+  /**
+   * True only when the queue was **fully drained** this cycle (`pending === 0`).
+   * A cycle that halts early on a retryable head-of-line failure reports
+   * `isComplete: false` with `pending > 0` — it did NOT finish (issue #2637).
+   */
   isComplete: boolean;
 }
 
@@ -305,9 +317,22 @@ export function useOfflineSupport(): UseOfflineSupportReturn {
         const flushStartIds = new Set(queue.map((a) => a.id));
 
         // Initialize progress
-        const initialProgress: SyncProgress = { total, current: 0, failed: 0, isComplete: false };
+        const initialProgress: SyncProgress = {
+          total,
+          current: 0,
+          failed: 0,
+          pending: total,
+          isComplete: false,
+        };
         setSyncProgress(initialProgress);
         onProgress?.(initialProgress);
+
+        // Did the cycle stop early on a retryable head-of-line failure? If so
+        // the queue is NOT drained and the final progress must reflect that
+        // (issue #2637). `haltedAt` records how far we got so the final
+        // `current` is accurate.
+        let halted = false;
+        let haltedAt = total;
 
         // Classify every action in the ORIGINAL queue order so we can rebuild
         // the carry-forward list as a strict-FIFO subsequence (issue #1767):
@@ -364,10 +389,14 @@ export function useOfflineSupport(): UseOfflineSupportReturn {
               // UPDATE can never be dispatched ahead of an earlier CREATE that
               // is still being retried (which would hit a resource that doesn't
               // exist server-side yet). They retry next reconnect, in order.
+              halted = true;
+              haltedAt = i + 1;
               const haltedProgress: SyncProgress = {
                 total,
                 current: i + 1,
                 failed,
+                // Everything from the failed action onward is still queued.
+                pending: total - success - failed,
                 isComplete: false,
               };
               setSyncProgress(haltedProgress);
@@ -381,6 +410,7 @@ export function useOfflineSupport(): UseOfflineSupportReturn {
             total,
             current: i + 1,
             failed,
+            pending: total - success - failed,
             isComplete: false,
           };
           setSyncProgress(currentProgress);
@@ -420,8 +450,19 @@ export function useOfflineSupport(): UseOfflineSupportReturn {
         await AsyncStorage.setItem(LAST_SYNC_KEY, now.toString());
         setLastSyncTime(new Date(now));
 
-        // Final progress update
-        const finalProgress: SyncProgress = { total, current: total, failed, isComplete: true };
+        // Final progress update. `isComplete` reflects whether the queue was
+        // actually drained — NOT merely that the cycle ended (issue #2637). A
+        // cycle that halted early on a retryable head-of-line failure leaves
+        // `merged` non-empty, so it must report `isComplete: false` with the
+        // carried-forward `pending` count rather than falsely claiming success.
+        const pending = merged.length;
+        const finalProgress: SyncProgress = {
+          total,
+          current: halted ? haltedAt : total,
+          failed,
+          pending,
+          isComplete: pending === 0,
+        };
         setSyncProgress(finalProgress);
         onProgress?.(finalProgress);
 


### PR DESCRIPTION
## Task
useOfflineSupport.processQueue reports isComplete:true after a head-of-line-blocked (halted) sync cycle. Fix processQueue so it does NOT report the queue as complete when it halted early (head-of-line blocking) with items still pending; distinguish "fully drained" from "halted with remaining work" and reflect that in the returned state. Add a regression test: a queue that halts mid-cycle must report isComplete:false (and pending>0).

## Root cause
On a retryable head-of-line failure the loop set a `haltedProgress` tick with `isComplete:false` and `break`ed, but the post-loop code then unconditionally emitted a **final** progress tick `{ total, current: total, failed, isComplete: true }` — overwriting the halted state and falsely reporting completion while items were still queued.

## Fix
- Added a `pending: number` field to `SyncProgress` (actions still awaiting a successful/terminal outcome).
- The final progress tick now derives `pending = merged.length` (the carried-forward + newly-enqueued queue after the cycle) and `isComplete = pending === 0`. A halted cycle leaves `merged` non-empty → `isComplete:false, pending>0`. A clean drain → `isComplete:true, pending:0`.
- `current` in the final tick reflects how far the cycle actually got when it halted (`haltedAt`) rather than always claiming `total`.
- All intermediate progress ticks now carry a consistent `pending` count.

No public behavior change for consumers reading individual fields (App.tsx / SyncProgressToast). `pending` is additive.

## Owner
pm-backend (backlog tag). Code lives in the React Native app — implemented by the react-native specialist.

## Scope drift
`scope_drift=true` (expected/benign per task): owner_role is `pm-backend` but the fix is entirely in `frontend/apps/mobile`:
- `frontend/apps/mobile/src/hooks/useOfflineSupport.ts`
- `frontend/apps/mobile/src/hooks/useOfflineSupport.test.ts`

## Code-reuse review
none — no new security/auth/crypto/http-client helper introduced.

## Verification
```
VERIFY-PLAN base=93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec files=2
  cd frontend && pnpm exec biome check apps/mobile/src/hooks/useOfflineSupport.test.ts apps/mobile/src/hooks/useOfflineSupport.ts
  cd frontend && pnpm --filter "...[93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec]" typecheck
  cd frontend && pnpm --filter "...[93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec]" test
```
```
VERIFY OK 47ac644a77ecf5e3909daa74f3758ebf236fbfab
```
Test result: 47 suites / 596 tests passed, including the new regression test `(e) does NOT report isComplete after a head-of-line-blocked (halted) cycle` and its positive counterpart `reports isComplete with pending:0 when the queue fully drains`.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
Regression coverage: test (e) fails against the pre-fix code (the final tick reported `isComplete:true`); it now asserts the last progress tick and the exposed `syncProgress` state both report `isComplete:false` with `pending>0`, and that both queued actions survive in strict-FIFO order for the next reconnect.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EioYRDbfEAaKLEjCc8hXhn)_