### PR TITLE
code-review-mobile-rn-auth-restore-stale-token: refresh expired access token on cold-start / biometric unlock

### DIFF
--- a/frontend/apps/mobile/src/contexts/AuthContext.tsx
+++ b/frontend/apps/mobile/src/contexts/AuthContext.tsx
@@ -7,12 +7,18 @@ import type { ReactNode } from 'react';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { resetLocalData } from '../services/resetLocalData';
+import { isJwtExpired } from '../utils/jwt';
 
 // Token storage keys
 const ACCESS_TOKEN_KEY = 'ppt_access_token';
 const REFRESH_TOKEN_KEY = 'ppt_refresh_token';
 const USER_KEY = 'ppt_user';
 const BIOMETRIC_ENABLED_KEY = 'ppt_biometric_enabled';
+
+// Treat an access token that expires within this many seconds as already stale,
+// so a restored session refreshes it proactively instead of handing the app a
+// bearer that dies on (or moments after) the first request.
+const TOKEN_REFRESH_SKEW_SECONDS = 30;
 
 export interface User {
   id: string;
@@ -69,49 +75,6 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
     biometricEnabled: false,
     biometricAvailable: false,
   });
-
-  // Check biometric availability and load stored auth on mount
-  useEffect(() => {
-    async function initialize() {
-      try {
-        // Check biometric availability
-        const compatible = await LocalAuthentication.hasHardwareAsync();
-        const enrolled = await LocalAuthentication.isEnrolledAsync();
-        const biometricAvailable = compatible && enrolled;
-
-        // Load stored tokens
-        const accessToken = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
-        const userJson = await SecureStore.getItemAsync(USER_KEY);
-        const biometricEnabled = await SecureStore.getItemAsync(BIOMETRIC_ENABLED_KEY);
-
-        if (accessToken && userJson) {
-          const user = JSON.parse(userJson) as User;
-          setState({
-            isLoading: false,
-            isAuthenticated: true,
-            user,
-            accessToken,
-            biometricEnabled: biometricEnabled === 'true',
-            biometricAvailable,
-          });
-        } else {
-          setState((prev) => ({
-            ...prev,
-            isLoading: false,
-            biometricAvailable,
-          }));
-        }
-      } catch (error) {
-        console.error('Failed to initialize auth:', error);
-        setState((prev) => ({
-          ...prev,
-          isLoading: false,
-        }));
-      }
-    }
-
-    initialize();
-  }, []);
 
   const login = useCallback(
     async (email: string, password: string) => {
@@ -301,11 +264,27 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
 
         if (accessToken && userJson) {
           const user = JSON.parse(userJson) as User;
+          // The device may have sat locked past the access-token TTL, so the
+          // stored bearer can be expired even though the refresh token is still
+          // valid. Refresh it before restoring the session — but preserve the
+          // #2399 intent above: only the *token* is refreshed here, we still do
+          // NOT refetch the user's cached data.
+          let activeToken = accessToken;
+          if (isJwtExpired(accessToken, TOKEN_REFRESH_SKEW_SECONDS)) {
+            try {
+              await refreshToken();
+              activeToken = (await SecureStore.getItemAsync(ACCESS_TOKEN_KEY)) ?? accessToken;
+            } catch {
+              // refreshToken() already logged out (clearing SecureStore) when
+              // the refresh failed — the session is dead, fall back to login.
+              return false;
+            }
+          }
           setState((prev) => ({
             ...prev,
             isAuthenticated: true,
             user,
-            accessToken,
+            accessToken: activeToken,
           }));
           return true;
         }
@@ -316,7 +295,85 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
       console.error('Biometric authentication failed:', error);
       return false;
     }
-  }, [state.biometricEnabled, state.biometricAvailable, t]);
+  }, [state.biometricEnabled, state.biometricAvailable, t, refreshToken]);
+
+  // Check biometric availability and load any stored session on mount. This
+  // runs after the callbacks above so it can reuse `refreshToken()` when a
+  // restored access token has expired (rather than duplicating refresh logic).
+  useEffect(() => {
+    async function initialize() {
+      try {
+        // Check biometric availability
+        const compatible = await LocalAuthentication.hasHardwareAsync();
+        const enrolled = await LocalAuthentication.isEnrolledAsync();
+        const biometricAvailable = compatible && enrolled;
+
+        // Load stored tokens
+        const accessToken = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+        const userJson = await SecureStore.getItemAsync(USER_KEY);
+        const biometricEnabled = await SecureStore.getItemAsync(BIOMETRIC_ENABLED_KEY);
+
+        if (accessToken && userJson) {
+          const user = JSON.parse(userJson) as User;
+          const biometricEnabledFlag = biometricEnabled === 'true';
+
+          // Access tokens are short-lived: a cold start after the TTL would
+          // otherwise restore `isAuthenticated: true` with an already-expired
+          // bearer. Refresh it first when the stored token is expired/near
+          // expiry, and only trust the session once a fresh token is in hand.
+          if (isJwtExpired(accessToken, TOKEN_REFRESH_SKEW_SECONDS)) {
+            try {
+              await refreshToken();
+              const refreshed = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+              setState({
+                isLoading: false,
+                isAuthenticated: true,
+                user,
+                accessToken: refreshed,
+                biometricEnabled: biometricEnabledFlag,
+                biometricAvailable,
+              });
+            } catch {
+              // refreshToken() already ran logout() (clearing SecureStore +
+              // caches) on failure; drop to the login screen.
+              setState((prev) => ({
+                ...prev,
+                isLoading: false,
+                isAuthenticated: false,
+                user: null,
+                accessToken: null,
+                biometricEnabled: biometricEnabledFlag,
+                biometricAvailable,
+              }));
+            }
+          } else {
+            setState({
+              isLoading: false,
+              isAuthenticated: true,
+              user,
+              accessToken,
+              biometricEnabled: biometricEnabledFlag,
+              biometricAvailable,
+            });
+          }
+        } else {
+          setState((prev) => ({
+            ...prev,
+            isLoading: false,
+            biometricAvailable,
+          }));
+        }
+      } catch (error) {
+        console.error('Failed to initialize auth:', error);
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+        }));
+      }
+    }
+
+    initialize();
+  }, [refreshToken]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
+++ b/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
@@ -31,6 +31,14 @@ import enLocale from '../../locales/en.json';
 import huLocale from '../../locales/hu.json';
 import plLocale from '../../locales/pl.json';
 import skLocale from '../../locales/sk.json';
+import { makeJwt } from '../jwt';
+
+/** Current time in whole seconds — the unit JWT `exp` claims use. */
+const nowSec = () => Math.floor(Date.now() / 1000);
+/** A well-formed access token whose `exp` is already in the past. */
+const expiredToken = () => makeJwt({ sub: 'u-1', exp: nowSec() - 60 });
+/** A well-formed access token valid for another hour. */
+const validToken = () => makeJwt({ sub: 'u-1', exp: nowSec() + 3600 });
 
 // AuthProvider now purges the AsyncStorage-backed tenant caches on
 // login/logout (issue #2399), so swap the shared jest stub for a real
@@ -160,6 +168,75 @@ describe('AuthContext integration', () => {
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
       expect(result.current.biometricAvailable).toBe(false);
+    });
+  });
+
+  // Regression for the code-review finding: the cold-start `initialize()` effect
+  // used to restore `isAuthenticated: true` whenever a stored access token +
+  // user existed, without checking the token's `exp`. Access tokens are
+  // short-lived, so a cold start after the TTL restored an already-expired
+  // bearer. The same gap existed on the biometric-unlock path.
+  describe('stale access-token restore (exp check)', () => {
+    it('refreshes an expired stored access token on cold start before restoring the session', async () => {
+      const store = primeSecureStore({
+        ppt_access_token: expiredToken(),
+        ppt_refresh_token: 'stored-refresh',
+        ppt_user: JSON.stringify(sampleUser),
+      });
+      // initialize() must exchange the expired bearer via /auth/refresh.
+      mockFetchOnce({ access_token: 'refreshed-access', refresh_token: 'refreshed-refresh' });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+      // The refresh endpoint was hit on cold start (not the login endpoint).
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `${API_BASE}/api/v1/auth/refresh`,
+        expect.objectContaining({ method: 'POST' })
+      );
+      const [, init] = (globalThis.fetch as jest.Mock).mock.calls.at(-1) ?? [];
+      expect(JSON.parse(init.body)).toEqual({ refresh_token: 'stored-refresh' });
+      // The session is trusted only with the freshly-issued token.
+      expect(result.current.accessToken).toBe('refreshed-access');
+      expect(result.current.user).toEqual(sampleUser);
+      expect(store.get('ppt_access_token')).toBe('refreshed-access');
+      expect(store.get('ppt_refresh_token')).toBe('refreshed-refresh');
+    });
+
+    it('drops to the login screen when the cold-start refresh of an expired token fails', async () => {
+      const store = primeSecureStore({
+        ppt_access_token: expiredToken(),
+        ppt_refresh_token: 'stored-refresh',
+        ppt_user: JSON.stringify(sampleUser),
+      });
+      mockFetchOnce({}, 401); // refresh rejected
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      // Never restore an expired session when it cannot be refreshed.
+      expect(result.current.isAuthenticated).toBe(false);
+      expect(result.current.user).toBeNull();
+      expect(result.current.accessToken).toBeNull();
+      // The failed refresh cascaded through logout(), clearing SecureStore.
+      expect(store.has('ppt_access_token')).toBe(false);
+      expect(store.has('ppt_refresh_token')).toBe(false);
+    });
+
+    it('restores the session without a refresh when the stored access token is still valid', async () => {
+      const token = validToken();
+      primeSecureStore({
+        ppt_access_token: token,
+        ppt_refresh_token: 'stored-refresh',
+        ppt_user: JSON.stringify(sampleUser),
+      });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+      expect(result.current.accessToken).toBe(token);
+      // A valid token must NOT trigger a network round-trip on boot.
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -602,6 +679,87 @@ describe('AuthContext integration', () => {
       // it must NOT purge the cache (resetLocalData is intentionally not called).
       expect(result.current.isAuthenticated).toBe(true);
       expect(asyncStore.has('ppt_cache_faults_list')).toBe(true);
+    });
+
+    it('authenticateWithBiometric refreshes an expired stored token on unlock without refetching (#2399)', async () => {
+      // Boot with a still-valid token so mount restores cleanly (no refresh).
+      primeSecureStore({
+        ppt_access_token: validToken(),
+        ppt_refresh_token: 'stored-refresh',
+        ppt_user: JSON.stringify(sampleUser),
+        ppt_biometric_enabled: 'true',
+      });
+      mockedLocalAuth.authenticateAsync.mockResolvedValue({ success: true });
+      // A same-user persisted cache entry that must survive the unlock.
+      asyncStore.set('ppt_cache_faults_list', JSON.stringify([{ id: 'f-1' }]));
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+      // Simulate the device sitting locked past the access-token TTL: the stored
+      // bearer is now expired, but the refresh token is still valid.
+      const store = primeSecureStore({
+        ppt_access_token: expiredToken(),
+        ppt_refresh_token: 'stored-refresh',
+        ppt_user: JSON.stringify(sampleUser),
+        ppt_biometric_enabled: 'true',
+      });
+      mockFetchOnce({ access_token: 'unlocked-access', refresh_token: 'unlocked-refresh' });
+
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.authenticateWithBiometric();
+      });
+
+      expect(ok).toBe(true);
+      expect(result.current.isAuthenticated).toBe(true);
+      // The token was refreshed on unlock...
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        `${API_BASE}/api/v1/auth/refresh`,
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(result.current.accessToken).toBe('unlocked-access');
+      expect(store.get('ppt_access_token')).toBe('unlocked-access');
+      // ...but the user's cached data was preserved (only the token refreshed,
+      // no resetLocalData / user refetch — #2399 intent kept intact).
+      expect(asyncStore.has('ppt_cache_faults_list')).toBe(true);
+      expect(globalThis.fetch).not.toHaveBeenCalledWith(
+        `${API_BASE}/api/v1/auth/login`,
+        expect.anything()
+      );
+    });
+
+    it('authenticateWithBiometric returns false when the expired-token refresh fails', async () => {
+      primeSecureStore({
+        ppt_access_token: validToken(),
+        ppt_refresh_token: 'stored-refresh',
+        ppt_user: JSON.stringify(sampleUser),
+        ppt_biometric_enabled: 'true',
+      });
+      mockedLocalAuth.authenticateAsync.mockResolvedValue({ success: true });
+
+      const { result } = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(true));
+
+      // Log out, then present an expired stored token whose refresh is rejected.
+      await act(async () => {
+        await result.current.logout();
+      });
+      primeSecureStore({
+        ppt_access_token: expiredToken(),
+        ppt_refresh_token: 'stored-refresh',
+        ppt_user: JSON.stringify(sampleUser),
+        ppt_biometric_enabled: 'true',
+      });
+      mockFetchOnce({}, 401);
+
+      let ok: boolean | undefined;
+      await act(async () => {
+        ok = await result.current.authenticateWithBiometric();
+      });
+
+      expect(ok).toBe(false);
+      await waitFor(() => expect(result.current.isAuthenticated).toBe(false));
     });
 
     it('authenticateWithBiometric is a no-op when biometric is not enabled', async () => {

--- a/frontend/apps/mobile/src/utils/jwt.test.ts
+++ b/frontend/apps/mobile/src/utils/jwt.test.ts
@@ -10,7 +10,9 @@
  */
 
 import { makeJwt } from '../test/jwt';
-import { decodeJwtPayload, extractTenantId } from './jwt';
+import { decodeJwtPayload, extractTenantId, isJwtExpired } from './jwt';
+
+const nowSec = () => Math.floor(Date.now() / 1000);
 
 describe('decodeJwtPayload', () => {
   it('decodes a well-formed payload into an object', () => {
@@ -91,5 +93,32 @@ describe('extractTenantId', () => {
 
   it('returns null (no throw) for a malformed token', () => {
     expect(extractTenantId('not-a-jwt')).toBeNull();
+  });
+});
+
+describe('isJwtExpired', () => {
+  it('returns true for a token whose exp is in the past', () => {
+    expect(isJwtExpired(makeJwt({ sub: 'u-1', exp: nowSec() - 60 }))).toBe(true);
+  });
+
+  it('returns false for a token whose exp is comfortably in the future', () => {
+    expect(isJwtExpired(makeJwt({ sub: 'u-1', exp: nowSec() + 3600 }))).toBe(false);
+  });
+
+  it('treats a token within the skew window as already expired', () => {
+    // exp is 10s out but the skew is 30s, so it should be considered stale.
+    expect(isJwtExpired(makeJwt({ exp: nowSec() + 10 }), 30)).toBe(true);
+    // Outside the skew window it is still valid.
+    expect(isJwtExpired(makeJwt({ exp: nowSec() + 120 }), 30)).toBe(false);
+  });
+
+  it('returns false when exp is missing or non-numeric (defer to server 401)', () => {
+    expect(isJwtExpired(makeJwt({ sub: 'u-1' }))).toBe(false);
+    expect(isJwtExpired(makeJwt({ exp: 'soon' }))).toBe(false);
+  });
+
+  it('returns false (no throw) for a malformed token', () => {
+    expect(isJwtExpired('not-a-jwt')).toBe(false);
+    expect(isJwtExpired('')).toBe(false);
   });
 });

--- a/frontend/apps/mobile/src/utils/jwt.ts
+++ b/frontend/apps/mobile/src/utils/jwt.ts
@@ -37,3 +37,29 @@ export function extractTenantId(token: string): string | null {
   const value = payload?.tenant_id;
   return typeof value === 'string' ? value : null;
 }
+
+/**
+ * Report whether a JWT's `exp` claim is at/past `now + skewSeconds`.
+ *
+ * `skewSeconds` (default 0) lets callers treat a token that is *about* to
+ * expire as already expired, so a proactive refresh happens before the bearer
+ * goes stale rather than after the first 401.
+ *
+ * Access tokens are short-lived, so a cold start (or a biometric unlock after
+ * the device sat locked) can restore a token whose TTL already elapsed. Callers
+ * use this to decide whether to `refreshToken()` before trusting a restored
+ * session (see AuthContext `initialize` / `authenticateWithBiometric`).
+ *
+ * Semantics are deliberately narrow: this returns `true` only for a token that
+ * carries a *readable numeric* `exp` in the past. A malformed token, or one
+ * with a missing/non-numeric `exp`, returns `false` — we can't prove it is
+ * expired, so we defer to the server's own 401 (which drives the normal refresh
+ * path) rather than eagerly discarding a session at boot.
+ */
+export function isJwtExpired(token: string, skewSeconds = 0): boolean {
+  const payload = decodeJwtPayload(token);
+  const exp = payload?.exp;
+  if (typeof exp !== 'number') return false;
+  const nowSeconds = Date.now() / 1000;
+  return exp <= nowSeconds + skewSeconds;
+}


### PR DESCRIPTION
## Task
frontend/apps/mobile/src/contexts/AuthContext.tsx:85-95 — the cold-start `initialize()` effect restores `isAuthenticated:true` whenever a stored access token + userJson exist, WITHOUT checking the token's `exp` claim or calling the existing `refreshToken()` (:209). Access tokens are short-lived, so a cold-start after TTL restores the user with an already-expired bearer. Same gap on the biometric-unlock path `authenticateWithBiometric` (:296-312). Fix: on `initialize()` and on successful biometric unlock, decode the access token `exp` (utils/jwt.ts ships a guarded `decodeJwtPayload`) and if expired/near-expiry `await refreshToken()` before setting `isAuthenticated:true` (fall back to login screen if refresh fails). Note issue #2399's deliberate no-refetch comment on the biometric path — preserve that intent (don't refetch user), only add exp-check + token refresh. Add a jest regression test for the expired-token-restore path.

## Owner
pm-backend (specialist: react-native / mobile-rn)

## What changed
- `utils/jwt.ts`: added `isJwtExpired(token, skewSeconds=0)` built on the existing guarded `decodeJwtPayload`. Deliberately narrow — returns `true` only for a token with a *readable numeric* `exp` in the past (± skew). A malformed / missing-`exp` token returns `false`, deferring to the server's own 401 rather than eagerly discarding a session at boot (this also keeps existing placeholder-token tests valid).
- `contexts/AuthContext.tsx`:
  - `initialize()`: when a stored token+user exist, if the token is expired/near-expiry (30s skew) it `await refreshToken()` and only then sets `isAuthenticated:true` with the fresh token; if the refresh fails it falls back to the login screen (unauthenticated). The mount effect was moved below the callbacks so it can reuse `refreshToken()` (no duplicated refresh logic — reuse-grep clean).
  - `authenticateWithBiometric()`: same exp-check + refresh before restoring the session. Issue #2399's no-refetch intent is preserved — only the *token* is refreshed; `resetLocalData()` / user refetch is still NOT called.
- Regression tests (jwt unit + AuthContext integration).

## Verification
```
VERIFY-PLAN base=e092fc5dc58928bcd58515bae3abbc1e82ca7d13 files=4
  cd frontend && pnpm exec biome check apps/mobile/src/contexts/AuthContext.tsx apps/mobile/src/test/integration/auth.integration.test.tsx apps/mobile/src/utils/jwt.test.ts apps/mobile/src/utils/jwt.ts
  cd frontend && pnpm --filter "...[e092fc5...]" typecheck
  cd frontend && pnpm --filter "...[e092fc5...]" test
```
- biome check: clean (4 files).
- typecheck: clean.
- **Full `@ppt/mobile` jest suite: 622/622 pass** (`jest --runInBand`). My new tests: `jwt.test.ts` + `auth.integration.test.tsx` = 45/45 pass.

⚠️ **Pre-existing flaky test (NOT caused by this change).** Under the default *parallel* jest run in this CPU-contended sandbox, one unrelated test times out: `DocumentUploadScreen validate() › disables the submit button while an upload is in flight (double-submit guard)` (a `waitFor` on the "uploading" label disappearing). Evidence it is pre-existing and unrelated:
  - It passes in isolation (~0.9s) and passes for the whole suite under `--runInBand` (622/622).
  - It fails **identically on clean `origin/dev`** full-suite parallel runs under the same load (i.e. `dev` fails this same gate).
  - My two changed test files + `DocumentUploadScreen.test.tsx` run together in-band pass 52/52 → no cross-file pollution from this change.
  CI's dedicated runner should not hit the contention; flagging for the reviewer rather than shipping a masked regression.

## CI parity (Band C — hot-path only)
This touches auth token handling (arguably hot-path). No backend/workflow change was made; the change is client-side only and covered by the mobile jest suite that `frontend.yml` runs. No `act`/workflow replication performed.

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 because `pm-backend` maps to the backend area, but this is a mobile-rn task (owner_role is a hint, not authoritative — the react-native specialist handled it). All changed paths are within `frontend/apps/mobile/`:
- `frontend/apps/mobile/src/contexts/AuthContext.tsx`
- `frontend/apps/mobile/src/utils/jwt.ts`
- `frontend/apps/mobile/src/utils/jwt.test.ts`
- `frontend/apps/mobile/src/test/integration/auth.integration.test.tsx`

## Code-reuse review
`reuse-grep.sh --specialist react-native`: none. `isJwtExpired` reuses the existing `decodeJwtPayload`; the refresh path reuses the existing `refreshToken()` callback rather than duplicating fetch logic.

## Remote-tested
skipped (ppt-bridge MCP not used).

## Notes
- `isJwtExpired` semantics chosen to be fail-safe-but-non-destructive: only a provably-past `exp` triggers a boot-time refresh, so a malformed token isn't eagerly discarded (it defers to the normal 401→refresh path). This is why the existing placeholder-token restore/biometric tests continue to pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfykegraQZePjUduG7kNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfykegraQZePjUduG7kNGd)_