### PR TITLE
code-review-api-handlers-enhanced-chat-stub: fail closed (501) for stubbed enhanced_chat handler

### DIFF
--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -1111,51 +1111,43 @@ async fn publish_description(
     path = "/api/v1/ai/llm/chat/enhanced",
     request_body = EnhancedChatRequest,
     responses(
-        (status = 200, description = "Chat response with context"),
         (status = 401, description = "Unauthorized", body = ErrorResponse),
+        (status = 501, description = "Enhanced (RAG) chat not implemented", body = ErrorResponse),
     ),
     tag = "AI LLM"
 )]
 async fn enhanced_chat(
-    State(state): State<AppState>,
     mut rls: RlsConnection,
-    Json(req): Json<EnhancedChatRequest>,
+    Json(_req): Json<EnhancedChatRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
-    let tenant_id = rls.tenant_id();
-
-    // Get escalation config
-    let config = state
-        .llm_document_repo
-        .get_escalation_config(rls.conn(), tenant_id)
-        .await;
+    // Fail closed (code review — code-review-api-handlers-enhanced-chat-stub).
+    //
+    // The RAG pipeline this endpoint promises — (1) search document embeddings
+    // for relevant context, (2) call the LLM with that context, (3) score the
+    // response confidence against the escalation threshold — is NOT implemented.
+    //
+    // The previous placeholder returned a 200 success payload built entirely
+    // from fabricated data: a canned echo `response`, a hardcoded
+    // `confidence: 0.85`, `tokens_used: 150`, an empty `sources: []`, and an
+    // `escalated` flag derived from that fake confidence. Clients — and any
+    // escalation automation reading those metrics — could act on invented data.
+    // Until the real embedding + LLM pipeline lands, return 501 so no caller
+    // mistakes a stub for a real answer.
+    //
+    // `RlsConnection` is still extracted so unauthenticated requests are
+    // rejected with 401 before reaching here; release it immediately as we do
+    // no database work.
     rls.release().await;
-    let config = config.map_err(|e| {
-        tracing::error!("Failed to get escalation config: {}", e);
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get config")),
-        )
-    })?;
 
-    // Placeholder response - real implementation would:
-    // 1. Search document embeddings for relevant context
-    // 2. Call LLM with context
-    // 3. Check confidence against threshold
-    let confidence = 0.85; // Placeholder
-    let escalated = confidence < config.confidence_threshold;
-
-    let response = serde_json::json!({
-        "message_id": Uuid::new_v4(),
-        "response": format!("I understand you're asking about: {}. Let me help you with that.", req.message),
-        "confidence": confidence,
-        "sources": [],
-        "escalated": escalated,
-        "escalation_reason": if escalated { Some("Low confidence in response") } else { None },
-        "language_detected": req.language,
-        "tokens_used": 150
-    });
-
-    Ok(Json(response))
+    Err((
+        StatusCode::NOT_IMPLEMENTED,
+        Json(ErrorResponse::new(
+            "ENHANCED_CHAT_NOT_IMPLEMENTED",
+            "Enhanced (RAG) chat is not yet implemented: the document-embedding \
+             search and LLM pipeline are not wired up, so no chat response, \
+             confidence score, or escalation decision can be produced.",
+        )),
+    ))
 }
 
 async fn get_escalation_config(

--- a/backend/servers/api-server/tests/suites/ai_llm_workflow_batch5_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_llm_workflow_batch5_tests.rs
@@ -11,8 +11,11 @@
 //! Skipped (require live external provider calls):
 //!   • POST /api/v1/ai/llm/lease/generate     (LLM call)
 //!   • POST /api/v1/ai/llm/listing/description (LLM call)
-//!   • POST /api/v1/ai/llm/chat/enhanced       (LLM call)
 //!   • POST /api/v1/ai/llm/voice/devices       (OAuth exchange)
+//!
+//! Note: POST /api/v1/ai/llm/chat/enhanced is covered below as a fail-closed
+//! (501 NOT_IMPLEMENTED) regression test — the handler no longer fabricates a
+//! success payload, so it needs no live provider.
 
 use axum::http::StatusCode;
 use serde_json::json;
@@ -624,6 +627,63 @@ async fn update_escalation_config_returns_ok(pool: PgPool) {
         StatusCode::OK,
         "update escalation config must return 200; body={}",
         resp.text()
+    );
+}
+
+// =============================================================================
+// ai/llm.rs — enhanced (RAG) chat
+// =============================================================================
+
+// POST /api/v1/ai/llm/chat/enhanced → 501 NOT_IMPLEMENTED
+//
+// Regression guard (code-review-api-handlers-enhanced-chat-stub): this handler
+// used to return a 200 success payload with fabricated metrics (a canned echo
+// response, a hardcoded confidence of 0.85, tokens_used: 150, empty sources,
+// and an escalated flag derived from the fake confidence) despite doing no
+// embedding search and no LLM call. It now fails closed with 501 so clients
+// never act on invented data. Assert both the status AND the absence of the
+// fabricated fields.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn enhanced_chat_fails_closed_not_implemented(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) =
+        create_authenticated_user_with_org(&app, &user, "llm-enhanced-chat").await;
+    let session = app.session(token, org_id);
+
+    let resp = app
+        .execute(
+            session
+                .post("/api/v1/ai/llm/chat/enhanced")
+                .json(json!({
+                    "message": "How do I report a leak in my unit?",
+                    "language": "en"
+                }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_IMPLEMENTED,
+        "enhanced chat must fail closed with 501, not return fabricated success; body={}",
+        resp.text()
+    );
+
+    // The old stub leaked these invented metrics in a 200 body — none of them
+    // must ever appear in the fail-closed response.
+    let body = resp.text();
+    assert!(
+        !body.contains("\"confidence\""),
+        "response must not carry a fabricated confidence score; body={body}"
+    );
+    assert!(
+        !body.contains("\"tokens_used\""),
+        "response must not carry a fabricated token count; body={body}"
+    );
+    assert!(
+        !body.contains("\"escalated\""),
+        "response must not carry a fabricated escalation flag; body={body}"
     );
 }
 


### PR DESCRIPTION
## Task
backend/servers/api-server/src/routes/ai/llm.rs:1119-1158 — `enhanced_chat` is a stubbed production handler mounted at POST /chat/enhanced (llm.rs:49). It ignores the request and returns fabricated data: canned echo `response`, hardcoded `confidence: 0.85`, `tokens_used: 150`, empty `sources: []`, and an `escalated` flag derived from the fake confidence. No LLM call, no embedding search. RECOMMENDED FIX: fail closed — return `501 NOT_IMPLEMENTED` instead of a success payload with fabricated confidence/token/escalation metrics, so no client acts on invented data. Add a regression test asserting the endpoint no longer returns fabricated success metrics.

## Owner
pm-backend (specialist: rust-backend)

## What changed
- `enhanced_chat` now fails closed with `501 NOT_IMPLEMENTED` and error code `ENHANCED_CHAT_NOT_IMPLEMENTED`, mirroring the existing NOT_IMPLEMENTED convention in `routes/rentals.rs` (`extract_guest_id_document` → `501 OCR_NOT_CONFIGURED`). All fabricated fields (canned response, `confidence: 0.85`, `tokens_used: 150`, empty `sources`, derived `escalated`) are removed.
- `RlsConnection` is still extracted so unauthenticated requests get `401` before reaching the handler; it is released immediately since the handler does no DB work. The unused `State`/escalation-config read is dropped.
- utoipa `responses(...)` updated: dropped the `200` success shape, added `501`.
- Regression test `enhanced_chat_fails_closed_not_implemented` in `tests/suites/ai_llm_workflow_batch5_tests.rs` asserts the endpoint returns `501` AND that the body carries none of the previously fabricated `confidence` / `tokens_used` / `escalated` fields. The top-of-file "Skipped" note is updated (chat/enhanced is now covered rather than skipped).

## Verification
`just verify` / local `cargo clippy`+`cargo test` for the api-server crate CANNOT complete in this environment: the `utoipa-swagger-ui` build script downloads swagger-ui from github.com, which is egress-blocked. This is the known, expected block — not a code failure.

Local gate that did run:
```
cd backend && cargo fmt --all -- --check   # exit 0 (clean)
```

Authoritative build/clippy/test gate for this PR is CI `backend.yml`. Opened as draft accordingly.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change) — this narrows behavior (removes a fabricated success payload) behind existing auth.

## Remote-tested
skipped

## Scope drift
None — `scope-check.sh --owner pm-backend` exited 0. Only `backend/servers/api-server/**` touched.

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` emitted no warnings. Reuses the existing `ErrorResponse::new` + `StatusCode::NOT_IMPLEMENTED` convention; no new helpers added.

## Notes
- Implementing the full embedding + LLM RAG pipeline is intentionally out of scope for this low-priority fix; this change only stops the handler from emitting invented data.
- The remaining `tokens_used` / `0.85` occurrences in `llm.rs` belong to `generate_lease` / `generate_listing_description`, which return real provider token counts — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfykegraQZePjUduG7kNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfykegraQZePjUduG7kNGd)_