### PR TITLE
code-review-ppt-web-core-route-error-boundary-gap: scope route errors with a route-outlet ErrorBoundary

### DIFF
--- a/frontend/apps/ppt-web/src/App.route-error-boundary.test.tsx
+++ b/frontend/apps/ppt-web/src/App.route-error-boundary.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Route-outlet ErrorBoundary regression coverage.
+ *
+ * Guards the fix for the "core route error-boundary gap": before it, ppt-web
+ * had no boundary between the route outlet and the application shell, so a
+ * single stale-chunk `lazy()` rejection (or any uncaught render error in one
+ * route) propagated to the top-level `<ErrorBoundary>` in `main.tsx` — which
+ * wraps the entire `<App />` — and unmounted the whole shell (nav included).
+ *
+ * `RouteErrorBoundary` (App.tsx) is rendered as a child of `<main>` and a
+ * sibling *below* `<AppNavigation>`. These tests reproduce that arrangement
+ * (a shell sibling outside the boundary + a route outlet inside it) and prove:
+ *   1. a route that throws during render shows the scoped fallback while the
+ *      shell survives;
+ *   2. a stale-chunk `lazy()` rejection is caught the same way (the shell
+ *      survives, the fallback with a reload affordance renders);
+ *   3. navigating to another route after a failure recovers automatically
+ *      (the boundary is keyed on pathname) — no full page reload required.
+ */
+/// <reference types="vitest/globals" />
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type ComponentType, lazy, Suspense } from 'react';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RouteErrorBoundary } from './App';
+
+// React logs caught render errors to console.error; silence it so the
+// expected-failure tests don't spam the reporter.
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** A route component that always throws during render. */
+function ThrowingRoute(): never {
+  throw new Error('boom: route render failure');
+}
+
+const SHELL = 'app-shell-nav';
+const FALLBACK_TITLE = 'Something went wrong'; // errors.somethingWentWrong (en)
+const RELOAD_LABEL = /reload page/i; // common.reloadPage (en)
+
+describe('RouteErrorBoundary', () => {
+  it('renders the scoped fallback for a throwing route while the shell survives', () => {
+    render(
+      <MemoryRouter initialEntries={['/boom']}>
+        {/* Shell sibling — mirrors <AppNavigation> living outside <main>. */}
+        <nav>{SHELL}</nav>
+        <main>
+          <RouteErrorBoundary>
+            <Routes>
+              <Route path="/boom" element={<ThrowingRoute />} />
+            </Routes>
+          </RouteErrorBoundary>
+        </main>
+      </MemoryRouter>
+    );
+
+    // Fallback is shown inside the content region…
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(FALLBACK_TITLE)).toBeInTheDocument();
+    // …with a reload affordance…
+    expect(screen.getByRole('button', { name: RELOAD_LABEL })).toBeInTheDocument();
+    // …and the shell is still mounted (not unmounted with the app).
+    expect(screen.getByText(SHELL)).toBeInTheDocument();
+  });
+
+  it('catches a stale-chunk lazy() rejection without unmounting the shell', async () => {
+    // Simulates a deploy that invalidated the old chunk: the dynamic import
+    // rejects instead of resolving to a module.
+    const StaleChunkRoute = lazy(
+      () =>
+        Promise.reject(new Error('Failed to fetch dynamically imported module')) as Promise<{
+          default: ComponentType;
+        }>
+    );
+
+    render(
+      <MemoryRouter initialEntries={['/stale']}>
+        <nav>{SHELL}</nav>
+        <main>
+          <RouteErrorBoundary>
+            <Suspense fallback={<div>loading route…</div>}>
+              <Routes>
+                <Route path="/stale" element={<StaleChunkRoute />} />
+              </Routes>
+            </Suspense>
+          </RouteErrorBoundary>
+        </main>
+      </MemoryRouter>
+    );
+
+    // The rejection resolves asynchronously; the boundary then renders the
+    // fallback rather than letting the error escape to the app root.
+    expect(await screen.findByText(FALLBACK_TITLE)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: RELOAD_LABEL })).toBeInTheDocument();
+    // Shell survives the lazy failure.
+    expect(screen.getByText(SHELL)).toBeInTheDocument();
+  });
+
+  it('recovers automatically when the user navigates to another route', () => {
+    render(
+      <MemoryRouter initialEntries={['/boom']}>
+        {/* In-shell nav link — clicking it changes the pathname, which the
+            boundary is keyed on, so it resets and renders the new route. */}
+        <Link to="/safe">go-safe</Link>
+        <main>
+          <RouteErrorBoundary>
+            <Routes>
+              <Route path="/boom" element={<ThrowingRoute />} />
+              <Route path="/safe" element={<div>safe-route-content</div>} />
+            </Routes>
+          </RouteErrorBoundary>
+        </main>
+      </MemoryRouter>
+    );
+
+    // Start on the failing route: fallback visible.
+    expect(screen.getByText(FALLBACK_TITLE)).toBeInTheDocument();
+
+    // Navigate away — the pathname-keyed boundary remounts and clears.
+    fireEvent.click(screen.getByText('go-safe'));
+
+    expect(screen.getByText('safe-route-content')).toBeInTheDocument();
+    expect(screen.queryByText(FALLBACK_TITLE)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/App.tsx
+++ b/frontend/apps/ppt-web/src/App.tsx
@@ -3,7 +3,7 @@ import { setMfaChallengeHandler } from '@ppt/api-client';
 import { AccessibilityProvider, SkipNavigation } from '@ppt/ui-kit';
 import { type ReactNode, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BrowserRouter, Link, useNavigate } from 'react-router-dom';
+import { BrowserRouter, Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   AnnouncerProvider,
   ConnectionStatus,
@@ -11,6 +11,7 @@ import {
   OfflineIndicator,
   ToastProvider,
 } from './components';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './styles/accessibility.css';
 import './features/settings/styles/accessibility.css';
 import { AuthProvider, OrganizationProvider, useAuth, WebSocketProvider } from './contexts';
@@ -193,6 +194,30 @@ function RouteLoading() {
 }
 
 /**
+ * Route-outlet-level error boundary.
+ *
+ * Scopes render/lazy failures to the route outlet so they can't unmount the
+ * whole application shell. Without this, a single stale-chunk `lazy()`
+ * rejection (or any uncaught render error in one route) propagates all the way
+ * to the top-level `<ErrorBoundary>` in `main.tsx`, which wraps the *entire*
+ * `<App />` — nav, providers and all — and replaces the whole UI with the
+ * global fallback. Placing a boundary here, as a child of `<main>` and a
+ * sibling *below* `<AppNavigation>`, keeps the shell (nav, language switcher,
+ * connection status) mounted and renders the fallback only inside the content
+ * region. The reused `ErrorBoundary` fallback already offers a reload
+ * affordance ("Reload Page") plus an in-place "Try Again".
+ *
+ * The boundary is keyed on `pathname` so that navigating to a different route
+ * after a failure resets it automatically — the user recovers by clicking a
+ * nav link, without a full page reload. Must be rendered inside
+ * `BrowserRouter` for `useLocation` to resolve.
+ */
+export function RouteErrorBoundary({ children }: { children: ReactNode }) {
+  const { pathname } = useLocation();
+  return <ErrorBoundary key={pathname}>{children}</ErrorBoundary>;
+}
+
+/**
  * Command Palette wrapper that registers navigation commands.
  * Must be rendered inside BrowserRouter for useNavigate to work.
  */
@@ -226,9 +251,11 @@ function App() {
                               never see impersonation tokens directly. */}
                           <AppNavigation />
                           <main id="main-content">
-                            <Suspense fallback={<RouteLoading />}>
-                              <AppRoutes />
-                            </Suspense>
+                            <RouteErrorBoundary>
+                              <Suspense fallback={<RouteLoading />}>
+                                <AppRoutes />
+                              </Suspense>
+                            </RouteErrorBoundary>
                           </main>
                         </div>
                       </CommandPaletteWrapper>


### PR DESCRIPTION
## Task
ppt-web has no route-outlet ErrorBoundary — a single stale-chunk lazy() rejection unmounts the entire application shell. Add a route-outlet-level ErrorBoundary so a lazy()/render error in one route renders a scoped fallback (with reload affordance) instead of unmounting the whole app shell. Reuse any existing error-boundary/fallback component if present. Add a regression test proving a throwing route renders the fallback and the shell survives.

task_id: `code-review-ppt-web-core-route-error-boundary-gap`

## Owner
pm-backend (backlog tag). Code lives in `frontend/apps/ppt-web` — implemented by the react-web specialist. Frontend scope drift is expected and benign per the task brief.

## What changed
Before: the only `ErrorBoundary` in ppt-web lived in `main.tsx` wrapping the **entire** `<App />`. Any uncaught render error or stale-chunk `lazy()` rejection in one route bubbled to that top-level boundary and unmounted the whole shell (nav, language switcher, connection status) — replacing the full UI with the global fallback.

- `App.tsx`: added `RouteErrorBoundary`, a thin wrapper that **reuses the existing `components/ErrorBoundary`** and is keyed on `pathname`. It wraps the route outlet (`<Suspense><AppRoutes/></Suspense>`) inside `<main>`, as a sibling **below** `<AppNavigation>`. A route failure is now scoped to the content region; the shell stays mounted. The `pathname` key auto-resets the boundary on navigation (recover by clicking a nav link), and the reused fallback still offers a "Reload Page" affordance.
- `App.route-error-boundary.test.tsx`: regression coverage — (1) a throwing route renders the fallback while the shell sibling survives; (2) a stale-chunk `lazy()` rejection is caught the same way; (3) navigating to another route auto-resets the boundary.

## Verification
```
VERIFY-PLAN base=2f1565a9b9872485cb2c0fecb335be697158ca0c files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/App.route-error-boundary.test.tsx apps/ppt-web/src/App.tsx
  cd frontend && pnpm --filter "...[2f1565a9b9872485cb2c0fecb335be697158ca0c]" typecheck
  cd frontend && pnpm --filter "...[2f1565a9b9872485cb2c0fecb335be697158ca0c]" test
```
```
VERIFY OK 4f3bf6dbfaa08269151d16bf1eafc4d5a2b13469
```
Full ppt-web suite: 108 files / 2132 tests passed (incl. the 3 new ones). Typecheck + biome clean.

## Code-reuse review
`reuse-grep.sh` (react-web): no warnings. The fix reuses the existing `components/ErrorBoundary` rather than adding a new boundary/fallback.

## Scope drift
Diff vs `origin/dev` is exactly 2 files, both under `frontend/apps/ppt-web/src/` — outside `owner_role=pm-backend`'s area. This is expected/benign: the task brief states the finding is tagged pm-backend but the code lives in ppt-web and is implemented by the react-web specialist.

## Goal-check (IG1–IG8)
`goal-check.sh` reports IG3 ok (separate test:/fix: commits) and IG7 ok (verify gate, run in Step 3). IG1 (`.research/plans/<slug>.md`) and IG2 (`impl/<slug>` branch) FAIL — both are plan-flow checks that don't apply to a dispatcher-spawned code-review finding (no plan file; branch pre-chosen as `auto-impl/...`). IG4–IG6/IG8 skip (no plan).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
`RouteErrorBoundary` is exported from `App.tsx` so the regression test can mount it in isolation with a shell sibling. No screen-map change: no routes were added/removed/renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJGSGrdKmcBgr4iLMJefif

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGSGrdKmcBgr4iLMJefif)_