### PR TITLE
code-review-mobile-rn-thread-send-silent-fail: surface failed message sends in ThreadDetailScreen

### DIFF
--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.send.test.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.send.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * ThreadDetailScreen — send-failure regression test.
+ *
+ * Guards the code-review finding (code-review-mobile-rn-thread-send-silent-fail):
+ * the send-message mutation used to have `onSuccess` only, so a failed POST was
+ * swallowed — the Send button reset and the drafted text vanished with no error
+ * shown. This suite asserts that a failed send:
+ *   1. surfaces the failure inline (error banner + retry affordance), and
+ *   2. does NOT silently discard the drafted message (it stays in the composer).
+ *
+ * The pure-helper tests (parse/title/toUiMessages) live in the sibling
+ * `ThreadDetailScreen.test.ts`; this file renders the component.
+ *
+ * The `useApiMutation` mock is a synchronous, state-driven stand-in: `mutate`
+ * flips real React state (so the `isError` banner re-renders) and invokes the
+ * caller's `onSuccess` / `onError` — exactly the contract the screen relies on,
+ * without the flakiness of a real async TanStack mutation under jest-expo.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { ThreadDetailScreen } from './ThreadDetailScreen';
+
+const mockMutationFn = jest.fn();
+// Toggled per test to make the next `mutate` succeed or fail.
+let mockSendShouldFail = false;
+const SEND_ERROR = 'Network unreachable';
+
+jest.mock('../../hooks/useApi', () => {
+  const React = require('react');
+  return {
+    useApiQuery: jest.fn(),
+    useApiMutation: () => {
+      const [state, setState] = React.useState({
+        isPending: false,
+        isError: false,
+        error: undefined as Error | undefined,
+      });
+      const mutate = (
+        vars: unknown,
+        opts?: { onSuccess?: () => void; onError?: (e: Error) => void }
+      ) => {
+        mockMutationFn(vars);
+        if (mockSendShouldFail) {
+          const err = new Error(SEND_ERROR);
+          setState({ isPending: false, isError: true, error: err });
+          opts?.onError?.(err);
+        } else {
+          setState({ isPending: false, isError: false, error: undefined });
+          opts?.onSuccess?.();
+        }
+      };
+      return { mutate, ...state };
+    },
+  };
+});
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u-1' } }),
+}));
+
+const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
+
+function renderScreen() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ThreadDetailScreen threadId="thread-1" />
+    </QueryClientProvider>
+  );
+}
+
+describe('ThreadDetailScreen — send outcomes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSendShouldFail = false;
+    // An empty, loaded thread so the composer renders.
+    mockUseApiQuery.mockReturnValue({
+      data: { participants: [], messages: [] },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+      isFetching: false,
+    });
+  });
+
+  it('surfaces an error and keeps the draft when the send mutation rejects', () => {
+    mockSendShouldFail = true;
+    renderScreen();
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText('Write a message…'),
+      'Please fix the elevator'
+    );
+    fireEvent.press(screen.getByText('Send'));
+
+    // The send was actually attempted (not a silent no-op).
+    expect(mockMutationFn).toHaveBeenCalledTimes(1);
+    expect(mockMutationFn).toHaveBeenCalledWith({ content: 'Please fix the elevator' });
+
+    // The failure is surfaced inline (reused QueryErrorBanner) with a retry.
+    // The banner shows a user-facing message, never the raw backend error.
+    expect(screen.getByText(/Couldn't send/)).toBeTruthy();
+    expect(screen.queryByText(new RegExp(SEND_ERROR))).toBeNull();
+    expect(screen.getByText('common.retry')).toBeTruthy(); // i18n key in tests
+
+    // The drafted message is NOT silently discarded — it stays in the composer
+    // so the user can retry without retyping.
+    expect(screen.getByDisplayValue('Please fix the elevator')).toBeTruthy();
+  });
+
+  it('clears the draft and shows no error banner on a successful send', () => {
+    renderScreen();
+
+    fireEvent.changeText(screen.getByPlaceholderText('Write a message…'), 'Thanks!');
+    fireEvent.press(screen.getByText('Send'));
+
+    expect(mockMutationFn).toHaveBeenCalledTimes(1);
+    expect(screen.queryByDisplayValue('Thanks!')).toBeNull();
+    expect(screen.queryByText(/Couldn't send/)).toBeNull();
+  });
+});

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -25,6 +25,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { QueryErrorBanner } from '../../components/QueryErrorBanner';
 import { useAuth } from '../../contexts/AuthContext';
 import { useApiMutation, useApiQuery } from '../../hooks/useApi';
 import { warnIfListDegraded, warnIfParseFailed } from '../shared/parserWarnings';
@@ -159,6 +160,11 @@ export function ThreadDetailScreen({
           setDraft('');
           refetch();
         },
+        onError: () => {
+          // Surface the failure inline (see `sendMessage.isError` banner
+          // below) and deliberately DO NOT clear `draft` — the user's message
+          // stays in the composer so they can retry without retyping.
+        },
       }
     );
   };
@@ -216,6 +222,18 @@ export function ThreadDetailScreen({
         {isFetching && !isLoading ? <Text style={styles.syncing}>Syncing…</Text> : null}
         <View style={s.bottomSpacer} />
       </ScrollView>
+
+      {sendMessage.isError ? (
+        // Surface the failed send inline, above the composer, and keep the
+        // drafted text intact (handleSend only clears `draft` on success) so
+        // the user can retry without retyping. A localized, non-leaking
+        // message per the QueryErrorBanner contract — never the raw
+        // backend/error string.
+        <QueryErrorBanner
+          message="Couldn't send your message. Please try again."
+          onRetry={handleSend}
+        />
+      ) : null}
 
       <View style={styles.composer}>
         <TextInput


### PR DESCRIPTION
## Task
mobile (React Native, frontend/apps/mobile) — ThreadDetailScreen.handleSend send-message mutation has onSuccess only, no onError, so failed sends are silent. Add an onError handler that surfaces the failure to the user (error state / toast / retry affordance consistent with the app's existing error UX) and does not lose the drafted message. Add a regression test that a failed send mutation triggers the error surface (and the message is not silently discarded).

## Owner
pm-backend (backlog tag; code lives in the mobile React Native app — implemented by the react-native specialist)

## What changed
- `ThreadDetailScreen.tsx`: `handleSend` now passes an `onError` alongside `onSuccess`. On failure the drafted text is deliberately **not** cleared (only `onSuccess` clears `draft`), so the user keeps their message. An inline error surface renders above the composer whenever `sendMessage.isError`, using the **existing** `QueryErrorBanner` component (inline, retryable, non-leaking message) — its `onRetry` re-runs `handleSend`. No raw backend error string is shown (per the banner's contract).
- `ThreadDetailScreen.send.test.tsx` (new): renders the screen, makes the send mutation reject, and asserts (1) the error banner appears, (2) the raw backend error is not leaked, (3) the `Retry` affordance is present, and (4) the drafted message stays in the composer. A companion test asserts the happy path still clears the draft and shows no banner.

## Regression evidence (IG3)
With the source fix stashed, the new test fails on the pre-fix screen:
```
✕ surfaces an error and keeps the draft when the send mutation rejects
  expect(screen.getByText(/Couldn't send/)) — Unable to find an element with text: /Couldn't send/
```
With the fix applied it passes (15/15 in the messages suite).

## Verification
```
VERIFY-PLAN base=d08d5f92d3b2d2a0b6251c27cc4f24523b317bf7 files=2
  cd frontend && pnpm exec biome check apps/mobile/src/screens/messages/ThreadDetailScreen.send.test.tsx apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
  cd frontend && pnpm --filter "...[d08d5f92d3b2d2a0b6251c27cc4f24523b317bf7]" typecheck
  cd frontend && pnpm --filter "...[d08d5f92d3b2d2a0b6251c27cc4f24523b317bf7]" test
```
```
VERIFY OK 4a88325ae801adc9dc8f1e54924f4ba6ff53aecd
```
(biome clean, mobile typecheck clean, 48 suites / 596 tests passed.)

## Scope drift
`scope_drift=true` — owner_role is `pm-backend` but the finding lives in `frontend/apps/mobile`. Expected and benign per the task brief (the mobile/react-native specialist implements it). Diff is limited to the two files above.

## Code-reuse review
Deterministic `reuse-grep` returned no warnings. Notably this change **reuses** the existing `QueryErrorBanner` component (`frontend/apps/mobile/src/components/QueryErrorBanner.tsx`) instead of hand-rolling banner JSX/styles.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- The screen is not currently internationalized (all copy is hardcoded English: "Loading…", "Send", etc.), so the banner message is a hardcoded English sentence to match. Only the banner's own `Retry` button uses `t('common.retry')` (that comes from the reused component). Introducing an i18n key/namespace for this one string was left out to avoid scope creep on an otherwise un-i18n'd screen.
- goal-check.sh IG1/IG2/IG4/IG5/IG6 report FAIL only because this is a dispatcher auto-impl code-review task (no `.research/plans/<slug>.md`, `auto-impl/*` branch, single `fix:` commit) rather than the manual plan flow those checks target; IG7 (verify) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EioYRDbfEAaKLEjCc8hXhn)_