### PR TITLE
code-review-api-core-api-call-ssrf-hostname: close DNS-hostname SSRF bypass in api_call action

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1615,6 +1615,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.19",
+ "tokio",
  "unic-langid",
  "url",
  "utoipa",

--- a/backend/crates/common/Cargo.toml
+++ b/backend/crates/common/Cargo.toml
@@ -20,3 +20,7 @@ intl-memoizer = { workspace = true }
 sha2 = { workspace = true }
 url = { workspace = true }
 async-trait = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/backend/crates/common/src/url_validation.rs
+++ b/backend/crates/common/src/url_validation.rs
@@ -12,10 +12,26 @@
 //!   (`metadata.google.internal`, `169.254.169.254`, ...),
 //! * `.local` / `.internal` TLD suffixes.
 //!
-//! **Important -- DNS rebinding**: this is a *static* check on the string.
-//! Callers that resolve the hostname themselves (e.g. import workers) MUST
-//! re-validate the resolved IP at fetch time.
+//! **DNS-hostname SSRF**: [`validate_external_url`] is a *static* check on
+//! the string — a hostname that has no literal-IP form (e.g.
+//! `attacker.example.com`) but resolves to a private/internal address at
+//! request time sails through it untouched. Any caller that is about to
+//! issue the actual outbound request (i.e. every caller in this codebase)
+//! **MUST** additionally call [`validate_resolved_host`] with the validated
+//! URL's host/port immediately before sending the request, and reject on
+//! error. `validate_resolved_host` resolves the hostname and checks *every*
+//! returned address against the same forbidden ranges, failing closed
+//! (resolution error, empty result, or any forbidden address => reject).
+//!
+//! Note this still leaves a narrow DNS-rebinding window between the
+//! `validate_resolved_host` lookup and the HTTP client's own connect-time
+//! lookup (TOCTOU) since the underlying HTTP client, not this module, owns
+//! the socket connect. Closing that fully would require pinning the
+//! validated IP for the connection (a custom resolver/connector), which is
+//! out of scope here; re-resolving immediately before the request narrows
+//! the window to the two lookups happening back-to-back.
 
+use std::net::IpAddr;
 use url::{Host, Url};
 
 /// Structured error returned when a URL fails SSRF validation.
@@ -35,6 +51,11 @@ pub enum UrlValidationError {
     PrivateOrReservedIp(String),
     /// Host ends with a blocked TLD (`.local`, `.internal`).
     BlockedTld(String),
+    /// DNS resolution failed, or resolved to zero addresses. Fail closed:
+    /// we can't prove the destination is safe, so we reject it.
+    ResolutionFailed(String),
+    /// The hostname resolved to (at least one) IP in a forbidden range.
+    ResolvedToPrivateIp(String),
 }
 
 impl std::fmt::Display for UrlValidationError {
@@ -56,6 +77,10 @@ impl std::fmt::Display for UrlValidationError {
                 write!(f, "URL points to a forbidden network range: {}", reason)
             }
             Self::BlockedTld(h) => write!(f, "Internal domain not allowed: {}", h),
+            Self::ResolutionFailed(e) => write!(f, "Could not resolve host: {}", e),
+            Self::ResolvedToPrivateIp(reason) => {
+                write!(f, "Host resolves to a forbidden network range: {}", reason)
+            }
         }
     }
 }
@@ -118,51 +143,118 @@ pub fn validate_external_url(raw: &str) -> Result<Url, UrlValidationError> {
         return Err(UrlValidationError::BlockedTld(host_str.to_string()));
     }
 
-    // IP range checks.
+    // IP range checks (literal IPs only — see `validate_resolved_host` for
+    // the DNS-hostname case, which this static check cannot see).
     match host {
         Host::Ipv4(ip) => {
-            if let Err(reason) = check_ipv4(ip) {
+            if let Err(reason) = is_forbidden_ip(IpAddr::V4(ip)) {
                 return Err(UrlValidationError::PrivateOrReservedIp(reason));
             }
         }
         Host::Ipv6(ip) => {
-            if let Some(v4) = ip.to_ipv4_mapped() {
-                if let Err(reason) = check_ipv4(v4) {
-                    return Err(UrlValidationError::PrivateOrReservedIp(reason));
-                }
-            } else {
-                let segs = ip.segments();
-                if (segs[0] & 0xfe00) == 0xfc00 {
-                    return Err(UrlValidationError::PrivateOrReservedIp(
-                        "fc00::/7 (IPv6 unique-local)".into(),
-                    ));
-                }
-                if (segs[0] & 0xffc0) == 0xfe80 {
-                    return Err(UrlValidationError::PrivateOrReservedIp(
-                        "fe80::/10 (IPv6 link-local)".into(),
-                    ));
-                }
-                if (segs[0] & 0xff00) == 0xff00 {
-                    return Err(UrlValidationError::PrivateOrReservedIp(
-                        "ff00::/8 (IPv6 multicast)".into(),
-                    ));
-                }
-                if ip.is_loopback() {
-                    return Err(UrlValidationError::PrivateOrReservedIp(
-                        "::1 (IPv6 loopback)".into(),
-                    ));
-                }
-                if ip.is_unspecified() {
-                    return Err(UrlValidationError::PrivateOrReservedIp(
-                        ":: (IPv6 unspecified)".into(),
-                    ));
-                }
+            if let Err(reason) = is_forbidden_ip(IpAddr::V6(ip)) {
+                return Err(UrlValidationError::PrivateOrReservedIp(reason));
             }
         }
         Host::Domain(_) => {}
     }
 
     Ok(parsed)
+}
+
+/// Resolve `host`/`port` and validate that **every** returned address is a
+/// routable, non-forbidden IP. This is the second half of SSRF defence for
+/// DNS hostnames — [`validate_external_url`] only inspects the literal
+/// string and cannot see where a domain actually resolves.
+///
+/// Fails closed: a resolution error, an empty result set, or any single
+/// forbidden address in the result set causes rejection. Call this
+/// immediately before issuing the outbound request (after
+/// `validate_external_url` has already passed), using the same host/port
+/// the HTTP client is about to connect to.
+pub async fn validate_resolved_host(host: &str, port: u16) -> Result<(), UrlValidationError> {
+    validate_resolved_host_with(host.to_string(), port, resolve_host).await
+}
+
+/// Same as [`validate_resolved_host`] but with the resolver injected, so
+/// tests can exercise the private-IP-rejection path with a fake resolver
+/// instead of depending on live DNS/network access (which CI/sandbox
+/// runners may not have).
+///
+/// `host` is owned (`String`) rather than borrowed: an `F: FnOnce(&str, ..)
+/// -> Fut` bound ties `Fut` to the elided lifetime of that borrow, which
+/// rustc can't unify with the higher-ranked lifetime the call site needs
+/// (`implementation of FnOnce is not general enough`). Taking ownership
+/// sidesteps the borrow-checker issue entirely.
+async fn validate_resolved_host_with<F, Fut>(
+    host: String,
+    port: u16,
+    resolve: F,
+) -> Result<(), UrlValidationError>
+where
+    F: FnOnce(String, u16) -> Fut,
+    Fut: std::future::Future<Output = std::io::Result<Vec<IpAddr>>>,
+{
+    let addrs = resolve(host.clone(), port)
+        .await
+        .map_err(|e| UrlValidationError::ResolutionFailed(e.to_string()))?;
+
+    if addrs.is_empty() {
+        return Err(UrlValidationError::ResolutionFailed(format!(
+            "no addresses found for host '{}'",
+            host
+        )));
+    }
+
+    for ip in addrs {
+        if let Err(reason) = is_forbidden_ip(ip) {
+            return Err(UrlValidationError::ResolvedToPrivateIp(format!(
+                "{} resolves to {} ({})",
+                host, ip, reason
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Default resolver: real DNS via the OS resolver (through Tokio's async
+/// wrapper around `getaddrinfo`). Extracted so tests can substitute a fake
+/// resolver instead of depending on live DNS/network access.
+async fn resolve_host(host: String, port: u16) -> std::io::Result<Vec<IpAddr>> {
+    let addrs = tokio::net::lookup_host((host.as_str(), port)).await?;
+    Ok(addrs.map(|sa| sa.ip()).collect())
+}
+
+/// Returns `Ok(())` when `ip` is a routable, non-forbidden address (IPv4 or
+/// IPv6). Backs both the literal-IP check in `validate_external_url` and
+/// the resolved-IP check in `validate_resolved_host`.
+fn is_forbidden_ip(ip: IpAddr) -> Result<(), String> {
+    match ip {
+        IpAddr::V4(v4) => check_ipv4(v4),
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return check_ipv4(v4);
+            }
+            let segs = v6.segments();
+            if (segs[0] & 0xfe00) == 0xfc00 {
+                return Err("fc00::/7 (IPv6 unique-local)".into());
+            }
+            if (segs[0] & 0xffc0) == 0xfe80 {
+                return Err("fe80::/10 (IPv6 link-local)".into());
+            }
+            if (segs[0] & 0xff00) == 0xff00 {
+                return Err("ff00::/8 (IPv6 multicast)".into());
+            }
+            if v6.is_loopback() {
+                return Err("::1 (IPv6 loopback)".into());
+            }
+            if v6.is_unspecified() {
+                return Err(":: (IPv6 unspecified)".into());
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Returns `Ok(())` when `ip` is routable public IPv4.
@@ -354,6 +446,114 @@ mod tests {
         assert!(matches!(
             validate_external_url("not a url"),
             Err(UrlValidationError::InvalidFormat(_))
+        ));
+    }
+
+    /// A domain host has no literal-IP form, so `validate_external_url`
+    /// (the static check) can't reject it on IP-range grounds — this is by
+    /// design; the resolved-IP check is a separate, second step.
+    #[test]
+    fn validate_external_url_lets_ordinary_domains_through() {
+        assert!(validate_external_url("https://attacker.example.com/x").is_ok());
+    }
+
+    /// Regression (SSRF via DNS): a hostname with no literal-IP form that
+    /// resolves to a private/internal address must be rejected. Before
+    /// `validate_resolved_host` existed, every caller only ran the static
+    /// `validate_external_url` check — which explicitly no-ops on
+    /// `Host::Domain` — so a hostname like `internal.attacker.example`
+    /// resolving to `10.0.0.5` sailed straight through to the outbound
+    /// request. Fails to compile on `dev` (`validate_resolved_host_with`
+    /// does not exist there); passes here because every resolved address is
+    /// checked against the forbidden ranges and any hit is rejected.
+    ///
+    /// Uses an injected fake resolver so the test is hermetic — no real DNS
+    /// lookup, no network access required — matching this repo's SSRF-test
+    /// convention (see `workflow_webhook_ssrf_tests.rs`).
+    #[tokio::test]
+    async fn validate_resolved_host_rejects_hostname_resolving_to_private_ip() {
+        async fn fake_resolve(_host: String, _port: u16) -> std::io::Result<Vec<IpAddr>> {
+            Ok(vec!["10.0.0.5".parse().unwrap()])
+        }
+
+        let result =
+            validate_resolved_host_with("internal.attacker.example".to_string(), 443, fake_resolve)
+                .await;
+
+        assert!(
+            matches!(result, Err(UrlValidationError::ResolvedToPrivateIp(_))),
+            "expected rejection for a hostname resolving to a private IP, got: {result:?}"
+        );
+    }
+
+    /// Fail-closed: if *any* resolved address is forbidden, the whole
+    /// hostname is rejected — even when other addresses in the answer are
+    /// public. A caller/HTTP client could pick any of the returned
+    /// addresses, so accepting on the presence of a public one and ignoring
+    /// the private one would leave the SSRF hole open.
+    #[tokio::test]
+    async fn validate_resolved_host_rejects_when_any_resolved_ip_is_private() {
+        async fn fake_resolve(_host: String, _port: u16) -> std::io::Result<Vec<IpAddr>> {
+            Ok(vec![
+                "93.184.216.34".parse().unwrap(),
+                "169.254.169.254".parse().unwrap(),
+            ])
+        }
+
+        let result =
+            validate_resolved_host_with("multi-answer.example".to_string(), 443, fake_resolve)
+                .await;
+
+        assert!(
+            matches!(result, Err(UrlValidationError::ResolvedToPrivateIp(_))),
+            "expected rejection when one of several resolved IPs is private, got: {result:?}"
+        );
+    }
+
+    /// A hostname that resolves only to public addresses must pass.
+    #[tokio::test]
+    async fn validate_resolved_host_accepts_hostname_resolving_to_public_ip() {
+        async fn fake_resolve(_host: String, _port: u16) -> std::io::Result<Vec<IpAddr>> {
+            Ok(vec!["93.184.216.34".parse().unwrap()])
+        }
+
+        let result =
+            validate_resolved_host_with("example.com".to_string(), 443, fake_resolve).await;
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+    }
+
+    /// Fail closed on resolution errors too — we can't prove the
+    /// destination is safe, so we don't proceed.
+    #[tokio::test]
+    async fn validate_resolved_host_rejects_on_resolution_error() {
+        async fn fake_resolve(_host: String, _port: u16) -> std::io::Result<Vec<IpAddr>> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "simulated NXDOMAIN",
+            ))
+        }
+
+        let result =
+            validate_resolved_host_with("nonexistent.example".to_string(), 443, fake_resolve).await;
+        assert!(matches!(
+            result,
+            Err(UrlValidationError::ResolutionFailed(_))
+        ));
+    }
+
+    /// Fail closed on an empty answer set too.
+    #[tokio::test]
+    async fn validate_resolved_host_rejects_on_empty_resolution() {
+        async fn fake_resolve(_host: String, _port: u16) -> std::io::Result<Vec<IpAddr>> {
+            Ok(vec![])
+        }
+
+        let result =
+            validate_resolved_host_with("empty-answer.example".to_string(), 443, fake_resolve)
+                .await;
+        assert!(matches!(
+            result,
+            Err(UrlValidationError::ResolutionFailed(_))
         ));
     }
 }

--- a/backend/servers/api-server/src/services/actions/api_call.rs
+++ b/backend/servers/api-server/src/services/actions/api_call.rs
@@ -169,9 +169,23 @@ impl ActionExecutor for ApiCallExecutor {
         // documentation ranges. Delegating keeps scheme allowlisting
         // (http(s) only, plain-http gated to `RUST_ENV=development`), blocked
         // hosts/TLDs, and private/reserved IP checks in lock-step everywhere.
-        if let Err(e) = common::url_validation::validate_external_url(&url) {
-            return Err(ActionError::ConfigurationError(e.to_string()));
-        }
+        let parsed_url = common::url_validation::validate_external_url(&url)
+            .map_err(|e| ActionError::ConfigurationError(e.to_string()))?;
+
+        // SSRF via DNS: `validate_external_url` only inspects the literal
+        // string — a hostname with no literal-IP form (e.g.
+        // "attacker.example.com") that resolves to a private/internal
+        // address at request time sailed straight through it. Resolve now,
+        // right before the request is issued, and reject if *any* resolved
+        // address falls in a forbidden range. Fails closed: a resolution
+        // error also rejects.
+        let host = parsed_url.host_str().ok_or_else(|| {
+            ActionError::ConfigurationError("API call URL must have a host".to_string())
+        })?;
+        let port = parsed_url.port_or_known_default().unwrap_or(443);
+        common::url_validation::validate_resolved_host(host, port)
+            .await
+            .map_err(|e| ActionError::ConfigurationError(e.to_string()))?;
 
         // Build request
         let mut request = match api_config.method {
@@ -419,6 +433,55 @@ mod tests {
             other => panic!(
                 "expected ConfigurationError (SSRF rejection) for a multicast \
                  address, got: {other:?}"
+            ),
+        }
+    }
+
+    /// Regression (SSRF via DNS): `validate_external_url` only inspected the
+    /// literal URL string, so a DNS hostname with no literal-IP form (e.g.
+    /// `internal.attacker.example`) sailed through even when it resolves to
+    /// a private/internal address at request time — the guard never ran a
+    /// DNS lookup at all. `common::url_validation::validate_resolved_host`
+    /// covers the "resolves to a private IP" case itself, using an injected
+    /// fake resolver so it stays hermetic (see
+    /// `common::url_validation::tests::validate_resolved_host_rejects_hostname_resolving_to_private_ip`).
+    ///
+    /// This test proves the executor actually *wires in* that check (rather
+    /// than the fix existing only in the library, unused) by exercising the
+    /// fail-closed branch: a hostname under the IETF-reserved `.invalid` TLD
+    /// (RFC 2606) can never resolve, so DNS resolution errors out and the
+    /// fail-closed `ResolutionFailed` branch rejects it — fast and without
+    /// depending on any specific external network state, since the
+    /// non-delegation of `.invalid` is guaranteed rather than incidental.
+    /// Fails on `dev`: `execute` there never calls
+    /// `validate_resolved_host`/`validate_resolved_host_with`, so a
+    /// non-literal-IP hostname was never re-validated post-DNS and this call
+    /// would instead fail later with an `ExternalServiceError` from
+    /// `reqwest` (a connect failure), not the `ConfigurationError` this test
+    /// asserts.
+    #[tokio::test]
+    async fn execute_rejects_hostname_that_fails_dns_resolution() {
+        let executor = ApiCallExecutor::new();
+        let context = ActionContext::new(
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            serde_json::json!({}),
+        );
+        let config = serde_json::json!({
+            "url": "https://this-host-cannot-resolve.invalid/webhook"
+        });
+
+        match executor.execute(&config, &context).await {
+            Err(ActionError::ConfigurationError(msg)) => {
+                assert!(
+                    msg.contains("resolve"),
+                    "expected a DNS-resolution rejection message, got: {msg}"
+                );
+            }
+            other => panic!(
+                "expected ConfigurationError (fail-closed DNS resolution) for an \
+                 unresolvable host, got: {other:?}"
             ),
         }
     }


### PR DESCRIPTION
## Task
`backend/servers/api-server/src/services/actions/api_call.rs` (`validate_external_url` call in `ApiCallExecutor::execute`) — the private/internal-IP guard only ran when the host was a LITERAL IP. A DNS hostname that resolves to a private/internal address (SSRF via DNS) bypassed the guard entirely. Fix: resolve the hostname and validate ALL resolved IPs against the private/internal/loopback/link-local/metadata ranges (fail closed), or use a vetted SSRF-safe resolver. Add a regression test (IG3: failing-on-main) covering a hostname that resolves to a private IP being rejected.

Note: by the time this task landed, the file had already been refactored (in an earlier PR) to delegate to the shared `common::url_validation::validate_external_url` instead of a private copy — but that shared validator has the exact same gap the finding describes: it's a *static* string check, and its `Host::Domain(_)` arm was a documented no-op (see its own module doc: "Callers that resolve the hostname themselves ... MUST re-validate the resolved IP at fetch time" — but no caller actually did). This PR fixes it at the source.

## Owner
pm-backend

## What changed
- `backend/crates/common/src/url_validation.rs`: added `pub async fn validate_resolved_host(host, port)`, which resolves the hostname and checks **every** returned address against the same forbidden ranges (private/loopback/link-local/metadata/CGNAT/reserved/multicast, IPv4 + IPv6). Fails closed on any forbidden address, an empty answer set, or a resolution error. Refactored the duplicated IPv4/IPv6 range-check logic (previously inline per literal-IP arm) into a shared `is_forbidden_ip` so the literal-IP and resolved-IP paths can't drift apart. The resolver is injectable (`validate_resolved_host_with`) purely so tests can supply a fake resolver instead of depending on live DNS/network access — matching this repo's existing SSRF-test convention (`workflow_webhook_ssrf_tests.rs`: "rejected ... before any network call, so the test is fast and deterministic").
- `backend/servers/api-server/src/services/actions/api_call.rs`: `ApiCallExecutor::execute` now calls `validate_resolved_host` immediately before issuing the outbound request (after the existing static `validate_external_url` check passes).
- `backend/crates/common/Cargo.toml`: added `tokio` (workspace dep, already used everywhere else) for `tokio::net::lookup_host`, plus `tokio` dev-dependency with `rt-multi-thread`/`macros` for `#[tokio::test]`.

### Scope note
`common::url_validation::validate_external_url` has 3 other call sites with the same theoretical DNS-hostname gap (`crates/integrations/src/workflow_executor.rs`, `servers/api-server/src/routes/integrations/webhook.rs`, `servers/api-server/src/routes/signatures.rs`) — documented in the module doc as a caller obligation, but not wired up in this PR. The task explicitly scoped this fix to `api_call.rs`; the other 3 are a reasonable, low-effort follow-up (same one-line `validate_resolved_host` call after their existing `validate_external_url` check) — flagging for the reviewer/dispatcher to file as a follow-up task rather than silently expanding this PR's scope.

There's also a narrower residual TOCTOU (DNS-rebinding) window between this resolve-and-check and the HTTP client's own connect-time resolution, since the client — not this module — owns the socket connect. Closing that fully needs a custom resolver/connector pinning the checked IP; out of scope here and called out in the module doc.

## Regression tests (IG3 — failing on `dev`)
- `common::url_validation::tests::validate_resolved_host_rejects_hostname_resolving_to_private_ip` — the literal scenario from the finding: a hostname resolving to `10.0.0.5` is rejected. Fails to compile on `dev` (`validate_resolved_host_with` doesn't exist there).
- `validate_resolved_host_rejects_when_any_resolved_ip_is_private` — fail-closed when only *one* of several resolved addresses is private.
- `validate_resolved_host_accepts_hostname_resolving_to_public_ip`, `validate_resolved_host_rejects_on_resolution_error`, `validate_resolved_host_rejects_on_empty_resolution` — supporting coverage for the fail-closed contract.
- `api_call.rs::tests::execute_rejects_hostname_that_fails_dns_resolution` — proves `ApiCallExecutor::execute` actually *invokes* the new check (not just that the library function exists) via the fail-closed resolution-error branch, using an RFC 2606 `.invalid` hostname (guaranteed unresolvable, so the test is fast and doesn't depend on any specific external network state). On `dev`, `execute` never calls `validate_resolved_host`, so this would instead surface as a later `ExternalServiceError` from `reqwest`'s own connect failure, not the `ConfigurationError` this test asserts.

All hermetic — no real DNS lookups, no network access required, per this repo's SSRF-test convention.

## Verification
Local sandbox has a known, pre-existing egress gap: `api-server` (and hence full-workspace clippy/test) pulls in `utoipa-swagger-ui`, whose build script fetches `https://github.com/swagger-api/swagger-ui/archive/...zip` at build time; the sandbox's egress proxy returns `403` for that request, so *any* build touching the `api-server` crate fails at that build script — unrelated to this change (reproduced identically on unrelated worktrees in the same sandbox). CI runners have normal GitHub access, so this is not expected to reproduce there.

What was actually run and passed in-sandbox:
```
cd backend && cargo fmt --all -- --check                                  # clean
SQLX_OFFLINE=true cargo clippy -p common --all-targets -- -D warnings     # clean, 0 warnings
SQLX_OFFLINE=true cargo test -p common url_validation                     # 25 passed; 0 failed
SQLX_OFFLINE=true cargo check -p api-server                               # all crates check clean up
                                                                            # to (and excluding) the
                                                                            # utoipa-swagger-ui build
                                                                            # script failure
SQLX_OFFLINE=true cargo clippy --workspace --all-targets -- -D warnings   # same egress-403 failure,
                                                                            # nothing past it exercised
```

`VERIFY-PLAN base=f6d1ed93ed5bd3eb153c9af07f1817ae8157c860 files=4` escalated to full-workspace clippy+test (Cargo.lock changed, per the escalation rules), which is what hits the egress gap above. `api_call.rs`'s new code (the added `parsed_url.host_str()`/`port_or_known_default()`/`validate_resolved_host(...).await` calls) itself was not directly typechecked by `rustc` in this sandbox — it's plain, standard `url`/`common` API usage, and the `integrations` crate (a sibling consumer of the same new `common::url_validation` API surface) compiled clean, which gives good confidence the API is correctly typed and used. **CI (`backend.yml`, which runs on GitHub-hosted runners with normal internet access) is the real gate for `api-server` here — please confirm green there before merge.**

## CI parity (Band C — hot-path only)
This is a security/SSRF fix, so flagging as hot-path: could not replicate `backend.yml`'s `check`/`test` jobs beyond what's shown above, for the same sandbox egress-gap reason. Deferring to CI.

## Remote-tested
skipped (ppt-bridge MCP not used this session)

## Notes
- `scope-check.sh --owner pm-backend`: clean (exit 0, no drift) — all changes are in `backend/crates/common/` and `backend/servers/api-server/`, both within `rust-backend`'s owned areas.
- `reuse-grep.sh --specialist rust-backend`: clean (exit 0, no warnings) — `is_forbidden_ip`/`validate_resolved_host` are new, not duplicates of anything in `api-core`/`auth`/`db`.
- Please double check CI is green on `check`/`test` for `api-server` before merging, since local verification of that crate was blocked by the sandbox-only egress gap described above.


---
_Generated by [Claude Code](https://claude.ai/code/session_015dxD3jKjGckhr5VkCi4Vnb)_