### PR TITLE
refactor-churn-hotspot-infra-ops-authz-backfill-2026-07-23-retry1: strengthen infra_ops authz backfill assertions (BIT-268)

### DIFF
--- a/backend/servers/api-server/tests/suites/infra_ops_authz_backfill_tests.rs
+++ b/backend/servers/api-server/tests/suites/infra_ops_authz_backfill_tests.rs
@@ -5,8 +5,20 @@
 //! endpoints that were previously marked as partial or none.
 //!
 //! For each endpoint:
-//!   1. an unauthenticated request is rejected (401) — auth is now required;
-//!   2. an authenticated *non-admin* request is rejected with 403.
+//!   1. an unauthenticated request is rejected with **401 Unauthorized** — the
+//!      `AuthUser` extractor (`FromRequestParts`) runs before any body/path
+//!      extraction, so this holds for every method regardless of payload;
+//!   2. an authenticated *non-admin* request is rejected with **403 Forbidden**.
+//!
+//! Assertion strength note (point 2): the handlers extract `Json<T>` *before*
+//! the in-handler platform-admin check runs, so a body-bearing request whose
+//! payload fails validation could surface a 4xx validation error ahead of the
+//! 403. For the bodyless endpoints (all GET/DELETE plus the no-`Json` POSTs)
+//! the 403 is deterministic and asserted exactly; for body-bearing endpoints we
+//! assert the caller was authenticated (not 401) yet still rejected (4xx). This
+//! is strictly stronger than a bare `is_client_error()` check: it proves auth is
+//! actually enforced (a stray 404 would now fail) rather than merely that *some*
+//! error occurred.
 //!
 //! Note that `/api/v1/infrastructure/health/metrics` is intentionally exempt from
 //! the platform-admin capability gate since it is a Prometheus scrape endpoint.
@@ -43,6 +55,29 @@ fn authed(token: &str, method: Method, uri: &str, body: Option<&str>) -> Request
             .body(Body::from(j.to_string()))
             .unwrap(),
         None => b.body(Body::empty()).unwrap(),
+    }
+}
+
+/// Assert that an authenticated *non-admin* caller is rejected.
+///
+/// For bodyless requests (no `Json<T>` extraction can precede the in-handler
+/// platform-admin check) the rejection is deterministically `403 Forbidden`.
+/// For body-bearing requests, `Json` deserialization runs before the admin
+/// check, so an incomplete/invalid payload may legitimately surface a 4xx
+/// validation error ahead of the 403 — there we assert the caller was
+/// authenticated (not `401`) yet still rejected (`4xx`).
+fn assert_non_admin_rejected(bodyless: bool, status: StatusCode, method: &Method, uri: &str) {
+    if bodyless {
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "{method} {uri} must reject an authenticated non-admin with 403, got {status}"
+        );
+    } else {
+        assert!(
+            status.is_client_error() && status != StatusCode::UNAUTHORIZED,
+            "{method} {uri} must reject an authenticated non-admin (4xx, not 401), got {status}"
+        );
     }
 }
 
@@ -306,9 +341,10 @@ async fn infrastructure_endpoints_require_auth(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     for (method, uri, body) in infrastructure_cases() {
         let resp = app.execute(anon(method.clone(), &uri, body)).await;
-        assert!(
-            resp.status.is_client_error(),
-            "{method} {uri} must require auth (4xx), got {}",
+        assert_eq!(
+            resp.status,
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} must reject an unauthenticated caller with 401, got {}",
             resp.status
         );
     }
@@ -320,14 +356,11 @@ async fn infrastructure_endpoints_reject_non_platform_admin(pool: PgPool) {
     let (token, _r) = create_authenticated_user(&app, &TestUser::new()).await;
 
     for (method, uri, body) in infrastructure_cases() {
+        let bodyless = body.is_none();
         let resp = app
             .execute(authed(&token, method.clone(), &uri, body))
             .await;
-        assert!(
-            resp.status.is_client_error(),
-            "{method} {uri} must reject non-admin (4xx), got {}",
-            resp.status
-        );
+        assert_non_admin_rejected(bodyless, resp.status, &method, &uri);
     }
 }
 
@@ -336,9 +369,10 @@ async fn operations_endpoints_require_auth(pool: PgPool) {
     let app = TestApp::new(pool.clone()).await;
     for (method, uri, body) in operations_cases() {
         let resp = app.execute(anon(method.clone(), &uri, body)).await;
-        assert!(
-            resp.status.is_client_error(),
-            "{method} {uri} must require auth (4xx), got {}",
+        assert_eq!(
+            resp.status,
+            StatusCode::UNAUTHORIZED,
+            "{method} {uri} must reject an unauthenticated caller with 401, got {}",
             resp.status
         );
     }
@@ -350,13 +384,10 @@ async fn operations_endpoints_reject_non_platform_admin(pool: PgPool) {
     let (token, _r) = create_authenticated_user(&app, &TestUser::new()).await;
 
     for (method, uri, body) in operations_cases() {
+        let bodyless = body.is_none();
         let resp = app
             .execute(authed(&token, method.clone(), &uri, body))
             .await;
-        assert!(
-            resp.status.is_client_error(),
-            "{method} {uri} must reject non-admin (4xx), got {}",
-            resp.status
-        );
+        assert_non_admin_rejected(bodyless, resp.status, &method, &uri);
     }
 }


### PR DESCRIPTION
## Task
Churn hotspot: `infra_ops_authz_backfill_tests.rs` (BIT-268 test backfill, ~364 lines). Retry 1/2. Add/repair the authz-backfill test coverage for the infra_ops area — backfill meaningful assertions for the authz backfill path.

## Owner
pm-tech-lead

## What changed
The file already enumerated every infrastructure (Epic 71/72/89) + operations (Epic 73) endpoint, but each of the four sweep tests asserted only `status.is_client_error()` — a *weak* check that a stray `404` (route not actually gated) or `405` would silently pass, defeating the point of an authz backfill. This retry tightens the assertions to the file's own documented contract, after verifying it against the handler code:

- **Unauthenticated → exactly `401`.** `AuthUser` is a `FromRequestParts` extractor that runs before `Path`/`Json`, so 401 is deterministic for every method/endpoint regardless of payload. (`infrastructure.rs` gates all 38 routes via `require_platform_admin`; `operations.rs` gates all 39 via inline `is_platform_admin()`; `health/metrics` stays public.)
- **Authenticated non-admin → `403`** for bodyless endpoints (all GET/DELETE + the no-`Json` POSTs — deterministic), and **`4xx`-and-not-`401`** for body-bearing endpoints. The `Json<T>` body is extracted *before* the in-handler admin check, so a sparse payload could surface a validation `4xx` ahead of the `403`; the "authenticated (not 401) yet rejected" assertion is still strictly stronger than the old `is_client_error()` and doesn't depend on payload-schema details.

Test-only change; no production code touched.

## Verification
Local gate was run against a locally-provisioned Postgres 16 (223 migrations applied) with the Swagger-UI build asset supplied from the `utoipa-swagger-ui-vendored` crate (this sandbox's egress policy blocks the build script's GitHub download; the vendored `v5.17.14.zip` is byte-identical to the upstream asset).

```
VERIFY-PLAN base=7efd00b6e4b1268895b35f0a59df58c12c4ee173 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` → **OK**
- `cargo clippy -p api-server --all-targets -- -D warnings` → **OK** (no warnings)
- `cargo test -p api-server` (full suite, `--no-fail-fast`) → **2393 passed, 3 failed**
  - The 5 target tests all pass:
    `infra_ops_authz_backfill_tests::{health_metrics_is_public, infrastructure_endpoints_require_auth, infrastructure_endpoints_reject_non_platform_admin, operations_endpoints_require_auth, operations_endpoints_reject_non_platform_admin}` → **5/5 ok**

**⚠️ The 3 failures are pre-existing and unrelated to this change** — all are third-party-integration tests that require outbound access to external providers (Airbnb / Booking.com), which this sandbox's egress policy blocks. They fail identically on unmodified `dev` and cannot be affected by a test-only edit to `infra_ops_authz_backfill_tests.rs`:
  - `airbnb_oauth_routes_tests::token_exchange_returns_503_when_not_configured` (external Airbnb OAuth call → 400 instead of 503)
  - `booking_cross_user_idor_tests::get_booking_as_owner_is_allowed`
  - `booking_cross_user_idor_tests::get_booking_from_other_user_is_rejected`

CI (with proper provider config / network) is the authoritative gate for those. No `VERIFY OK` line is claimed because the aggregate command exits non-zero in this sandbox solely for the environmental reasons above.

## CI parity (Band C — hot-path only)
skipped: not a hot-path change (test-only; no security/auth/billing/data-integrity production code touched — it *asserts* existing auth behavior).

## Remote-tested
skipped (ppt-bridge MCP not connected in this session).

## Scope drift
`scope-check.sh --owner pm-tech-lead` flagged `backend/servers/api-server/tests/suites/infra_ops_authz_backfill_tests.rs` as outside the `pm-tech-lead` owner-area map (advisory, exit 2). This is expected — the generic tech-lead role doesn't map to backend test paths, and the file is exactly the one the task assigned. Single-file diff; reviewer to confirm.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings.

## Notes
- Static analysis backing the exact-code assertions: all sparse `{}` request bodies deserialize (the corresponding Update/Ack/Resolve/Retry structs are fully `Option`), and every `None`-body POST in the case lists maps to a handler with no `Json` param — so the bodyless-403 path is deterministic.
- Retry context: this is retry 1/2. Scope was clear and the change is landable (target tests green); not blocked.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CNi2T8G4raMSQTNEn464Yk)_