### PR TITLE
code-review-mobile-rn-push-debug-console-log: guard push-token path against ungated debug logging

### DIFF
--- a/frontend/apps/mobile/src/hooks/usePushNotifications.test.ts
+++ b/frontend/apps/mobile/src/hooks/usePushNotifications.test.ts
@@ -19,6 +19,13 @@
 import { apiRequest } from './useApi';
 import { buildPushTokenRegistration, sendPushTokenToBackend } from './usePushNotifications';
 
+// The mobile tsconfig limits `types` to jest + testing-library (no @types/node),
+// so declare the tiny node surface we use — same pattern as
+// `screens/documents/DocumentUploadScreen.parity.test.ts`.
+declare const __dirname: string;
+declare function require(id: 'node:fs'): { readFileSync(path: string, encoding: 'utf8'): string };
+declare function require(id: 'node:path'): { join(...parts: string[]): string };
+
 jest.mock('./useApi', () => ({
   apiRequest: jest.fn(),
 }));
@@ -97,5 +104,53 @@ describe('sendPushTokenToBackend (PR #918 double-encode regression)', () => {
     expect(typeof init.body).toBe('object');
     expect(init.body).toEqual(body);
     expect(typeof init.body).not.toBe('string');
+  });
+});
+
+// Regression guard: no ungated debug logging on the push-token register /
+// unregister production path (code-review-mobile-rn-push-debug-console-log).
+//
+// The two `console.log` calls on that path are intentional dev-only
+// breadcrumbs, but they MUST stay wrapped in `if (__DEV__)` — Metro strips
+// those blocks from release builds, so nothing reaches the production path.
+// This is the same source-level contract lock used by `config/constants.test.ts`.
+// A raw `console.log('...')` slipping back in un-gated (or one that logs the
+// token itself) would re-open the finding, so we assert the shape of the
+// source rather than rendering the hook.
+describe('usePushNotifications — no ungated debug logging on the token path', () => {
+  const { readFileSync } = require('node:fs');
+  const { join } = require('node:path');
+  const source = readFileSync(join(__dirname, 'usePushNotifications.ts'), 'utf8');
+  const lines = source.split('\n');
+
+  const consoleLineNumbers = lines
+    .map((line, i) => ({ line, n: i }))
+    .filter(({ line }) => /\bconsole\.\w+\s*\(/.test(line));
+
+  it('has console calls to guard (fixture sanity)', () => {
+    // If the calls are ever removed entirely that is also acceptable, but this
+    // keeps the guard honest while they exist.
+    expect(consoleLineNumbers.length).toBeGreaterThan(0);
+  });
+
+  it('gates every console.* call behind `if (__DEV__)`', () => {
+    // Any console.* whose nearest non-blank preceding line is not `if (__DEV__) {`
+    // is un-gated and would ship to the production path.
+    const ungated = consoleLineNumbers.filter(({ n }) => {
+      let prev = n - 1;
+      while (prev >= 0 && lines[prev].trim() === '') prev--;
+      return lines[prev]?.trim() !== 'if (__DEV__) {';
+    });
+    expect(ungated.map(({ line }) => line.trim())).toEqual([]);
+  });
+
+  it('never logs the raw push token value', () => {
+    // SECURITY: the native FCM/APNs token grants push-send authority for the
+    // device. A static breadcrumb string may say the word "token", but no
+    // console statement may interpolate or concatenate the actual value.
+    for (const { line } of consoleLineNumbers) {
+      expect(line).not.toContain('${'); // no template-literal interpolation
+      expect(line).not.toMatch(/\+\s*(?:native)?[Pp]ushToken|encodedToken\b|\btoken\b\s*\)/);
+    }
   });
 });


### PR DESCRIPTION
## Task
mobile (React Native, frontend/apps/mobile) — usePushNotifications has a debug console.log left on the device-token register/unregister production path. Remove the debug console.log(s) from that production path (or gate behind `__DEV__` if the surrounding code convention does so for legitimate logging). Add/adjust a lightweight test or lint assertion if the repo pattern supports it; otherwise ensure existing tests still pass. Keep the diff minimal.

## Owner
pm-backend (backlog tag; code lives in the mobile React Native app — implemented by the react-native specialist)

## Finding disposition
Investigated `frontend/apps/mobile/src/hooks/usePushNotifications.ts`. The two `console.log` breadcrumbs on the register (`sendTokenToBackend`, line ~240) and unregister (`unregisterPushNotifications`, line ~267) paths are **already wrapped in `if (__DEV__)`**, and each is preceded by a `// SECURITY: never log the raw token` comment — the calls log a static string only, never the token value. `__DEV__`-gating is the established, legitimate mobile logging convention (`config/api.ts`, `services/backgroundNotifications.ts`, `qrcode/QRCodeScanner.ts`, `qrcode/DeepLinkHandler.ts`, `widgets/WidgetDataProvider.ts`). Metro strips `if (__DEV__)` blocks from release builds, so nothing reaches the production path.

The task explicitly permits this form ("…or gate behind `__DEV__` if the surrounding code convention does so"). No production-code change was therefore needed. To close the finding durably and satisfy "add a lightweight test if the repo pattern supports it", this PR adds a source-level regression guard (same pattern as `config/constants.test.ts` and `screens/documents/DocumentUploadScreen.parity.test.ts`) to `usePushNotifications.test.ts` that:
- asserts every `console.*` on this path stays behind `if (__DEV__)` (un-gating one makes the test fail — verified locally), and
- asserts no `console.*` interpolates/concatenates the raw push token value (security invariant).

**Diff: test-only, +55 lines, one file.**

## Verification
```
VERIFY-PLAN base=93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec files=1
  cd frontend && pnpm exec biome check apps/mobile/src/hooks/usePushNotifications.test.ts
  cd frontend && pnpm --filter "...[93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec]" typecheck
  cd frontend && pnpm --filter "...[93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec]" test
```
```
VERIFY OK cfd0efdb21237e8b8eabc68aa62a602002f6ee9a
```
Frontend suite: 47 suites / 597 tests passed (incl. the 8 in `usePushNotifications.test.ts`). Mobile typecheck clean, Biome clean.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (test-only mobile change; no security/auth/billing/data-integrity code change).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-backend` flags `frontend/apps/mobile/src/hooks/usePushNotifications.test.ts` as outside the pm-backend owner area — expected and benign: the finding is a mobile React Native issue tagged to pm-backend in the backlog; the code legitimately lives in `frontend/apps/mobile`.

## Notes
- Test-only PR: production code was already in the desired (`__DEV__`-gated) state, so there is no `fix:` commit — the deliverable is the regression guard that locks the contract.
- Guard was proven to bite: temporarily un-gating one `console.log` fails `gates every console.* call behind \`if (__DEV__)\``.
- Code-reuse pre-flight: no warnings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EioYRDbfEAaKLEjCc8hXhn)_