### PR TITLE
code-review-ppt-web-core-ws-pong-timeout-drop: drop redundant client app-level WS heartbeat

### DIFF
--- a/frontend/apps/ppt-web/src/lib/websocket.test.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.test.ts
@@ -17,8 +17,13 @@
  * every event, so the round-trip is asserted explicitly.
  */
 
-import { describe, expect, it } from 'vitest';
-import { buildWebSocketUrl, parseServerMessage, WS_NOTIFICATIONS_PATH } from './websocket';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildWebSocketUrl,
+  parseServerMessage,
+  WebSocketService,
+  WS_NOTIFICATIONS_PATH,
+} from './websocket';
 
 describe('buildWebSocketUrl', () => {
   it('appends the canonical handler path to a bare origin', () => {
@@ -86,5 +91,92 @@ describe('parseServerMessage', () => {
     expect(parseServerMessage(null)).toBeNull();
     expect(parseServerMessage('string')).toBeNull();
     expect(parseServerMessage(42)).toBeNull();
+  });
+});
+
+/**
+ * Minimal `WebSocket` double so the service lifecycle can be driven under fake
+ * timers without a real network. Records every instance and every `close()`
+ * call so a test can assert the client never force-closes a healthy socket.
+ */
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string; wasClean: boolean }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+
+  readonly url: string;
+  readonly sent: string[] = [];
+  readonly closeCalls: { code?: number; reason?: string }[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code: code ?? 1000, reason: reason ?? '', wasClean: code === 1000 });
+  }
+
+  /** Test helper: drive the handshake to open. */
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
+}
+
+describe('WebSocketService heartbeat (regression: #ws-pong-timeout-drop)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', MockWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('does not force-close the socket after 60s with no app-level pong reply', () => {
+    // Regression: the client used to send an application-level {type:'ping'}
+    // every 30s and force-close with code 4000 "Pong timeout" 10s later because
+    // the api-server never emits an app-level {type:'pong'}. Liveness now lives
+    // purely at the protocol layer (server Ping + browser auto-Pong), so a
+    // healthy socket that receives no app-level pong must stay open.
+    const service = new WebSocketService({ getToken: () => 'jwt-token' });
+
+    service.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const socket = MockWebSocket.instances[0];
+    socket.simulateOpen();
+    expect(service.getConnectionState()).toBe('connected');
+
+    // Well past the old 30s heartbeat + 10s pong-timeout window.
+    vi.advanceTimersByTime(60_000);
+
+    // The client must not have closed the socket…
+    expect(socket.closeCalls).toHaveLength(0);
+    // …must never send an app-level heartbeat frame…
+    expect(socket.sent).toHaveLength(0);
+    // …must not have scheduled a reconnect (no second socket)…
+    expect(MockWebSocket.instances).toHaveLength(1);
+    // …and must still report itself connected.
+    expect(service.getConnectionState()).toBe('connected');
+
+    service.disconnect();
   });
 });

--- a/frontend/apps/ppt-web/src/lib/websocket.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.ts
@@ -5,8 +5,14 @@
  * - Authentication via JWT token
  * - Automatic reconnection with exponential backoff
  * - Connection state machine
- * - Heartbeat/ping-pong mechanism
  * - Event emitter pattern for message handling
+ *
+ * Liveness is handled entirely at the WebSocket protocol layer: the api-server
+ * sends protocol-level `Ping` frames (`Message::Ping` in `ws_notifications.rs`)
+ * and the browser answers them with an automatic protocol-level `Pong`. The
+ * client does NOT run any application-level `{type:'ping'}`/`{type:'pong'}`
+ * heartbeat — that redundant mechanism used to force-close the socket every
+ * ~40 s because the server never emits an app-level `{type:'pong'}` reply.
  */
 
 /**
@@ -49,8 +55,8 @@ export interface ServerWsEnvelope {
  * Normalise one decoded server frame into the client's internal
  * {@link WebSocketMessage} shape.
  *
- * Returns `null` for frames that are not a recognised event envelope (e.g. a
- * bare `pong` heartbeat or malformed JSON) so callers can short-circuit.
+ * Returns `null` for frames that are not a recognised event envelope (e.g.
+ * malformed JSON or a stray non-event frame) so callers can short-circuit.
  *
  * The server emits `{ event, payload }`; we map `event` -> `type` and supply a
  * client-side receive `timestamp` (the server envelope carries none) so gap
@@ -166,18 +172,6 @@ export interface WebSocketServiceConfig {
   maxReconnectDelay?: number;
 
   /**
-   * Heartbeat interval in milliseconds.
-   * @default 30000
-   */
-  heartbeatInterval?: number;
-
-  /**
-   * Pong timeout in milliseconds (how long to wait for pong after ping).
-   * @default 10000
-   */
-  pongTimeout?: number;
-
-  /**
    * Maximum number of reconnect attempts before giving up.
    * After exceeding this, the client emits a `connection:max-retries-exceeded`
    * message and stops retrying. Call `connect()` again to resume.
@@ -216,8 +210,8 @@ function defaultWebSocketUrl(): string {
 /**
  * Dev-only diagnostic logging for the WebSocket client.
  *
- * The connection diagnostics below (send failures, handler errors, pong
- * timeouts, reconnect give-up) are valuable while developing but must not
+ * The connection diagnostics below (send failures, handler errors, reconnect
+ * give-up) are valuable while developing but must not
  * leak to the browser console in production builds: they surface internal
  * connection state and add noise for end users. Gating on `import.meta.env.DEV`
  * — the same convention `lib/api.ts` uses for its retry logging — lets Vite
@@ -259,19 +253,12 @@ export class WebSocketService {
   private readonly getToken: () => string | null;
   private readonly minReconnectDelay: number;
   private readonly maxReconnectDelay: number;
-  private readonly heartbeatInterval: number;
-  private readonly pongTimeout: number;
   private readonly maxReconnectAttempts: number;
 
   // Reconnection state
   private reconnectAttempts = 0;
   private reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private shouldReconnect = true;
-
-  // Heartbeat state
-  private heartbeatIntervalId: ReturnType<typeof setInterval> | null = null;
-  private pongTimeoutId: ReturnType<typeof setTimeout> | null = null;
-  private awaitingPong = false;
 
   // Event handlers
   private messageHandlers: Map<string, Set<MessageHandler>> = new Map();
@@ -285,8 +272,6 @@ export class WebSocketService {
     this.getToken = config.getToken;
     this.minReconnectDelay = config.minReconnectDelay ?? 1000;
     this.maxReconnectDelay = config.maxReconnectDelay ?? 30000;
-    this.heartbeatInterval = config.heartbeatInterval ?? 30000;
-    this.pongTimeout = config.pongTimeout ?? 10000;
     this.maxReconnectAttempts = config.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
   }
 
@@ -376,7 +361,6 @@ export class WebSocketService {
   disconnect(): void {
     this.shouldReconnect = false;
     this.clearReconnectTimeout();
-    this.stopHeartbeat();
 
     if (this.socket) {
       this.socket.close(1000, 'Client disconnecting');
@@ -400,8 +384,6 @@ export class WebSocketService {
    */
   private teardownStaleSocket(): void {
     if (!this.socket) return;
-
-    this.stopHeartbeat();
 
     const stale = this.socket;
     stale.onopen = null;
@@ -489,12 +471,9 @@ export class WebSocketService {
       this.reconnectAttempts = 0;
       this.lastError = null;
       this.setConnectionState('connected');
-      this.startHeartbeat();
     };
 
     this.socket.onclose = (event) => {
-      this.stopHeartbeat();
-
       if (event.wasClean) {
         this.setConnectionState('disconnected');
       } else {
@@ -522,14 +501,6 @@ export class WebSocketService {
   private handleMessage(event: MessageEvent): void {
     try {
       const data = JSON.parse(event.data as string);
-
-      // Handle pong response. The client emits `{ type: 'ping' }` and the
-      // server may echo `{ type: 'pong' }`; either heartbeat reply is matched
-      // here before the canonical-envelope path below.
-      if (data && typeof data === 'object' && data.type === 'pong') {
-        this.handlePong();
-        return;
-      }
 
       // Server speaks the canonical `{ event, payload }` envelope. Normalise
       // it into the internal message shape (event -> type) so subscribers can
@@ -660,60 +631,6 @@ export class WebSocketService {
     if (this.reconnectTimeoutId) {
       clearTimeout(this.reconnectTimeoutId);
       this.reconnectTimeoutId = null;
-    }
-  }
-
-  private startHeartbeat(): void {
-    this.stopHeartbeat();
-
-    this.heartbeatIntervalId = setInterval(() => {
-      this.sendPing();
-    }, this.heartbeatInterval);
-  }
-
-  private stopHeartbeat(): void {
-    if (this.heartbeatIntervalId) {
-      clearInterval(this.heartbeatIntervalId);
-      this.heartbeatIntervalId = null;
-    }
-
-    if (this.pongTimeoutId) {
-      clearTimeout(this.pongTimeoutId);
-      this.pongTimeoutId = null;
-    }
-
-    this.awaitingPong = false;
-  }
-
-  private sendPing(): void {
-    if (!this.isConnected() || this.awaitingPong) {
-      return;
-    }
-
-    const pingMessage: WebSocketMessage = {
-      type: 'ping',
-      payload: null,
-      timestamp: new Date().toISOString(),
-    };
-
-    if (this.send(pingMessage)) {
-      this.awaitingPong = true;
-
-      this.pongTimeoutId = setTimeout(() => {
-        if (this.awaitingPong) {
-          wsWarn('[WebSocket] Pong timeout - closing connection');
-          this.socket?.close(4000, 'Pong timeout');
-        }
-      }, this.pongTimeout);
-    }
-  }
-
-  private handlePong(): void {
-    this.awaitingPong = false;
-
-    if (this.pongTimeoutId) {
-      clearTimeout(this.pongTimeoutId);
-      this.pongTimeoutId = null;
     }
   }
 }


### PR DESCRIPTION
## Task
`frontend/apps/ppt-web/src/lib/websocket.ts:688-709` — the client heartbeat sent an APPLICATION-level ping frame `{type:'ping'}` every 30s and armed a 10s `pongTimeout` that ONLY cleared on an app-level `{type:'pong'}` text frame. The api-server WS handler (`backend/servers/api-server/src/routes/ws_notifications.rs`) NEVER sends an app-level `{type:'pong'}` — it treats every inbound client frame as a heartbeat and only uses protocol-level Ping/Pong. Result: every ~40s the client force-closed with code 4000 'Pong timeout' and reconnected, churning the notification socket for the whole session. Fix: remove the redundant client-side app-level `sendPing`/`pongTimeout` logic and rely on the server's protocol-level `Message::Ping` + the browser's automatic protocol-level pong for liveness; add a regression test proving the client no longer force-closes on a healthy connection that receives no app-level pong.

## Owner
`pm-backend` (label). NOTE: despite the label this is a FRONTEND-only `ppt-web` change; specialist = `react-web` (see Scope drift below).

## What changed
`frontend/apps/ppt-web/src/lib/websocket.ts`
- Removed `sendPing()`, `handlePong()`, `startHeartbeat()`, `stopHeartbeat()` and the `awaitingPong` / `heartbeatIntervalId` / `pongTimeoutId` state.
- Removed the `heartbeatInterval` / `pongTimeout` config fields, their class members, and their constructor defaults.
- Removed the dead `data.type === 'pong'` branch from `handleMessage`.
- Removed the now-unused `startHeartbeat`/`stopHeartbeat` calls in `onopen`/`onclose`/`disconnect`/`teardownStaleSocket`.
- Updated the module/JSDoc comments to document that liveness is protocol-layer only (server `Message::Ping` + browser auto-Pong).

`frontend/apps/ppt-web/src/lib/websocket.test.ts`
- Added regression test `does not force-close the socket after 60s with no app-level pong reply` (fake timers + mock WebSocket). Asserts: zero `close()` calls, zero app-level frames sent, no reconnect (single socket), state stays `connected` after 60s.

Backend `ws_notifications.rs:27` comment was intentionally NOT touched — the existing "any client message is treated as a heartbeat" wording remains accurate, and leaving it avoids unnecessary cross-stack drift (see Out of scope).

## Suggested-approach cross-reference (plan IG4)
1. Delete `sendPing`/`pongTimeout`/`awaitingPong`/`handlePong` — done.
2. Remove the app-level heartbeat (`startHeartbeat`/`stopHeartbeat`) — done (rely on protocol Ping + browser auto-Pong).
3. Drop the `type:'pong'` branch in `handleMessage` — done. (`parseServerMessage` already returns `null` for non-event frames; left as-is since it is generic and correct.)
4. Remove `heartbeatInterval`/`pongTimeout` config fields + defaults — done. `WebSocketContext` set no overrides, so nothing else changed.
5. Regression test — done (see above).
6. Manual 5-min DevTools verification — NOT run (cloud implementer, no browser). Covered by the fake-timer regression test.
7. Update `ws_notifications.rs:27` comment — intentionally skipped (comment still accurate; keeps diff frontend-only).

## Verification
```
VERIFY-PLAN base=e092fc5dc58928bcd58515bae3abbc1e82ca7d13 files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/lib/websocket.test.ts apps/ppt-web/src/lib/websocket.ts
  cd frontend && pnpm --filter "...[e092fc5...]" typecheck
  cd frontend && pnpm --filter "...[e092fc5...]" test
VERIFY OK fdc276c2dd94d1f8f759548cc1e44b1e07679ab0
```
Full `ppt-web` suite: 112 test files, 2143 tests passed. Typecheck clean.

Test-plan commands (plan IG5):
- `pnpm -F @ppt/web test -- websocket` → exit 0 (19 passed).
- `pnpm -F @ppt/web typecheck` → exit 0.
- IG3 proof: reverting `websocket.ts` to base and re-running the suite makes the new test FAIL (2 `close()` calls / 1 app-frame sent at ~40s); with the fix it passes.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 (drift) because the task's `owner_role` label is `pm-backend` but the diff is frontend-only. Re-running with the correct frontend owner (`--owner pm-frontend`) exits 0 — every changed path is in-scope for a frontend owner. The drift is entirely an owner-label artifact (the dispatcher flagged this in the task inputs: "this is a FRONTEND ppt-web task despite the owner label"). Changed paths, both under `frontend/apps/ppt-web/src/lib/`:
- `websocket.ts`
- `websocket.test.ts`

## Notes
- Branch is `auto-impl/...` per the dispatcher's pre-chosen name; goal-check IG2 (which expects `impl/<slug>`) reports a mismatch on that basis only — no goal-shape issue. IG1/IG3/IG5/IG6 pass; IG7 (verify) green above; IG8 (archive move + backlog flip) deferred to the final pre-merge commit per the plan's After-merge section.
- Out of scope (respected): the reconnect give-up gap (`code-review-ppt-web-core-ws-giveup-no-resume`), server-side WS refactors, and any `WsEvent` envelope/event-name/payload changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GfykegraQZePjUduG7kNGd)_