### PR TITLE
gh-issue-2654: route ThreadDetailScreen send-error banner through i18n

### DIFF
--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -525,7 +525,8 @@
     "emptyText": "Začněte konverzaci se správcem nebo sousedy.",
     "threadLoadError": "Nepodařilo se načíst konverzaci",
     "threadEmptyTitle": "Zatím žádné zprávy",
-    "threadEmptyText": "Pozdravte a začněte konverzaci."
+    "threadEmptyText": "Pozdravte a začněte konverzaci.",
+    "threadSendError": "Zprávu se nepodařilo odeslat. Zkuste to znovu."
   },
   "leases": {
     "loadError": "Nepodařilo se načíst nájemní smlouvy",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -485,7 +485,8 @@
     "emptyText": "Beginnen Sie ein Gespräch mit Ihrer Verwaltung oder Ihren Nachbarn.",
     "threadLoadError": "Unterhaltung konnte nicht geladen werden",
     "threadEmptyTitle": "Noch keine Nachrichten",
-    "threadEmptyText": "Sagen Sie Hallo, um das Gespräch zu beginnen."
+    "threadEmptyText": "Sagen Sie Hallo, um das Gespräch zu beginnen.",
+    "threadSendError": "Ihre Nachricht konnte nicht gesendet werden. Bitte versuchen Sie es erneut."
   },
   "leases": {
     "loadError": "Mietverträge konnten nicht geladen werden",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -525,7 +525,8 @@
     "emptyText": "Start a conversation with your manager or neighbours.",
     "threadLoadError": "Couldn't load conversation",
     "threadEmptyTitle": "No messages yet",
-    "threadEmptyText": "Say hello to start the conversation."
+    "threadEmptyText": "Say hello to start the conversation.",
+    "threadSendError": "Couldn't send your message. Please try again."
   },
   "leases": {
     "loadError": "Couldn't load leases",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -485,7 +485,8 @@
     "emptyText": "Kezdjen beszélgetést a kezelővel vagy a szomszédokkal.",
     "threadLoadError": "A beszélgetés nem tölthető be",
     "threadEmptyTitle": "Még nincsenek üzenetek",
-    "threadEmptyText": "Köszönjön, és kezdje el a beszélgetést."
+    "threadEmptyText": "Köszönjön, és kezdje el a beszélgetést.",
+    "threadSendError": "Az üzenet elküldése nem sikerült. Kérjük, próbálja újra."
   },
   "leases": {
     "loadError": "A bérleti szerződések nem tölthetők be",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -485,7 +485,8 @@
     "emptyText": "Rozpocznij rozmowę z zarządcą lub sąsiadami.",
     "threadLoadError": "Nie można załadować rozmowy",
     "threadEmptyTitle": "Brak wiadomości",
-    "threadEmptyText": "Przywitaj się, aby rozpocząć rozmowę."
+    "threadEmptyText": "Przywitaj się, aby rozpocząć rozmowę.",
+    "threadSendError": "Nie udało się wysłać wiadomości. Spróbuj ponownie."
   },
   "leases": {
     "loadError": "Nie można załadować umów najmu",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -525,7 +525,8 @@
     "emptyText": "Začnite konverzáciu so správcom alebo susedmi.",
     "threadLoadError": "Nepodarilo sa načítať konverzáciu",
     "threadEmptyTitle": "Zatiaľ žiadne správy",
-    "threadEmptyText": "Pozdravte a začnite konverzáciu."
+    "threadEmptyText": "Pozdravte a začnite konverzáciu.",
+    "threadSendError": "Správu sa nepodarilo odoslať. Skúste to znova."
   },
   "leases": {
     "loadError": "Nepodarilo sa načítať nájomné zmluvy",

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.send.test.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.send.test.tsx
@@ -99,8 +99,10 @@ describe('ThreadDetailScreen — send outcomes', () => {
     expect(mockMutationFn).toHaveBeenCalledWith({ content: 'Please fix the elevator' });
 
     // The failure is surfaced inline (reused QueryErrorBanner) with a retry.
-    // The banner shows a user-facing message, never the raw backend error.
-    expect(screen.getByText(/Couldn't send/)).toBeTruthy();
+    // The banner message is i18n-driven (the `t(key) => key` test mock renders
+    // the key, proving the copy routes through useTranslation, never a raw
+    // English literal and never the raw backend error).
+    expect(screen.getByText('messages.threadSendError')).toBeTruthy();
     expect(screen.queryByText(new RegExp(SEND_ERROR))).toBeNull();
     expect(screen.getByText('common.retry')).toBeTruthy(); // i18n key in tests
 
@@ -117,6 +119,6 @@ describe('ThreadDetailScreen — send outcomes', () => {
 
     expect(mockMutationFn).toHaveBeenCalledTimes(1);
     expect(screen.queryByDisplayValue('Thanks!')).toBeNull();
-    expect(screen.queryByText(/Couldn't send/)).toBeNull();
+    expect(screen.queryByText('messages.threadSendError')).toBeNull();
   });
 });

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -231,10 +231,7 @@ export function ThreadDetailScreen({
         // the user can retry without retyping. A localized, non-leaking
         // message per the QueryErrorBanner contract — never the raw
         // backend/error string.
-        <QueryErrorBanner
-          message="Couldn't send your message. Please try again."
-          onRetry={handleSend}
-        />
+        <QueryErrorBanner message={t('messages.threadSendError')} onRetry={handleSend} />
       ) : null}
 
       <View style={styles.composer}>


### PR DESCRIPTION
## Task
Follow-up: ThreadDetailScreen send-error banner is hardcoded English, bypassing i18n (PR #2641). Add a `messages.threadSendError` key to all six mobile locale bundles (`frontend/apps/mobile/src/locales/*.json` — en, sk, cs, de, pl, hu) and route the banner text through the existing `useTranslation()` `t`. Update the `ThreadDetailScreen.send.test.tsx` regression to assert on the i18n key so it proves the copy is i18n-driven.

Closes #2654

## Owner
pm-frontend (mobile / React Native i18n) — specialist: `react-native`

## Changes
- `frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx` — the `QueryErrorBanner` send-failure message now reads `t('messages.threadSendError')` instead of the raw English literal `"Couldn't send your message. Please try again."`. The retry affordance already resolved via `common.retry`, so the banner is now fully localized.
- `frontend/apps/mobile/src/locales/{en,sk,cs,de,pl,hu}.json` — added `messages.threadSendError`, placed alongside the sibling `thread*` keys (`threadLoadError`, `threadEmptyTitle`, `threadEmptyText`) that PR #2642 introduced. English copy is preserved verbatim from the old literal; the other five are translated.
- `frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.send.test.tsx` — the failure-path regression now asserts `getByText('messages.threadSendError')` (rendered verbatim by the repo's `t(key) => key` test mock, matching the `common.retry` assertion already in the test), proving the copy routes through i18n. The success-path assertion was updated to the same key for consistency. The raw-backend-error-leak assertion is unchanged.

## Verification
```
VERIFY-PLAN base=c0daf4e49c35245fadf372e00ae207e53209cf6e files=8
  cd frontend && pnpm exec biome check apps/mobile/src/locales/cs.json apps/mobile/src/locales/de.json apps/mobile/src/locales/en.json apps/mobile/src/locales/hu.json apps/mobile/src/locales/pl.json apps/mobile/src/locales/sk.json apps/mobile/src/screens/messages/ThreadDetailScreen.send.test.tsx apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
  cd frontend && pnpm --filter "...[c0daf4e49c35245fadf372e00ae207e53209cf6e]" typecheck
  cd frontend && pnpm --filter "...[c0daf4e49c35245fadf372e00ae207e53209cf6e]" test
VERIFY OK 6ee1a5116db23b60bef6456e6e498f7f94866285
```
Biome clean, typecheck clean, jest-expo: 49 suites / 607 tests passed.

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. All changes under `frontend/apps/mobile/src/`.

## Code-reuse review
None — `reuse-grep.sh --specialist react-native` produced no warnings. No new helpers added; reuses the existing `QueryErrorBanner` component and `useTranslation()` `t`.

## Goal-check (IG1–IG8)
- IG3 (TDD: separate `test:` + `fix:` commits) — ok.
- IG7 (verify gate) — ran green in the Verification block above.
- IG1 (plan file) / IG2 (`impl/<slug>` branch name) — reported FAIL only because this is a gh-issue-driven task, not a `.research/plans/` plan-flow task (no plan file; branch is the dispatcher-assigned `auto-impl/...`). Structural mismatches of the plan-oriented checker, not goal failures.
- IG6 — no "Out of scope" paths declared. IG8 (archive move) — N/A for a gh-issue task.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
`messages.threadSendError` chosen over `messages.sendError` (both offered in the issue) to match the `thread*` naming of the sibling keys in the same component. English string is byte-identical to the removed literal, so no en-locale copy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NK7dHkGakFYcpEwgK1it2

---
_Generated by [Claude Code](https://claude.ai/code/session_019NK7dHkGakFYcpEwgK1it2)_