### PR TITLE
screen-map-drift-pr-2649-ppt: reconcile financial-payments screen-map with PR #2649 onError toasts

### DIFF
--- a/docs/screens/ppt/financial-payments.md
+++ b/docs/screens/ppt/financial-payments.md
@@ -30,8 +30,33 @@ Stubbed by team audit on 2026-05-18. Route exists in code; flesh out useCases, e
 ## Notes
 
 ### Specific (recent)
+- 2026-08-04 — **money-movement mutations now surface failures via error toast, PR #2649.**
+  The two reconciliation mutations in `PaymentManagementPageRoute`
+  (`groups/financial.tsx`) — `matchMutation` (`allocatePayment`, the "Match"
+  action) and `autoMatchMutation` (`autoMatchPayments`, "Auto-Match All") —
+  previously had `onSuccess` (invalidate payments/invoices) but **no `onError`**,
+  so a rejected reconciliation call produced zero user feedback (the click looked
+  like a no-op). Both mutations now wire `onError` handlers that fire an `error`
+  `useToast()` — titles `financial.payments.matchFailed` ("Failed to allocate
+  payment") / `financial.payments.autoMatchFailed` ("Failed to auto-match
+  payments") via the established `t(key, { defaultValue })` fallback (same UX as
+  the sibling `sendInvoice`/`downloadInvoicePdf` toasts in
+  `InvoiceManagementPageRoute`). Handlers only raise a toast — no query/form
+  state is touched, so pending reconciliation input is preserved. Regression
+  coverage: `frontend/apps/ppt-web/src/routes/groups/financial.payments-onerror.route.test.tsx`
+  (mounts the production `/financial/payments` route, drives "Auto-Match All"
+  against a rejecting `autoMatchPayments`, asserts the error toast). This is a
+  failure-feedback UX addition — `buildStatus`/`apiStatus` unchanged.
 - 2026-05-18 — audit: stub created from `frontend/apps/ppt-web/src/App.tsx:530`.
 
 ## Agent Log
+- 2026-08-04 — agent: screen-map-drift-pr-2649-ppt — reconciled this screen-map
+  with PR #2649 (surface rentals/financial mutation failures via error toast).
+  Documented the new `onError` error-toast wiring on the `allocatePayment` /
+  `autoMatchPayments` money-movement mutations under Notes > Specific. Note: the
+  merged #2649 diff only touched `groups/financial.tsx` (+ its route test) — the
+  rentals `onError` handling referenced in the PR body is the #2648 auth-guard,
+  already tracked on `ppt/rentals-dashboard`, so no rentals screen-map change was
+  warranted. Docs-only reconcile; no frontmatter outcome changed.
 - 2026-05-18 — agent: created stub for unmapped route.
 - 2026-06-22 — agent: confirmed PaymentManagementPageRoute wired (#975.5) to listPayments + listUnallocatedPayments + listInvoices via TanStack Query, with allocatePayment (onMatch) and autoMatchPayments (onAutoMatch) mutations; apiStatus stub -> partial (no building_id filter param; buildings stays []).


### PR DESCRIPTION
## Task
screen-map drift: PR #2649 touched ppt-web rentals + financial routes (onError toasts) without updating docs/screens/ppt/

## Owner
pm-qa

## What changed
Docs-only screen-map reconcile — `docs/screens/ppt/financial-payments.md` only.

Investigated PR #2649. Its **merged** diff (`changed_files=2`, `+134` = 114 test + 20 `financial.tsx`) touched only:
- `frontend/apps/ppt-web/src/routes/groups/financial.tsx` — added `onError` error-toasts to the two `PaymentManagementPageRoute` money-movement mutations `matchMutation` (`allocatePayment`) and `autoMatchMutation` (`autoMatchPayments`), previously `onSuccess`-only (silent failures).
- `financial.payments-onerror.route.test.tsx` — regression test.

The PR **body** also describes `rentals.tsx` changes, but those are **not** in the merged diff — `groups/rentals.tsx`'s `onError` handling is the `handleRentalsAuthError` auth-guard from PR #2648, which is already documented on `ppt/rentals-dashboard` (2026-08-04). So no rentals screen-map change is warranted; touching it would invent churn.

The `financial-payments` screen-map documented these mutations (2026-06-22) but not the new failure-feedback UX. Added a `Notes > Specific` entry + `Agent Log` entry. Frontmatter unchanged (`buildStatus: shipped`, `apiStatus: partial`) — this is client-side error-feedback wiring, no API/build-status change.

`/screens validate`: **Validated 167 screen-maps: 0 errors, 0 warnings.**

## Verification
```
VERIFY-PLAN base=76df00be10b8a23aa0e731d7cb08ef108fe71ace files=1
VERIFY OK 9a1de234d8a2d8e613344a1c1d9fce4ccc639804
```
(Docs-only diff → empty impact plan, as expected. `@ppt/screen-map cli validate` clean.)

## CI parity (Band C — hot-path only)
skipped: docs-only screen-map reconcile, no security/auth/billing/data-integrity change.

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-qa` exits 2: `pm-qa` maps to test dirs (`**/tests/**`, `e2e/**`) while the diff is `docs/screens/ppt/financial-payments.md` (owned by pm-frontend / pm-tech-lead areas). Expected and benign — the task is a docs-only screen-map reconcile mis-tagged to pm-qa. Diff is exactly the one file listed above.

## Code-reuse review
`reuse-grep.sh` — no warnings. Docs-only; no helpers introduced.

## Notes
Goal-check (IG1–IG8): IG7 (`just verify` / impact gate) passes. IG1/IG4/IG5/IG6 are plan-flow checks and N/A — this is a dispatcher action-list task with no `.research/plans/*.md`. IG2 flags the branch name; the `auto-impl/…` prefix was assigned by the dispatcher and kept as mandated. IG3 (TDD test:/fix: pair) is N/A — pure-docs change, no regression test warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PKaiufPw1o4G6QEdhYFb2r

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKaiufPw1o4G6QEdhYFb2r)_