### PR TITLE
code-review-api-handlers-voice-webhook-token-authbypass: regression test for absent voice access token

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -1770,6 +1770,17 @@ mod tests {
         assert_eq!(status, StatusCode::UNAUTHORIZED);
         assert_eq!(body.0.code, "INVALID_ACCESS_TOKEN");
 
+        // (d) An absent (empty or whitespace-only) access token is rejected
+        // outright — the fail-closed early return, before any device lookup, so
+        // a caller presenting no token can never be authenticated as a device.
+        for absent in ["", "   "] {
+            let (status, body) = authenticate_voice_user(&mut conn, absent, voice_platform::ALEXA)
+                .await
+                .expect_err("absent token must be rejected");
+            assert_eq!(status, StatusCode::UNAUTHORIZED);
+            assert_eq!(body.0.code, "INVALID_ACCESS_TOKEN");
+        }
+
         std::env::remove_var(integrations::ENCRYPTION_KEY_ENV);
     }
 


### PR DESCRIPTION
## Task
`voice_webhooks.rs` — `authenticate_voice_user()` performs NO token validation: the `_access_token` parameter is unused (underscore-prefixed) and the function returns whatever device the query `SELECT ... FROM voice_devices ...` yields, so any caller is authenticated as that device (auth bypass). Fix: actually validate the presented access token against the stored token for the device (constant-time compare / hashed lookup), reject on mismatch/expiry. Add a regression test proving an invalid/absent token is rejected. Keep scope to this file/handler.

## Owner
pm-security

## Finding: the auth bypass is already remediated on `dev`
The described bypass (unused `_access_token`, "return any device") no longer exists on `dev` — the line numbers in the task (963-999) refer to a pre-fix revision. `authenticate_voice_user` (currently `voice_webhooks.rs:1059`) was hardened by the issue **#2658 #1** / **#2662** work and already:

- rejects an absent/blank token outright (`if access_token.trim().is_empty()`);
- fails **closed** when the integration encryption key is unavailable (stored tokens are ciphertext — can't validate → refuse, never authenticate);
- selects the candidate device by a keyed HMAC lookup (`access_token_hash`) and then **decrypts + constant-time-compares** the stored token via `voice_device_token_matches` (defence in depth — the hash only narrows the search);
- rejects an expired `token_expires_at`.

Existing regression tests already cover: wrong token, missing stored token, expired token, cross-key decrypt failure (`voice_token_match_is_exact_and_rejects_mismatch_missing_and_expired`), plus the DB-backed owner-selection / unknown-token-401 / expired-401 path (`authenticate_voice_user_selects_owner_and_rejects_others`).

## Change in this PR (minimal, test-only)
The one part of the task's explicit "invalid/**absent** token is rejected" requirement not yet asserted was the `authenticate_voice_user` empty/whitespace-token early-return. This PR adds case **(d)** to the DB-backed auth test: an empty and a whitespace-only token each yield `401 INVALID_ACCESS_TOKEN` before any device lookup. +11 lines, confined to the `authenticate_voice_user` test path.

## Verification
```
VERIFY-PLAN base=1236553 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```
- `cargo fmt --all -- --check` — **exit 0** (green).
- `cargo clippy -p api-server --all-targets -- -D warnings` — **exit 0** (green). This compiles the new test code. NB: the api-server build pulls `utoipa-swagger-ui`, whose build script downloads Swagger UI from GitHub; GitHub asset downloads are disabled in this sandbox, so the dist was sourced from the allow-listed npm registry (`swagger-ui-dist@5.17.14`) via `SWAGGER_UI_DOWNLOAD_URL=file://…` — a local build-env override only, no repo files changed.
- `cargo test -p api-server` — the new assertions live inside a `#[sqlx::test]`, which needs a live Postgres. This sandbox has no `DATABASE_URL`, so the DB-backed step is deferred to CI (`backend.yml` provisions Postgres and is the authority). Non-DB unit tests + clippy pass locally.

## Scope drift
`scope_drift=true` (advisory). `pm-security`'s mapped areas (`scripts/owner-areas.json`) cover auth/mfa handlers + extractors, not `routes/voice_webhooks.rs`; but this file is exactly the target the task names, so the drift is expected/justified. Only path touched:
- `backend/servers/api-server/src/routes/voice_webhooks.rs`

## Code-reuse review
None — the change adds only test assertions (no new auth/crypto/http helpers). `code_reuse_warn=none`.

## CI parity (Band C — hot-path)
This is a security/auth-path change but the diff is test-only; the authoritative security assertions run in `backend.yml`'s Postgres-backed test job (the local sandbox cannot replicate it — no DB). No divergence expected.

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- A sibling task (`code-review-api-handlers-voice-webhook-timing-cmp`) also touches this file; this diff is deliberately confined to the `authenticate_voice_user` test path to minimise conflict. That sibling's `ct_eq_str` constant-time work is already merged on `dev`.
- If the reviewer considers the pre-existing coverage sufficient, this PR can simply be closed without merge — no code behaviour changes either way.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu8dzoc96VAqGcJuwRAKJi)_