### PR TITLE
code-review-ppt-web-core-logout-cache-purge-gap: purge analytics query roots on logout

### DIFF
--- a/frontend/apps/ppt-web/src/contexts/AuthContext.test.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.test.tsx
@@ -197,6 +197,16 @@ describe('AuthContext.logout — Issue #712', () => {
       'predictive-maintenance',
       'sentiment',
       'notification-analytics',
+      // Tenant-scoped financial + operational caches — the most sensitive
+      // data in the app (invoices, contacts, bank statements, payment
+      // matching, AR aging, report schedules) plus rentals/meters and the
+      // user's active-session list. These must never survive logout.
+      'accounting',
+      'financial',
+      'reports',
+      'rentals',
+      'meters',
+      'auth',
     ]) {
       expect(AUTHED_QUERY_KEY_ROOTS).toContain(root);
     }
@@ -217,6 +227,18 @@ describe('AuthContext.logout — Issue #712', () => {
     queryClient.setQueryData(['predictive-maintenance', 'needing-maintenance'], [{ id: 'e-1' }]);
     queryClient.setQueryData(['sentiment', 'dashboard'], { score: 0.42 });
     queryClient.setQueryData(['notification-analytics', {}], { delivered: 10 });
+    // Tenant-scoped financial + operational caches — real keys from
+    // queryKeys.accounting (invoices/contacts/statements/matching),
+    // financial.tsx (['financial','ar-aging',orgId]), reportKeys
+    // (['reports','schedules',…]), rentals.tsx (['rentals','reservations',…]),
+    // meterKeys (['meters','building-list',…]) and SessionsPage
+    // (['auth','sessions']). All must be evicted on logout.
+    queryClient.setQueryData(['accounting', 'invoices'], [{ id: 'inv-1' }]);
+    queryClient.setQueryData(['financial', 'ar-aging', 'org-1'], { total: 999 });
+    queryClient.setQueryData(['reports', 'schedules', 'list', 'org-1'], [{ id: 'rs-1' }]);
+    queryClient.setQueryData(['rentals', 'reservations', 'tenant-1'], [{ id: 'res-1' }]);
+    queryClient.setQueryData(['meters', 'building-list', 'b-1'], [{ id: 'm-1' }]);
+    queryClient.setQueryData(['auth', 'sessions'], [{ id: 'sess-1' }]);
     queryClient.setQueryData(['router', 'breadcrumbs'], ['home']);
 
     // Sanity: all entries present before logout.
@@ -230,6 +252,12 @@ describe('AuthContext.logout — Issue #712', () => {
     ).toBeDefined();
     expect(queryClient.getQueryData(['sentiment', 'dashboard'])).toBeDefined();
     expect(queryClient.getQueryData(['notification-analytics', {}])).toBeDefined();
+    expect(queryClient.getQueryData(['accounting', 'invoices'])).toBeDefined();
+    expect(queryClient.getQueryData(['financial', 'ar-aging', 'org-1'])).toBeDefined();
+    expect(queryClient.getQueryData(['reports', 'schedules', 'list', 'org-1'])).toBeDefined();
+    expect(queryClient.getQueryData(['rentals', 'reservations', 'tenant-1'])).toBeDefined();
+    expect(queryClient.getQueryData(['meters', 'building-list', 'b-1'])).toBeDefined();
+    expect(queryClient.getQueryData(['auth', 'sessions'])).toBeDefined();
     expect(queryClient.getQueryData(['router', 'breadcrumbs'])).toBeDefined();
 
     // Trigger logout via the live context.
@@ -256,6 +284,13 @@ describe('AuthContext.logout — Issue #712', () => {
     ).toBeUndefined();
     expect(queryClient.getQueryData(['sentiment', 'dashboard'])).toBeUndefined();
     expect(queryClient.getQueryData(['notification-analytics', {}])).toBeUndefined();
+    // Tenant-scoped financial + operational caches must not survive logout.
+    expect(queryClient.getQueryData(['accounting', 'invoices'])).toBeUndefined();
+    expect(queryClient.getQueryData(['financial', 'ar-aging', 'org-1'])).toBeUndefined();
+    expect(queryClient.getQueryData(['reports', 'schedules', 'list', 'org-1'])).toBeUndefined();
+    expect(queryClient.getQueryData(['rentals', 'reservations', 'tenant-1'])).toBeUndefined();
+    expect(queryClient.getQueryData(['meters', 'building-list', 'b-1'])).toBeUndefined();
+    expect(queryClient.getQueryData(['auth', 'sessions'])).toBeUndefined();
 
     // (c) Non-auth-scoped cache survives — the purge is bounded to the
     // AUTHED_QUERY_KEY_ROOTS list, not a blanket `queryClient.clear()`.

--- a/frontend/apps/ppt-web/src/contexts/AuthContext.test.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.test.tsx
@@ -185,7 +185,19 @@ describe('AuthContext.logout — Issue #712', () => {
     // Sanity: AUTHED_QUERY_KEY_ROOTS must cover the real query keys we
     // expect to evict. If a root is dropped from the source list, this
     // assertion will fail loudly rather than letting data silently leak.
-    for (const root of ['user', 'faults', 'announcements', 'ai-chat', 'developer']) {
+    for (const root of [
+      'user',
+      'faults',
+      'announcements',
+      'ai-chat',
+      'developer',
+      // Tenant-scoped analytics dashboards — regression guard for the
+      // logout cache-purge gap where these roots leaked across sessions
+      // on shared workstations.
+      'predictive-maintenance',
+      'sentiment',
+      'notification-analytics',
+    ]) {
       expect(AUTHED_QUERY_KEY_ROOTS).toContain(root);
     }
 
@@ -200,6 +212,11 @@ describe('AuthContext.logout — Issue #712', () => {
     queryClient.setQueryData(['announcements', 'unread-count'], 3);
     queryClient.setQueryData(['ai-chat', 'sessions'], [{ id: 's-1' }]);
     queryClient.setQueryData(['developer', 'apiKeys'], [{ id: 'k-1' }]);
+    // Tenant-scoped analytics dashboards — real key factories from
+    // predictiveKeys / sentimentKeys / notificationAnalyticsKeys.
+    queryClient.setQueryData(['predictive-maintenance', 'needing-maintenance'], [{ id: 'e-1' }]);
+    queryClient.setQueryData(['sentiment', 'dashboard'], { score: 0.42 });
+    queryClient.setQueryData(['notification-analytics', {}], { delivered: 10 });
     queryClient.setQueryData(['router', 'breadcrumbs'], ['home']);
 
     // Sanity: all entries present before logout.
@@ -208,6 +225,11 @@ describe('AuthContext.logout — Issue #712', () => {
     expect(queryClient.getQueryData(['announcements', 'unread-count'])).toBeDefined();
     expect(queryClient.getQueryData(['ai-chat', 'sessions'])).toBeDefined();
     expect(queryClient.getQueryData(['developer', 'apiKeys'])).toBeDefined();
+    expect(
+      queryClient.getQueryData(['predictive-maintenance', 'needing-maintenance'])
+    ).toBeDefined();
+    expect(queryClient.getQueryData(['sentiment', 'dashboard'])).toBeDefined();
+    expect(queryClient.getQueryData(['notification-analytics', {}])).toBeDefined();
     expect(queryClient.getQueryData(['router', 'breadcrumbs'])).toBeDefined();
 
     // Trigger logout via the live context.
@@ -228,6 +250,12 @@ describe('AuthContext.logout — Issue #712', () => {
     expect(queryClient.getQueryData(['announcements', 'unread-count'])).toBeUndefined();
     expect(queryClient.getQueryData(['ai-chat', 'sessions'])).toBeUndefined();
     expect(queryClient.getQueryData(['developer', 'apiKeys'])).toBeUndefined();
+    // Tenant-scoped analytics dashboards must not survive logout.
+    expect(
+      queryClient.getQueryData(['predictive-maintenance', 'needing-maintenance'])
+    ).toBeUndefined();
+    expect(queryClient.getQueryData(['sentiment', 'dashboard'])).toBeUndefined();
+    expect(queryClient.getQueryData(['notification-analytics', {}])).toBeUndefined();
 
     // (c) Non-auth-scoped cache survives — the purge is bounded to the
     // AUTHED_QUERY_KEY_ROOTS list, not a blanket `queryClient.clear()`.

--- a/frontend/apps/ppt-web/src/lib/queryKeys.ts
+++ b/frontend/apps/ppt-web/src/lib/queryKeys.ts
@@ -335,18 +335,25 @@ export const queryKeys = {
  * the cache purge to user data while leaving any unrelated/non-session cache
  * (e.g. router-internal caches, future public/lookup queries) untouched.
  *
- * Covers both the centralized {@link queryKeys} factory roots and the
- * ad-hoc roots used directly in feature hooks (`developer`, `ocr`,
- * `actionQueue`, `executionLogs`, `executionStats`, `ai-chat`,
- * `predictive-maintenance`, `sentiment`, `notification-analytics`).
+ * Covers the centralized {@link queryKeys} factory roots (including
+ * `accounting`), the shared `@ppt/api-client` key-factory roots consumed by
+ * ppt-web (`messages`, `meters`, `reports`), and the ad-hoc roots used
+ * directly in feature hooks (`developer`, `ocr`, `actionQueue`,
+ * `executionLogs`, `executionStats`, `ai-chat`, `predictive-maintenance`,
+ * `sentiment`, `notification-analytics`, `financial`, `rentals`, and the
+ * `auth`-rooted active-sessions cache).
  *
  * When you add a new auth-scoped query root, add it here too — otherwise the
- * cached data will leak into the next user's session.
+ * cached data will leak into the next user's session. This must cover ALL
+ * tenant-/user-scoped caches; the financial roots (`accounting`, `financial`,
+ * `reports`) are the most sensitive and must never survive logout on a shared
+ * workstation.
  *
  * @see Issue #712 — logout `queryClient.clear()` was too aggressive
  */
 export const AUTHED_QUERY_KEY_ROOTS = [
   // queryKeys factory roots
+  'accounting',
   'announcements',
   'faults',
   'documents',
@@ -359,6 +366,9 @@ export const AUTHED_QUERY_KEY_ROOTS = [
   'user',
   'buildings',
   'notifications',
+  // Shared @ppt/api-client key-factory roots consumed by ppt-web
+  'meters',
+  'reports',
   // Ad-hoc roots used directly in feature hooks
   'developer',
   'ocr',
@@ -366,6 +376,10 @@ export const AUTHED_QUERY_KEY_ROOTS = [
   'executionLogs',
   'executionStats',
   'ai-chat',
+  'financial',
+  'rentals',
+  // Active-session management (SessionsPage — ['auth', 'sessions'])
+  'auth',
   // Feature-local key factories (analytics dashboards — tenant-scoped)
   'predictive-maintenance',
   'sentiment',

--- a/frontend/apps/ppt-web/src/lib/queryKeys.ts
+++ b/frontend/apps/ppt-web/src/lib/queryKeys.ts
@@ -337,7 +337,8 @@ export const queryKeys = {
  *
  * Covers both the centralized {@link queryKeys} factory roots and the
  * ad-hoc roots used directly in feature hooks (`developer`, `ocr`,
- * `actionQueue`, `executionLogs`, `executionStats`, `ai-chat`).
+ * `actionQueue`, `executionLogs`, `executionStats`, `ai-chat`,
+ * `predictive-maintenance`, `sentiment`, `notification-analytics`).
  *
  * When you add a new auth-scoped query root, add it here too — otherwise the
  * cached data will leak into the next user's session.
@@ -365,6 +366,10 @@ export const AUTHED_QUERY_KEY_ROOTS = [
   'executionLogs',
   'executionStats',
   'ai-chat',
+  // Feature-local key factories (analytics dashboards — tenant-scoped)
+  'predictive-maintenance',
+  'sentiment',
+  'notification-analytics',
 ] as const;
 
 // ============================================================================


### PR DESCRIPTION
## Task
ppt-web logout leaves 3 tenant-scoped TanStack Query roots un-purged (predictive-maintenance, sentiment, notification-analytics) — cross-user data leak on shared workstations. Fix logout so ALL tenant-scoped query caches are purged (remove/invalidate the affected query roots on logout, consistent with how the other tenant-scoped roots are already purged). Add a regression test proving the affected query roots are cleared on logout.

## Owner
pm-backend (task hint) — implemented by react-web specialist (ppt-web frontend change)

## Fix
`AuthContext.logout` purges the TanStack Query cache by iterating the explicit `AUTHED_QUERY_KEY_ROOTS` catalogue in `frontend/apps/ppt-web/src/lib/queryKeys.ts` and calling `queryClient.removeQueries({ queryKey: [root] })` (prefix match) per root. Three tenant-scoped analytics dashboards use feature-local key factories whose root segments were missing from that list, so their cached data survived logout:

- `predictive-maintenance` (`predictiveKeys.all`)
- `sentiment` (`sentimentKeys.all`)
- `notification-analytics` (`notificationAnalyticsKeys.all`)

Added the three roots to `AUTHED_QUERY_KEY_ROOTS` so they are evicted on logout exactly like the other tenant-scoped roots. No logout logic changed — the catalogue is the single source of truth the loop already consumes.

## Regression test
Extended `AuthContext.test.tsx` (`removes auth-scoped subtrees…`) to seed real `predictiveKeys`/`sentimentKeys`/`notificationAnalyticsKeys` entries and assert each is `undefined` after logout, plus a source-of-truth assertion that the three roots are present in `AUTHED_QUERY_KEY_ROOTS`. Verified the test FAILS on the pre-fix list and PASSES with the fix (IG3).

## Verification
```
VERIFY-PLAN base=db66d4376814a48978cac6942d5f5d4246b07e19 files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/contexts/AuthContext.test.tsx apps/ppt-web/src/lib/queryKeys.ts
  cd frontend && pnpm --filter "...[db66d4376814a48978cac6942d5f5d4246b07e19]" typecheck
  cd frontend && pnpm --filter "...[db66d4376814a48978cac6942d5f5d4246b07e19]" test
```
VERIFY OK bc88f435ad7f141e7b46767025263f27facb8f8e

(frontend impact band: biome + typecheck + test — 108 files / 2130 tests passed.)

## CI parity (Band C — hot-path only)
skipped: no server-side security/auth/billing/data-integrity code changed (client-side cache-eviction list only).

## Remote-tested
skipped

## Scope drift
scope-check (owner pm-backend) exit 0 — no drift. Change is confined to two ppt-web files.

## Code-reuse review
none — no new helper added; reused the existing `AUTHED_QUERY_KEY_ROOTS` catalogue and logout loop.

## Notes
- IG1/IG2 goal-checks are N/A for this dispatcher `auto-impl/` code-review task (no `.research/plans/` file; branch name fixed by dispatcher). IG3 (TDD split) and IG7 (verify) pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_013aLiTsEHkSFXrubTZBU4Wf)_