### PR TITLE
pm-scrum-master-wire-ppt-web-direct-s3-84-1-retry1: pin DocumentUpload to direct-to-S3 path

### DIFF
--- a/frontend/apps/ppt-web/src/features/documents/components/DocumentUpload.test.tsx
+++ b/frontend/apps/ppt-web/src/features/documents/components/DocumentUpload.test.tsx
@@ -1,0 +1,120 @@
+/// <reference types="vitest/globals" />
+/**
+ * Integration regression test for the document upload component (gap-84-1).
+ *
+ * The Story-39.2 upload UI was migrated from the byte-proxying multipart
+ * `POST /api/v1/documents/upload` path (`useUploadDocument`) to the
+ * direct-to-S3 path (`useUploadDocumentDirect` →
+ * `POST /api/v1/documents/upload-url` → presigned S3 PUT → register). The
+ * api-client layer of that flow is pinned by `api.test.ts`; this test pins the
+ * *component integration* so it cannot silently regress back to proxying bytes
+ * through the api-server:
+ *
+ *   1. selecting a file + confirming drives the DIRECT upload mutation
+ *      (`useUploadDocumentDirect`), carrying the file, title and category;
+ *   2. the legacy multipart mutation (`useUploadDocument`) is never invoked;
+ *   3. a successful upload surfaces the returned document id via
+ *      `onUploadComplete`.
+ *
+ * Only the `@ppt/api-client` upload hooks (the network boundary) are mocked.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DocumentUpload } from './DocumentUpload';
+
+// ─── network boundary: @ppt/api-client upload hooks ─────────────────────────
+const directMutateAsync = vi.fn();
+const legacyMutateAsync = vi.fn();
+const useUploadDocumentDirectMock = vi.fn(() => ({
+  mutateAsync: directMutateAsync,
+  isPending: false,
+}));
+const useUploadDocumentMock = vi.fn(() => ({
+  mutateAsync: legacyMutateAsync,
+  isPending: false,
+}));
+
+vi.mock('@ppt/api-client', () => ({
+  // Real category list the component renders in its <select>.
+  DOCUMENT_CATEGORIES: [
+    'contract',
+    'invoice',
+    'receipt',
+    'report',
+    'minutes',
+    'policy',
+    'notice',
+    'maintenance',
+    'insurance',
+    'legal',
+    'financial',
+    'correspondence',
+    'other',
+  ],
+  useUploadDocumentDirect: () => useUploadDocumentDirectMock(),
+  // Legacy multipart hook — exposed so the test can assert it is NOT used.
+  useUploadDocument: () => useUploadDocumentMock(),
+}));
+
+function selectFile(container: HTMLElement, file: File) {
+  const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DocumentUpload — direct-to-S3 integration (gap-84-1)', () => {
+  it('drives the direct-to-S3 upload mutation, not the legacy multipart path', async () => {
+    directMutateAsync.mockResolvedValue({ id: 'doc-42', message: 'created' });
+    const onUploadComplete = vi.fn();
+
+    const { container } = render(
+      <DocumentUpload organizationId="org-1" onUploadComplete={onUploadComplete} />
+    );
+
+    // Selecting a file auto-fills the title from the filename, enabling upload.
+    const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+    selectFile(container, file);
+
+    fireEvent.click(screen.getByRole('button', { name: /Upload & Process/i }));
+
+    await waitFor(() => {
+      expect(directMutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    // The direct-to-S3 mutation carried the file, the derived title and the
+    // selected category (defaults to 'other').
+    expect(directMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file,
+        title: 'report',
+        category: 'other',
+        organizationId: 'org-1',
+      })
+    );
+
+    // The byte-proxying multipart path must never fire — the whole point of
+    // gap-84-1 is that bytes go straight to S3.
+    expect(legacyMutateAsync).not.toHaveBeenCalled();
+
+    // The uploaded document id is surfaced to the caller.
+    await waitFor(() => {
+      expect(onUploadComplete).toHaveBeenCalledWith('doc-42');
+    });
+  });
+
+  it('does not upload when no file is selected', () => {
+    render(<DocumentUpload organizationId="org-1" />);
+
+    const uploadBtn = screen.getByRole('button', { name: /Upload & Process/i });
+    // With no pending file the action is disabled and firing it is a no-op.
+    expect(uploadBtn).toBeDisabled();
+    fireEvent.click(uploadBtn);
+
+    expect(directMutateAsync).not.toHaveBeenCalled();
+    expect(legacyMutateAsync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Task
Wire ppt-web direct-to-S3 upload via POST /api/v1/documents/upload-url — api-client binding + UploadDocument integration + regression test (84-1, finish-what-is-started).

## Owner
pm-frontend

## What was found (finish-what-is-started)
Three of the task's deliverables were **already present on `dev`**, landed under commit `a3870e2a2` (a dispatcher "pre-spawn claim" commit that appears to have swept a prior implementer's working tree — the auto-commit hazard the ppt-implement skill's Step 2.5b guards against):

- **api-client binding** — `createUploadUrl`, `uploadFileToPresignedUrl`, `uploadDocumentDirect`, `deleteUploadedFile` in `frontend/packages/api-client/src/documents/api.ts` + `CreateUploadUrlRequest`/`CreateUploadUrlResponse` types + `useUploadDocumentDirect` hook. ✅
- **UploadDocument integration** — `frontend/apps/ppt-web/src/features/documents/components/DocumentUpload.tsx` already imports and drives `useUploadDocumentDirect`. ✅
- **api-layer regression test** — `documents/api.test.ts` pins the presign → S3 PUT → register chain, the `building_id` omission (#2366), and orphan-cleanup (#2564). ✅

The genuine gap this PR closes: there was **no component-level test** proving `DocumentUpload` actually drives the direct-to-S3 path. That is the risky integration wiring — it could silently regress back to the byte-proxying multipart `useUploadDocument` with no test catching it.

## Change
Adds `frontend/apps/ppt-web/src/features/documents/components/DocumentUpload.test.tsx`:
1. selecting a file + confirming drives the **direct** upload mutation (`useUploadDocumentDirect`) with the file/title/category;
2. the legacy multipart mutation (`useUploadDocument`) is **never** invoked;
3. a successful upload surfaces the returned id via `onUploadComplete`;
4. no file selected → upload disabled and no mutation fires.

This is a real regression guard: if the component reverts to `useUploadDocument`, assertion 1 fails because `directMutateAsync` is never called.

## Verification
```
VERIFY-PLAN base=92a77e8d512758ff05baffe758331c39c98e1682 files=1
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/documents/components/DocumentUpload.test.tsx
  cd frontend && pnpm --filter "...[92a77e8d5...]" typecheck
  cd frontend && pnpm --filter "...[92a77e8d5...]" test
```
`VERIFY OK 33adfe6348252e084a2c5cd0fa6b573da9b063eb` — biome + typecheck clean, 113 test files / 2144 tests pass (incl. the 2 new component tests).

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. Single new file under `apps/ppt-web/src/features/documents/`.

## Code-reuse review
`reuse-grep.sh` clean (test-only change, no new helpers).

## Goal-check (IG1–IG8)
Exit 0. IG7 (verify) green. IG1/IG2 report FAIL only because this is a dispatcher task-text flow (no `.research/plans/` file; pre-assigned `auto-impl/` branch), not the plan-file flow the check assumes. IG3 is a WARN by design — the `fix:` code was already landed on `dev`, so this finishing increment is a pure `test:` commit.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- `depends_on: []`. Endpoint/binding already existed in the api-client, so nothing was scoped down for missing backend.
- Reviewer may want to note the `a3870e2a2` provenance: the feature code reached `dev` without its own PR/review. This PR does not re-touch that code (it is green and covered); it only adds the missing component test. If a separate review of the already-merged binding is desired, that is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bd3VxFj2MxAx6YMHkiYXMr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bd3VxFj2MxAx6YMHkiYXMr)_