### PR TITLE
code-review-reality-server-ssrf-ipv4-mapped-ipv6: reject IPv4-mapped IPv6 in SSRF URL guard

### DIFF
--- a/backend/servers/reality-server/src/util/url_validator.rs
+++ b/backend/servers/reality-server/src/util/url_validator.rs
@@ -61,6 +61,49 @@ fn is_development() -> bool {
     std::env::var("RUST_ENV").unwrap_or_default() == "development"
 }
 
+/// Returns `Some(reason)` when an IPv4 address falls in a private, loopback,
+/// link-local, reserved, broadcast, or multicast range that must not be
+/// fetched server-side; `None` when the address is publicly routable.
+///
+/// Shared by the [`Host::Ipv4`] arm and the [`Host::Ipv6`] arm (after
+/// unmapping IPv4-mapped / IPv4-compatible addresses) so the same policy
+/// can't be bypassed by re-encoding a forbidden IPv4 address into IPv6.
+fn ipv4_forbidden_reason(octets: [u8; 4]) -> Option<&'static str> {
+    // 10.0.0.0/8 — private
+    if octets[0] == 10 {
+        return Some("10.0.0.0/8 (private)");
+    }
+    // 172.16.0.0/12 — private
+    if octets[0] == 172 && (16..=31).contains(&octets[1]) {
+        return Some("172.16.0.0/12 (private)");
+    }
+    // 192.168.0.0/16 — private
+    if octets[0] == 192 && octets[1] == 168 {
+        return Some("192.168.0.0/16 (private)");
+    }
+    // 127.0.0.0/8 — loopback
+    if octets[0] == 127 {
+        return Some("127.0.0.0/8 (loopback)");
+    }
+    // 169.254.0.0/16 — link-local (covers AWS/GCP metadata 169.254.169.254)
+    if octets[0] == 169 && octets[1] == 254 {
+        return Some("169.254.0.0/16 (link-local / cloud metadata)");
+    }
+    // 0.0.0.0/8 — reserved
+    if octets[0] == 0 {
+        return Some("0.0.0.0/8 (reserved)");
+    }
+    // 255.255.255.255 — broadcast
+    if octets == [255, 255, 255, 255] {
+        return Some("255.255.255.255 (broadcast)");
+    }
+    // 224.0.0.0/4 — multicast
+    if octets[0] >= 224 && octets[0] <= 239 {
+        return Some("224.0.0.0/4 (multicast)");
+    }
+    None
+}
+
 /// Validate that `raw` is a safe URL to fetch server-side.
 ///
 /// On success returns the parsed [`Url`]. On failure returns a structured
@@ -91,55 +134,8 @@ pub fn validate_fetch_url(raw: &str) -> Result<Url, UrlValidationError> {
 
     match host {
         Host::Ipv4(ip) => {
-            let octets = ip.octets();
-
-            // 10.0.0.0/8 — private
-            if octets[0] == 10 {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "10.0.0.0/8 (private)".into(),
-                ));
-            }
-            // 172.16.0.0/12 — private
-            if octets[0] == 172 && (16..=31).contains(&octets[1]) {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "172.16.0.0/12 (private)".into(),
-                ));
-            }
-            // 192.168.0.0/16 — private
-            if octets[0] == 192 && octets[1] == 168 {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "192.168.0.0/16 (private)".into(),
-                ));
-            }
-            // 127.0.0.0/8 — loopback
-            if octets[0] == 127 {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "127.0.0.0/8 (loopback)".into(),
-                ));
-            }
-            // 169.254.0.0/16 — link-local (covers AWS/GCP metadata 169.254.169.254)
-            if octets[0] == 169 && octets[1] == 254 {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "169.254.0.0/16 (link-local / cloud metadata)".into(),
-                ));
-            }
-            // 0.0.0.0/8 — reserved
-            if octets[0] == 0 {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "0.0.0.0/8 (reserved)".into(),
-                ));
-            }
-            // 255.255.255.255 — broadcast
-            if octets == [255, 255, 255, 255] {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "255.255.255.255 (broadcast)".into(),
-                ));
-            }
-            // 224.0.0.0/4 — multicast
-            if octets[0] >= 224 && octets[0] <= 239 {
-                return Err(UrlValidationError::PrivateOrReservedIp(
-                    "224.0.0.0/4 (multicast)".into(),
-                ));
+            if let Some(reason) = ipv4_forbidden_reason(ip.octets()) {
+                return Err(UrlValidationError::PrivateOrReservedIp(reason.into()));
             }
         }
         Host::Ipv6(ip) => {
@@ -147,6 +143,19 @@ pub fn validate_fetch_url(raw: &str) -> Result<Url, UrlValidationError> {
                 return Err(UrlValidationError::PrivateOrReservedIp(
                     "::1 (IPv6 loopback)".into(),
                 ));
+            }
+            // IPv4-mapped (`::ffff:a.b.c.d`) and IPv4-compatible (`::a.b.c.d`)
+            // addresses embed a real IPv4 destination. Unmap and run the IPv4
+            // policy, otherwise the guard can be bypassed by re-encoding a
+            // forbidden IPv4 address (e.g. `::ffff:169.254.169.254`,
+            // `::ffff:127.0.0.1`) into IPv6.
+            if let Some(v4) = ip.to_ipv4() {
+                if let Some(reason) = ipv4_forbidden_reason(v4.octets()) {
+                    return Err(UrlValidationError::PrivateOrReservedIp(format!(
+                        "IPv4-mapped IPv6 -> {}",
+                        reason
+                    )));
+                }
             }
             let segments = ip.segments();
             // fc00::/7 — IPv6 unique local
@@ -298,5 +307,44 @@ mod tests {
             validate_fetch_url("https://[::1]/"),
             Err(UrlValidationError::PrivateOrReservedIp(_))
         ));
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_metadata_ip() {
+        // `::ffff:169.254.169.254` must be unmapped and rejected as cloud
+        // metadata link-local, not slipped through the IPv6 branch.
+        let _g = EnvGuard::set("production");
+        assert!(matches!(
+            validate_fetch_url("https://[::ffff:169.254.169.254]/latest/meta-data/"),
+            Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_loopback() {
+        // `::ffff:127.0.0.1` must be unmapped and rejected as IPv4 loopback.
+        let _g = EnvGuard::set("production");
+        assert!(matches!(
+            validate_fetch_url("https://[::ffff:127.0.0.1]/"),
+            Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_ipv4_mapped_private() {
+        // `::ffff:10.0.0.5` must be unmapped and rejected as RFC1918 private.
+        let _g = EnvGuard::set("production");
+        assert!(matches!(
+            validate_fetch_url("https://[::ffff:10.0.0.5]/feed.xml"),
+            Err(UrlValidationError::PrivateOrReservedIp(_))
+        ));
+    }
+
+    #[test]
+    fn accepts_ipv4_mapped_public() {
+        // A publicly-routable IPv4-mapped address must still pass so the
+        // unmapping doesn't over-block legitimate destinations.
+        let _g = EnvGuard::set("production");
+        assert!(validate_fetch_url("https://[::ffff:93.184.216.34]/").is_ok());
     }
 }


### PR DESCRIPTION
## Task

backend/servers/reality-server/src/util/url_validator.rs:145-164 — `validate_fetch_url()`'s `Host::Ipv6` branch does not reject IPv4-mapped IPv6 addresses (e.g. `::ffff:169.254.169.254` / `::ffff:127.0.0.1`), so the SSRF guard that blocks link-local/loopback/private IPv4 can be bypassed by mapping the same address into IPv6. Fix: when the host is an IPv6 address, detect IPv4-mapped/compat forms, unmap to the embedded IPv4, and run the existing IPv4 private/loopback/link-local checks (also reject IPv6 loopback `::1`, ULA `fc00::/7`, link-local `fe80::/10`). Add regression tests for `::ffff:169.254.169.254`, `::ffff:127.0.0.1`, and `::1`. Keep scope to this file.

## Owner

pm-backend

## Fix summary

- Extracted the IPv4 private/loopback/link-local/reserved/broadcast/multicast policy from the `Host::Ipv4` arm into a shared `ipv4_forbidden_reason([u8; 4]) -> Option<&'static str>` helper (no behaviour change for the IPv4 path).
- In the `Host::Ipv6` arm, after the existing `::1` loopback check, unmap IPv4-mapped (`::ffff:a.b.c.d`) and IPv4-compatible (`::a.b.c.d`) addresses via `Ipv6Addr::to_ipv4()` and run the same IPv4 policy — closing the `::ffff:169.254.169.254` / `::ffff:127.0.0.1` bypass. The existing `fc00::/7` (ULA) and `fe80::/10` (link-local) IPv6 checks are retained.
- Added regression tests: `rejects_ipv4_mapped_metadata_ip`, `rejects_ipv4_mapped_loopback`, `rejects_ipv4_mapped_private`, and `accepts_ipv4_mapped_public` (guards against over-blocking a publicly-routable mapped address). The pre-existing `rejects_ipv6_loopback` (`::1`) test covers the third requested vector.

Scope kept to the single file.

## Verification

```
VERIFY-PLAN base=2ab5a3e0a90ceedac12dd5a44efeffc5558ddfed files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo test -p reality-server
VERIFY OK fee80b0db563288bfc0777967466dbe9c81838ba
```

`cargo test -p reality-server` results: lib 66 passed, main 66 passed, `layout_namespace_tests` 3 passed, `suite_1` 55 passed (47 ignored), `suite_2` 63 passed (47 ignored); 0 failed. The 14 `url_validator` unit tests (incl. the 4 new IPv4-mapped cases) pass.

Note for reviewer: the verify run required two out-of-band env accommodations for this sandbox only (not code changes): `SWAGGER_UI_DOWNLOAD_URL` pointed at a locally-staged `v5.17.14.zip` (the `utoipa-swagger-ui` build script's GitHub download host is denied by egress policy here), and `DATABASE_URL=postgres://postgres:postgres@localhost:5433/postgres` for the `#[sqlx::test]` integration tests. CI provides both normally.

## CI parity (Band C — hot-path / security)

This is a security (SSRF) fix. `just verify` is green as above. The backend workflow job (`backend.yml`: `cargo fmt`, `clippy`, `cargo test`) mirrors the exact commands in the verify plan; not separately re-run via `act` in this sandbox (no Docker; `gh` unavailable). CI `backend.yml` will run on this PR.

## Remote-tested

skipped (ppt-bridge MCP not connected)

## Notes

- No new helper duplicates an existing one — `ipv4_forbidden_reason` is a local refactor of code that already lived inline in this file; `Ipv6Addr::to_ipv4()` is std.
- Error reason strings for the unmapped case are prefixed `IPv4-mapped IPv6 -> …` for operator clarity.
- Out of scope but worth a follow-up: `validate_fetch_url` is a static string check; the module doc already notes the worker must re-validate the resolved IP post-DNS.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu8dzoc96VAqGcJuwRAKJi)_