### PR TITLE
code-review-reality-server-invite-authz: gate agency invitation creation on membership

### DIFF
--- a/backend/servers/reality-server/src/routes/agencies.rs
+++ b/backend/servers/reality-server/src/routes/agencies.rs
@@ -358,6 +358,16 @@ pub async fn list_members(
 }
 
 /// Create agency invitation.
+///
+/// SECURITY (invite-authz audit): requires an authenticated principal who is
+/// an active member of the target agency. Previously this handler called the
+/// repo directly with no membership gate, so ANY authenticated user could
+/// invite themselves (or anyone) into ANY agency via
+/// `POST /api/v1/agencies/{id}/invitations` — a self-service privilege
+/// escalation. We now apply the same `check_agency_membership` gate the
+/// sibling mutators (`update_agency`, `update_branding`) use: `404` when the
+/// agency doesn't exist and `403` for a non-member (never leaks cross-agency
+/// membership).
 #[utoipa::path(
     post,
     path = "/api/v1/agencies/{id}/invitations",
@@ -367,8 +377,10 @@ pub async fn list_members(
     responses(
         (status = 201, description = "Invitation created", body = RealityAgencyInvitation),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a member of this agency"),
         (status = 404, description = "Agency not found")
-    )
+    ),
+    security(("session_token" = []))
 )]
 pub async fn create_invitation(
     State(state): State<AppState>,
@@ -376,6 +388,19 @@ pub async fn create_invitation(
     Path(agency_id): Path<Uuid>,
     Json(data): Json<CreateAgencyInvitation>,
 ) -> Result<Json<RealityAgencyInvitation>, (axum::http::StatusCode, String)> {
+    // SECURITY (invite-authz): gate on active membership of the target agency
+    // via the shared helper — single source of truth for "is this user allowed
+    // to mutate this agency's data?". Returns 404 (unknown agency) / 403
+    // (non-member) before any invitation is created.
+    let mut conn = state.acquire_public_conn().await.map_err(|e| {
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Database error: {}", e),
+        )
+    })?;
+    super::agency_imports::check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
+    drop(conn);
+
     let invitation = state
         .reality_portal_repo
         .create_invitation(agency_id, principal.user_id, data)

--- a/backend/servers/reality-server/tests/suites/agencies_authz_tests.rs
+++ b/backend/servers/reality-server/tests/suites/agencies_authz_tests.rs
@@ -38,6 +38,51 @@ async fn seed_user(pool: &PgPool, tag: &str) -> Uuid {
     .unwrap_or_else(|e| panic!("seed_user({tag}): {e}"))
 }
 
+/// Seed a `platform`-kind user so the `RequestPrincipal` extractor clears the
+/// tenant gate on the host-less test router and the request reaches the
+/// handler's own membership check (mirrors the happy-path suite).
+async fn seed_platform_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'hash', $2, 'active', NOW(), 'platform')
+        RETURNING id
+        "#,
+    )
+    .bind(format!("{tag}@agencies-authz.test"))
+    .bind(format!("AgenciesAuthz {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_platform_user({tag}): {e}"))
+}
+
+async fn seed_agency(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO reality_agencies (name, slug, email)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(format!("Agency {slug}"))
+    .bind(format!("agency-{slug}"))
+    .bind(format!("{slug}@agencies-authz.test"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_agency({slug}): {e}"))
+}
+
+async fn seed_membership(pool: &PgPool, agency_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO reality_agency_members (agency_id, user_id, role) VALUES ($1, $2, 'owner')",
+    )
+    .bind(agency_id)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("seed_membership failed");
+}
+
 // ── list_agencies (public) ────────────────────────────────────────────────────
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
@@ -209,6 +254,56 @@ async fn create_invitation_authenticated_unknown_agency_returns_non_401(pool: Pg
     assert_ne!(
         status, 401,
         "authenticated create_invitation must not return 401"
+    );
+}
+
+// REGRESSION (invite-authz audit): `create_invitation` had NO membership
+// gate, so any authenticated user could invite themselves/others into ANY
+// agency. A non-member acting on an *existing* agency must be rejected with
+// 403 — not allowed to create the invitation. Uses a `platform` caller so the
+// request clears the `RequestPrincipal` extractor and the 403 can only come
+// from the handler's own `check_agency_membership` gate.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invitation_non_member_returns_403(pool: PgPool) {
+    let outsider = seed_platform_user(&pool, "inv-outsider").await;
+    let agency_id = seed_agency(&pool, "inv-403").await;
+    // NB: no membership seeded for `outsider` in this agency.
+    let token = mint_token(outsider);
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        &format!("/api/v1/agencies/{agency_id}/invitations"),
+        Some(&token),
+        json!({"email": "invite@example.com", "role": "agent"}),
+    )
+    .await;
+    assert_eq!(
+        status, 403,
+        "a non-member must NOT be able to create invitations for an agency, got {status}"
+    );
+}
+
+// Companion: the gate must not over-reject — an active member of the agency
+// is allowed past the membership check (i.e. does NOT get 403).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn create_invitation_member_not_forbidden(pool: PgPool) {
+    let member = seed_platform_user(&pool, "inv-member").await;
+    let agency_id = seed_agency(&pool, "inv-member").await;
+    seed_membership(&pool, agency_id, member).await;
+    let token = mint_token(member);
+    let app = agencies_router(pool);
+    let status = send_json(
+        &app,
+        Method::POST,
+        &format!("/api/v1/agencies/{agency_id}/invitations"),
+        Some(&token),
+        json!({"email": "invite@example.com", "role": "agent"}),
+    )
+    .await;
+    assert_ne!(
+        status, 403,
+        "an active member must pass the membership gate, got {status}"
     );
 }
 


### PR DESCRIPTION
## Task
`backend/servers/reality-server/src/routes/agencies.rs:373-401` — `create_invitation` (wired at line 38: `POST /api/v1/agencies/{id}/invitations`) performed NO membership/role check before calling the repo, unlike its siblings `update_agency` etc. Any authenticated user could invite themselves/others into any agency. Fix: add the same org/agency membership+role gate the sibling handlers use (404 on cross-agency, 403 on insufficient role) before creating the invitation. Add a regression test proving a non-member is rejected. Keep scope to this file/handler.

## Owner
pm-security

## Fix
`create_invitation` now acquires a public connection and calls the shared
`super::agency_imports::check_agency_membership(&mut conn, agency_id, principal.user_id)`
gate — the exact same helper used by the sibling mutators `update_agency` and
`update_branding` — before delegating to the repo. The helper returns:
- **404** `Agency not found` when the agency doesn't exist (no cross-agency existence leak), and
- **403** `Not a member of this agency` for an authenticated non-member (never leaks cross-agency membership).

The `#[utoipa::path]` responses were updated to document the new `403` and to
declare `security(("session_token" = []))`, matching the siblings. Scope kept
to this one handler + its test suite.

## Regression tests
Added to `tests/suites/agencies_authz_tests.rs` (runs via `suite_1`):
- `create_invitation_non_member_returns_403` — a `platform`-kind caller (clears the `RequestPrincipal` extractor on the host-less test router, so the 403 can only originate from the handler's own membership gate) acting on an **existing** agency they are not a member of gets **403**. This test fails on `dev` (pre-fix the request reached the repo and did not 403).
- `create_invitation_member_not_forbidden` — an active member passes the gate (asserts non-403), proving the gate does not over-reject.

## Verification
```
VERIFY-PLAN base=2ab5a3e0a90ceedac12dd5a44efeffc5558ddfed files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo test -p reality-server
```
All three ran green in an isolated worktree:
- `cargo fmt --all -- --check` → clean
- `cargo clippy -p reality-server --all-targets -- -D warnings` → exit 0
- `cargo test -p reality-server` → exit 0, 0 failures (targeted run: `create_invitation_non_member_returns_403 ... ok`, `create_invitation_member_not_forbidden ... ok`)

Environment notes (sandbox): a local PostgreSQL 16 cluster was stood up for the `#[sqlx::test]` suite; `utoipa-swagger-ui`'s build-time GitHub download is blocked by egress policy (HTTP 403), so the build was pointed at a cached zip via `SWAGGER_UI_DOWNLOAD_URL=file:…/v5.17.14.zip`. Neither affects the shipped code.

VERIFY OK — fmt+clippy+test green for `reality-server`.

## CI parity (Band C — hot-path)
This is an authz/security change. `backend.yml` runs `cargo fmt` + `clippy` + `cargo test` on backend changes; the same three commands were replicated locally above and are green. `act`/`gh workflow` not available in-sandbox to replay the job container.

## Remote-tested
skipped (no ppt-bridge MCP in this session)

## Scope drift
None — diff is exactly the two intended files (`routes/agencies.rs`, `tests/suites/agencies_authz_tests.rs`). `scope-check.sh --owner pm-security` exited 0.

## Code-reuse review
None — reuse-grep clean; the fix reuses the existing `check_agency_membership` helper rather than adding a new one.

## Notes
- IG goal-check flags are flow-mismatch artifacts, not defects: this is a dispatcher code-review task (no `.research/plans/<slug>.md`, pre-assigned `auto-impl/…` branch), and IG7 "just verify failed" is because `just` is not installed in-sandbox (the equivalent fmt/clippy/test gate was run manually and is green). Test + fix are in a single `fix:` commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xu8dzoc96VAqGcJuwRAKJi)_