### PR TITLE
gh-issue-2652: gate mobile-native/KMP tasks at claim time (dispatcher)

### DIFF
--- a/.github/workflows/dispatcher-self-test.yml
+++ b/.github/workflows/dispatcher-self-test.yml
@@ -10,11 +10,13 @@ on:
       - ".research/retry-remint.sh"
       - ".research/issue-ingest.sh"
       - ".research/mcp-push-size-guard.sh"
+      - ".research/mobile-native-gate.sh"
       - ".research/test-backlog-refill.sh"
       - ".research/test-backlog-reconcile.sh"
       - ".research/test-retry-remint.sh"
       - ".research/test-issue-ingest.sh"
       - ".research/test-mcp-push-size-guard.sh"
+      - ".research/test-mobile-native-gate.sh"
       - ".research/management/assignments.json"
       - ".claude/skills/ppt-implement/**"
       - ".claude/skills/ppt-pr-merge/**"
@@ -49,6 +51,8 @@ jobs:
         run: bash .research/test-issue-ingest.sh
       - name: mcp-push-size-guard behavioral smoke test
         run: bash .research/test-mcp-push-size-guard.sh
+      - name: mobile-native-gate behavioral smoke test
+        run: bash .research/test-mobile-native-gate.sh
       - name: goal-check (enforcing)
         env:
           GOAL_CHECK_ENFORCE: "1"

--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -1243,10 +1243,23 @@ ARCHIVED_IDS=$(jq -r '.assignments[]
 active_stems = {stem(r.task_id) for r in assignments
                 if r.status in ("in-progress", "review", "quarantined")}
 
+# MOBILE_NATIVE_GATED = the set of open action-list ids whose work is
+# mobile-native/KMP-owned and therefore STRUCTURALLY UNLANDABLE in the cloud
+# runner (issue #2652 — the `mobile-native/` verify gate `./gradlew
+# spotlessCheck test` fails at config: AGP resolves from dl.google.com, which
+# the egress proxy 403-denies). Claiming one burns a slot + an implementer
+# subagent that can only ever return partial/blocked. This is the claim-time
+# analogue of the Phase 5.5 `awaiting-macos-build` PR gate. The predicate is a
+# deterministic shell helper (id-token OR pure-mobile-native plan Files scope);
+# see the "Mobile-native / KMP claim-time gate" subsection below.
+MOBILE_NATIVE_GATED=$(.research/mobile-native-gate.sh \
+  --action-list .research/management/action-list.json | cut -f1 | sort -u)
+
 candidates = [c for c in action-list
               if c.status == "open"
               and c.id not in active_ids
               and c.id not in ARCHIVED_IDS                  # exact-id archive check (incl. failed — issue #1739 #3)
+              and c.id not in MOBILE_NATIVE_GATED           # issue #2652: skip KMP/mobile-native — unlandable in cloud
               and (c.get("retry_of")                        # retry re-mint rows (Tier 1c) EXEMPT from the stem-aware
                    or stem(c.id) not in {stem(t) for t in ARCHIVED_IDS})   # archive check — their stem matches the failed
                                                             # original BY DESIGN; retry-remint.sh already enforced
@@ -1303,6 +1316,44 @@ claim any task_id that appears in either `assignments.json` (active) OR
 would resurrect a merged/failed task with a fresh `claimed_at` — a bug.
 The `c.id not in ARCHIVED_IDS` check above enforces this (ARCHIVED_IDS
 includes `failed`, so previously-failed ids are also refused — issue #1739 #3).
+
+**Mobile-native / KMP claim-time gate (NEW — issue #2652):**
+
+The mandatory verify gate for any `mobile-native/` change is
+`cd mobile-native && ./gradlew spotlessCheck test`, which fails at Gradle
+*configuration* in the cloud runner: AGP resolves from `dl.google.com`, and the
+org egress proxy 403-denies that host. Every mobile-native/KMP task is
+therefore **structurally unlandable here** — an implementer subagent can only
+ever return `partial`/`blocked`, so claiming one wastes a claim slot and a
+subagent. This is the *claim-time* counterpart of the Phase 5.5
+`awaiting-macos-build` gate for iOS/Swift PRs (which fires at merge time,
+after a PR already exists): both are **expected terminal-for-dispatcher states,
+NOT transient blocks**, and neither the AGP-egress fix nor the ppt-bridge MCP
+route is an in-repo change the dispatcher can make (both are operator-only infra
+options — see issue #2652).
+
+The predicate is a deterministic helper, `.research/mobile-native-gate.sh`,
+run once per Phase 3 in batch mode over `action-list.json` (the
+`MOBILE_NATIVE_GATED` set built above). A candidate is gated iff **either**:
+- its `id` carries a `mobile-native` or `kmp` token (e.g.
+  `code-review-mobile-native-*`, `churn-hotspot-mobile-native-*`,
+  `gap-N-kmp-*`) — the churn/code-review id prefixes called out in #2652 are
+  the strong signal. This deliberately does **not** match `mobile-rn` (React
+  Native — verifiable in cloud via jest) or `frontend/apps/mobile/**`; or
+- the candidate's plan `## Files` scope is **pure** `mobile-native/` (≥1 path
+  under `mobile-native/` and every non-test source path under it). A
+  cross-stack plan that also carries a verifiable backend/frontend slice is
+  intentionally NOT gated.
+
+Gated candidates are excluded from the `candidates` list (the
+`c.id not in MOBILE_NATIVE_GATED` term above) so they **never consume a claim
+slot**. They are NOT dropped: surface every gated OPEN id in Phase 7 under the
+dedicated `Mobile-native gated:` line so the operator sees exactly which
+backlog items are parked on infra (mirrors `Awaiting-macOS-build:`). Because
+the dispatcher can never clear this in-repo, do not retry and do not let gated
+items inflate any starvation/buffer-health metric — they are parked, not
+failed. (The helper's smoke test is `.research/test-mobile-native-gate.sh`;
+self-test T32 asserts the wiring stays encoded.)
 
 **Same-epic burst-claim guard (NEW — item #2):**
 
@@ -2345,6 +2396,7 @@ CI-stuck escalations:     [PR#<n> task=<id> waited=<h>, …]                (gap
 Approved+CI-pending:      [PR#<n> task=<id> attempted=<iso8601> wait=<h>, …]  (gap 4; [] if none)
 Approved+human-gated:     [PR#<n> task=<id>, …]                     (Phase 5.5 needs-human-review SKIP; [] if none)
 Awaiting-macOS-build:     [PR#<n> task=<id>, …]                     (Phase 5.5 macos-build-gated; structural — no macOS runner; NOT a merge failure; [] if none)
+Mobile-native gated:      [<id> signal=<id|files>, …]               (Phase 3 issue #2652: KMP/mobile-native candidates skipped at claim time — AGP egress-blocked; structural, NOT a claim failure; parked not dropped; [] if none)
 Rebase attempts (this run):[PR#<n> rebased=<true|false> <note>, …]  (item #6; [] if none)
 Sandbox reclaims (this run):[<task_id> branch=<branch> reason=sandbox-timeout, …]  (P3; [] if none)
 Empty branches deleted:   [<branch>, …]                             (item #1; [] if none)

--- a/.research/dispatcher-self-test.sh
+++ b/.research/dispatcher-self-test.sh
@@ -811,6 +811,39 @@ if [ -f "$ACTION_LIST" ]; then
 fi
 echo
 
+# --- T32: mobile-native/KMP claim-time gate wiring (2026-08-04, issue #2652) -
+# The cloud runner cannot verify any `mobile-native/` change (the `./gradlew`
+# verify gate 403s on AGP from dl.google.com), so such candidates must be
+# skipped at CLAIM time — the analogue of the Phase 5.5 awaiting-macos-build PR
+# gate. Assert three things stay encoded:
+#   (a) the helper + its smoke test exist and are executable;
+#   (b) the prompt wires the helper into the Phase 3 claim predicate AND
+#       surfaces gated items in Phase 7 (Mobile-native gated: line);
+#   (c) the helper is behaviorally correct on a canonical id (positive) and a
+#       React-Native id (negative) — a cheap invariant guard so a future edit
+#       to the id-token regex can't silently start gating (or stop gating) the
+#       wrong thing.
+echo "T32 mobile-native gate wiring: helper present + Phase 3/7 encoded + predicate sane"
+MNGATE="${MNGATE:-.research/mobile-native-gate.sh}"
+if [ -x "$MNGATE" ]; then note "mobile-native-gate.sh present + executable"
+else fail "mobile-native-gate.sh missing or not executable ($MNGATE)"; fi
+if [ -x ".research/test-mobile-native-gate.sh" ]; then note "test-mobile-native-gate.sh present + executable"
+else fail "test-mobile-native-gate.sh missing or not executable"; fi
+if [ -f "$PROMPT" ]; then
+  grep -q 'mobile-native-gate.sh' "$PROMPT"        && note "prompt wires Phase 3 mobile-native gate" || fail "prompt missing mobile-native-gate wiring"
+  grep -q 'MOBILE_NATIVE_GATED' "$PROMPT"          && note "prompt excludes gated ids from candidates" || fail "prompt missing MOBILE_NATIVE_GATED claim exclusion"
+  grep -q 'Mobile-native gated:' "$PROMPT"         && note "prompt surfaces Phase 7 Mobile-native gated line" || fail "prompt missing Phase 7 Mobile-native gated line"
+fi
+if [ -x "$MNGATE" ]; then
+  if bash "$MNGATE" --id code-review-mobile-native-kmp-foo >/dev/null 2>&1; then
+    note "predicate gates a canonical mobile-native id"
+  else fail "predicate did NOT gate code-review-mobile-native-kmp-foo"; fi
+  if bash "$MNGATE" --id code-review-mobile-rn-report-fault >/dev/null 2>&1; then
+    fail "predicate wrongly gated a mobile-rn (React Native) id"
+  else note "predicate does NOT gate mobile-rn (React Native) ids"; fi
+fi
+echo
+
 # --- Summary ---------------------------------------------------------------
 if [ "$FAIL" = "0" ]; then
   echo "==> dispatcher-self-test: PASS"

--- a/.research/mobile-native-gate.sh
+++ b/.research/mobile-native-gate.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# mobile-native-gate.sh — claim-time gate for mobile-native / KMP-owned tasks
+# (issue #2652).
+#
+# WHY: the cloud dispatcher's verify gate for any `mobile-native/` change is
+#   `cd mobile-native && ./gradlew spotlessCheck test`, which fails at Gradle
+#   configuration — AGP resolves from dl.google.com, and the org egress proxy
+#   403-denies that host. Every mobile-native/KMP task is therefore
+#   STRUCTURALLY UNLANDABLE in the cloud runner: a claimed one burns a claim
+#   slot + an implementer subagent and can only ever return partial/blocked.
+#   This is the exact analogue of the iOS/Swift `awaiting-macos-build` PR gate
+#   (Phase 5.5) — except it must fire at CLAIM time, before a slot is spent.
+#
+# WHAT: classify whether a task is mobile-native/KMP-owned, using signals that
+#   are available at claim time (id shape + the plan's `## Files` scope):
+#     - `id`   — the id contains a `mobile-native` or `kmp` token
+#                (e.g. `code-review-mobile-native-*`, `churn-hotspot-mobile-native-*`).
+#                Note this deliberately does NOT match `mobile-rn` (React
+#                Native, verifiable in cloud via jest) or `frontend/apps/mobile`.
+#     - `files`— the plan at `.research/plans/<id>.md` lists ≥1 path under
+#                `mobile-native/` AND every non-test source path it touches is
+#                under `mobile-native/` (a pure-KMP plan). A cross-stack plan
+#                with a verifiable slice is intentionally NOT gated.
+#
+# The dispatcher's Phase 3 uses this to SKIP such candidates (without consuming
+# a claim slot) and surface them in Phase 7 under `Mobile-native gated:`.
+#
+# Modes:
+#   --id <task_id> [--plan <path>]      single predicate; exit 0 gated / 1 not
+#   --action-list <path> [--plans-dir]  batch; prints one `id<TAB>signal` line
+#                                        per OPEN gated item; always exit 0
+#
+# Single-mode output (stdout, grep-friendly):
+#   id=<id> gated=<true|false> signal=<id|files|none> reason=<short>
+#
+# Exit codes:
+#   single mode:  0 — gated · 1 — not gated · 64 — usage · 65 — bad input
+#   batch  mode:  0 — ran (regardless of how many rows matched) · 65 — bad input
+#
+# Usage:
+#   mobile-native-gate.sh --id churn-hotspot-mobile-native-shared-foo
+#   mobile-native-gate.sh --action-list .research/management/action-list.json
+
+set -euo pipefail
+
+MODE=""
+ID=""
+PLAN=""
+ACTION_LIST=""
+PLANS_DIR="${PLANS_DIR:-.research/plans}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --id)          MODE="single"; ID="$2"; shift 2;;
+    --plan)        PLAN="$2"; shift 2;;
+    --action-list) MODE="batch"; ACTION_LIST="$2"; shift 2;;
+    --plans-dir)   PLANS_DIR="$2"; shift 2;;
+    -h|--help)     sed -n '2,40p' "$0"; exit 0;;
+    *) echo "unknown arg: $1" >&2; exit 64;;
+  esac
+done
+
+# ---- id-signal predicate -------------------------------------------
+# A `mobile-native` or `kmp` token bounded by start/end or a `-`/`_`
+# separator. Case-insensitive. Kept in one place so the batch and single
+# modes agree.
+id_signal() {
+  printf '%s' "$1" | grep -Eiq '(^|[-_])(mobile-native|kmp)([-_]|$)'
+}
+
+# ---- files-signal predicate ----------------------------------------
+# Parse the plan's `## Files` section. Return 0 (gated) iff at least one
+# listed path is under `mobile-native/` AND every non-test source path is
+# under `mobile-native/`. Missing/empty plan → 1 (can't judge on files).
+#
+# Path extraction: lines between `## Files` and the next `## ` header;
+# take backtick-quoted tokens first, else the `- <path>` bullet token;
+# strip a trailing `:<line>` suffix.
+files_signal() {
+  local plan="$1"
+  [ -n "$plan" ] && [ -f "$plan" ] || return 1
+
+  local section total mn nontest_nonmn
+  section=$(awk '
+    /^## Files[[:space:]]*$/ { infiles=1; next }
+    /^## / { infiles=0 }
+    infiles { print }
+  ' "$plan")
+
+  total=0; mn=0; nontest_nonmn=0
+  while IFS= read -r line; do
+    local path
+    # Prefer a backtick-quoted path; else the first token after a leading "- ".
+    # shellcheck disable=SC2016  # single-quoted sed script is intentional (no shell expansion)
+    path=$(printf '%s' "$line" | sed -n 's/.*`\([^`]*\)`.*/\1/p' | head -n1)
+    if [ -z "$path" ]; then
+      path=$(printf '%s' "$line" | sed -n 's/^[[:space:]]*-[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -n1)
+    fi
+    [ -z "$path" ] && continue
+    path="${path%%:*}"                 # strip :<line>
+    case "$path" in
+      \<*|'') continue;;               # skip template placeholders
+    esac
+    total=$((total + 1))
+    case "$path" in
+      mobile-native/*) mn=$((mn + 1)); continue;;
+    esac
+    # A non-mobile-native path. Test paths don't disqualify a KMP plan;
+    # any non-test path under another root makes it cross-stack (not gated).
+    case "$path" in
+      */tests/*|*_test.rs|*.test.ts|*.test.tsx|*.test.js|*.test.jsx|*/__tests__/*) continue;;
+      *) nontest_nonmn=$((nontest_nonmn + 1));;
+    esac
+  done <<EOF
+$section
+EOF
+
+  [ "$mn" -ge 1 ] && [ "$nontest_nonmn" -eq 0 ] && [ "$total" -ge 1 ]
+}
+
+# ---- classify one id (+ optional plan) -----------------------------
+# Echoes the signal name and returns 0 (gated) / 1 (not gated).
+classify() {
+  local id="$1" plan="$2"
+  if id_signal "$id"; then echo "id"; return 0; fi
+  if [ -z "$plan" ]; then plan="$PLANS_DIR/$id.md"; fi
+  if files_signal "$plan"; then echo "files"; return 0; fi
+  echo "none"; return 1
+}
+
+# ---- single mode ---------------------------------------------------
+if [ "$MODE" = "single" ]; then
+  [ -n "$ID" ] || { echo "error: --id requires a value" >&2; exit 64; }
+  if signal=$(classify "$ID" "$PLAN"); then
+    case "$signal" in
+      id)    reason="id token (mobile-native|kmp)";;
+      files) reason="plan Files scope is pure mobile-native/";;
+    esac
+    printf 'id=%s gated=true signal=%s reason=%s\n' "$ID" "$signal" "$reason"
+    exit 0
+  else
+    printf 'id=%s gated=false signal=none reason=%s\n' "$ID" "no mobile-native/KMP signal"
+    exit 1
+  fi
+fi
+
+# ---- batch mode ----------------------------------------------------
+if [ "$MODE" = "batch" ]; then
+  [ -f "$ACTION_LIST" ] || { echo "error: missing action-list: $ACTION_LIST" >&2; exit 65; }
+  command -v jq >/dev/null 2>&1 || { echo "error: jq required" >&2; exit 64; }
+  # OPEN items only — a gated candidate only matters while it is claimable.
+  while IFS= read -r id; do
+    [ -z "$id" ] && continue
+    if signal=$(classify "$id" ""); then
+      printf '%s\t%s\n' "$id" "$signal"
+    fi
+  done < <(jq -r '.items[] | select(.status=="open") | .id' "$ACTION_LIST")
+  exit 0
+fi
+
+echo "error: specify --id <task_id> or --action-list <path>" >&2
+exit 64

--- a/.research/test-mobile-native-gate.sh
+++ b/.research/test-mobile-native-gate.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Smoke test for mobile-native-gate.sh — deterministic, offline (fixture-fed).
+# Covers: id-token signal (positive + boundary negatives), plan Files-scope
+# signal (pure-KMP positive, cross-stack negative, test-only-overlap allowed),
+# single-mode exit codes, and batch mode over an action-list fixture.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$HERE/mobile-native-gate.sh"
+FAIL=0
+ok()  { printf '  ok    %s\n' "$1"; }
+bad() { printf '  FAIL  %s\n' "$1"; FAIL=1; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+PLANS="$TMP/plans"; mkdir -p "$PLANS"
+AL="$TMP/action-list.json"
+
+# gated? single-mode helper: prints "gated" / "notgated" based on exit code.
+g() { if bash "$SCRIPT" --id "$1" --plans-dir "$PLANS" >/dev/null 2>&1; then echo gated; else echo notgated; fi; }
+
+echo "== mobile-native-gate smoke test =="
+
+# --- 1. id-token signal: positives -----------------------------------------
+for id in code-review-mobile-native-kmp-android-sso-deeplink \
+          churn-hotspot-mobile-native-shared-networkclient \
+          gap-42-kmp-shared-auth \
+          pm-mobile-native-refactor; do
+  [ "$(g "$id")" = gated ] && ok "id '$id' gated (id token)" || bad "id '$id' NOT gated"
+done
+
+# --- 2. id-token signal: boundary NEGATIVES --------------------------------
+# mobile-rn (React Native) is verifiable in cloud — must NOT be gated.
+# frontend/apps/mobile is React Native too. Substrings inside a word must not trip.
+for id in code-review-mobile-rn-report-fault-fake-submit \
+          gap-7-frontend-apps-mobile-fault-list \
+          churn-hotspot-backend-servers-api-server \
+          some-kmpish-word-thing; do
+  [ "$(g "$id")" = notgated ] && ok "id '$id' NOT gated (boundary)" || bad "id '$id' wrongly gated"
+done
+
+# --- 3. plan Files-scope signal --------------------------------------------
+# 3a. pure mobile-native plan (no id token) -> gated by files
+cat > "$PLANS/plan-pure-kmp.md" <<'MD'
+# plan-pure-kmp
+## Files
+- `mobile-native/shared/src/commonMain/kotlin/Foo.kt`
+- `mobile-native/androidApp/src/main/kotlin/Bar.kt:42`
+## Dependencies
+MD
+[ "$(g plan-pure-kmp)" = gated ] && ok "pure-KMP plan gated (files scope)" || bad "pure-KMP plan NOT gated"
+
+# 3b. cross-stack plan (backend + mobile-native) -> NOT gated (has verifiable slice)
+cat > "$PLANS/plan-cross-stack.md" <<'MD'
+# plan-cross-stack
+## Files
+- `backend/crates/api-core/src/lib.rs`
+- `mobile-native/shared/src/commonMain/kotlin/Foo.kt`
+## Dependencies
+MD
+[ "$(g plan-cross-stack)" = notgated ] && ok "cross-stack plan NOT gated" || bad "cross-stack plan wrongly gated"
+
+# 3c. mobile-native + test-only other path -> gated (test paths don't disqualify)
+cat > "$PLANS/plan-kmp-plus-test.md" <<'MD'
+# plan-kmp-plus-test
+## Files
+- `mobile-native/shared/src/commonMain/kotlin/Foo.kt`
+- `mobile-native/shared/src/commonTest/kotlin/FooTest.kt`
+- `backend/crates/api-core/tests/it.rs`
+## Dependencies
+MD
+[ "$(g plan-kmp-plus-test)" = gated ] && ok "KMP + test-only overlap gated" || bad "KMP + test-only NOT gated"
+
+# 3d. no plan, no id signal -> not gated
+[ "$(g totally-unrelated-backend-task)" = notgated ] && ok "no plan + no id signal NOT gated" || bad "unrelated task wrongly gated"
+
+# --- 4. single-mode exit codes + output ------------------------------------
+if bash "$SCRIPT" --id code-review-mobile-native-foo --plans-dir "$PLANS" >/dev/null 2>&1; then
+  ok "single mode exit 0 for gated id"
+else bad "single mode did not exit 0 for gated id"; fi
+OUT=$(bash "$SCRIPT" --id code-review-mobile-native-foo --plans-dir "$PLANS" 2>/dev/null || true)
+echo "$OUT" | grep -q 'gated=true signal=id' && ok "single-mode line: gated=true signal=id" || bad "single-mode line wrong: $OUT"
+if bash "$SCRIPT" --id plain-backend-task --plans-dir "$PLANS" >/dev/null 2>&1; then
+  bad "single mode exit 0 for NON-gated id"
+else ok "single mode exit 1 for non-gated id"; fi
+bash "$SCRIPT" --bogus >/dev/null 2>&1 && bad "usage error did not exit nonzero" || ok "usage error exits nonzero"
+
+# --- 5. batch mode over an action-list -------------------------------------
+cat > "$AL" <<'JSON'
+{"generated":"2026-08-04T00:00:00Z","items":[
+  {"id":"code-review-mobile-native-kmp-sso","status":"open"},
+  {"id":"churn-hotspot-mobile-native-shared","status":"open"},
+  {"id":"code-review-mobile-rn-fault","status":"open"},
+  {"id":"gap-9-backend-auth","status":"open"},
+  {"id":"code-review-mobile-native-already-done","status":"done"},
+  {"id":"plan-pure-kmp","status":"open"}
+]}
+JSON
+cp "$PLANS/plan-pure-kmp.md" "$PLANS/plan-pure-kmp.md" 2>/dev/null || true
+BATCH=$(bash "$SCRIPT" --action-list "$AL" --plans-dir "$PLANS" 2>/dev/null | cut -f1 | sort | tr '\n' ',')
+EXP="churn-hotspot-mobile-native-shared,code-review-mobile-native-kmp-sso,plan-pure-kmp,"
+[ "$BATCH" = "$EXP" ] && ok "batch gated set correct (open only, rn/backend excluded)" || bad "batch set=[$BATCH] expected=[$EXP]"
+
+echo
+if [ "$FAIL" = "0" ]; then echo "==> mobile-native-gate smoke test PASSED"; exit 0
+else echo "==> mobile-native-gate smoke test FAILED"; exit 1; fi


### PR DESCRIPTION
## Task
dispatcher: mobile-native / KMP tasks are unlandable in the cloud runner (AGP from dl.google.com blocked by egress 403). Gate KMP-owned tasks at claim time so the dispatcher stops spending claims + implementer subagents on structurally-unlandable work. **Closes #2652**

## Owner
pm-tech-lead

## What & why
The mandatory verify gate for any `mobile-native/` change is `cd mobile-native && ./gradlew spotlessCheck test`, which fails at Gradle **configuration**: AGP resolves from `dl.google.com`, which the org egress proxy 403-denies. Every mobile-native/KMP task is therefore **structurally unlandable in the cloud runner** — an implementer subagent can only ever return `partial`/`blocked`, so claiming one wastes a claim slot and a subagent.

Of the three operator options in #2652, only **Option 3 (gate KMP-owned tasks at claim time)** is an in-repo fix. Options 1 (allow `dl.google.com` egress) and 2 (connect ppt-bridge MCP) are operator-only infra changes and are intentionally NOT attempted here.

This adds the **claim-time analogue** of the existing Phase 5.5 `awaiting-macos-build` PR gate for iOS/Swift (which fires at merge time). Both are expected terminal-for-dispatcher states, not transient blocks.

## Changes (dispatcher-logic only — no `mobile-native/**` code touched)
- **`.research/mobile-native-gate.sh`** (new) — deterministic predicate. A candidate is gated iff **either** its `id` carries a `mobile-native`/`kmp` token (e.g. `code-review-mobile-native-*`, `churn-hotspot-mobile-native-*`, `gap-N-kmp-*`) — deliberately NOT matching `mobile-rn` (React Native, verifiable via jest) or `frontend/apps/mobile/**` — **or** its plan `## Files` scope is pure `mobile-native/` (≥1 path under it, every non-test source path under it; cross-stack plans with a verifiable slice are NOT gated). Single-mode (`--id`, exit 0/1) + batch-mode (`--action-list`, prints gated open ids).
- **`.research/dispatcher-prompt.md`** — Phase 3 builds `MOBILE_NATIVE_GATED` via the helper and excludes those ids from the `candidates` pool (no slot consumed); a new subsection documents the gate; Phase 7 gains a dedicated `Mobile-native gated:` line so parked items are surfaced, not silently dropped (mirrors `Awaiting-macOS-build:`).
- **`.research/test-mobile-native-gate.sh`** (new) — offline smoke test: id-token positives, boundary negatives (`mobile-rn`, `frontend-apps-mobile`, backend), plan Files-scope (pure-KMP gated, cross-stack not gated, test-only overlap allowed), single-mode exit codes, batch mode.
- **`.research/dispatcher-self-test.sh`** — new **T32** asserts the helper + smoke test exist and are executable, the prompt wires the Phase 3 predicate + Phase 7 line, and the predicate is behaviorally sane (gates a canonical KMP id, does NOT gate a `mobile-rn` id).
- **`.github/workflows/dispatcher-self-test.yml`** — trigger paths + a smoke-test step for the new script.

## Verification
```
VERIFY-PLAN base=fcb9daed365680509ecee573d95ef9756f8e2529 files=5
VERIFY OK 49fdbf1f5febc46daaa658a91c84e7adfb7d49ca
```
(Docs + shell only — no Rust/TS/KMP build in scope, so the impact plan is empty.) Additionally green locally:
- `bash .research/dispatcher-self-test.sh` → PASS (incl. new T32)
- `bash .research/test-mobile-native-gate.sh` → PASSED
- `shellcheck` on both new scripts → clean at warning/error severity (only info-level SC2015 in the test, matching the existing `test-*.sh` baseline)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
None — all changes under `.research/**` and `.github/workflows/**` (pm-tech-lead / pm-devops areas). No `mobile-native/**` code touched (out of scope + unverifiable in this runner).

## Notes
The gate is structural and cannot be cleared in-repo, so gated items are parked (not failed) and should not inflate starvation/buffer-health metrics. If Option 1 or 2 is ever adopted by an operator, remove the `c.id not in MOBILE_NATIVE_GATED` claim exclusion to re-enable KMP claiming.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPbfP68FjnUYVpngEr9kqW)_