### PR TITLE
code-review-api-core-voice-cmd-fabricated-success: stop fabricating success on voice check-balance

### DIFF
--- a/backend/servers/api-server/src/services/voice_commands.rs
+++ b/backend/servers/api-server/src/services/voice_commands.rs
@@ -248,33 +248,30 @@ impl VoiceCommandProcessor {
 
     async fn action_check_balance(
         &self,
-        device: &VoiceAssistantDevice,
+        _device: &VoiceAssistantDevice,
         parsed: &ParsedVoiceCommand,
     ) -> Result<VoiceActionResult, VoiceCommandError> {
-        // In a real implementation, this would query the financial repository
-        // For now, return a placeholder response
+        // No financial repository is wired into the voice processor yet, so
+        // there is no real balance to report. This used to fabricate a
+        // "your balance is zero" success response on this live webhook path
+        // (code review: fabricated success) — a resident could be told they
+        // owe nothing when the actual balance was never queried. Fail
+        // honestly instead: tell the caller the feature isn't available yet
+        // rather than making up a number.
         let response = match parsed.language.as_str() {
-            "sk" => "Vas aktualni zostatok je nula eur. Nemate ziadne nezaplatene poplatky.",
-            "cs" => "Vas aktualni zustatek je nula korun. Nemate zadne nezaplacene poplatky.",
-            _ => "Your current balance is zero. You have no outstanding fees.",
+            "sk" => "Kontrola zostatku hlasom momentalne nie je dostupna. Prosim, pouzite mobilnu aplikaciu alebo webovy portal.",
+            "cs" => "Kontrola zustatku hlasem momentalne neni dostupna. Prosim, pouzijte mobilni aplikaci nebo webovy portal.",
+            _ => "Balance checking is not yet available via voice assistant. Please use the mobile app or web portal.",
         };
 
         Ok(VoiceActionResult {
-            success: true,
+            success: false,
             action_type: voice_intent::CHECK_BALANCE.to_string(),
             response_text: response.to_string(),
             ssml: Some(format!("<speak>{}</speak>", response)),
-            card: Some(VoiceCard {
-                title: self.localize("Balance", &parsed.language),
-                content: response.to_string(),
-                image_url: None,
-            }),
+            card: None,
             should_end_session: true,
-            data: Some(json!({
-                "balance": 0.0,
-                "currency": "EUR",
-                "unit_id": device.unit_id
-            })),
+            data: None,
         })
     }
 
@@ -750,6 +747,43 @@ mod tests {
         let parsed = processor.parse_command("Skontroluj moj zostatok", "sk-SK");
         assert_eq!(parsed.intent, voice_intent::CHECK_BALANCE);
         assert_eq!(parsed.language, "sk");
+    }
+
+    /// Regression (code-review: voice check-balance fabricated success): the
+    /// handler used to unconditionally report `success: true` with a
+    /// hardcoded "your balance is zero" response on this live webhook path,
+    /// without ever consulting a financial repository. No balance service is
+    /// wired in yet, so it must now fail honestly — `success: false`, no
+    /// fabricated `data` (balance/currency), and a response that tells the
+    /// caller the feature isn't available rather than inventing a number.
+    #[tokio::test]
+    async fn test_check_balance_fails_honestly_instead_of_fabricating_success() {
+        let processor = create_test_processor();
+        let org = Uuid::new_v4();
+        let user = Uuid::new_v4();
+        let unit = Uuid::new_v4();
+        let device = make_device(org, user, Some(unit));
+        let parsed = processor.parse_command("What is my balance?", "en-US");
+
+        // action_check_balance doesn't touch the database, so it can be
+        // called directly without acquiring a real connection.
+        let result = processor
+            .action_check_balance(&device, &parsed)
+            .await
+            .expect("check-balance must not error, it must fail honestly in-band");
+
+        assert!(
+            !result.success,
+            "check-balance must not report fabricated success"
+        );
+        assert!(
+            result.data.is_none(),
+            "no balance/currency data must be fabricated when no financial repository was queried"
+        );
+        assert!(
+            !result.response_text.to_lowercase().contains("zero"),
+            "response must not claim a fabricated zero balance"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Task
`backend/servers/api-server/src/services/voice_commands.rs:248` and `:278` — `action_check_balance()` and `action_report_fault()` are shipped stubs that return `VoiceActionResult{ success: true }` with fabricated data on a LIVE webhook path (not gated behind a TODO/feature flag). Fix: either wire these to the real balance/fault services, or (if not yet implemented) make them fail honestly ("not yet available") instead of fabricating success. Add a regression test (IG3: failing-on-main) asserting the handler no longer returns fabricated success.

## Owner
pm-backend

## Investigation
Checked current `dev` state first, per the task note: `action_report_fault()` was already fixed on `dev` by PR #2666 — it now persists a real `faults` row via `FaultRepository::create_rls` and returns the persisted id, with its own regression tests (`test_report_fault_persists_fault`, `test_report_fault_without_unit_errors`). This PR does not touch that path.

The remaining fabricated-success stub is `action_check_balance()`: it unconditionally returned `success: true` with a hardcoded "your balance is zero, no outstanding fees" response and `data: {"balance": 0.0, "currency": "EUR", ...}`, without ever querying a financial repository. `VoiceCommandProcessor` has no financial repository wired in (only `llm_document_repo`, `fault_repo`, `unit_repo`), and the existing `FinancialRepository::get_unit_ledger` doesn't accept an RLS-scoped connection — wiring it in properly is a larger, riskier change than this low-priority finding warrants. Per the task's explicit fallback, this fails honestly instead: `success: false`, no fabricated `data`, and a localized "balance checking is not yet available via voice assistant" response — mirroring the existing honest pattern already used by `action_book_facility()`.

## Verification
`cargo clippy`/`cargo test -p api-server` could not run to completion in this sandbox: the `utoipa-swagger-ui` build script needs to download `https://github.com/swagger-api/swagger-ui/archive/...` and the sandbox's egress proxy returns `403 GitHub access to this repository is not enabled for this session` for that host — a pre-existing, environment-wide block (reproduced identically across five unrelated worktrees on this host right now), unrelated to this diff.

As a local-only diagnostic (never committed — reverted immediately after, confirmed via `diff` against the pre-change files), I temporarily commented out the `utoipa-swagger-ui` dependency/usage to get `api-server` past that specific build script, then ran:

```
cargo test -p api-server --lib services::voice_commands
```

Result: the crate compiles cleanly and all `voice_commands` unit tests pass, including the new regression test:

```
test services::voice_commands::tests::test_check_balance_fails_honestly_instead_of_fabricating_success ... ok
test services::voice_commands::tests::test_build_fault_title ... ok
test services::voice_commands::tests::test_extract_language ... ok
test services::voice_commands::tests::test_parse_command_balance ... ok
test services::voice_commands::tests::test_parse_command_fault ... ok
test services::voice_commands::tests::test_parse_command_slovak ... ok
test services::voice_commands::tests::test_parse_command_help ... ok
```

(The two `#[sqlx::test]` fault-persist tests fail locally with `DATABASE_URL must be set` — pre-existing, unrelated to this change; no local Postgres in this sandbox, they run under `backend.yml` CI.)

`cargo fmt -p api-server -- --check` — clean, no diff.

`VERIFY-PLAN base=f6d1ed93ed5bd3eb153c9af07f1817ae8157c860 files=1` planned `cargo fmt --all -- --check`, `cargo clippy -p api-server --all-targets -- -D warnings`, `cargo test -p api-server` — the clippy/test steps hit the swagger-ui download block described above (`VERIFY FAIL: cd backend && cargo clippy -p api-server --all-targets -- -D warnings`, failure is the `utoipa-swagger-ui` build script, not this diff). Real `backend.yml` CI (full network access) should pass; please confirm CI is green before taking this out of draft.

## Scope drift
`scope-check.sh --owner pm-backend` → exit 0, no drift. Only `backend/servers/api-server/src/services/voice_commands.rs` changed.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings.

## CI parity (Band C — hot-path only)
Skipped — this is a low-priority, non-security/billing/auth-critical fix (a voice-assistant informational response), not a hot-path change.

## Remote-tested
Skipped — ppt-bridge MCP not used this session.

## Notes
- This PR is opened as **draft** specifically because local verification was blocked by the sandbox's GitHub egress restriction, not by anything in the diff. Please let `backend.yml` CI run and confirm clippy/test are green before merging.
- Other action handlers in this file (`action_check_announcements`, `action_check_meter`) have a similar shape (claim "0 pending/none" without querying), but were not named in this review finding and are out of scope here to keep this fix minimal and reviewable.


---
_Generated by [Claude Code](https://claude.ai/code/session_015dxD3jKjGckhr5VkCi4Vnb)_