### PR TITLE
screen-map-drift-pr-2636-reality: sync agency-import + agency-inquiries screen-maps to PR #2636 i18n rewrite

### DIFF
--- a/docs/screens/reality/agency-import.md
+++ b/docs/screens/reality/agency-import.md
@@ -4,7 +4,8 @@ name: Agency Import (UC-50)
 product: reality
 implementations:
   reality-web:
-    component: AgencyImportWizard
+    route: "/agency/import"
+    component: AgencyImportPage
     buildStatus: in-progress
     redesignStatus: in-progress
     apiStatus: partial
@@ -25,6 +26,7 @@ sharedComponents:
   - data-table
   - status-pill
   - validation-patterns
+  - next-intl
 designSources:
   - adapter: claude-design
     file: guest-registration-v2-design-system/project/pages/agency-import.html
@@ -96,6 +98,8 @@ UC-50 agency property import. Connects to external CRMs / XML feeds to bulk-impo
 
 ### Specific (recent)
 
+- i18n (PR #2636): the whole agency/import cluster is now fully localized via next-intl — no hardcoded English left. Route `/agency/import` renders `AgencyImportPage` (a 3-tab layout: CSV · CRM · Feed) mounting `CsvImport` / `CrmConnection` / `FeedImport`; `SyncSchedule` exists in `components/import` (exported, uses `import.schedule`) but is not yet mounted in the page. Note: the shipped tab layout differs from the 9-step wizard in the design bundle above — the wizard checklist remains aspirational (`buildStatus: in-progress`).
+- i18n message keys live under the `import` namespace with nested `page` / `steps` / `csv` / `crm` / `feed` / `schedule` groups, present in all 6 reality-web locales (en, sk, cs, de, pl, hu — superset of the sk/cs/de/en named in UC-50). Follow the sibling `useTranslations('import.<group>')` pattern when adding strings; auto-derived CSV/CRM/feed field-name labels are intentionally left untranslated (technical schema identifiers, not UI copy).
 - "Beží" status pill uses pulsing dot animation (success-500); respects reduced-motion → static green dot.
 - Skipped-count link drilldown shows which fields blocked import for each skipped row (useful for fixing source data).
 - Webhook URL must be HTTPS only; show inline validation error for HTTP.
@@ -106,4 +110,5 @@ UC-50 agency property import. Connects to external CRMs / XML feeds to bulk-impo
 
 <!-- newest entries on top -->
 
+- 2026-08-03 — agent: synced to PR #2636 i18n rewrite. Corrected component `AgencyImportWizard` → `AgencyImportPage`, added route `/agency/import`, added `next-intl` to sharedComponents, documented `import.*` namespace (page/steps/csv/crm/feed/schedule × 6 locales) and the shipped 3-tab (CSV/CRM/Feed) vs design-bundle 9-step-wizard divergence. buildStatus/apiStatus unchanged (pure i18n refactor, no behavior/API change).
 - 2026-05-09 — agent: bootstrapped from bundle (pages/agency-import.html — 9 sections: 4 steps + confirm + history loaded/empty + 4 error cards); UC-50; parent agency-dashboard; sibling agency-branding

--- a/docs/screens/reality/agency-inquiries.md
+++ b/docs/screens/reality/agency-inquiries.md
@@ -9,14 +9,17 @@ implementations:
     component: AgencyInquiriesPage
     buildStatus: shipped
     redesignStatus: not-started
-    apiStatus: stub
-endpoints: []
+    apiStatus: partial
+endpoints:
+  - inquiries_list
 relatedScreens:
   - id: reality/agency-dashboard
     rel: parent
-sharedComponents: []
+sharedComponents:
+  - next-intl
 diagrams: []
-useCases: []
+useCases:
+  - UC-49.5
 epics: []
 designSources: []
 owner: reality-frontend
@@ -24,12 +27,15 @@ owner: reality-frontend
 
 # Agency Inquiries
 
-Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, epics, and redesign notes when known.
+Lists inquiries received for the signed-in principal's listings/agency (UC-49.5). `AgencyInquiriesPage` wraps `AgencyInquiriesContent` in `ProtectedRoute` + Header/Footer, with a status-filter chip strip (all / pending / responded / scheduled / completed / cancelled) and per-inquiry rows linking back to the listing.
 
 ## Notes
 
 ### Specific (recent)
+- i18n (PR #2636): page fully localized via next-intl namespace `agencyInquiries` (title, subtitle, loading, loadError, empty, `status.*`) across all 6 reality-web locales (en, sk, cs, de, pl, hu). No hardcoded English remains. Status chip/badge labels resolve through dynamic `t('status.${value}')` keys.
+- API: wired to the generic `inquiries_list` endpoint (`GET /api/v1/inquiries`) via the reused `useMyInquiries` hook — the API filters by the requesting principal. `apiStatus: partial` because a dedicated `/agencies/{id}/inquiries` endpoint/hook is still pending (see the page's own TODO comment); the current reuse works but is not agency-scoped server-side.
 - 2026-05-18 — audit: stub created from `frontend/apps/reality-web/src/app/[locale]/agency/inquiries/page.tsx`.
 
 ## Agent Log
+- 2026-08-03 — agent: synced to PR #2636 i18n rewrite. Documented `agencyInquiries` next-intl namespace (6 locales); added `inquiries_list` endpoint + `UC-49.5` + `next-intl` shared component; bumped apiStatus stub → partial (real `useMyInquiries` wiring, dedicated agency endpoint pending); replaced stub body with actual page description.
 - 2026-05-18 — agent: created stub for unmapped route.


### PR DESCRIPTION
## Task
docs/screens/reality/agency-import + agency-inquiries out of sync with PR #2636 i18n rewrite. Update the two reality screen-map docs (docs/screens/reality/agency-import and agency-inquiries) to reflect PR #2636's i18n rewrite — refresh frontmatter (apiStatus/buildStatus if changed), components/endpoints, add an Agent Log entry, and update Notes. Run `/screens validate` and ensure it passes. This is a docs/screen-map task.

## Owner
pm-qa

## What changed
Synced both reality screen-maps to the merged PR #2636 (`feat(reality-web): i18n the agency/import feature cluster`, commit 89165f7).

**`docs/screens/reality/agency-import.md`**
- Corrected component drift: `AgencyImportWizard` → `AgencyImportPage` (the actual `app/[locale]/agency/import/page.tsx` default export).
- Added missing `route: "/agency/import"`.
- Added `next-intl` to `sharedComponents`.
- Notes: documented the `import.*` next-intl namespace (nested `page`/`steps`/`csv`/`crm`/`feed`/`schedule`) across all 6 reality-web locales (en, sk, cs, de, pl, hu), and recorded that the shipped 3-tab layout (CSV · CRM · Feed, mounting `CsvImport`/`CrmConnection`/`FeedImport`; `SyncSchedule` exported but not mounted) diverges from the design-bundle 9-step wizard the checklist still describes.
- `buildStatus`/`apiStatus` left unchanged — #2636 is a pure i18n refactor, no behavior/API change.

**`docs/screens/reality/agency-inquiries.md`**
- Documented the `agencyInquiries` next-intl namespace (title/subtitle/loading/loadError/empty/`status.*`) across all 6 locales.
- Added `inquiries_list` endpoint (page fetches `GET /api/v1/inquiries` via reused `useMyInquiries`), `UC-49.5`, and `next-intl` shared component.
- Bumped `apiStatus: stub → partial` — the route is wired to a real endpoint via the generic `useMyInquiries` hook (a pre-existing wiring surfaced during this sync, not introduced by #2636); a dedicated agency-scoped `/agencies/{id}/inquiries` endpoint is still pending.
- Replaced the placeholder stub body with an accurate page description.

Both files have an Agent Log entry dated 2026-08-03.

## Verification
```
VERIFY-PLAN base=2f1565a9b9872485cb2c0fecb335be697158ca0c files=2
```
```
VERIFY OK e17c2c1e8755c62f0977bb59e8e7817068052a90
```
Docs-only diff → empty verify plan (no build/test commands apply). Screen-map validate is the domain gate:

```
pnpm --filter @ppt/screen-map cli validate --root <repo> --strict
  ok  docs/screens/reality/agency-import.md
  ok  docs/screens/reality/agency-inquiries.md
Validated 167 screen-maps: 0 errors, 0 warnings.
```

## Scope drift
`scope-check.sh --owner pm-qa --base origin/dev` reports exit 2: the two changed paths (`docs/screens/reality/agency-import.md`, `docs/screens/reality/agency-inquiries.md`) fall outside the `pm-qa` owner-area map. This is expected and intended — the task is explicitly a docs/screen-map task and screen-map docs under `docs/screens/**` are the designated deliverable. No code paths touched. Reviewer to adjudicate.

## Code-reuse review
N/A — docs-only change (no new helpers/symbols added).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (docs-only; no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Endpoint id `inquiries_list` is a known `@ppt/sitemap` operation id (`GET /api/v1/inquiries`), which `useMyInquiries` calls — validation passes strict.
- The agency-import functionality checklist (9-step wizard) is retained as aspirational design (`buildStatus: in-progress`); a note now flags the divergence from the shipped tab UI for future agents.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGSGrdKmcBgr4iLMJefif)_