### PR TITLE
gh-issue-2662: harden voice-webhook auth device lookup (Closes #2662)

### DIFF
--- a/backend/crates/db/migrations/00226_voice_assistant_devices_token_hash.sql
+++ b/backend/crates/db/migrations/00226_voice_assistant_devices_token_hash.sql
@@ -1,0 +1,84 @@
+-- Create the (previously unmigrated) `voice_assistant_devices` table and add an
+-- indexed, keyed-HMAC lookup column for voice-webhook authentication (#2662).
+--
+-- Background
+-- ----------
+-- `create_voice_device` / `update_voice_device_tokens` / `find_voice_device` and
+-- the voice-webhook auth path (`authenticate_voice_user`,
+-- api-server routes/voice_webhooks.rs) have always read and written a
+-- `voice_assistant_devices` table, but **no migration ever created it** (grep
+-- for `voice_assistant_devices` across backend/**/*.sql returned zero hits
+-- before this file — the same missing-DDL class fixed for
+-- `portal_webhook_events` in 00219). The table was relying on an ambient /
+-- hand-created schema, which is why the `#[sqlx::test]`-backed regression for
+-- the multi-device selection path could not be written (see the note in
+-- tests/suites/voice_oauth_exchange_auth_tests.rs). This lands the DDL so that
+-- selection path is testable and the auth query below is index-backed.
+--
+-- The #2662 improvement
+-- ---------------------
+-- `authenticate_voice_user` used to `fetch_all` every active, token-bearing
+-- device for the platform (cross-org, system-wide) and AES-GCM-decrypt +
+-- constant-time-compare each in a linear scan — O(N) decryptions per webhook
+-- request and an amplification/DoS vector. `access_token_hash` stores a keyed
+-- HMAC-SHA256 of the access token (keyed with INTEGRATION_ENCRYPTION_KEY, so it
+-- is not an offline-guessable plain digest) alongside the encrypted token, so
+-- the candidate device is selected by the partial index below in SQL and only
+-- that single row is decrypted + constant-time-verified (defence in depth).
+--
+-- Backfill
+-- --------
+-- Existing rows keep a NULL `access_token_hash`: the HMAC needs the plaintext
+-- token, and only the AES-GCM ciphertext is stored — it cannot be recomputed in
+-- SQL. Such rows are re-hashed the next time their token is written (device
+-- linking / token refresh); until then `authenticate_voice_user` falls back to
+-- the linear scan over NULL-hash rows only, so no device is locked out.
+--
+-- RLS
+-- ---
+-- Intentionally NOT `ENABLE/FORCE ROW LEVEL SECURITY`. Voice devices are matched
+-- on the *unauthenticated* voice-webhook path (`authenticate_voice_user` runs a
+-- cross-org token lookup; `oauth_token_refresh` uses a context-cleared public
+-- connection), which carries no `app.current_organization_id` GUC. An org-scoped
+-- policy would deny-all those reads. `organization_id` / `user_id` are logical
+-- FKs (bound from the verified PM access token on the write paths) but are left
+-- unconstrained here to keep the unauthenticated match path working.
+
+CREATE TABLE IF NOT EXISTS voice_assistant_devices (
+    id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id          UUID NOT NULL,
+    user_id                  UUID NOT NULL,
+    unit_id                  UUID,
+    platform                 VARCHAR(50) NOT NULL,   -- alexa, google_assistant
+    device_id                VARCHAR(255) NOT NULL,
+    device_name              VARCHAR(255),
+    linked_at                TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_used_at             TIMESTAMPTZ,
+    access_token_encrypted   TEXT,                   -- base64(nonce+AES-GCM ciphertext)
+    refresh_token_encrypted  TEXT,
+    token_expires_at         TIMESTAMPTZ,
+    is_active                BOOLEAN NOT NULL DEFAULT TRUE,
+    capabilities             JSONB NOT NULL DEFAULT '[]'::jsonb,
+    access_token_hash        BYTEA,                  -- keyed HMAC-SHA256 lookup key (#2662)
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- For environments where the table already existed (hand-created schema) without
+-- the lookup column, add it idempotently.
+ALTER TABLE voice_assistant_devices
+    ADD COLUMN IF NOT EXISTS access_token_hash BYTEA;
+
+-- Fast-path selection index for `authenticate_voice_user`:
+--   WHERE platform = $1 AND is_active = TRUE AND access_token_hash = $2 LIMIT 1
+-- Partial (hash IS NOT NULL) so un-backfilled rows don't bloat it.
+CREATE INDEX IF NOT EXISTS idx_voice_devices_platform_token_hash
+    ON voice_assistant_devices (platform, access_token_hash)
+    WHERE access_token_hash IS NOT NULL;
+
+-- Supporting indexes for the other lookup paths (by owner, by external device).
+CREATE INDEX IF NOT EXISTS idx_voice_devices_user
+    ON voice_assistant_devices (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_voice_devices_platform_device
+    ON voice_assistant_devices (platform, device_id);

--- a/backend/crates/db/src/models/llm_document.rs
+++ b/backend/crates/db/src/models/llm_document.rs
@@ -472,6 +472,12 @@ pub struct VoiceAssistantDevice {
     pub token_expires_at: Option<DateTime<Utc>>,
     pub is_active: bool,
     pub capabilities: serde_json::Value,
+    /// Keyed HMAC-SHA256 of the access token — an indexed, deterministic lookup
+    /// key so voice-webhook auth selects the candidate device in SQL instead of
+    /// decrypt-and-scanning every active device for the platform (#2662). NULL
+    /// for rows linked before the column existed (fall back to the linear scan).
+    #[serde(default)]
+    pub access_token_hash: Option<Vec<u8>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }

--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -1632,6 +1632,10 @@ impl LlmDocumentRepository {
         refresh_token_encrypted: Option<&str>,
         token_expires_at: Option<DateTime<Utc>>,
         capabilities: serde_json::Value,
+        // Keyed HMAC-SHA256 of the access token (#2662): indexed lookup key so
+        // voice-webhook auth avoids the O(N) decrypt-and-scan. NULL is accepted
+        // and simply defers the device to the linear-scan fallback.
+        access_token_hash: Option<&[u8]>,
     ) -> Result<VoiceAssistantDevice, SqlxError>
     where
         E: Executor<'e, Database = Postgres>,
@@ -1641,9 +1645,9 @@ impl LlmDocumentRepository {
             INSERT INTO voice_assistant_devices (
                 organization_id, user_id, unit_id, platform, device_id,
                 device_name, access_token_encrypted, refresh_token_encrypted,
-                token_expires_at, capabilities, linked_at
+                token_expires_at, capabilities, access_token_hash, linked_at
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW())
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
             RETURNING *
             "#,
         )
@@ -1657,6 +1661,7 @@ impl LlmDocumentRepository {
         .bind(refresh_token_encrypted)
         .bind(token_expires_at)
         .bind(&capabilities)
+        .bind(access_token_hash)
         .fetch_one(executor)
         .await
     }
@@ -1872,6 +1877,10 @@ impl LlmDocumentRepository {
         access_token_encrypted: &str,
         refresh_token_encrypted: Option<&str>,
         token_expires_at: Option<DateTime<Utc>>,
+        // Keyed HMAC-SHA256 of the new access token (#2662): kept in lock-step
+        // with `access_token_encrypted` so the indexed lookup stays correct
+        // after a token refresh.
+        access_token_hash: Option<&[u8]>,
     ) -> Result<Option<VoiceAssistantDevice>, SqlxError>
     where
         E: Executor<'e, Database = Postgres>,
@@ -1882,6 +1891,7 @@ impl LlmDocumentRepository {
                 access_token_encrypted = $2,
                 refresh_token_encrypted = COALESCE($3, refresh_token_encrypted),
                 token_expires_at = $4,
+                access_token_hash = $5,
                 updated_at = NOW()
             WHERE id = $1 AND is_active = TRUE
             RETURNING *
@@ -1891,6 +1901,7 @@ impl LlmDocumentRepository {
         .bind(access_token_encrypted)
         .bind(refresh_token_encrypted)
         .bind(token_expires_at)
+        .bind(access_token_hash)
         .fetch_optional(executor)
         .await
     }

--- a/backend/scripts/check-rls-coverage.sh
+++ b/backend/scripts/check-rls-coverage.sh
@@ -79,6 +79,9 @@ done
 #   login_attempts           : pre-authentication, no org context exists yet
 #   portal_webhook_events    : pre-auth portal webhook ingest log; unauthenticated path,
 #                              no org GUC; FK-scoped, RLS intentionally omitted — see migration
+#   voice_assistant_devices  : pre-auth voice-webhook match path; unauthenticated cross-org
+#                              token lookup, no org GUC; token refresh uses a context-cleared
+#                              public connection — RLS intentionally omitted, see migration 00226
 # Keep this list in sync with validate_rls_coverage() in 00006.
 # -----------------------------------------------------------------------------
 EXEMPT_TABLES=(
@@ -91,6 +94,7 @@ EXEMPT_TABLES=(
     password_reset_tokens
     login_attempts
     portal_webhook_events
+    voice_assistant_devices
 )
 
 echo "🔍 RLS policy-coverage gate (tenant-data manifest)"

--- a/backend/servers/api-server/src/routes/ai/voice.rs
+++ b/backend/servers/api-server/src/routes/ai/voice.rs
@@ -95,6 +95,11 @@ pub(crate) async fn link_voice_device(
             refresh_token_encrypted.as_deref(),
             token_expires_at,
             serde_json::json!(["check_balance", "report_fault", "check_announcements"]),
+            // #2662: this linking path only sees the already-encrypted token
+            // (the plaintext lives inside `exchange_voice_oauth_tokens`), so it
+            // stores a NULL lookup hash; `authenticate_voice_user` falls back to
+            // the linear scan for such rows until the token is next refreshed.
+            None,
         )
         .await;
     rls.release().await;

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -361,7 +361,7 @@ async fn oauth_token_exchange(
     let oauth_manager = VoiceOAuthManager::from_env();
     let crypto = IntegrationCrypto::try_from_env();
 
-    let (access_encrypted, refresh_encrypted, expires_at) = if oauth_manager
+    let (access_encrypted, refresh_encrypted, expires_at, access_hash) = if oauth_manager
         .has_platform(voice_platform)
     {
         // Get redirect URI from environment
@@ -396,8 +396,15 @@ async fn oauth_token_exchange(
         let refresh_encrypted =
             encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref())
                 .map_err(voice_encryption_required)?;
+        // #2662: derive the indexed lookup hash from the plaintext token.
+        let access_hash = voice_access_token_hash(&tokens.access_token);
 
-        (access_encrypted, refresh_encrypted, tokens.expires_at)
+        (
+            access_encrypted,
+            refresh_encrypted,
+            tokens.expires_at,
+            access_hash,
+        )
     } else if cfg!(debug_assertions) {
         // Platform not configured - use simulated tokens for development only.
         // Gated behind `debug_assertions` (security fix #890): release builds
@@ -408,6 +415,7 @@ async fn oauth_token_exchange(
         );
         let simulated_access = format!("voice_access_{}_{}", request.platform, Uuid::new_v4());
         let simulated_refresh = format!("voice_refresh_{}_{}", request.platform, Uuid::new_v4());
+        let access_hash = voice_access_token_hash(&simulated_access);
         (
             encrypt_required(crypto.as_ref(), &simulated_access)
                 .map_err(voice_encryption_required)?,
@@ -416,6 +424,7 @@ async fn oauth_token_exchange(
                     .map_err(voice_encryption_required)?,
             ),
             Some(Utc::now() + Duration::hours(1)),
+            access_hash,
         )
     } else {
         tracing::error!(
@@ -467,6 +476,7 @@ async fn oauth_token_exchange(
             refresh_encrypted.as_deref(),
             expires_at,
             serde_json::json!(["check_balance", "report_fault", "check_announcements"]),
+            access_hash.as_deref(),
         )
         .await
         .map_err(|e| {
@@ -578,48 +588,57 @@ async fn oauth_token_refresh(
         )
     })?;
 
-    let (new_access_encrypted, new_refresh_encrypted, new_expires_at) = if oauth_manager
-        .has_platform(voice_platform)
-    {
-        // Decrypt the refresh token
-        let refresh_token = decrypt_if_available(crypto.as_ref(), refresh_token_encrypted);
+    let (new_access_encrypted, new_refresh_encrypted, new_expires_at, new_access_hash) =
+        if oauth_manager.has_platform(voice_platform) {
+            // Decrypt the refresh token
+            let refresh_token = decrypt_if_available(crypto.as_ref(), refresh_token_encrypted);
 
-        // Refresh the tokens using OAuth client
-        let tokens = oauth_manager
-            .refresh_token(voice_platform, &refresh_token)
-            .await
-            .map_err(|e| {
-                tracing::error!("Token refresh failed: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(ErrorResponse::new(
-                        "TOKEN_REFRESH_FAILED",
-                        format!("Failed to refresh token: {}", e),
-                    )),
-                )
-            })?;
+            // Refresh the tokens using OAuth client
+            let tokens = oauth_manager
+                .refresh_token(voice_platform, &refresh_token)
+                .await
+                .map_err(|e| {
+                    tracing::error!("Token refresh failed: {}", e);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(ErrorResponse::new(
+                            "TOKEN_REFRESH_FAILED",
+                            format!("Failed to refresh token: {}", e),
+                        )),
+                    )
+                })?;
 
-        // Issue #765: encryption is MANDATORY — fail closed if no key is set.
-        let access_encrypted = encrypt_required(crypto.as_ref(), &tokens.access_token)
-            .map_err(voice_encryption_required)?;
-        let refresh_encrypted =
-            encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref())
+            // Issue #765: encryption is MANDATORY — fail closed if no key is set.
+            let access_encrypted = encrypt_required(crypto.as_ref(), &tokens.access_token)
                 .map_err(voice_encryption_required)?;
+            let refresh_encrypted =
+                encrypt_optional_required(crypto.as_ref(), tokens.refresh_token.as_deref())
+                    .map_err(voice_encryption_required)?;
+            // #2662: keep the indexed lookup hash in lock-step with the new token.
+            let access_hash = voice_access_token_hash(&tokens.access_token);
 
-        (access_encrypted, refresh_encrypted, tokens.expires_at)
-    } else {
-        // Platform not configured - use simulated tokens for development
-        tracing::warn!(
-            "Voice OAuth not configured for platform {}, using simulated refresh",
-            device.platform
-        );
-        let new_access = format!("voice_access_refreshed_{}", Uuid::new_v4());
-        (
-            encrypt_required(crypto.as_ref(), &new_access).map_err(voice_encryption_required)?,
-            None,
-            Some(Utc::now() + Duration::hours(1)),
-        )
-    };
+            (
+                access_encrypted,
+                refresh_encrypted,
+                tokens.expires_at,
+                access_hash,
+            )
+        } else {
+            // Platform not configured - use simulated tokens for development
+            tracing::warn!(
+                "Voice OAuth not configured for platform {}, using simulated refresh",
+                device.platform
+            );
+            let new_access = format!("voice_access_refreshed_{}", Uuid::new_v4());
+            let access_hash = voice_access_token_hash(&new_access);
+            (
+                encrypt_required(crypto.as_ref(), &new_access)
+                    .map_err(voice_encryption_required)?,
+                None,
+                Some(Utc::now() + Duration::hours(1)),
+                access_hash,
+            )
+        };
 
     // Update the device tokens under the device's own org/user RLS context.
     let mut guard = rls_pool
@@ -643,6 +662,7 @@ async fn oauth_token_refresh(
             &new_access_encrypted,
             new_refresh_encrypted.as_deref(),
             new_expires_at,
+            new_access_hash.as_deref(),
         )
         .await
         .map_err(|e| {
@@ -976,6 +996,23 @@ fn verify_hmac_signature(signature: &str, body: &str) -> Result<bool, String> {
     Ok(ct_eq_str(signature, &expected))
 }
 
+/// Keyed HMAC-SHA256 of a voice OAuth access token, used as a deterministic,
+/// indexed lookup key (`voice_assistant_devices.access_token_hash`) so
+/// `authenticate_voice_user` selects the candidate device in SQL instead of
+/// decrypt-and-scanning every active device for the platform (issue #2662).
+///
+/// Keyed with `INTEGRATION_ENCRYPTION_KEY` — the same secret that encrypts the
+/// token at rest — so the persisted value is a keyed MAC, not an offline-
+/// guessable plain digest. Returns `None` when the key is unavailable: write
+/// paths then persist a NULL hash and the read path falls back to the linear
+/// scan, so a device is never locked out.
+fn voice_access_token_hash(access_token: &str) -> Option<Vec<u8>> {
+    let key = std::env::var(integrations::ENCRYPTION_KEY_ENV).ok()?;
+    let mut mac = HmacSha256::new_from_slice(key.as_bytes()).ok()?;
+    mac.update(access_token.as_bytes());
+    Some(mac.finalize().into_bytes().to_vec())
+}
+
 /// Whether `presented` is the access token that owns `device`: it must match
 /// the device's decrypted stored token (constant-time) and not be expired.
 ///
@@ -1055,30 +1092,73 @@ async fn authenticate_voice_user(
         )
     })?;
 
-    // Fetch the active, token-bearing devices for this platform. We cannot match
-    // the token in SQL because the stored value is AES-GCM ciphertext (random
-    // nonce per encryption), so equality is checked after decryption below.
+    let now = Utc::now();
+    let db_error = || {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
+        )
+    };
+
+    // Fast path (issue #2662): select the single candidate device by a keyed
+    // HMAC-SHA256 of the presented token, resolved by the partial index on
+    // (platform, access_token_hash), instead of AES-GCM-decrypting every active
+    // device for the platform. The decrypt + constant-time verify below remains
+    // the authority (defence in depth) — the hash only narrows the search, so a
+    // hash collision or a stale/rotated row still cannot authenticate.
+    let token_hash = voice_access_token_hash(access_token);
+    if let Some(hash) = token_hash.as_deref() {
+        let candidate = sqlx::query_as::<_, db::models::VoiceAssistantDevice>(
+            r#"
+            SELECT * FROM voice_assistant_devices
+            WHERE platform = $1
+              AND is_active = TRUE
+              AND access_token_hash = $2
+            LIMIT 1
+            "#,
+        )
+        .bind(platform)
+        .bind(hash)
+        .fetch_optional(&mut *conn)
+        .await
+        .map_err(|e| {
+            tracing::error!("Database error: {}", e);
+            db_error()
+        })?;
+
+        if let Some(device) = candidate {
+            if voice_device_token_matches(&crypto, &device, access_token, now) {
+                return Ok(device);
+            }
+        }
+    }
+
+    // Fallback: linear decrypt-and-scan. When a hash was computed we only need
+    // the rows that predate the hash column (NULL hash) — the indexed path above
+    // already covered every backfilled row; when no key/hash is available we
+    // scan all active token-bearing devices (legacy behaviour). Either way the
+    // AES-GCM ciphertext (random nonce per encryption) cannot be matched in SQL,
+    // so equality is checked after decryption.
+    let scanned_hashed = token_hash.is_some();
     let devices = sqlx::query_as::<_, db::models::VoiceAssistantDevice>(
         r#"
         SELECT * FROM voice_assistant_devices
         WHERE platform = $1
           AND is_active = TRUE
           AND access_token_encrypted IS NOT NULL
+          AND (NOT $2 OR access_token_hash IS NULL)
         ORDER BY last_used_at DESC NULLS LAST
         "#,
     )
     .bind(platform)
+    .bind(scanned_hashed)
     .fetch_all(&mut *conn)
     .await
     .map_err(|e| {
         tracing::error!("Database error: {}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("DATABASE_ERROR", "Database error")),
-        )
+        db_error()
     })?;
 
-    let now = Utc::now();
     devices
         .into_iter()
         .find(|device| voice_device_token_matches(&crypto, device, access_token, now))
@@ -1541,6 +1621,10 @@ mod tests {
             token_expires_at: expires_at,
             is_active: true,
             capabilities: serde_json::json!([]),
+            // The pure predicate ignores the lookup hash (it re-derives trust
+            // from the decrypted ciphertext); the DB-backed selection is covered
+            // by `authenticate_voice_user_*` below.
+            access_token_hash: None,
             created_at: now,
             updated_at: now,
         }
@@ -1591,6 +1675,102 @@ mod tests {
         // A token encrypted under a different key can't be decrypted -> no match.
         let other = IntegrationCrypto::new(&"cd".repeat(32)).expect("crypto");
         assert!(!voice_device_token_matches(&other, &dev, "real-token", now));
+    }
+
+    // --- authenticate_voice_user (DB-backed selection path, issue #2662) ------
+    //
+    // Postgres-backed via `#[sqlx::test]` (runs under backend.yml CI; the cloud
+    // verify gate skips it — no DATABASE_URL). This drives the real fetch +
+    // selection loop the pure `voice_device_token_matches` predicate cannot
+    // reach: the #2660 regression lived exactly here (the old code returned
+    // *any* active device for the platform regardless of the presented token).
+
+    /// Seed one active voice device on `platform` whose stored token is `token`
+    /// (encrypted under `crypto`) and whose indexed lookup hash is the keyed
+    /// HMAC of `token`, expiring at `expires_at`. Returns the new device id.
+    async fn seed_voice_device(
+        pool: &sqlx::PgPool,
+        crypto: &IntegrationCrypto,
+        platform: &str,
+        token: &str,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Uuid {
+        let id = Uuid::new_v4();
+        sqlx::query(
+            r#"
+            INSERT INTO voice_assistant_devices (
+                id, organization_id, user_id, platform, device_id,
+                access_token_encrypted, access_token_hash, token_expires_at,
+                is_active, capabilities
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE, '[]'::jsonb)
+            "#,
+        )
+        .bind(id)
+        .bind(Uuid::new_v4())
+        .bind(Uuid::new_v4())
+        .bind(platform)
+        .bind(format!("dev-{id}"))
+        .bind(crypto.encrypt(token).expect("encrypt seed token"))
+        .bind(voice_access_token_hash(token))
+        .bind(expires_at)
+        .execute(pool)
+        .await
+        .expect("seed voice device");
+        id
+    }
+
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn authenticate_voice_user_selects_owner_and_rejects_others(pool: sqlx::PgPool) {
+        // `authenticate_voice_user` reads the encryption key from the process
+        // environment — both to decrypt stored tokens and to key the lookup
+        // hash — so pin a deterministic key. This is the only in-crate test that
+        // touches INTEGRATION_ENCRYPTION_KEY.
+        let key = "ab".repeat(32); // 64 hex chars = 32 bytes
+        std::env::set_var(integrations::ENCRYPTION_KEY_ENV, &key);
+        let crypto = IntegrationCrypto::new(&key).expect("crypto");
+
+        // Two devices on the same platform with distinct tokens (the priv-esc
+        // guard: presenting A's token must never authenticate as B).
+        let id_a = seed_voice_device(&pool, &crypto, voice_platform::ALEXA, "token-A", None).await;
+        let _id_b = seed_voice_device(&pool, &crypto, voice_platform::ALEXA, "token-B", None).await;
+
+        let mut conn = pool.acquire().await.expect("acquire connection");
+
+        // (a) Presenting A's token resolves to exactly device A, never B.
+        let dev = authenticate_voice_user(&mut conn, "token-A", voice_platform::ALEXA)
+            .await
+            .expect("token-A must authenticate as device A");
+        assert_eq!(
+            dev.id, id_a,
+            "presented token-A must resolve to device A only"
+        );
+
+        // (b) A token matching no device -> 401 INVALID_ACCESS_TOKEN.
+        let (status, body) =
+            authenticate_voice_user(&mut conn, "token-UNKNOWN", voice_platform::ALEXA)
+                .await
+                .expect_err("unknown token must be rejected");
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body.0.code, "INVALID_ACCESS_TOKEN");
+
+        // (c) An expired but otherwise-matching token is rejected.
+        let past = Utc::now() - Duration::hours(1);
+        seed_voice_device(
+            &pool,
+            &crypto,
+            voice_platform::ALEXA,
+            "token-EXP",
+            Some(past),
+        )
+        .await;
+        let (status, body) = authenticate_voice_user(&mut conn, "token-EXP", voice_platform::ALEXA)
+            .await
+            .expect_err("expired token must be rejected");
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body.0.code, "INVALID_ACCESS_TOKEN");
+
+        std::env::remove_var(integrations::ENCRYPTION_KEY_ENV);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Task

Follow-up to PR #2660 (#2662). `authenticate_voice_user` in
`backend/servers/api-server/src/routes/voice_webhooks.rs` did an unbounded
`fetch_all` of every active token-bearing device for the platform and
AES-GCM-decrypted + constant-time-compared each in a linear scan — O(N)
decryptions per webhook request (amplification/DoS vector). This adds a keyed
HMAC-SHA256 lookup column (`access_token_hash bytea`, indexed) populated wherever
the encrypted token is written, so the candidate device is selected in SQL
(`WHERE platform=$1 AND is_active AND access_token_hash=$2 LIMIT 1`) with the
existing constant-time verify of the single decrypted token retained as defence
in depth. Plus a Postgres-backed `#[sqlx::test]` for the multi-device selection
path (priv-escalation guard, 401 on no match, expired-token rejection).

## Owner

`pm-tech-lead` → specialist `rust-backend` (security lens: broken-auth / DoS).

## What changed

- **`voice_webhooks.rs`** — new `voice_access_token_hash()` (keyed HMAC-SHA256 of
  the token, keyed with `INTEGRATION_ENCRYPTION_KEY`); `authenticate_voice_user`
  now does the indexed lookup first, then the constant-time AEAD verify as the
  authority. Un-backfilled (NULL-hash) rows fall back to the linear scan over
  **only that remainder** (`NOT $2 OR access_token_hash IS NULL`), so no device
  is locked out. The two write paths (`oauth_token_exchange`,
  `oauth_token_refresh`) compute and persist the hash in lock-step with the
  ciphertext.
- **`db` model + repo** — `VoiceAssistantDevice.access_token_hash: Option<Vec<u8>>`;
  `create_voice_device` / `update_voice_device_tokens` thread the hash into the
  INSERT/UPDATE.
- **`ai/voice.rs`** — the other `create_voice_device` caller passes `None` (its
  plaintext lives inside `exchange_voice_oauth_tokens`); those rows use the scan
  fallback until their token is next refreshed.
- **Migration `00226`** — the `voice_assistant_devices` table had **no migration
  at all** (grep returned zero hits; the same missing-DDL class as
  `portal_webhook_events`/#2358, and documented in
  `tests/suites/voice_oauth_exchange_auth_tests.rs`). Without it the requested
  `#[sqlx::test]` could not run. 00226 creates the table (RLS-off, matching the
  unauthenticated match path) + the partial `(platform, access_token_hash)`
  index, and `ADD COLUMN IF NOT EXISTS` for any env that already had the table.
- **Test** — `authenticate_voice_user_selects_owner_and_rejects_others`
  (`#[sqlx::test]`): seeds devices A + B with distinct tokens, asserts A's token
  → A (never B), unknown token → 401 `INVALID_ACCESS_TOKEN`, expired-but-matching
  → 401.

## Verification

Ran locally (cloud runner):
- `cd backend && cargo fmt --all` — OK.
- `cd backend && cargo clippy -p db --all-targets -- -D warnings` — **OK (exit 0)**
  (covers the model + repository changes).

**Deferred to CI (`backend.yml`)** — could not run locally:
- `cargo clippy -p api-server` / full-workspace clippy: the `api-server` build
  transitively runs `utoipa-swagger-ui`'s build script, which downloads
  `swagger-ui` from `github.com` — **403-blocked by this session's egress
  policy** (verified: the download returns a 378-byte JSON error, not the zip).
  Per the proxy rules I did not route around it. This is an environment limit,
  not a code issue; `backend.yml` builds it normally.
- The `#[sqlx::test]` DB suite (no `DATABASE_URL` in the cloud gate) — runs under
  `backend.yml`.

The `api-server` handler/test changes were hand-reviewed for type/borrow
correctness (tuple extension, param threading, one new helper, one restructured
query). `just verify` will escalate to full-workspace on the migration touch in
CI.

## CI parity (Band C — hot-path)

This is an auth/security hot-path change. Local Band-C replication
(`act`/`gh workflow`) was blocked by the same `github.com` egress 403 that
blocks the `api-server` build. `backend.yml` is the authority and must be green
before this leaves draft.

## Scope drift

`scope-check.sh --owner pm-tech-lead` → exit 2 on all 5 changed paths. All are
intended and necessary for this task: the fix in `voice_webhooks.rs` requires
threading the new hash column through the `db` model + repo, and the requested
`#[sqlx::test]` requires the (previously missing) table migration. The other
`create_voice_device` caller (`ai/voice.rs`) had to be updated for the new
parameter.

- `backend/crates/db/migrations/00226_voice_assistant_devices_token_hash.sql`
- `backend/crates/db/src/models/llm_document.rs`
- `backend/crates/db/src/repositories/llm_document.rs`
- `backend/servers/api-server/src/routes/ai/voice.rs`
- `backend/servers/api-server/src/routes/voice_webhooks.rs`

## Code-reuse review

`reuse-grep.sh` — clean (no warnings). `voice_access_token_hash` returns raw
`Vec<u8>` (bytea) keyed by the encryption key, distinct in purpose/type from
`integrations::compute_hmac_sha256` (hex string, webhook-signature keyed).

## Notes

- **Backfill:** existing rows keep NULL `access_token_hash` — the HMAC needs the
  plaintext token and only the AES-GCM ciphertext is stored, so it cannot be
  recomputed in SQL. Such rows re-hash on the next token write and meanwhile use
  the bounded scan fallback. Documented in the migration.
- **RLS:** table intentionally not RLS-bound — the match path is unauthenticated
  (cross-org lookup; refresh uses a public connection), matching existing code
  expectations and the `portal_webhook_events` precedent.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeEBZQgYNaTrZJkZ6NM4Gk)_