### PR TITLE
code-review-ppt-web-core-notfound-i18n-gap: i18n route-wrapper 'not found' fallbacks

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -740,7 +740,15 @@
     "waitBeforeRetry": "Před opakováním počkejte.",
     "somethingWentWrong": "Něco se pokazilo",
     "unexpectedError": "Omlouváme se za nepříjemnosti. Došlo k neočekávané chybě.",
-    "copyErrorDetailsSupport": "Kopírovat podrobnosti chyby pro podporu"
+    "copyErrorDetailsSupport": "Kopírovat podrobnosti chyby pro podporu",
+    "groupNotFound": "Skupina nebyla nalezena",
+    "announcementNotFound": "Oznámení nebylo nalezeno",
+    "threadNotFound": "Konverzace nebyla nalezena",
+    "buildingNotFound": "Budova nebyla nalezena",
+    "bookingNotFound": "Rezervace nebyla nalezena",
+    "faultNotFound": "Závada nebyla nalezena",
+    "meterNotFound": "Měřič nebyl nalezen",
+    "entityNotFound": "{{entity}} nebylo nalezeno"
   },
   "notifications": {
     "title": "Oznámení",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -693,7 +693,15 @@
     "waitBeforeRetry": "Bitte warten Sie, bevor Sie es erneut versuchen.",
     "somethingWentWrong": "Etwas ist schiefgelaufen",
     "unexpectedError": "Wir entschuldigen uns für die Unannehmlichkeiten. Ein unerwarteter Fehler ist aufgetreten.",
-    "copyErrorDetailsSupport": "Fehlerdetails für den Support kopieren"
+    "copyErrorDetailsSupport": "Fehlerdetails für den Support kopieren",
+    "groupNotFound": "Gruppe nicht gefunden",
+    "announcementNotFound": "Ankündigung nicht gefunden",
+    "threadNotFound": "Konversation nicht gefunden",
+    "buildingNotFound": "Gebäude nicht gefunden",
+    "bookingNotFound": "Buchung nicht gefunden",
+    "faultNotFound": "Störung nicht gefunden",
+    "meterNotFound": "Zähler nicht gefunden",
+    "entityNotFound": "{{entity}} nicht gefunden"
   },
   "notifications": {
     "title": "Benachrichtigungen",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -877,7 +877,15 @@
     "waitBeforeRetry": "Please wait before trying again.",
     "somethingWentWrong": "Something went wrong",
     "unexpectedError": "We apologize for the inconvenience. An unexpected error has occurred.",
-    "copyErrorDetailsSupport": "Copy error details for support"
+    "copyErrorDetailsSupport": "Copy error details for support",
+    "groupNotFound": "Group not found",
+    "announcementNotFound": "Announcement not found",
+    "threadNotFound": "Thread not found",
+    "buildingNotFound": "Building not found",
+    "bookingNotFound": "Booking not found",
+    "faultNotFound": "Fault not found",
+    "meterNotFound": "Meter not found",
+    "entityNotFound": "{{entity}} not found"
   },
   "notifications": {
     "title": "Notifications",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -693,7 +693,15 @@
     "waitBeforeRetry": "Kérem várjon az újrapróbálkozás előtt.",
     "somethingWentWrong": "Valami hiba történt",
     "unexpectedError": "Elnézést kérünk a kellemetlenségért. Váratlan hiba történt.",
-    "copyErrorDetailsSupport": "Hibarészletek másolása az ügyfélszolgálatnak"
+    "copyErrorDetailsSupport": "Hibarészletek másolása az ügyfélszolgálatnak",
+    "groupNotFound": "A csoport nem található",
+    "announcementNotFound": "A közlemény nem található",
+    "threadNotFound": "A beszélgetés nem található",
+    "buildingNotFound": "Az épület nem található",
+    "bookingNotFound": "A foglalás nem található",
+    "faultNotFound": "A hiba nem található",
+    "meterNotFound": "A mérő nem található",
+    "entityNotFound": "{{entity}} nem található"
   },
   "notifications": {
     "title": "Értesítések",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -695,7 +695,15 @@
     "waitBeforeRetry": "Proszę poczekać przed ponowną próbą.",
     "somethingWentWrong": "Coś poszło nie tak",
     "unexpectedError": "Przepraszamy za niedogodności. Wystąpił nieoczekiwany błąd.",
-    "copyErrorDetailsSupport": "Kopiuj szczegóły błędu dla wsparcia"
+    "copyErrorDetailsSupport": "Kopiuj szczegóły błędu dla wsparcia",
+    "groupNotFound": "Grupa nie została znaleziona",
+    "announcementNotFound": "Ogłoszenie nie zostało znalezione",
+    "threadNotFound": "Wątek nie został znaleziony",
+    "buildingNotFound": "Budynek nie został znaleziony",
+    "bookingNotFound": "Rezerwacja nie została znaleziona",
+    "faultNotFound": "Usterka nie została znaleziona",
+    "meterNotFound": "Licznik nie został znaleziony",
+    "entityNotFound": "Nie znaleziono: {{entity}}"
   },
   "notifications": {
     "title": "Powiadomienia",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -742,7 +742,15 @@
     "waitBeforeRetry": "Pred opakovaním počkajte.",
     "somethingWentWrong": "Niečo sa pokazilo",
     "unexpectedError": "Ospravedlňujeme sa za nepríjemnosti. Vyskytla sa neočakávaná chyba.",
-    "copyErrorDetailsSupport": "Kopírovať podrobnosti chyby pre podporu"
+    "copyErrorDetailsSupport": "Kopírovať podrobnosti chyby pre podporu",
+    "groupNotFound": "Skupina nebola nájdená",
+    "announcementNotFound": "Oznam nebol nájdený",
+    "threadNotFound": "Konverzácia nebola nájdená",
+    "buildingNotFound": "Budova nebola nájdená",
+    "bookingNotFound": "Rezervácia nebola nájdená",
+    "faultNotFound": "Porucha nebola nájdená",
+    "meterNotFound": "Merač nebol nájdený",
+    "entityNotFound": "{{entity}} sa nenašlo"
   },
   "notifications": {
     "title": "Oznámenia",

--- a/frontend/apps/ppt-web/src/routes/groups/announcements.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/announcements.tsx
@@ -517,8 +517,9 @@ export function ViewAnnouncementPageInner({ announcementId }: { announcementId: 
 /** Route wrapper — guards for missing param before mounting inner component */
 function ViewAnnouncementPageRoute() {
   const { announcementId } = useParams<{ announcementId: string }>();
+  const { t } = useTranslation();
   if (!announcementId) {
-    return <div>Announcement not found</div>;
+    return <div>{t('errors.announcementNotFound', 'Announcement not found')}</div>;
   }
   return <ViewAnnouncementPageInner announcementId={announcementId} />;
 }
@@ -592,8 +593,9 @@ function EditAnnouncementPageInner({ announcementId }: { announcementId: string 
 /** Route wrapper — guards for missing param before mounting inner component */
 function EditAnnouncementPageRoute() {
   const { announcementId } = useParams<{ announcementId: string }>();
+  const { t } = useTranslation();
   if (!announcementId) {
-    return <div>Announcement not found</div>;
+    return <div>{t('errors.announcementNotFound', 'Announcement not found')}</div>;
   }
   return <EditAnnouncementPageInner announcementId={announcementId} />;
 }

--- a/frontend/apps/ppt-web/src/routes/groups/buildings.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/buildings.tsx
@@ -4,6 +4,7 @@
  * Owns the building route-wrapper components and the `<Route>` table fragment
  * for buildings + facilities. Extracted from App.tsx to isolate this work.
  */
+import { useTranslation } from 'react-i18next';
 import { Route, useNavigate, useParams } from 'react-router-dom';
 import { ProtectedRoute } from '../../components';
 import {
@@ -32,8 +33,9 @@ function BuildingsPageRoute() {
 /** Route wrapper for building detail (Epic 3, Story 3.1) — gap-sweep */
 function BuildingDetailPageRoute() {
   const { buildingId } = useParams<{ buildingId: string }>();
+  const { t } = useTranslation();
   if (!buildingId) {
-    return <div>Building not found</div>;
+    return <div>{t('errors.buildingNotFound', 'Building not found')}</div>;
   }
   return <BuildingDetailPage buildingId={buildingId} />;
 }

--- a/frontend/apps/ppt-web/src/routes/groups/community.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/community.tsx
@@ -5,6 +5,7 @@
  * Extracted from App.tsx to isolate community work.
  */
 import type { CommunityGroup } from '@ppt/api-client';
+import { useTranslation } from 'react-i18next';
 import { Route, useNavigate, useParams } from 'react-router-dom';
 import { useToast } from '../../components';
 import { useAuth } from '../../contexts';
@@ -73,9 +74,10 @@ function CreateGroupPageRoute() {
 function GroupDetailPageRoute() {
   const { groupId } = useParams<{ groupId: string }>();
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   if (!groupId) {
-    return <div>Group not found</div>;
+    return <div>{t('errors.groupNotFound', 'Group not found')}</div>;
   }
 
   // Mock group data

--- a/frontend/apps/ppt-web/src/routes/groups/faults.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/faults.tsx
@@ -415,7 +415,7 @@ function FaultDetailPageRoute() {
   }, [error, showToast, t]);
 
   if (!faultId) {
-    return <div>Fault not found</div>;
+    return <div>{t('errors.faultNotFound', 'Fault not found')}</div>;
   }
 
   const isManager = isManagerRole(user?.role);
@@ -464,12 +464,13 @@ function EditFaultPageRoute() {
   const { faultId } = useParams<{ faultId: string }>();
   const navigate = useNavigate();
   const { showToast } = useToast();
+  const { t } = useTranslation();
   const { data, isLoading } = useFault(faultId ?? '');
   const { data: buildingsData } = useBuildings();
   const updateFault = useUpdateFault(faultId ?? '');
 
   if (!faultId) {
-    return <div>Fault not found</div>;
+    return <div>{t('errors.faultNotFound', 'Fault not found')}</div>;
   }
   if (isLoading || !data) {
     return <div className="p-6">Loading…</div>;

--- a/frontend/apps/ppt-web/src/routes/groups/leases.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/leases.tsx
@@ -49,6 +49,7 @@ import {
   useViolations,
 } from '@ppt/api-client';
 import { lazy } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Route, useNavigate, useParams } from 'react-router-dom';
 import { ProtectedRoute, useToast } from '../../components';
 import type {
@@ -832,10 +833,14 @@ function LeaseLoadingNotice({
   isLoading?: boolean;
   label?: string;
 }) {
+  const { t } = useTranslation();
+  const entity = `${label[0].toUpperCase()}${label.slice(1)}`;
   return (
     <div className="mx-auto max-w-md py-16 text-center">
       <h1 className="text-lg font-semibold text-gray-900">
-        {isLoading ? `Loading ${label}…` : `${label[0].toUpperCase()}${label.slice(1)} not found`}
+        {isLoading
+          ? `Loading ${label}…`
+          : t('errors.entityNotFound', { entity, defaultValue: '{{entity}} not found' })}
       </h1>
       {!isLoading && (
         <p className="mt-2 text-sm text-gray-500">

--- a/frontend/apps/ppt-web/src/routes/groups/messaging.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/messaging.tsx
@@ -169,7 +169,7 @@ function ThreadDetailPageRoute() {
   const deleteMessage = useDeleteMessage();
 
   if (!threadId) {
-    return <div>Thread not found</div>;
+    return <div>{t('errors.threadNotFound', 'Thread not found')}</div>;
   }
 
   const handleThreadSendMessage = async (data: SendMessageRequest) => {

--- a/frontend/apps/ppt-web/src/routes/groups/meters.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/meters.tsx
@@ -29,6 +29,7 @@ import {
 } from '@ppt/api-client';
 import { useQueries } from '@tanstack/react-query';
 import { lazy } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Route, useNavigate, useParams } from 'react-router-dom';
 import { ProtectedRoute, useToast } from '../../components';
 import type {
@@ -369,10 +370,11 @@ function ReadingComparisonPageRoute() {
  * fetch is in flight (or when the entity is missing).
  */
 function MeterLoadingNotice({ onBack, isLoading }: { onBack: () => void; isLoading?: boolean }) {
+  const { t } = useTranslation();
   return (
     <div className="mx-auto max-w-md py-16 text-center">
       <h1 className="text-lg font-semibold text-gray-900">
-        {isLoading ? 'Loading meter…' : 'Meter not found'}
+        {isLoading ? 'Loading meter…' : t('errors.meterNotFound', 'Meter not found')}
       </h1>
       {!isLoading && (
         <p className="mt-2 text-sm text-gray-500">

--- a/frontend/apps/ppt-web/src/routes/groups/notFoundI18n.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/notFoundI18n.test.tsx
@@ -1,0 +1,80 @@
+/// <reference types="vitest/globals" />
+/**
+ * Regression test for the ppt-web route-wrapper "X not found" fallbacks
+ * (code-review-ppt-web-core-notfound-i18n-gap).
+ *
+ * The route wrappers under src/routes/groups/ used to render hardcoded English
+ * "<Entity> not found" strings, so sk/cs/de/hu/pl users saw untranslated copy.
+ * They now render via `t('errors.<entity>NotFound', '<English fallback>')`.
+ *
+ * This test pins that behaviour using the buildings detail wrapper as a
+ * representative case: with the active language switched to Slovak, the
+ * not-found fallback must render the *translated* Slovak string — proving the
+ * copy is driven by i18n and not a hardcoded English literal.
+ */
+import { render, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import { MemoryRouter, Routes } from 'react-router-dom';
+import sk from '../../../messages/sk.json';
+import { buildingRoutes } from './buildings';
+
+// Force the :buildingId param to be missing so the wrapper hits its
+// not-found fallback branch, while keeping the rest of react-router real.
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useParams: () => ({}) };
+});
+
+// Keep the auth gate and lazy pages out of the way — we only care about the
+// not-found branch, which renders before any inner page mounts.
+vi.mock('../../components', () => ({
+  ProtectedRoute: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../lazyRoutes', () => ({
+  BookFacilityPage: () => <div />,
+  BuildingDetailPage: () => <div data-testid="building-detail-page" />,
+  BuildingsPage: () => <div />,
+  CreateFacilityPage: () => <div />,
+  EditFacilityPage: () => <div />,
+  FacilitiesPage: () => <div />,
+  MyBookingsPage: () => <div />,
+  MyUnitPage: () => <div />,
+  PendingBookingsPage: () => <div />,
+}));
+
+function renderBuildingDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/buildings/does-not-matter']}>
+      <Routes>{buildingRoutes()}</Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('route-wrapper "not found" fallbacks are i18n-driven', () => {
+  afterEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  it('renders the English fallback via the i18n key (not the inner page)', () => {
+    renderBuildingDetail();
+    expect(screen.queryByTestId('building-detail-page')).not.toBeInTheDocument();
+    expect(screen.getByText('Building not found')).toBeInTheDocument();
+  });
+
+  it('renders the translated Slovak string when the language is Slovak', async () => {
+    // The Slovak bundle is not loaded by the shared test setup (English-only),
+    // so register it here before switching languages.
+    i18n.addResourceBundle('sk', 'translation', sk, true, true);
+    await i18n.changeLanguage('sk');
+
+    renderBuildingDetail();
+
+    const expected = sk.errors.buildingNotFound;
+    // Guard: the assertion is only meaningful if the translation actually differs
+    // from the English literal that used to be hardcoded here.
+    expect(expected).not.toBe('Building not found');
+    expect(screen.getByText(expected)).toBeInTheDocument();
+    expect(screen.queryByText('Building not found')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/routes/groups/rentals.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/rentals.tsx
@@ -25,6 +25,7 @@ import {
 } from '@ppt/api-client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lazy, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Route, useNavigate, useParams } from 'react-router-dom';
 import { ProtectedRoute } from '../../components';
 import { useAuth } from '../../contexts';
@@ -356,6 +357,7 @@ function BookingDetailPageRoute() {
   const navigate = useNavigate();
   const auth = useRentalsAuth();
   const queryClient = useQueryClient();
+  const { t } = useTranslation();
 
   const { data, isLoading } = useQuery({
     queryKey: ['rentals', 'reservation', bookingId, auth?.xTenantId],
@@ -396,7 +398,7 @@ function BookingDetailPageRoute() {
   });
 
   if (!bookingId) {
-    return <div>Booking not found</div>;
+    return <div>{t('errors.bookingNotFound', 'Booking not found')}</div>;
   }
 
   if (isLoading || !data || !data.data) {


### PR DESCRIPTION
## Task
ppt-web route wrappers render 8 hardcoded English 'X not found' fallbacks — sk/cs/de users see untranslated text. Replace the ~8 hardcoded English 'X not found' fallback strings in the ppt-web route wrappers with i18n keys following the existing react-i18next convention; add the keys to all locale resource files. Add a regression test proving a representative 'not found' fallback renders a translated (non-hardcoded) string.

## Owner
pm-backend (backlog tag; code lives in frontend/apps/ppt-web — implemented by the react-web specialist)

## What changed
Replaced the hardcoded English `<Entity> not found` fallbacks in 8 route-wrapper files under `frontend/apps/ppt-web/src/routes/groups/` with `t('errors.<entity>NotFound', '<English fallback>')`, following the existing `errors.*` react-i18next namespace convention (same pattern already used by `neighbors.tsx`):

| File | Fallback(s) | New key |
| --- | --- | --- |
| buildings.tsx | Building not found | `errors.buildingNotFound` |
| community.tsx | Group not found | `errors.groupNotFound` |
| announcements.tsx | Announcement not found (x2) | `errors.announcementNotFound` |
| messaging.tsx | Thread not found | `errors.threadNotFound` |
| faults.tsx | Fault not found (x2) | `errors.faultNotFound` |
| rentals.tsx | Booking not found | `errors.bookingNotFound` |
| meters.tsx | Meter not found | `errors.meterNotFound` |
| leases.tsx | `<Label> not found` (dynamic) | `errors.entityNotFound` (`{{entity}}` interpolation) |

Added all 8 keys to every locale bundle: `en, sk, cs, de, hu, pl`. Wrappers that lacked `t` in scope gained a `useTranslation()` hook (and the import where missing), placed before the early return so hook order stays stable.

## Regression test
`src/routes/groups/notFoundI18n.test.tsx` renders the buildings detail route-wrapper's not-found branch, switches the active language to Slovak, and asserts the rendered text equals the Slovak translation (`Budova nebola nájdená`) — not the old hardcoded English literal. Would fail on `dev` (where the string is a hardcoded English literal). IG3 satisfied via a separate `test:` + `fix:` commit pair.

## Verification
```
VERIFY-PLAN base=2f1565a9b9872485cb2c0fecb335be697158ca0c files=15
  cd frontend && pnpm exec biome check <15 changed files>
  cd frontend && pnpm --filter "...[2f1565a9b9872485cb2c0fecb335be697158ca0c]" typecheck
  cd frontend && pnpm --filter "...[2f1565a9b9872485cb2c0fecb335be697158ca0c]" test

VERIFY OK 71256b0d49613c155b8f7109e09906702871f0c1
```
(biome clean, typecheck clean, 108 test files / 2131 tests pass)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
Owner role is `pm-backend` (backlog tag) but the code legitimately lives in `frontend/apps/ppt-web` — this pm-backend→frontend drift is expected and benign per the task brief. `scope-check.sh` exits 2 for this reason; all 15 changed paths are inside `frontend/apps/ppt-web/`.

## Notes
- goal-check.sh IG1/IG2/IG8 fail structurally: this is a plan-less dispatcher code-review finding on an `auto-impl/*` branch (no `.research/plans/<slug>.md`, no `impl/<slug>` branch, no archive/backlog move — `.research/**` is intentionally untouched). The one applicable check, IG3 (test+fix commit pair), passes.
- The Slovak `entityNotFound` uses a gender-neutral phrasing (`{{entity}} sa nenašlo`) since the interpolated label is a dynamic English noun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJGSGrdKmcBgr4iLMJefif

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGSGrdKmcBgr4iLMJefif)_