### PR TITLE
code-review-ppt-web-core-api-token-provider-unset: configure getApiClient() token provider at auth bootstrap

### DIFF
--- a/frontend/apps/ppt-web/src/contexts/AuthContext.api-client-token.test.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.api-client-token.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Regression: AuthProvider must configure the hand-rolled axios client in
+ * lib/api.ts so getApiClient() requests carry the Authorization header.
+ *
+ * Before this fix, configureApiClient() was never called in production code —
+ * only in unit tests — so getApiClient() returned a default instance whose
+ * request interceptor had no token getter. Every request made through
+ * getApiClient() (sentiment, predictive-maintenance, …) therefore went out
+ * with NO Authorization header, even for a fully authenticated user.
+ *
+ * This test renders <AuthProvider> with a seeded, authenticated session and
+ * asserts that a request issued via getApiClient() is stamped with
+ * `Authorization: Bearer <access-token>`. It fails on the unfixed code
+ * (header undefined) and passes once AuthProvider wires configureApiClient.
+ */
+/// <reference types="vitest/globals" />
+
+// jsdom under vitest 4 does not expose localStorage by default (mirrors the
+// polyfill in AuthContext.test.tsx). Provide an in-memory shim before any SUT
+// module is imported so tokenStorage.* can read/write.
+const __memStore = new Map<string, string>();
+const __localStorageShim: Storage = {
+  get length() {
+    return __memStore.size;
+  },
+  clear: () => __memStore.clear(),
+  getItem: (k) => (__memStore.has(k) ? (__memStore.get(k) as string) : null),
+  key: (i) => Array.from(__memStore.keys())[i] ?? null,
+  removeItem: (k) => {
+    __memStore.delete(k);
+  },
+  setItem: (k, v) => {
+    __memStore.set(k, String(v));
+  },
+};
+if (typeof globalThis.localStorage === 'undefined') {
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: __localStorageShim,
+    configurable: true,
+    writable: true,
+  });
+}
+if (typeof window !== 'undefined' && typeof window.localStorage === 'undefined') {
+  Object.defineProperty(window, 'localStorage', {
+    value: __localStorageShim,
+    configurable: true,
+    writable: true,
+  });
+}
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import type { AxiosAdapter, AxiosResponse } from 'axios';
+import { AxiosHeaders } from 'axios';
+import type React from 'react';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getApiClient, resetApiClient } from '../lib/api';
+import { AuthProvider, useAuth } from './AuthContext';
+
+const ACCESS_TOKEN_KEY = 'ppt_access_token';
+const USER_KEY = 'ppt_user';
+const ACCESS_TOKEN = 'access-token-abc123';
+
+function seedAuthedSession() {
+  localStorage.setItem(ACCESS_TOKEN_KEY, ACCESS_TOKEN);
+  localStorage.setItem(
+    USER_KEY,
+    JSON.stringify({ id: 'u-1', email: 'alice@example.com', name: 'Alice' })
+  );
+}
+
+/** Adapter that records the Authorization header and returns 200. */
+function recordingAdapter(): {
+  adapter: AxiosAdapter;
+  authHeaders: () => Array<string | undefined>;
+} {
+  const seenAuth: Array<string | undefined> = [];
+  const adapter: AxiosAdapter = (config) => {
+    const headers = AxiosHeaders.from(config.headers);
+    seenAuth.push(headers.get('Authorization') as string | undefined);
+    const response: AxiosResponse = {
+      data: { ok: true },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config,
+    };
+    return Promise.resolve(response);
+  };
+  return { adapter, authHeaders: () => seenAuth };
+}
+
+function AuthProbe({
+  ctxRef,
+}: {
+  ctxRef: { current: ReturnType<typeof useAuth> | null };
+}): React.ReactElement {
+  const auth = useAuth();
+  useEffect(() => {
+    ctxRef.current = auth;
+  });
+  return <div data-testid="auth-state">{auth.isAuthenticated ? 'authed' : 'anon'}</div>;
+}
+
+describe('AuthContext — configures getApiClient() token provider', () => {
+  beforeEach(() => {
+    resetApiClient();
+    seedAuthedSession();
+  });
+
+  afterEach(() => {
+    resetApiClient();
+    localStorage.clear();
+  });
+
+  it('sends the Authorization header on getApiClient() requests once authed', async () => {
+    const ctxRef: { current: ReturnType<typeof useAuth> | null } = { current: null };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider>
+          <AuthProbe ctxRef={ctxRef} />
+        </AuthProvider>
+      </QueryClientProvider>
+    );
+
+    // Wait for AuthProvider to bootstrap the authed state (and run the effect
+    // that calls configureApiClient).
+    await waitFor(() => {
+      expect(ctxRef.current?.isAuthenticated).toBe(true);
+    });
+
+    // Install the recording adapter on the *configured* instance and issue a
+    // request the way feature hooks do.
+    const instance = getApiClient();
+    const { adapter, authHeaders } = recordingAdapter();
+    instance.defaults.adapter = adapter;
+
+    const res = await instance.get('/widgets');
+    expect(res.status).toBe(200);
+
+    // The core assertion: the request carried the bearer token from storage.
+    expect(authHeaders()).toHaveLength(1);
+    expect(authHeaders()[0]).toBe(`Bearer ${ACCESS_TOKEN}`);
+  });
+});

--- a/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.tsx
@@ -36,6 +36,7 @@ import {
   useState,
 } from 'react';
 import { trackSignupLoggedIn } from '../features/auth/analytics';
+import { configureApiClient, resetApiClient } from '../lib/api';
 import { AUTHED_QUERY_KEY_ROOTS } from '../lib/queryKeys';
 
 export type { AuthErrorCode, AuthUser };
@@ -322,12 +323,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
    * This ensures that all API calls automatically include the auth token.
    */
   useEffect(() => {
-    // Register the token provider with the api-client
+    // Register the token provider with the generated @ppt/api-client modules.
     setTokenProvider(getAccessToken);
+
+    // Also configure the hand-rolled axios client in lib/api.ts. This is the
+    // instance returned by getApiClient() and used directly by feature hooks
+    // (sentiment, predictive-maintenance, …). Its request interceptor reads a
+    // module-level token getter that is ONLY set via configureApiClient(); if
+    // this call is missing, getApiClient() falls back to a default instance
+    // with no token getter and every request goes out WITHOUT an Authorization
+    // header. Wiring it here — alongside setTokenProvider — keeps a single
+    // source of truth for the access token (getAccessToken).
+    configureApiClient({ getToken: getAccessToken });
 
     // Clean up on unmount
     return () => {
       clearTokenProvider();
+      resetApiClient();
     };
   }, [getAccessToken]);
 


### PR DESCRIPTION
## Task
ppt-web getApiClient() sends requests with no Authorization header — configureApiClient is never called, so the token provider stays undefined. Fix so the api client is configured with a token provider before use (wire configureApiClient at app/auth bootstrap or make getApiClient lazily resolve the current token), and add a regression test proving requests carry the Authorization header once auth is present.

## Root cause
`frontend/apps/ppt-web/src/lib/api.ts` keeps the token getter in a module-level `tokenGetter` that is set **only** inside `createAxiosInstance`, which receives a config exclusively through `configureApiClient()`. That function was never called in production code (only in `lib/api.test.tsx`). So `getApiClient()` lazily built a default instance with `tokenGetter === undefined`, and its request interceptor never attached an `Authorization` header. Feature hooks that use this client directly — `useSentiment`, `usePredictiveMaintenance` — therefore issued unauthenticated requests even for a logged-in user. (The generated `@ppt/api-client` was unaffected: `AuthContext` already wires it via `setTokenProvider`.)

## Fix
Wire `configureApiClient({ getToken: getAccessToken })` in the same `AuthContext` bootstrap `useEffect` that registers the generated client's token provider, and `resetApiClient()` on cleanup. This keeps a single source of truth for the access token (`getAccessToken`) across both clients. Chose the bootstrap-wiring option over lazy per-request resolution because it mirrors the existing `setTokenProvider` pattern and touches one call site.

- `frontend/apps/ppt-web/src/contexts/AuthContext.tsx` — import + effect wiring.
- `frontend/apps/ppt-web/src/contexts/AuthContext.api-client-token.test.tsx` — regression test.

## Regression test (IG3)
`AuthContext.api-client-token.test.tsx` renders `<AuthProvider>` with a seeded authenticated session, installs a recording axios adapter on `getApiClient()`, issues a request, and asserts it carries `Authorization: Bearer <token>`. Verified discriminating:
- Without the fix: `AssertionError: expected undefined to be 'Bearer access-token-abc123'`.
- With the fix: passes.

Committed as a separate `test:` commit (fails on base) followed by the `fix:` commit.

## Owner
pm-backend

## Scope drift
`scope_drift=true` (expected & benign). `owner_role=pm-backend` but the defect and fix live in the `ppt-web` frontend, per the task description ("the react-web specialist should implement it; scope drift to frontend is expected and benign"). Actual diff is confined to two files under `frontend/apps/ppt-web/src/contexts/`.

## Code-reuse review
`code_reuse_warn=none`. `reuse-grep` emitted only false positives from unrelated generated code (`reality-api-client` generated helpers) and a screen-map test — none are symbols introduced by this change.

## Verification
```
VERIFY-PLAN base=93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/contexts/AuthContext.api-client-token.test.tsx apps/ppt-web/src/contexts/AuthContext.tsx
  cd frontend && pnpm --filter "...[93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec]" typecheck
  cd frontend && pnpm --filter "...[93bbb94cff7fa2c9d6ebca7b94eae462164bf2ec]" test
```
```
VERIFY OK 9c2d470360d7cc354761e917b023d7cbc0637bae
```
(biome clean; `@ppt/web` typecheck clean; 108 test files / 2124 tests passed.)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (client-side header wiring; no server-side security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP).

## Notes
IG goal-check: IG7 (verify gate) ok; IG3 satisfied via split test:/fix: commits. IG1 (plan file) and IG2 (branch named `impl/…`) are N/A for this dispatcher-dispatched code-review task — there is no `.research/plans/<slug>.md` and the branch name (`auto-impl/…`) was pre-assigned by the dispatcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EioYRDbfEAaKLEjCc8hXhn)_