### PR TITLE
gh-issue-2651: normalise pick-target-epic epic_prefix to lowercase kebab (T21)

### DIFF
--- a/.research/pick-target-epic.sh
+++ b/.research/pick-target-epic.sh
@@ -77,11 +77,23 @@ done
 #   ^(gap-\d+[a-z]?)
 #   ^(pm-[a-z-]+?)-
 #   else: full task_id
+#
+# The result is lowercased (ascii_downcase). The gap-/pm- branches already
+# yield lowercase by construction, but the else-branch returns the full
+# task_id verbatim — and task_ids derived from camelCase source filenames
+# (e.g. churn-hotspot-…-useOfflineSupport-ts) carry uppercase characters.
+# An uppercase epic_prefix written to objective.json trips dispatcher
+# self-test T21 (epic_prefix must be all-lowercase kebab), which ABORTS the
+# finish-first Phase-6 commit (issue #2651). Normalising here keeps the
+# internal grouping self-consistent (STATS group-by and the KEEP comparison
+# both see the lowercased form) and guarantees the persisted target always
+# satisfies the T21 invariant.
 epic_prefix_jq='
   def epic_prefix:
-    if test("^gap-[0-9]+[a-z]?") then capture("^(?<e>gap-[0-9]+[a-z]?)").e
-    elif test("^pm-[a-z-]+?-") then capture("^(?<e>pm-[a-z-]+?)-").e
-    else . end;
+    ( if test("^gap-[0-9]+[a-z]?") then capture("^(?<e>gap-[0-9]+[a-z]?)").e
+      elif test("^pm-[a-z-]+?-") then capture("^(?<e>pm-[a-z-]+?)-").e
+      else . end
+    ) | ascii_downcase;
 '
 
 # Build the set of task_ids that are NOT claimable: in active assignments

--- a/.research/test-pick-target-epic.sh
+++ b/.research/test-pick-target-epic.sh
@@ -137,6 +137,43 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Case 6 — camelCase-derived flat task_id must yield a T21-valid epic_prefix.
+# Regression for issue #2651: a closest-to-done epic whose task_id derives
+# from a camelCase source filename (e.g. …-useOfflineSupport-ts) flows through
+# the epic_prefix else-branch (full task_id). Before the fix the picker wrote
+# the verbatim mixed-case id, which trips dispatcher self-test T21 (epic_prefix
+# must be all-lowercase kebab) and aborts the finish-first commit. The picker
+# must normalise the selected prefix to lowercase kebab.
+# ---------------------------------------------------------------------------
+write_actions '[
+  {"id":"churn-hotspot-frontend-mobile-src-hooks-useOfflineSupport-ts","status":"open","priority":"medium","depends_on":[]}
+]'
+write_assignments '[]'
+write_archive '[]'
+rm -f "$TMP/objective.json"
+
+# Same T21 acceptance regex as .research/dispatcher-self-test.sh.
+T21_KEBAB='^[a-z0-9][a-z0-9._-]*$'
+
+out=$("$PICKER" --json "${ARGS[@]}")
+ep=$(echo "$out" | jq -r '.epic_prefix')
+action=$(echo "$out" | jq -r '.action')
+if [ "$action" = "select" ] && printf '%s' "$ep" | grep -Eq "$T21_KEBAB"; then
+  ok "Case 6: camelCase task_id → T21-valid lowercase epic_prefix ($ep)"
+else
+  fail "Case 6: expected select + T21-valid lowercase kebab epic_prefix; got ep=$ep action=$action"
+fi
+
+# And the persisted objective.json must satisfy T21 too.
+"$PICKER" --update "${ARGS[@]}" >/dev/null
+persisted_ep=$(jq -r '.epic_prefix' "$TMP/objective.json")
+if printf '%s' "$persisted_ep" | grep -Eq "$T21_KEBAB"; then
+  ok "Case 6: persisted objective.epic_prefix passes T21 kebab ($persisted_ep)"
+else
+  fail "Case 6: persisted objective.epic_prefix trips T21; got '$persisted_ep'"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 if [ "$fail_count" -eq 0 ]; then


### PR DESCRIPTION
## Task
dispatcher: pick-target-epic picks camelCase-filename ids that trip self-test T21, aborting the finish-first commit (Closes #2651)

`pick-target-epic.sh` selects a finish-first target epic and writes its `epic_prefix` into `.research/management/objective.json`. When the closest-to-done epic's task_id derives from a camelCase source filename (e.g. `churn-hotspot-…-useOfflineSupport-ts`), the epic_prefix else-branch returns the full task_id verbatim — carrying uppercase characters — which trips dispatcher self-test **T21** (`epic_prefix` must be all-lowercase kebab), aborting the finish-first Phase-6 commit.

## Fix
Apply `ascii_downcase` to the result of the `epic_prefix` jq def in `pick-target-epic.sh`. The `gap-`/`pm-` branches are already lowercase by construction, so only the else-branch (flat task_id) is affected. Normalising in the shared def keeps the picker internally self-consistent — STATS group-by and the KEEP comparison both operate on the lowercased form — and guarantees the persisted `objective.epic_prefix` satisfies the T21 kebab invariant (`^[a-z0-9][a-z0-9._-]*$`). Minimal scope: picker + its test only.

## Owner
pm-tech-lead

## IG3 evidence (TDD)
- `test(research): …` commit adds Case 6 to `test-pick-target-epic.sh`: feeds `churn-hotspot-frontend-mobile-src-hooks-useOfflineSupport-ts` through the picker and asserts both the emitted and persisted `epic_prefix` match the same T21 kebab regex used by `dispatcher-self-test.sh`.
- Verified the new case FAILS against the pre-fix picker (`ep=…useOfflineSupport-ts`) and PASSES after the fix (`…useofflinesupport-ts`). All 5 pre-existing cases stay green (7/7 ok).

## Verification
```
VERIFY-PLAN base=5bd9d56a8f177706048e9843ff424de892b29710 files=2
VERIFY OK 191ee31306b4e9eb7494214a876e928702d5346e
```
(`.research/` shell tooling change → impact-scoped plan is empty of cargo/pnpm bands; picker test suite run manually: 7/7 ok.)

## Scope drift
None — scope-check.sh (owner=pm-tech-lead) exit 0.

## Code-reuse review
None — reuse-grep.sh (generic) empty.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- Specialist: generic (shell/bash tooling under `.research/`).
- goal-check.sh IG1/IG2/IG4-6 skipped/failed structurally: this is a direct GitHub-issue task (no `.research/plans/<slug>.md`) on the dispatcher-mandated `auto-impl/…` branch, not the plan-based `impl/<slug>` flow. IG3 (TDD) and IG7 (verify) both pass.
- Did not touch `.research/management/**` dispatcher state files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UALuo34qmAaCWeYQWUVwKW)_