### PR TITLE
code-review-api-handlers-missing-authz-article: enforce manager/author authz on news article lifecycle handlers

### DIFF
--- a/backend/servers/api-server/src/routes/news_articles.rs
+++ b/backend/servers/api-server/src/routes/news_articles.rs
@@ -607,11 +607,28 @@ async fn update_article(
 async fn publish_article(
     State(state): State<AppState>,
     TenantExtractor(tenant): TenantExtractor,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
     Json(req): Json<PublishArticleRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let repo = NewsArticleRepository::new(state.db.clone());
+
+    // Authorization check - only the author or managers can publish.
+    // The lookup is org-scoped, so a caller in another org gets 404 here
+    // rather than reaching the author/manager check.
+    let existing = repo
+        .find_by_id(id, tenant.tenant_id)
+        .await
+        .map_err(|e| internal_error(&format!("Failed to get article: {}", e)))?
+        .ok_or_else(|| not_found("Article not found"))?;
+
+    let is_manager = user.role.as_ref().map(|r| r.is_manager()).unwrap_or(false);
+    let is_author = existing.author_id == user.user_id;
+    if !is_manager && !is_author {
+        return Err(forbidden(
+            "Only the author or managers can publish this article",
+        ));
+    }
 
     let article = repo
         .publish(id, tenant.tenant_id, req.published_at)
@@ -642,10 +659,27 @@ async fn publish_article(
 async fn archive_article(
     State(state): State<AppState>,
     TenantExtractor(tenant): TenantExtractor,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse, ApiError> {
     let repo = NewsArticleRepository::new(state.db.clone());
+
+    // Authorization check - only the author or managers can archive.
+    // The lookup is org-scoped, so a caller in another org gets 404 here
+    // rather than reaching the author/manager check.
+    let existing = repo
+        .find_by_id(id, tenant.tenant_id)
+        .await
+        .map_err(|e| internal_error(&format!("Failed to get article: {}", e)))?
+        .ok_or_else(|| not_found("Article not found"))?;
+
+    let is_manager = user.role.as_ref().map(|r| r.is_manager()).unwrap_or(false);
+    let is_author = existing.author_id == user.user_id;
+    if !is_manager && !is_author {
+        return Err(forbidden(
+            "Only the author or managers can archive this article",
+        ));
+    }
 
     let article = repo
         .archive(id, tenant.tenant_id)
@@ -676,10 +710,27 @@ async fn archive_article(
 async fn restore_article(
     State(state): State<AppState>,
     TenantExtractor(tenant): TenantExtractor,
-    _user: AuthUser,
+    user: AuthUser,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse, ApiError> {
     let repo = NewsArticleRepository::new(state.db.clone());
+
+    // Authorization check - only the author or managers can restore.
+    // The lookup is org-scoped, so a caller in another org gets 404 here
+    // rather than reaching the author/manager check.
+    let existing = repo
+        .find_by_id(id, tenant.tenant_id)
+        .await
+        .map_err(|e| internal_error(&format!("Failed to get article: {}", e)))?
+        .ok_or_else(|| not_found("Article not found"))?;
+
+    let is_manager = user.role.as_ref().map(|r| r.is_manager()).unwrap_or(false);
+    let is_author = existing.author_id == user.user_id;
+    if !is_manager && !is_author {
+        return Err(forbidden(
+            "Only the author or managers can restore this article",
+        ));
+    }
 
     let article = repo
         .restore(id, tenant.tenant_id)
@@ -750,6 +801,23 @@ async fn pin_article(
     Json(req): Json<PinArticleRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let repo = NewsArticleRepository::new(state.db.clone());
+
+    // Authorization check - only the author or managers can pin/unpin.
+    // The lookup is org-scoped, so a caller in another org gets 404 here
+    // rather than reaching the author/manager check.
+    let existing = repo
+        .find_by_id(id, tenant.tenant_id)
+        .await
+        .map_err(|e| internal_error(&format!("Failed to get article: {}", e)))?
+        .ok_or_else(|| not_found("Article not found"))?;
+
+    let is_manager = user.role.as_ref().map(|r| r.is_manager()).unwrap_or(false);
+    let is_author = existing.author_id == user.user_id;
+    if !is_manager && !is_author {
+        return Err(forbidden(
+            "Only the author or managers can pin this article",
+        ));
+    }
 
     let article = repo
         .set_pinned(id, tenant.tenant_id, req.pinned, Some(user.user_id))

--- a/backend/servers/api-server/tests/suites/news_articles_tests.rs
+++ b/backend/servers/api-server/tests/suites/news_articles_tests.rs
@@ -28,7 +28,9 @@
 
 #![allow(dead_code)]
 
-use crate::common::{create_manager_with_org, TestApp, TestUser};
+use crate::common::{
+    create_authenticated_user, create_manager_with_org, mint_tenant_token, TestApp, TestUser,
+};
 use axum::http::StatusCode;
 use serde_json::{json, Value};
 use sqlx::PgPool;
@@ -103,6 +105,21 @@ async fn seed_comment(pool: &PgPool, article_id: Uuid, user_id: Uuid, content: &
     .fetch_one(pool)
     .await
     .expect("seed comment")
+}
+
+/// Register a second user who is neither a manager nor the article author,
+/// and return a Resident-role tenant token scoped to `org`. Used by the
+/// authorization regression tests for the mutating lifecycle endpoints.
+async fn non_manager_non_author_token(app: &TestApp, org: Uuid) -> String {
+    let intruder = TestUser::new();
+    let _ = create_authenticated_user(app, &intruder).await;
+    let intruder_id = user_id_for(&app.pool, &intruder.email).await;
+    mint_tenant_token(
+        intruder_id,
+        &intruder.email,
+        org,
+        common::tenant::TenantRole::Resident,
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -378,6 +395,116 @@ async fn pin_article_succeeds(pool: PgPool) {
     resp.assert_status(StatusCode::OK);
     let body: Value = resp.json_value();
     assert_eq!(body["article"]["pinned"].as_bool(), Some(true));
+}
+
+// ---------------------------------------------------------------------------
+// Authorization regression tests: a non-manager, non-author caller must NOT
+// be able to publish / archive / restore / pin another user's article.
+// (Previously these handlers extracted `_user: AuthUser` but never checked
+// is_manager()/authorship, so any authenticated user could mutate lifecycle.)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn publish_article_non_manager_non_author_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let manager = TestUser::new();
+    let (_mgr_token, org) = create_manager_with_org(&app, &manager, "news-publish-403").await;
+    let author_id = user_id_for(&app.pool, &manager.email).await;
+    let article_id = seed_article(&app.pool, org, author_id, "Not yours to publish").await;
+
+    let token = non_manager_non_author_token(&app, org).await;
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/news/{article_id}/publish"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &org.to_string())
+                .json(json!({}))
+                .build(),
+        )
+        .await;
+
+    resp.assert_status(StatusCode::FORBIDDEN);
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn archive_article_non_manager_non_author_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let manager = TestUser::new();
+    let (_mgr_token, org) = create_manager_with_org(&app, &manager, "news-archive-403").await;
+    let author_id = user_id_for(&app.pool, &manager.email).await;
+    let article_id = seed_published_article(&app.pool, org, author_id).await;
+
+    let token = non_manager_non_author_token(&app, org).await;
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/news/{article_id}/archive"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &org.to_string())
+                .json(json!({}))
+                .build(),
+        )
+        .await;
+
+    resp.assert_status(StatusCode::FORBIDDEN);
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn restore_article_non_manager_non_author_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let manager = TestUser::new();
+    let (_mgr_token, org) = create_manager_with_org(&app, &manager, "news-restore-403").await;
+    let author_id = user_id_for(&app.pool, &manager.email).await;
+
+    let article_id: Uuid = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO news_articles \
+         (organization_id, author_id, title, content, status, archived_at) \
+         VALUES ($1, $2, 'Archived article', 'Content.', 'archived', NOW()) \
+         RETURNING id",
+    )
+    .bind(org)
+    .bind(author_id)
+    .fetch_one(&app.pool)
+    .await
+    .expect("seed archived article");
+
+    let token = non_manager_non_author_token(&app, org).await;
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/news/{article_id}/restore"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &org.to_string())
+                .json(json!({}))
+                .build(),
+        )
+        .await;
+
+    resp.assert_status(StatusCode::FORBIDDEN);
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn pin_article_non_manager_non_author_is_forbidden(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let manager = TestUser::new();
+    let (_mgr_token, org) = create_manager_with_org(&app, &manager, "news-pin-403").await;
+    let author_id = user_id_for(&app.pool, &manager.email).await;
+    let article_id = seed_article(&app.pool, org, author_id, "Not yours to pin").await;
+
+    let token = non_manager_non_author_token(&app, org).await;
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/news/{article_id}/pin"))
+                .bearer(&token)
+                .header("X-Tenant-ID", &org.to_string())
+                .json(json!({"pinned": true}))
+                .build(),
+        )
+        .await;
+
+    resp.assert_status(StatusCode::FORBIDDEN);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Auto (dispatcher-opened; implementer pushed the branch but `gh` is unavailable in the runner).

**Security fix.** `publish_article`, `archive_article`, `restore_article`, `pin_article` in `backend/servers/api-server/src/routes/news_articles.rs` extracted `AuthUser` but never checked authorization — any authenticated user could publish/archive/restore/pin any article in their org. This adds the same gate `update_article` already uses to all four handlers: org-scoped `find_by_id` (404 on cross-org), then `is_manager || is_author`, else 403.

**Tests:** 4 new regression tests in `tests/suites/news_articles_tests.rs` (non-manager, non-author → 403 on each endpoint). All fail on `main`/pre-fix (returned 200), pass with the fix. `cargo fmt`/`clippy -D warnings` clean; `suite_6` news 28/28 green.

Owner role: pm-backend. Priority: high. Reclaimed after a prior sandbox timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMiwcGo1YFBvmUnEjPN28h)_