### PR TITLE
code-review-ppt-web-core-rentals-auth-nonnull-mutation: guard rentals mutation auth (handled session error, not TypeError)

### DIFF
--- a/frontend/apps/ppt-web/src/routes/groups/rentals.auth-guard.test.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/rentals.auth-guard.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Regression tests for the rentals mutation auth guard.
+ *
+ * Bug (code-review finding `code-review-ppt-web-core-rentals-auth-nonnull-mutation`):
+ * the rentals mutations built their request headers with `auth!.authorization`
+ * / `auth!.xTenantId`. Unlike the queries (which gate on `enabled: !!auth`),
+ * a `mutationFn` runs unconditionally on `.mutate()`, so a mid-session token
+ * loss (auth === null) made the dereference throw an opaque
+ * `TypeError: Cannot read properties of null` with no auth semantics — nothing
+ * mapped it to a session-expired UX.
+ *
+ * The fix routes every rentals request through `requireRentalsAuthHeaders`,
+ * which throws a typed `AuthError('SESSION_EXPIRED')` when auth is missing, and
+ * wires the mutations' `onError` to `handleRentalsAuthError`, which redirects to
+ * /login (via AuthContext `logout`) — matching how the rest of the app handles
+ * a dropped session.
+ *
+ * These tests prove the two seams the mutations rely on, plus one end-to-end
+ * check that a real `useMutation` wired exactly as the route wires it settles
+ * in a *handled* error state (not an uncaught throw) and triggers the redirect.
+ */
+import { AuthError } from '@ppt/api-client';
+import { QueryClient, QueryClientProvider, useMutation } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { handleRentalsAuthError, requireRentalsAuthHeaders } from './rentals';
+
+describe('requireRentalsAuthHeaders', () => {
+  it('throws a typed AuthError(SESSION_EXPIRED) — not a raw TypeError — when auth is null', () => {
+    let thrown: unknown;
+    try {
+      requireRentalsAuthHeaders(null);
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(AuthError);
+    // The whole point of the fix: the missing-auth failure is a recognised auth
+    // error, not the opaque TypeError the `auth!` dereference used to produce.
+    expect(thrown).not.toBeInstanceOf(TypeError);
+    expect((thrown as AuthError).code).toBe('SESSION_EXPIRED');
+  });
+
+  it('returns the generated-client header map when auth is present', () => {
+    expect(
+      requireRentalsAuthHeaders({ authorization: 'Bearer token-xyz', xTenantId: 'org-1' })
+    ).toEqual({ Authorization: 'Bearer token-xyz', 'X-Tenant-ID': 'org-1' });
+  });
+
+  it('documents the pre-fix hazard: dereferencing null auth throws a raw TypeError', () => {
+    // The old code did `auth!.authorization`; with auth === null that is a
+    // TypeError with no auth semantics — exactly what the guard now replaces.
+    expect(() => (null as unknown as { authorization: string }).authorization).toThrow(TypeError);
+  });
+});
+
+describe('handleRentalsAuthError', () => {
+  it('logs out (redirect to /login) on every session-loss AuthError code', () => {
+    const logout = vi.fn();
+    for (const code of ['SESSION_EXPIRED', 'TOKEN_EXPIRED', 'TOKEN_INVALID'] as const) {
+      logout.mockClear();
+      const handled = handleRentalsAuthError(new AuthError('gone', code), logout);
+      expect(handled).toBe(true);
+      expect(logout).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('leaves non-session errors alone (no logout)', () => {
+    const logout = vi.fn();
+    expect(handleRentalsAuthError(new AuthError('bad', 'INVALID_CREDENTIALS'), logout)).toBe(false);
+    expect(handleRentalsAuthError(new Error('network down'), logout)).toBe(false);
+    expect(handleRentalsAuthError(new TypeError('boom'), logout)).toBe(false);
+    expect(logout).not.toHaveBeenCalled();
+  });
+});
+
+describe('rentals mutation wired as the route wires it (mid-session token loss)', () => {
+  function wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  it('settles in a handled AuthError state (not thrown), never calls the API, and triggers logout', async () => {
+    const apiCall = vi.fn().mockResolvedValue({ data: {} });
+    const logout = vi.fn();
+    // Mid-session token loss: the auth the mutation closes over is null.
+    const auth = null;
+
+    const { result } = renderHook(
+      () =>
+        useMutation({
+          // Same shape as the production rentals mutations.
+          mutationFn: () => apiCall({ headers: requireRentalsAuthHeaders(auth) }),
+          onError: (error) => handleRentalsAuthError(error, logout),
+        }),
+      { wrapper }
+    );
+
+    // `.mutate()` must NOT surface an uncaught throw — TanStack Query catches
+    // the AuthError thrown inside mutationFn and routes it to the error state.
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeInstanceOf(AuthError);
+    expect(result.current.error).not.toBeInstanceOf(TypeError);
+    expect((result.current.error as AuthError).code).toBe('SESSION_EXPIRED');
+    // The guard short-circuits before any network call is attempted.
+    expect(apiCall).not.toHaveBeenCalled();
+    // The handled auth error drives the session-expired UX (redirect to /login).
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/apps/ppt-web/src/routes/groups/rentals.tsx
+++ b/frontend/apps/ppt-web/src/routes/groups/rentals.tsx
@@ -27,7 +27,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lazy, useState } from 'react';
 import { Route, useNavigate, useParams } from 'react-router-dom';
 import { ProtectedRoute } from '../../components';
-import { useAuth } from '../../contexts';
+import { AuthError, type AuthErrorCode, useAuth } from '../../contexts';
 import type {
   BookingListParams,
   BookingWithGuests,
@@ -166,11 +166,60 @@ function mapApiGuestToUi(guest: RentalsGuestRegistration): RentalGuest {
  * ShortTermRentalsService methods. Returns null when either is missing so
  * the calling query stays disabled.
  */
-function useRentalsAuth(): { authorization: string; xTenantId: string } | null {
+function useRentalsAuth(): RentalsAuth | null {
   const { user } = useAuth();
   const token = getToken();
   if (!token || !user?.organizationId) return null;
   return { authorization: `Bearer ${token}`, xTenantId: user.organizationId };
+}
+
+type RentalsAuth = { authorization: string; xTenantId: string };
+type RentalsAuthHeaders = { Authorization: string; 'X-Tenant-ID': string };
+
+/**
+ * Build the auth headers the generated ShortTermRentalsService methods require,
+ * or throw a typed {@link AuthError} when the session was lost mid-flight.
+ *
+ * Queries gate on `enabled: !!auth`, so their `queryFn` never runs while auth is
+ * null. Mutations have no such gate — TanStack Query invokes a `mutationFn`
+ * unconditionally on `.mutate()`. Previously the mutations dereferenced
+ * `auth!.authorization`, so a mid-session token loss surfaced as an opaque
+ * `TypeError: Cannot read properties of null` with no auth semantics. Throwing
+ * an `AuthError('SESSION_EXPIRED')` instead routes through TanStack Query's
+ * rejected-promise path, so the mutation lands in a handled error state and
+ * `onError` (see {@link handleRentalsAuthError}) can surface the app's
+ * session-expired UX (redirect to /login) instead of an uncaught crash.
+ */
+export function requireRentalsAuthHeaders(auth: RentalsAuth | null): RentalsAuthHeaders {
+  if (!auth) {
+    throw new AuthError('Your session has expired. Please sign in again.', 'SESSION_EXPIRED');
+  }
+  return { Authorization: auth.authorization, 'X-Tenant-ID': auth.xTenantId };
+}
+
+/**
+ * Auth-error codes that mean "the session is gone" — a failed rentals mutation
+ * carrying one of these should trigger the logout/redirect flow.
+ */
+const SESSION_LOST_CODES: ReadonlySet<AuthErrorCode> = new Set<AuthErrorCode>([
+  'SESSION_EXPIRED',
+  'TOKEN_EXPIRED',
+  'TOKEN_INVALID',
+]);
+
+/**
+ * Shared `onError` logic for the rentals mutations: when a mutation fails
+ * because the session was lost, clear it and redirect to /login (via the
+ * AuthContext `logout`), matching how the rest of the app handles a dropped
+ * session. Non-auth errors are left for the caller to surface. Returns whether
+ * the error was handled as a session loss.
+ */
+export function handleRentalsAuthError(error: unknown, logout: () => void): boolean {
+  if (error instanceof AuthError && SESSION_LOST_CODES.has(error.code)) {
+    logout();
+    return true;
+  }
+  return false;
 }
 
 /** Route wrapper for the rentals dashboard. */
@@ -182,10 +231,7 @@ function RentalsDashboardPageRoute() {
     queryKey: ['rentals', 'reservations', auth?.xTenantId],
     queryFn: () =>
       rentalsApiListReservations({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
       }),
     enabled: !!auth,
   });
@@ -193,10 +239,7 @@ function RentalsDashboardPageRoute() {
     queryKey: ['rentals', 'connections', auth?.xTenantId],
     queryFn: () =>
       rentalsApiListConnections({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
       }),
     enabled: !!auth,
   });
@@ -241,16 +284,14 @@ function RentalsDashboardPageRoute() {
 function PlatformConnectionsPageRoute() {
   const navigate = useNavigate();
   const auth = useRentalsAuth();
+  const { logout } = useAuth();
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery({
     queryKey: ['rentals', 'connections', auth?.xTenantId],
     queryFn: () =>
       rentalsApiListConnections({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
       }),
     enabled: !!auth,
   });
@@ -258,29 +299,25 @@ function PlatformConnectionsPageRoute() {
   const createConnection = useMutation({
     mutationFn: (vars: { unitId: string; platform: RentalPlatformType }) =>
       rentalsApiCreateConnection({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
         body: { unitId: vars.unitId, platform: vars.platform as RentalsRentalPlatform },
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['rentals', 'connections'] });
     },
+    onError: (error) => handleRentalsAuthError(error, logout),
   });
 
   const syncPlatforms = useMutation({
     mutationFn: (unitId: string) =>
       rentalsApiSyncPlatforms({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
         query: { unitId },
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['rentals', 'connections'] });
     },
+    onError: (error) => handleRentalsAuthError(error, logout),
   });
 
   const connections = (data?.data ?? []).map(mapApiConnectionToUi);
@@ -313,10 +350,7 @@ function BookingsPageRoute() {
     queryKey: ['rentals', 'reservations', auth?.xTenantId, filters],
     queryFn: () =>
       rentalsApiListReservations({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
         query: {
           unitId: filters.unitId,
           status: filters.status as RentalsReservation['status'],
@@ -355,16 +389,14 @@ function BookingDetailPageRoute() {
   const { bookingId } = useParams<{ bookingId: string }>();
   const navigate = useNavigate();
   const auth = useRentalsAuth();
+  const { logout } = useAuth();
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery({
     queryKey: ['rentals', 'reservation', bookingId, auth?.xTenantId],
     queryFn: () =>
       rentalsApiGetReservation({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
         path: { id: bookingId! },
       }),
     enabled: !!auth && !!bookingId,
@@ -373,26 +405,22 @@ function BookingDetailPageRoute() {
   const checkIn = useMutation({
     mutationFn: () =>
       rentalsApiCheckIn({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
         path: { id: bookingId! },
       }),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['rentals', 'reservation', bookingId] }),
+    onError: (error) => handleRentalsAuthError(error, logout),
   });
   const checkOut = useMutation({
     mutationFn: () =>
       rentalsApiCheckOut({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
         path: { id: bookingId! },
       }),
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: ['rentals', 'reservation', bookingId] }),
+    onError: (error) => handleRentalsAuthError(error, logout),
   });
 
   if (!bookingId) {
@@ -453,10 +481,7 @@ function GuestRegistrationPageRoute() {
     queryKey: ['rentals', 'guests', auth?.xTenantId],
     queryFn: () =>
       rentalsApiListGuests({
-        headers: {
-          Authorization: auth!.authorization,
-          'X-Tenant-ID': auth!.xTenantId,
-        },
+        headers: requireRentalsAuthHeaders(auth),
       }),
     enabled: !!auth,
   });


### PR DESCRIPTION
## Task
ppt-web rentals mutations dereference `auth!` non-null — mid-session token loss throws uncaught TypeError instead of a handled auth error. Replace the unsafe `auth!` non-null assertions in the rentals mutation path with a proper guarded auth check that surfaces a handled auth error (redirect to login / auth-error UX consistent with the app) rather than throwing an uncaught TypeError. Add a regression test proving mid-session missing auth is handled, not thrown.

## Owner
pm-backend (backlog tag). Code lives in `frontend/apps/ppt-web` — implemented by the react-web specialist. Cross-area by design.

## What changed
`frontend/apps/ppt-web/src/routes/groups/rentals.tsx`:
- New `requireRentalsAuthHeaders(auth)` — throws a typed `AuthError('SESSION_EXPIRED')` when auth is null instead of dereferencing `auth!.authorization` / `auth!.xTenantId`. All 10 rentals request sites (6 queries + 4 mutations) now route through it, removing every `auth!` non-null assertion from the request path.
- New `handleRentalsAuthError(error, logout)` — wired as `onError` on all four mutations (`createConnection`, `syncPlatforms`, `checkIn`, `checkOut`). On a session-loss `AuthError` it calls AuthContext `logout()`, which clears the session and lets `ProtectedRoute` redirect to `/login` — the app's existing dropped-session UX. Non-session errors are left untouched.

Queries were already safe (gated on `enabled: !!auth`); they were converted to the same helper so no `auth!` remains in the file.

## Regression test
`frontend/apps/ppt-web/src/routes/groups/rentals.auth-guard.test.tsx` (6 cases):
- `requireRentalsAuthHeaders(null)` throws an `AuthError(SESSION_EXPIRED)` and **not** a `TypeError`; returns the correct header map when auth is present; documents the pre-fix hazard (raw property access on null throws `TypeError`).
- `handleRentalsAuthError` logs out on every session-loss code and ignores non-session errors.
- A real `useMutation` wired exactly as the route wires it settles in a **handled** `AuthError` state (not an uncaught throw), never calls the API, and triggers `logout` — i.e. mid-session missing auth is handled, not thrown.

## Verification
```
VERIFY-PLAN base=2f1565a9b9872485cb2c0fecb335be697158ca0c files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/routes/groups/rentals.auth-guard.test.tsx apps/ppt-web/src/routes/groups/rentals.tsx
  cd frontend && pnpm --filter "...[2f1565a9b9872485cb2c0fecb335be697158ca0c]" typecheck
  cd frontend && pnpm --filter "...[2f1565a9b9872485cb2c0fecb335be697158ca0c]" test

VERIFY OK e118c5f2898c21bed418984b395db6efdaa6e00c
```
(108 test files / 2135 tests passed, including the 6 new regression cases.)

## CI parity (Band C — hot-path only)
skipped: front-end-only change with no network/token-issuance surface (guards a client-side null deref + redirects to existing login flow). No security/auth/billing/data-integrity backend change.

## Remote-tested
skipped

## Scope drift
owner_role=pm-backend but the code lives in `frontend/apps/ppt-web` — expected and benign per the task brief (backlog owner tag; react-web specialist implements). Real diff is exactly 2 files, both under `frontend/apps/ppt-web/src/routes/groups/`.

## Code-reuse review
none — `requireRentalsAuthHeaders` / `handleRentalsAuthError` are rentals-route-local composers over the existing `AuthError` type and AuthContext `logout`; no existing helper duplicated. (The scope/reuse pre-flight scripts emitted noise from a stale local `dev` ref far behind origin/dev; none pertain to the added symbols.)

## Notes
goal-check IG3 (separate `test:` + `fix:` commits) passes. IG1/IG2 fail only structurally: this is a dispatcher code-review-finding task with no `.research/plans/<slug>.md` (I must not touch `.research/**`) and uses the dispatcher-assigned `auto-impl/...` branch rather than `impl/<slug>`. Neither is a quality issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJGSGrdKmcBgr4iLMJefif

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJGSGrdKmcBgr4iLMJefif)_