### PR TITLE
code-review-api-core-llm-unscoped-idor-footguns: remove unscoped LlmDocumentRepository IDOR-footgun methods

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -92,23 +92,6 @@ impl LlmDocumentRepository {
         .await
     }
 
-    /// Find a generation request by ID.
-    pub async fn find_generation_request<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-    ) -> Result<Option<LlmGenerationRequest>, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as::<_, LlmGenerationRequest>(
-            "SELECT * FROM llm_generation_requests WHERE id = $1",
-        )
-        .bind(id)
-        .fetch_optional(executor)
-        .await
-    }
-
     /// Find a generation request by ID — tenant-scoped (issue #766 / #816).
     ///
     /// `org_id` must originate from the verified request principal. Returns
@@ -332,21 +315,6 @@ impl LlmDocumentRepository {
         .await
     }
 
-    /// Find a prompt template by ID.
-    pub async fn find_prompt_template<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-    ) -> Result<Option<LlmPromptTemplate>, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as::<_, LlmPromptTemplate>("SELECT * FROM llm_prompt_templates WHERE id = $1")
-            .bind(id)
-            .fetch_optional(executor)
-            .await
-    }
-
     /// Find a prompt template by ID — tenant-scoped (issue #766 / #816).
     ///
     /// `org_id` must originate from the verified request principal. A template
@@ -527,40 +495,6 @@ impl LlmDocumentRepository {
         .await
     }
 
-    /// Find a generated description by ID.
-    pub async fn find_listing_description<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-    ) -> Result<Option<GeneratedListingDescription>, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as::<_, GeneratedListingDescription>(
-            "SELECT * FROM generated_listing_descriptions WHERE id = $1",
-        )
-        .bind(id)
-        .fetch_optional(executor)
-        .await
-    }
-
-    /// List descriptions for a listing.
-    pub async fn list_listing_descriptions<'e, E>(
-        &self,
-        executor: E,
-        listing_id: Uuid,
-    ) -> Result<Vec<GeneratedListingDescription>, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as::<_, GeneratedListingDescription>(
-            "SELECT * FROM generated_listing_descriptions WHERE listing_id = $1 ORDER BY generated_at DESC",
-        )
-        .bind(listing_id)
-        .fetch_all(executor)
-        .await
-    }
-
     /// List descriptions for a listing — tenant-scoped (issue #766 / #816).
     ///
     /// `org_id` must originate from the verified request principal. The
@@ -614,23 +548,6 @@ impl LlmDocumentRepository {
         .bind(id)
         .bind(edited_description)
         .bind(edited_by)
-        .fetch_optional(executor)
-        .await
-    }
-
-    /// Mark description as published.
-    pub async fn publish_description<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-    ) -> Result<Option<GeneratedListingDescription>, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as::<_, GeneratedListingDescription>(
-            "UPDATE generated_listing_descriptions SET is_published = TRUE WHERE id = $1 RETURNING *",
-        )
-        .bind(id)
         .fetch_optional(executor)
         .await
     }
@@ -1508,21 +1425,6 @@ impl LlmDocumentRepository {
         .bind(&metadata)
         .fetch_one(executor)
         .await
-    }
-
-    /// Find photo enhancement by ID.
-    pub async fn find_photo_enhancement<'e, E>(
-        &self,
-        executor: E,
-        id: Uuid,
-    ) -> Result<Option<PhotoEnhancement>, SqlxError>
-    where
-        E: Executor<'e, Database = Postgres>,
-    {
-        sqlx::query_as::<_, PhotoEnhancement>("SELECT * FROM photo_enhancements WHERE id = $1")
-            .bind(id)
-            .fetch_optional(executor)
-            .await
     }
 
     /// Find photo enhancement by ID — tenant-scoped (issue #766 / #816).

--- a/backend/servers/api-server/tests/suites/ai_llm_cross_tenant_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_llm_cross_tenant_idor_tests.rs
@@ -19,6 +19,15 @@
 //! clause. The workflow router already used this `_for_org` idiom (#791);
 //! these tests pin the same contract for the AI/LLM repo methods.
 //!
+//! IDOR-footgun cleanup: the six unscoped `LlmDocumentRepository` methods
+//! named above (`find_generation_request`, `find_prompt_template`,
+//! `find_listing_description`, `list_listing_descriptions`,
+//! `publish_description`, `find_photo_enhancement`) have been **removed**
+//! from the repository entirely — they had zero remaining production call
+//! sites (every handler already called the `_for_org` twin) and existed only
+//! as a reachable-by-mistake footgun for future callers. The `_for_org`
+//! variants are now the only public surface for these lookups.
+//!
 //! Coverage in this file: chat-session read, feedback write, listing-description
 //! list read, listing-description PUBLISH (the cross-tenant mutate), and
 //! photo-enhancement read — the full LLM-document IDOR cluster from the
@@ -38,8 +47,12 @@
 //! pre-fix code). The IDOR fix itself lives in the repository's WHERE clause,
 //! so the security contract is asserted there directly: the scoped method
 //! must NOT return another org's row even though the raw (pre-fix) query
-//! would. Each test also runs the unscoped query to demonstrate the leak the
-//! `_for_org` variant closes.
+//! would. Where the pre-fix unscoped repo method still exists (chat
+//! sessions, whose unscoped path is a raw SQL query rather than a repo
+//! method — see (1)), the test also demonstrates the leak directly; for the
+//! `LlmDocumentRepository` methods the unscoped twins have since been
+//! deleted (see module note above), so the `_for_org` assertions alone pin
+//! the contract.
 //!
 //! These tests use the `ai_*` tables that ship migrations (`00042_create_ai_chat.sql`)
 //! so they run against `db::MIGRATOR` deterministically.
@@ -586,17 +599,11 @@ async fn list_listing_descriptions_for_org_blocks_cross_tenant_read(pool: PgPool
         "org B must NOT be able to read org A's listing descriptions"
     );
 
-    // Demonstrate the leak the org predicate closes: the unscoped lookup the
-    // pre-fix handler performed returns the row regardless of org.
-    let unscoped = repo
-        .list_listing_descriptions(&pool, listing_in_a)
-        .await
-        .expect("query ok");
-    assert_eq!(
-        unscoped.len(),
-        1,
-        "sanity: the unscoped query (the vulnerable pre-fix path) does leak the row"
-    );
+    // The pre-fix unscoped `list_listing_descriptions(listing_id)` repo method
+    // (the IDOR footgun this demonstrated) has been removed entirely —
+    // `list_listing_descriptions_for_org` is now the only reachable public
+    // surface for this query, so the leak it closes can no longer be
+    // reintroduced by a caller reaching for the "obvious" unscoped name.
 }
 
 // ---------------------------------------------------------------------------
@@ -773,14 +780,9 @@ async fn find_photo_enhancement_for_org_blocks_cross_tenant_read(pool: PgPool) {
         "org B must NOT be able to read org A's photo enhancement"
     );
 
-    // Demonstrate the leak the org predicate closes: the unscoped lookup the
-    // pre-fix handler performed returns the row regardless of org.
-    let unscoped = repo
-        .find_photo_enhancement(&pool, enh_in_a)
-        .await
-        .expect("query ok");
-    assert!(
-        unscoped.is_some(),
-        "sanity: the unscoped query (the vulnerable pre-fix path) does leak the row"
-    );
+    // The pre-fix unscoped `find_photo_enhancement(id)` repo method (the IDOR
+    // footgun this demonstrated) has been removed entirely —
+    // `find_photo_enhancement_for_org` is now the only reachable public
+    // surface for this query, so the leak it closes can no longer be
+    // reintroduced by a caller reaching for the "obvious" unscoped name.
 }


### PR DESCRIPTION
## Task
`code-review-api-core-llm-unscoped-idor-footguns` — `LlmDocumentRepository` still exposed six public **un-tenant-scoped** methods (pre-remediation twins of the `_for_org` variants added for the cross-tenant IDOR fix, #766/#816). Any caller forgetting the `_for_org` variant re-opens the cross-tenant leak.

## Fix
`backend/crates/db/src/repositories/llm_document.rs` — removed `find_generation_request`, `find_prompt_template`, `find_listing_description`, `list_listing_descriptions`, `publish_description`, `find_photo_enhancement`. A repo-wide grep confirmed **zero production call sites** — every handler in `routes/ai/llm.rs` already uses the `_for_org` twin, which is now the only reachable public surface for these lookups. Updated `backend/servers/api-server/tests/suites/ai_llm_cross_tenant_idor_tests.rs` (which used two of the removed methods to demonstrate the pre-fix leak) to note the vulnerable path can no longer be reintroduced, and refreshed the module doc.

## Verify
Ran local Postgres: `cargo clippy -p db --all-targets -- -D warnings` clean, `cargo test -p db` = 112 passed / 0 failed. The impact gate escalates to reverse-dependent server crates (`api-server`/`accounting-server`/`reality-server`), which cannot compile in the cloud sandbox — `utoipa-swagger-ui`'s build script downloads a Swagger UI zip from `github.com` and the egress proxy 403s it (known env gap `implementer-verify-env-blocked-github-egress-blocks-pr`, reproduced across 5 sibling worktrees, unrelated to this diff). **CI is the verification gate.**

Note: `scope_drift=true` — the fix necessarily spans the `db` crate plus an `api-server` test file; no production `api-server` logic changed. Opened as draft; dispatcher reviewer + CI gate the merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_015dxD3jKjGckhr5VkCi4Vnb)_