### PR TITLE
code-review-api-core-idempotency-lock-cancel-leak: make idempotency advisory-lock release cancellation-safe

### DIFF
--- a/backend/crates/api-core/src/middleware/idempotency.rs
+++ b/backend/crates/api-core/src/middleware/idempotency.rs
@@ -77,10 +77,25 @@ pub async fn handle_idempotent_request(
     let request_hash = request_hash(&method, &path, &request_body);
     let request = Request::from_parts(parts, Body::from(request_body.clone()));
 
-    let mut conn = match pool.acquire().await {
-        Ok(conn) => conn,
+    // Hold the idempotency serialization lock as a *transaction-scoped*
+    // advisory lock (`pg_advisory_xact_lock`) rather than a session-level
+    // `pg_advisory_lock`/`pg_advisory_unlock` pair on a bare pooled
+    // connection.
+    //
+    // This makes release cancellation-safe: `sqlx::Transaction::drop`
+    // unconditionally queues a `ROLLBACK` if the transaction was never
+    // committed, and returning the underlying `PoolConnection` to the pool
+    // flushes that queued rollback before the connection is made available
+    // again (see sqlx's `Floating::return_to_pool`, which pings the
+    // connection — flushing any pending writes — before releasing it). So
+    // even if this future is dropped mid-flight (client disconnect while
+    // `next.run(request).await` is pending), the transaction — and with it
+    // the xact-scoped advisory lock — is guaranteed to be torn down instead
+    // of leaking for the life of the pooled connection.
+    let mut tx = match pool.begin().await {
+        Ok(tx) => tx,
         Err(err) => {
-            tracing::error!(error = %err, "failed to acquire idempotency connection");
+            tracing::error!(error = %err, "failed to open idempotency transaction");
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "INTERNAL_ERROR",
@@ -90,12 +105,13 @@ pub async fn handle_idempotent_request(
     };
 
     let lock_id = advisory_lock_id(&tenant_scope, &method, &path, &key);
-    if let Err(err) = sqlx::query("SELECT pg_advisory_lock($1)")
+    if let Err(err) = sqlx::query("SELECT pg_advisory_xact_lock($1)")
         .bind(lock_id)
-        .execute(&mut *conn)
+        .execute(&mut *tx)
         .await
     {
         tracing::error!(error = %err, "failed to acquire idempotency advisory lock");
+        // `tx` drops here: queues a ROLLBACK, releasing any partial state.
         return error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             "INTERNAL_ERROR",
@@ -103,10 +119,9 @@ pub async fn handle_idempotent_request(
         );
     }
 
-    let cached = match load_cached_response(&mut conn, &tenant_scope, &method, &path, &key).await {
+    let cached = match load_cached_response(&mut tx, &tenant_scope, &method, &path, &key).await {
         Ok(row) => row,
         Err(err) => {
-            let _ = unlock(&mut conn, lock_id).await;
             tracing::error!(error = %err, "failed to load cached idempotency response");
             return error_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -118,7 +133,7 @@ pub async fn handle_idempotent_request(
 
     if let Some(row) = cached {
         if row.request_hash != request_hash {
-            let _ = unlock(&mut conn, lock_id).await;
+            let _ = tx.commit().await;
             return error_response(
                 StatusCode::UNPROCESSABLE_ENTITY,
                 "IDEMPOTENCY_KEY_REUSED",
@@ -126,7 +141,7 @@ pub async fn handle_idempotent_request(
             );
         }
 
-        let _ = unlock(&mut conn, lock_id).await;
+        let _ = tx.commit().await;
         return cached_response(row);
     }
 
@@ -135,7 +150,7 @@ pub async fn handle_idempotent_request(
         Ok(captured) => {
             if !captured.status.is_server_error() {
                 if let Err(err) = store_response(
-                    &mut conn,
+                    &mut tx,
                     &tenant_scope,
                     &method,
                     &path,
@@ -146,7 +161,6 @@ pub async fn handle_idempotent_request(
                 .await
                 {
                     tracing::error!(error = %err, "failed to store idempotent response");
-                    let _ = unlock(&mut conn, lock_id).await;
                     return error_response(
                         StatusCode::INTERNAL_SERVER_ERROR,
                         "INTERNAL_ERROR",
@@ -160,7 +174,7 @@ pub async fn handle_idempotent_request(
         Err(response) => response,
     };
 
-    let _ = unlock(&mut conn, lock_id).await;
+    let _ = tx.commit().await;
     response
 }
 
@@ -212,19 +226,8 @@ fn advisory_lock_id(tenant_scope: &str, method: &str, path: &str, key: &str) -> 
     i64::from_be_bytes(bytes)
 }
 
-async fn unlock(
-    conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
-    lock_id: i64,
-) -> Result<(), sqlx::Error> {
-    sqlx::query("SELECT pg_advisory_unlock($1)")
-        .bind(lock_id)
-        .execute(&mut **conn)
-        .await?;
-    Ok(())
-}
-
 async fn load_cached_response(
-    conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
+    conn: &mut sqlx::PgConnection,
     tenant_scope: &str,
     method: &str,
     path: &str,
@@ -244,7 +247,7 @@ async fn load_cached_response(
     .bind(method)
     .bind(path)
     .bind(key)
-    .execute(&mut **conn)
+    .execute(&mut *conn)
     .await?;
 
     sqlx::query_as::<_, CachedResponseRow>(
@@ -262,7 +265,7 @@ async fn load_cached_response(
     .bind(method)
     .bind(path)
     .bind(key)
-    .fetch_optional(&mut **conn)
+    .fetch_optional(&mut *conn)
     .await
 }
 
@@ -308,7 +311,7 @@ async fn capture_response(response: Response) -> Result<CapturedResponse, Respon
 }
 
 async fn store_response(
-    conn: &mut sqlx::pool::PoolConnection<sqlx::Postgres>,
+    conn: &mut sqlx::PgConnection,
     tenant_scope: &str,
     method: &str,
     path: &str,
@@ -349,7 +352,7 @@ async fn store_response(
     .bind(&response.content_type)
     .bind(&response.body)
     .bind(IDEMPOTENCY_TTL_HOURS)
-    .execute(&mut **conn)
+    .execute(&mut *conn)
     .await?;
 
     Ok(())

--- a/backend/crates/api-core/tests/idempotency_middleware_tests.rs
+++ b/backend/crates/api-core/tests/idempotency_middleware_tests.rs
@@ -5,9 +5,12 @@
 //!   * same key + different payload is rejected with 422,
 //!   * expired rows are lazily discarded and the handler executes again.
 
-use std::sync::{
-    atomic::{AtomicUsize, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 use axum::{
@@ -20,6 +23,9 @@ use axum::{
     Json, Router,
 };
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use sqlx::Connection;
+use tokio::sync::Notify;
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -105,6 +111,51 @@ fn post_demo_resolved(
         })
         .body(Body::from(body.to_string()))
         .expect("build request")
+}
+
+/// State for the "hanging handler" fixture used by the cancellation-safety
+/// regression test below: the handler signals `started` the moment it begins
+/// running (proving the idempotency middleware has acquired its lock and is
+/// now parked inside `next.run(request).await`), then hangs forever so the
+/// test can abort the request task mid-flight, deterministically.
+#[derive(Clone)]
+struct HangingTestState {
+    pool: db::DbPool,
+    started: Arc<Notify>,
+}
+
+impl TenantMembershipProvider for HangingTestState {
+    fn db_pool(&self) -> &db::DbPool {
+        &self.pool
+    }
+}
+
+async fn hanging_idempotency(
+    Extension(state): Extension<HangingTestState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    api_core::middleware::handle_idempotent_request(state.pool.clone(), request, next).await
+}
+
+async fn hanging_handler(State(state): State<HangingTestState>) -> (StatusCode, Json<Value>) {
+    state.started.notify_one();
+    // Never resolves — the test aborts the enclosing task while this is
+    // pending, simulating a client disconnect mid-request.
+    std::future::pending::<()>().await;
+    unreachable!("hanging_handler must be cancelled before resolving")
+}
+
+fn build_hanging_app(pool: db::DbPool, started: Arc<Notify>) -> Router {
+    let state = HangingTestState { pool, started };
+
+    Router::new()
+        .route(
+            "/demo",
+            post(hanging_handler).route_layer(from_fn(hanging_idempotency)),
+        )
+        .layer(Extension(state.clone()))
+        .with_state(state)
 }
 
 fn is_replayed(response: &Response) -> bool {
@@ -392,5 +443,132 @@ async fn spoofed_tenant_header_cannot_change_scope(pool: db::DbPool) {
         hits.load(Ordering::SeqCst),
         2,
         "the spoofed X-Tenant-ID header must never merge two tenants into one scope"
+    );
+}
+
+/// Reimplements `advisory_lock_id` (private to `idempotency.rs`) so the test
+/// can independently compute the exact lock id a given request will hash to,
+/// without needing the middleware to expose its internals.
+fn expected_lock_id(tenant_scope: &str, method: &str, path: &str, key: &str) -> i64 {
+    let mut hasher = Sha256::new();
+    hasher.update(tenant_scope.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(method.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(path.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(key.as_bytes());
+
+    let digest = hasher.finalize();
+    let mut bytes = [0_u8; 8];
+    bytes.copy_from_slice(&digest[..8]);
+    i64::from_be_bytes(bytes)
+}
+
+/// Regression test for the advisory-lock cancellation leak: if the request
+/// future carrying `handle_idempotent_request` is dropped mid-flight (e.g. a
+/// client disconnect while the wrapped handler is still running), the
+/// idempotency lock it holds must still be released — not leaked for the
+/// life of the pooled connection.
+///
+/// Pre-fix, the middleware acquired a *session-level* `pg_advisory_lock` on a
+/// bare pooled connection and released it only via an explicit
+/// `pg_advisory_unlock` after `next.run(request).await` returned. Dropping
+/// the future between those two points (as happens here) skipped the
+/// release entirely, wedging every subsequent request — from ANY session —
+/// that shares the same idempotency key behind a lock nobody would ever
+/// release.
+///
+/// The check below deliberately opens an *independent* Postgres connection
+/// (its own backend session/PID) rather than reusing `pool` to test for the
+/// lock: Postgres advisory locks are re-entrant *within the same session*,
+/// so probing from a connection the pool happens to hand back from its own
+/// recycled/leaked connection would trivially "succeed" even under the bug
+/// and prove nothing. Only a genuinely different session can distinguish
+/// "released" from "leaked but incidentally re-entered".
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn cancelled_request_does_not_leak_advisory_lock(pool: db::DbPool) {
+    // `#[sqlx::test]`'s fixture pool sets `idle_timeout(Some(1s))` on the
+    // per-test database (see sqlx-postgres's `testing::test_context`), so an
+    // idle connection — including one that leaked a session-level advisory
+    // lock — gets physically closed (and the lock incidentally released
+    // along with it) within about a second regardless of whether this
+    // middleware releases it correctly. That would mask the exact bug this
+    // test exists to catch. Build a dedicated pool against the same
+    // database with idle reaping disabled so only the middleware's own
+    // release behavior can free the lock.
+    let app_pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(5)
+        .idle_timeout(None)
+        .max_lifetime(None)
+        .connect_with(pool.connect_options().as_ref().clone())
+        .await
+        .expect("open dedicated no-idle-reap pool for the app");
+
+    let started = Arc::new(Notify::new());
+    let hanging_app = build_hanging_app(app_pool.clone(), started.clone());
+    let tenant_id = Uuid::new_v4();
+    let idempotency_key = "idem-cancel-leak";
+
+    let first_request = post_demo(idempotency_key, tenant_id, json!({"value": 1}));
+    let first_task = tokio::spawn(async move {
+        let _ = hanging_app.oneshot(first_request).await;
+    });
+
+    // Block until the handler has actually started — i.e. the idempotency
+    // middleware has acquired its advisory lock and is now parked inside
+    // `next.run(request).await`, exactly the window the bug leaked in.
+    started.notified().await;
+
+    // Simulate a client disconnect mid-flight by aborting the task while it
+    // is still inside the handler. This drops `handle_idempotent_request`'s
+    // future — and everything it was holding — without ever reaching the
+    // unlock/commit at the end of the function. Awaiting the aborted handle
+    // guarantees the future's Drop glue (and thus the transaction's queued
+    // rollback) has run before we proceed.
+    first_task.abort();
+    let _ = first_task.await;
+
+    // `post_demo` requests carry no `ResolvedTenant` extension, so
+    // `tenant_scope()` resolves to the fixed "global" sentinel regardless of
+    // the `x-tenant-id` header value (see `spoofed_tenant_header_cannot_change_scope`).
+    let lock_id = expected_lock_id("global", "POST", "/demo", idempotency_key);
+
+    // Open a brand-new connection to the same database, independent of
+    // `pool`'s recycling, so we're guaranteed to probe from a different
+    // backend session.
+    let mut checker = sqlx::PgConnection::connect_with(pool.connect_options().as_ref())
+        .await
+        .expect("open independent checker connection");
+
+    // The background flush that turns the queued `ROLLBACK` into bytes on
+    // the wire (sqlx's `Floating::return_to_pool` pinging the connection
+    // before releasing it) races with this check, so poll briefly instead of
+    // asserting on the first attempt. Pre-fix, this never becomes true and
+    // the outer timeout fails the test instead of hanging the suite.
+    let poll_result = tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+                .bind(lock_id)
+                .fetch_one(&mut checker)
+                .await
+                .expect("pg_try_advisory_lock query");
+            if acquired {
+                let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
+                    .bind(lock_id)
+                    .execute(&mut checker)
+                    .await;
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await;
+
+    assert!(
+        poll_result.is_ok(),
+        "advisory lock id={lock_id} is still held by another session after the \
+         first request was cancelled — the idempotency lock leaked past task \
+         cancellation instead of being released"
     );
 }


### PR DESCRIPTION
## Task
`backend/crates/api-core/src/middleware/idempotency.rs:93` — a session-level `pg_advisory_lock($1)` is acquired on a pooled connection and released only at line 163 after `next.run(request).await`. If the request future is cancelled (client disconnect) between acquire and release, the advisory lock leaks for the life of that pooled connection, and can wedge subsequent requests sharing the same idempotency key. Fix: make the lock release cancellation-safe (RAII guard / scopeguard that releases on drop, or use `pg_try_advisory_xact_lock` tied to a transaction that rolls back on drop). Add a regression test (IG3: failing-on-main) proving the lock is released even when the handler future is dropped mid-flight.

## Owner
pm-backend

## Fix

Replaced the session-level `pg_advisory_lock`/`pg_advisory_unlock` pair on a bare pooled connection with a transaction-scoped `pg_advisory_xact_lock` held on a dedicated `sqlx::Transaction`. `sqlx::Transaction::drop` unconditionally queues a `ROLLBACK` when the transaction was never committed, and `sqlx`'s pool flushes that queued rollback (via a ping) before the underlying connection becomes available again — so the lock is guaranteed to be released even if this middleware's future is dropped mid-flight (client disconnect while the wrapped handler is running), instead of leaking for the life of the pooled connection.

All explicit `unlock(...)` calls on error paths were removed in favor of letting `tx` drop (which triggers the same safe release path); the happy-path branches still `tx.commit().await` explicitly to keep release latency on par with the previous behavior.

## Regression test (IG3)

Added `cancelled_request_does_not_leak_advisory_lock` to `idempotency_middleware_tests.rs`:
1. Spawns a request against a handler that signals once it has started (proving the middleware has acquired its lock and is parked inside `next.run(...)`), then hangs forever.
2. Aborts the task mid-flight (simulating a client disconnect) and awaits the join handle so the future's Drop glue has definitely run.
3. Probes the lock from an **independent** Postgres connection/session (not reused from the app's pool) — Postgres advisory locks are re-entrant within a session, so checking from a connection the pool happens to hand back would trivially "succeed" under the bug and prove nothing.
4. Runs the app against a dedicated pool with idle-reaping disabled — `#[sqlx::test]`'s fixture pool sets `idle_timeout(1s)`, which would otherwise close the leaked connection (and incidentally free the session-level lock) within ~1s regardless of the fix, masking the bug.

Verified manually before finalizing:
- Against the true pre-fix `origin/dev` code: the test **fails** (times out waiting for the lock to be released — the session-level lock is genuinely leaked forever).
- Against the fix: all 6 tests in the file pass, including this one (~30s for the full file).

## Verification

```
cd backend && cargo fmt --all -- --check   # clean
cd backend && cargo clippy -p api-core --all-targets -- -D warnings   # clean, no warnings
```

`cargo test -p api-core --test idempotency_middleware_tests` was run against a locally bootstrapped Postgres 16 instance (no Docker daemon available in this sandbox) — all 6 tests pass:
```
test cancelled_request_does_not_leak_advisory_lock ... ok
test different_authenticated_tenants_do_not_collide ... ok
test duplicate_request_replays_cached_response ... ok
test expired_cached_row_is_recomputed ... ok
test payload_mismatch_with_reused_key_returns_422 ... ok
test spoofed_tenant_header_cannot_change_scope ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`just verify` / the impact-scoped gate was not run directly in this sandbox: workspace-wide `cargo check`/`clippy` for `api-server` fails to build here because `utoipa-swagger-ui`'s build script fetches from `github.com`, which the sandbox's egress proxy 403s — a known, pre-existing environment gap unrelated to this change. `api-core` itself (the crate this change touches, plus its reverse dependents `db`/`integrations`/`common`) compiles, lints, and tests clean as shown above; CI (which has full network egress) is the authoritative gate for the workspace-wide check.

## Scope drift
None — `scope-check.sh --owner pm-backend` exits 0 (diff stays inside `backend/crates/api-core/**`).

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` produced no warnings.

## Notes
- No migration or API contract change; purely an internal concurrency-safety fix plus a regression test.
- The fix trades a (previously non-transactional) checked-out connection for a transaction held open for the duration of `next.run(request).await`. This mirrors the original design's connection-holding lifetime, but reviewers should note that if `idle_in_transaction_session_timeout` is ever configured on the Postgres role/server, a very slow handler could have its guard transaction killed by that timeout — this is not currently configured anywhere in the repo (grepped for `idle_in_transaction_session_timeout`, no hits), so it's a latent trade-off rather than an active risk.


---
_Generated by [Claude Code](https://claude.ai/code/session_015dxD3jKjGckhr5VkCi4Vnb)_