### PR TITLE
screen-map-drift-pr-2648-ppt: reconcile ppt-web screen-map

### DIFF
--- a/docs/screens/ppt/rentals-dashboard.md
+++ b/docs/screens/ppt/rentals-dashboard.md
@@ -57,6 +57,25 @@ Rentals calls (via `@ppt/api-client` `ShortTermRentalsService` — `rentalsApi*`
 ## Notes
 
 ### Specific (recent)
+- 2026-08-04 — **rentals mutations now guard auth (session-expiry UX), PR #2648.**
+  The rentals route group (`groups/rentals.tsx`) no longer dereferences `auth!`
+  on the request path. All 10 rentals request sites route through
+  `requireRentalsAuthHeaders(auth)`, which throws a typed
+  `AuthError('SESSION_EXPIRED')` when the session is lost mid-flight instead of
+  raising an opaque `TypeError`. The four mutations —
+  `rentalsApiCreateConnection` (create connection), `rentalsApiSyncPlatforms`
+  (sync), `rentalsApiCheckIn`, `rentalsApiCheckOut` — wire
+  `handleRentalsAuthError(error, logout)` as their TanStack Query `onError`: a
+  session-loss `AuthError` calls AuthContext `logout()`, which clears the
+  session and lets `ProtectedRoute` redirect to `/login` (the app's existing
+  dropped-session UX); non-session errors are left untouched. Queries were
+  already gated on `enabled: !!auth` and were converted to the same helper for
+  consistency. Regression coverage:
+  `frontend/apps/ppt-web/src/routes/groups/rentals.auth-guard.test.tsx`
+  (`requireRentalsAuthHeaders(null)` throws `AuthError`, not `TypeError`; a
+  wired `useMutation` settles in a handled `AuthError` state and never hits the
+  API). `buildStatus`/`apiStatus` unchanged — this is a robustness/UX guard, not
+  a surface change.
 - 2026-07-09 — created this screen-map to give UC-29 (and UC-30) a canonical
   home. UC-29 had only been attached to `ppt/settings-integrations` (the Airbnb
   connect sub-flow, gap-83-1); the primary rentals management surface at
@@ -72,6 +91,11 @@ Rentals calls (via `@ppt/api-client` `ShortTermRentalsService` — `rentalsApi*`
   unmapped in the sitemap + screen-map tree — a follow-up drift item.
 
 ## Agent Log
+- 2026-08-04 — agent: screen-map-drift-pr-2648-ppt — reconciled this screen-map
+  with PR #2648 (guard rentals mutation auth). Documented the mutation
+  auth-guard / session-expiry redirect behavior (`requireRentalsAuthHeaders` +
+  `handleRentalsAuthError` on all four rentals mutations) under Notes > Specific.
+  Docs-only screen-map reconcile; no frontmatter outcome changed.
 - 2026-07-09 — agent: gap-screens-link-uc-29 — created the Short-Term Rentals
   Dashboard screen-map and linked UC-29 (+ UC-30) to it, giving the
   Short-Term Rental Management use case a canonical screen-map home beyond the


### PR DESCRIPTION
## Task
screen-map drift: PR #2648 touched ppt-web rentals route (mutation auth guard) without updating docs/screens/ppt/. Reconcile the screen-map docs under `docs/screens/ppt/` with the ppt-web rentals-route change PR #2648 made (mutation auth guard). Use `/screens update` to detect drift, edit the affected screen-map markdown + Agent Log per the Screen-Map Self-Management Protocol, then `/screens validate`. Keep scoped to `docs/screens/**`.

## Owner
pm-qa (docs-only screen-map reconcile; specialist: screens tooling)

## What changed
`docs/screens/ppt/rentals-dashboard.md` (the canonical screen-map anchor for the `/rentals*` route group) — 1 file, +24 lines, docs-only:
- **Notes > Specific (recent)** — recorded the mutation auth-guard / session-expiry UX that PR #2648 shipped to `frontend/apps/ppt-web/src/routes/groups/rentals.tsx`: all 10 rentals request sites now route through `requireRentalsAuthHeaders(auth)` (throws a typed `AuthError('SESSION_EXPIRED')` instead of dereferencing `auth!`); the four mutations (`createConnection`, `syncPlatforms`, `checkIn`, `checkOut`) wire `handleRentalsAuthError(error, logout)` as their TanStack Query `onError` → `logout()` → `ProtectedRoute` redirect to `/login`. Regression test: `rentals.auth-guard.test.tsx`.
- **Agent Log** — added the `2026-08-04 — agent: screen-map-drift-pr-2648-ppt` entry per the Screen-Map Self-Management Protocol.
- Frontmatter unchanged: `buildStatus: shipped` / `apiStatus: partial` — PR #2648 is a robustness/UX guard, not a surface change, so no outcome flipped.

## Drift analysis
`/screens update` (structural CLI) reports 368 pre-existing systemic issues (unknown-component / unknown-epic catalog registrations across the whole tree) — **none pertain to PR #2648** and all are left untouched (out of scope). The CLI can't detect PR #2648's change because it's a behavioral mutation-auth-guard change, not a route/endpoint/use-case/epic change — exactly the kind of screen-relevant code change the Protocol's Rule A covers via Notes + Agent Log. This is a genuine reconcile (a mid-session UX change future agents on this screen need), not a no-drift case.

## Verification
```
VERIFY-PLAN base=c0daf4e49c35245fadf372e00ae207e53209cf6e files=1
VERIFY OK c1451477eb8e492a1912accc59db7111a41e726c
```
Docs-only diff → empty impact plan (no build/test band triggered).

`/screens validate` → **Validated 167 screen-maps: 0 errors, 0 warnings** (`--strict` exit 0).

## CI parity (Band C — hot-path only)
skipped: docs-only screen-map reconcile (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Scope drift
`scope_drift=true` — `scope-check.sh --owner pm-qa` flags `docs/screens/ppt/rentals-dashboard.md` as outside pm-qa's owner-areas mapping. Benign and by design: the task explicitly scopes to `docs/screens/**`, which pm-qa's area map simply doesn't enumerate. Real diff is exactly 1 file under `docs/screens/`.

## Code-reuse review
none — no code added; docs-only.

## Notes
goal-check IG7 (verify gate) passes. IG1/IG2/IG8 fail only structurally — same as PR #2648 itself: this is a dispatcher code-review/drift task with no `.research/plans/*.md` (must not touch `.research/**`) and uses the dispatcher-assigned `auto-impl/...` branch rather than `impl/`. Neither is a quality issue. IG3 skipped (docs-only reconcile — no regression test required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019NK7dHkGakFYcpEwgK1it2

---
_Generated by [Claude Code](https://claude.ai/code/session_019NK7dHkGakFYcpEwgK1it2)_