### PR TITLE
gh-issue-2575: validate /disputes/kpis window ordering + executing test

### DIFF
--- a/backend/servers/api-server/src/routes/disputes.rs
+++ b/backend/servers/api-server/src/routes/disputes.rs
@@ -417,6 +417,25 @@ async fn get_kpis(
     Query(query): Query<KpisQuery>,
 ) -> Result<Json<DisputeKpis>, (StatusCode, Json<ErrorResponse>)> {
     let organization_id = require_org(&user)?;
+
+    // Issue #2575: validate the reporting window before touching the repo.
+    // `get_dispute_kpis` filters the cohort on `window_start <= filed_at <
+    // window_end`, so an inverted or empty window (`window_start >=
+    // window_end`) silently yields a degenerate zero-count `DisputeKpis` with
+    // a 200 — a caller cannot distinguish "no disputes in window" from
+    // "I inverted my bounds". Reject it up front, mirroring how the sibling
+    // mutating handlers surface `VALIDATION_ERROR` (see `resolve_dispute` /
+    // `update_mediation_notes`). Cheap guard, clearer contract.
+    if query.window_start >= query.window_end {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ErrorResponse::new(
+                "VALIDATION_ERROR",
+                "window_start must be strictly before window_end",
+            )),
+        ));
+    }
+
     state
         .dispute_repo
         .get_dispute_kpis(organization_id, query.window_start, query.window_end)

--- a/backend/servers/api-server/tests/suites/disputes_happy_path_tests.rs
+++ b/backend/servers/api-server/tests/suites/disputes_happy_path_tests.rs
@@ -555,8 +555,18 @@ async fn dispute_sessions_happy_path(pool: PgPool) {
 /// GET /api/v1/disputes/kpis returns the DisputeKpis JSON contract for the
 /// caller's org cohort. Files one dispute inside the window and asserts the
 /// full funnel + TTR shape, plus that the filed dispute is counted.
+///
+/// Issue #2575: this `#[sqlx::test]` DB-contract case remains under the
+/// systemic BIT-440 dev-hostage quarantine (un-quarantining it in isolation,
+/// while BIT-440 is unresolved, reintroduces the failing test that PR #1984
+/// quarantined to unblock the gate — see the BIT-417 de-quarantine precedent,
+/// which only lifted the marker once BIT-440 cleared). It must be
+/// de-quarantined together with the rest of the BIT-440 suite when that
+/// ticket clears. The endpoint's *executing* coverage now lives in
+/// `dispute_kpis_rejects_inverted_window` below, which is a plain
+/// `#[tokio::test]` outside BIT-440 scope.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-#[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440"]
+#[ignore = "BIT-440: quarantined — fails on dev (workspace hostage); see BIT-440 (de-quarantine tracked by #2575 when BIT-440 clears)"]
 async fn dispute_kpis_happy_path(pool: PgPool) {
     let ctx = setup(pool, "kpis").await;
     // Seed a cohort member (created_at defaults to NOW(), inside the window).
@@ -617,6 +627,98 @@ async fn dispute_kpis_happy_path(pool: PgPool) {
     assert!(
         ttr["count"].as_i64().is_some(),
         "ttr.count is an integer: {ttr}"
+    );
+
+    // Issue #2575: an inverted window (start after end) is rejected with a
+    // 422 VALIDATION_ERROR rather than silently returning a degenerate
+    // zero-count 200. Asserted here too so the DB-contract case covers the
+    // validation branch once BIT-440 clears and this test runs.
+    let inverted = ctx
+        .get(&format!(
+            "/api/v1/disputes/kpis?window_start={end}&window_end={start}"
+        ))
+        .send()
+        .await;
+    assert_eq!(
+        inverted.status.as_u16(),
+        422,
+        "inverted window should be rejected with 422, got {}: {}",
+        inverted.status,
+        inverted.text()
+    );
+    assert_eq!(
+        inverted.json_value().get("code").and_then(|c| c.as_str()),
+        Some("VALIDATION_ERROR"),
+        "inverted-window error code should be VALIDATION_ERROR: {}",
+        inverted.text()
+    );
+}
+
+/// Validation guard (issue #2575): an inverted or empty reporting window
+/// (`window_start >= window_end`) is rejected with `422 VALIDATION_ERROR`
+/// *before* the repository is consulted, so a caller gets an explicit error
+/// instead of a degenerate zero-count `DisputeKpis` with a `200`.
+///
+/// This is deliberately a plain `#[tokio::test]`, not `#[sqlx::test]`: the
+/// validation branch returns before any DB access (`require_org` reads the JWT
+/// claim, then the ordering check fires), so it needs no live Postgres and is
+/// therefore NOT subject to the BIT-440 dev-hostage quarantine that gates the
+/// `#[sqlx::test]` contract case above. It runs on every CI/dev `cargo test`,
+/// giving the endpoint executing coverage of its validation contract. The
+/// lazy pool never connects — the same pattern the `push_fanout.rs` /
+/// `voice_commands.rs` pure-path unit tests use.
+#[tokio::test]
+async fn dispute_kpis_rejects_inverted_window() {
+    let pool = sqlx::PgPool::connect_lazy("postgres://never-used:never@127.0.0.1:1/never")
+        .expect("connect_lazy builds without connecting");
+    let app = TestApp::new(pool).await;
+    let token = mint_token(Uuid::new_v4(), Uuid::new_v4());
+
+    // Z-suffixed RFC3339 avoids `+00:00` query encoding (mirrors the happy path).
+    let later = (chrono::Utc::now() + chrono::Duration::days(1))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+    let earlier = (chrono::Utc::now() - chrono::Duration::days(1))
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    // Inverted bounds: window_start strictly AFTER window_end.
+    let inverted = app
+        .get(&format!(
+            "/api/v1/disputes/kpis?window_start={later}&window_end={earlier}"
+        ))
+        .bearer(&token)
+        .send()
+        .await;
+    assert_eq!(
+        inverted.status.as_u16(),
+        422,
+        "inverted window should be rejected with 422, got {}: {}",
+        inverted.status,
+        inverted.text()
+    );
+    assert_eq!(
+        inverted.json_value().get("code").and_then(|c| c.as_str()),
+        Some("VALIDATION_ERROR"),
+        "error code should be VALIDATION_ERROR: {}",
+        inverted.text()
+    );
+
+    // Empty bounds: `[t, t)` is empty, so equal start/end is rejected too.
+    let same = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+    let empty = app
+        .get(&format!(
+            "/api/v1/disputes/kpis?window_start={same}&window_end={same}"
+        ))
+        .bearer(&token)
+        .send()
+        .await;
+    assert_eq!(
+        empty.status.as_u16(),
+        422,
+        "empty window (start == end) should be rejected with 422, got {}: {}",
+        empty.status,
+        empty.text()
     );
 }
 


### PR DESCRIPTION
## Task
Closes #2575 — `/disputes/kpis` endpoint has no window-ordering validation (start must precede end) and its only test is quarantined. Add window-ordering validation returning a 400/422 on inverted or invalid windows, and un-quarantine + fix the existing test (add coverage for the invalid-window case).

## Owner
pm-tech-lead (specialist: rust-backend)

## Change
- `routes/disputes.rs::get_kpis` — reject `window_start >= window_end` up front with **422 `VALIDATION_ERROR`** (before the repo call), mirroring the sibling `resolve_dispute` / `update_mediation_notes` guards. Previously an inverted/empty window flowed into the SQL cohort filter and silently returned a degenerate zero-count `DisputeKpis` with a `200`. 422 chosen over 400 to match the existing `VALIDATION_ERROR` convention in this file (lines 603/668).
- `tests/suites/disputes_happy_path_tests.rs` — new **`dispute_kpis_rejects_inverted_window`** (`#[tokio::test]`, failing-on-main). It drives the real router with a lazily-connected pool; the validation branch returns before any DB access, so it needs no live Postgres and is **outside the BIT-440 quarantine** — giving the endpoint executing contract coverage on every CI/dev `cargo test`.

### Note on "un-quarantine the existing test"
The existing contract test `dispute_kpis_happy_path` is a `#[sqlx::test]` under the **systemic BIT-440 dev-hostage quarantine** (12+ files). Un-quarantining it in isolation, while BIT-440 is unresolved, would reintroduce the exact failing test PR #1984 quarantined to unblock the gate — the BIT-417 precedent only lifted the marker *after* BIT-440 cleared. Doing so would ship a red CI, which the skill forbids. The research backlog's own note for this issue recommends "add non-`sqlx::test` handler-level test outside BIT-440 scope" — which is what this PR does. The quarantined test keeps its marker but now: (a) has the inverted-window assertion folded in for when it eventually runs, and (b) its ignore note explicitly tracks #2575 for de-quarantine when BIT-440 clears.

## Verification
Backend cannot fully compile in this cloud runner: the `utoipa-swagger-ui` build script fetches Swagger UI from github.com (egress-blocked → `InvalidArchive`). Expected environment limitation, not this code — mirrors PRs #2684/#2685. CI `backend.yml` is the authoritative gate; hence **draft**.

- `cd backend && cargo fmt --all -- --check` → exit **0** (clean).
- `cargo clippy -p api-server` / `cargo test -p api-server` → could NOT run locally (swagger-ui egress block). Deferred to CI.

## Scope drift
`scope-check.sh --owner pm-tech-lead` → exit 2 (advisory). The `pm-tech-lead` owner-area map doesn't include api-server routes, but these are the correct backend files for this rust-backend task:
- `backend/servers/api-server/src/routes/disputes.rs`
- `backend/servers/api-server/tests/suites/disputes_happy_path_tests.rs`

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → clean (no duplicated helpers).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change) — standard `backend.yml` gate applies.

## Remote-tested
skipped.

## Notes
- 422 vs 400: followed the in-file `VALIDATION_ERROR` convention (422 `UNPROCESSABLE_ENTITY`); the issue said "400/422".
- Equal bounds (`start == end`) are also rejected — `[t, t)` is an empty half-open window.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Bd3VxFj2MxAx6YMHkiYXMr)_