### PR TITLE
code-review-ppt-web-core-ws-giveup-no-resume: resume WebSocket reconnection after the retry budget is exhausted

### DIFF
--- a/frontend/apps/ppt-web/src/contexts/WebSocketContext.tsx
+++ b/frontend/apps/ppt-web/src/contexts/WebSocketContext.tsx
@@ -18,6 +18,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { useNetworkStatusEffect } from '../hooks/useNetworkStatus';
 import {
   type ConnectionState,
   type MessageHandler,
@@ -70,6 +71,15 @@ export interface WebSocketContextValue {
    * The last connection error, if any.
    */
   error: Error | null;
+
+  /**
+   * Whether the client has exhausted its reconnect-attempt budget and given up
+   * retrying for now. Cleared automatically once a connection is
+   * re-established (e.g. after the browser regains connectivity, or a manual
+   * {@link reconnect}). UIs can use this to surface an explicit "reconnect"
+   * affordance instead of a transient error.
+   */
+  maxRetriesExceeded: boolean;
 
   /**
    * Subscribe to WebSocket events of a specific type.
@@ -177,6 +187,7 @@ export function WebSocketProvider({
 }: WebSocketProviderProps) {
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
   const [error, setError] = useState<Error | null>(null);
+  const [maxRetriesExceeded, setMaxRetriesExceeded] = useState(false);
   const serviceRef = useRef<WebSocketService | null>(null);
   const wasConnectedRef = useRef(false);
   const previousStateRef = useRef<ConnectionState>('disconnected');
@@ -222,6 +233,8 @@ export function WebSocketProvider({
       setError(err ?? null);
 
       if (state === 'connected') {
+        // A live connection clears any prior give-up state.
+        setMaxRetriesExceeded(false);
         if (wasConnectedRef.current) {
           // This is a reconnection
           onReconnectedRef.current?.();
@@ -236,11 +249,37 @@ export function WebSocketProvider({
       }
     });
 
+    // Surface the terminal give-up state so the UI can offer an explicit
+    // reconnect affordance rather than silently losing realtime for the
+    // session. Cleared again on the next successful 'connected' transition.
+    const unsubscribeMaxRetries = service.subscribe('connection:max-retries-exceeded', () => {
+      setMaxRetriesExceeded(true);
+    });
+
     return () => {
       unsubscribe();
+      unsubscribeMaxRetries();
       service.disconnect();
     };
   }, []);
+
+  // Resume the socket when the browser regains connectivity. The service's
+  // exponential-backoff budget (default ~3 min) can be exhausted by a longer
+  // outage — sleep/resume, a VPN drop, or a server redeploy — after which the
+  // service gives up permanently for the session and nothing re-arms it.
+  // A regained-connectivity signal is exactly when to retry: connect() resets
+  // the reconnect budget and re-establishes the socket.
+  useNetworkStatusEffect(
+    useCallback(() => {
+      const service = serviceRef.current;
+      if (!service) return;
+      // Only resume while still authenticated — otherwise connect() would just
+      // error out on a missing token.
+      if (authRef.current.isAuthenticated && authRef.current.accessToken) {
+        service.connect();
+      }
+    }, [])
+  );
 
   // Handle auth changes - connect when authenticated, disconnect when not
   useEffect(() => {
@@ -335,12 +374,13 @@ export function WebSocketProvider({
       isConnecting: connectionState === 'connecting',
       connectionState,
       error,
+      maxRetriesExceeded,
       subscribe,
       send,
       getLastEventTimestamp,
       reconnect,
     }),
-    [connectionState, error, subscribe, send, getLastEventTimestamp, reconnect]
+    [connectionState, error, maxRetriesExceeded, subscribe, send, getLastEventTimestamp, reconnect]
   );
 
   return <WebSocketContext.Provider value={value}>{children}</WebSocketContext.Provider>;

--- a/frontend/apps/ppt-web/src/lib/websocket.reconnect.test.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.reconnect.test.ts
@@ -1,0 +1,172 @@
+/// <reference types="vitest/globals" />
+/**
+ * Reconnect-budget / resume-after-give-up regression tests.
+ *
+ * Bug: once `reconnectAttempts` reaches `maxReconnectAttempts`,
+ * `scheduleReconnect()` flips `shouldReconnect` off and gives up permanently.
+ * Nothing re-armed reconnection — `onclose` only reconnects while
+ * `shouldReconnect` is true, and `reconnectAttempts` only reset on a
+ * successful `onopen`. The default backoff budget is only ~3 min, so any
+ * longer outage (sleep/resume, VPN drop, redeploy) killed the notification
+ * socket for the rest of the session.
+ *
+ * Fix: an explicit `connect()` resets the attempt budget
+ * (`resetReconnectAttempts()`) and re-opens, so a resume after give-up gets a
+ * full set of attempts again. The internal backoff loop keeps calling the
+ * private `openConnection()` (never `connect()`), so a mid-backoff retry does
+ * NOT reset the budget — the cap can still be reached on a continuous outage.
+ *
+ * These tests install a controllable fake `WebSocket` and drive the backoff
+ * with fake timers to assert both halves of that contract.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { WebSocketService } from './websocket';
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static lastInstance: FakeWebSocket | null = null;
+  static constructed = 0;
+
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: { data: string }) => void) | null = null;
+  sent: string[] = [];
+
+  constructor(
+    public url: string,
+    public protocols?: string | string[]
+  ) {
+    FakeWebSocket.lastInstance = this;
+    FakeWebSocket.constructed += 1;
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  /** Simulate an unexpected (non-clean) drop that drives the reconnect path. */
+  simulateUncleanClose(code = 1006): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ wasClean: false, code });
+  }
+}
+
+function makeService(maxReconnectAttempts: number): WebSocketService {
+  return new WebSocketService({
+    url: 'ws://localhost:8080',
+    getToken: () => 'test-jwt',
+    minReconnectDelay: 1,
+    maxReconnectDelay: 50,
+    maxReconnectAttempts,
+  });
+}
+
+let originalWebSocket: typeof globalThis.WebSocket;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  originalWebSocket = globalThis.WebSocket;
+  // biome-ignore lint/suspicious/noExplicitAny: test double for the global WebSocket
+  globalThis.WebSocket = FakeWebSocket as any;
+  FakeWebSocket.lastInstance = null;
+  FakeWebSocket.constructed = 0;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  globalThis.WebSocket = originalWebSocket;
+  vi.restoreAllMocks();
+});
+
+/** Simulate the current socket dropping, then let its backoff timer fire. */
+function driveOneOutageCycle(): void {
+  const socket = FakeWebSocket.lastInstance;
+  if (!socket) throw new Error('expected a live socket to drop');
+  socket.simulateUncleanClose();
+  // Fire whatever reconnect timeout scheduleReconnect() queued (if any).
+  vi.advanceTimersByTime(1000);
+}
+
+describe('WebSocketService — reconnect budget & resume after give-up', () => {
+  it('gives up after the attempt budget is exhausted on a continuous outage', () => {
+    const service = makeService(2);
+    const maxRetries = vi.fn();
+    service.subscribe('connection:max-retries-exceeded', maxRetries);
+
+    service.connect(); // attempt seed — socket #1
+
+    // Each cycle: unclean close -> scheduleReconnect -> timer fires -> reopen.
+    // With max=2: attempts 0->1 (reopen), 1->2 (reopen), then 2>=2 -> give up.
+    driveOneOutageCycle(); // socket #2
+    driveOneOutageCycle(); // socket #3
+    driveOneOutageCycle(); // give up here
+
+    expect(maxRetries).toHaveBeenCalledTimes(1);
+    expect(service.getConnectionState()).toBe('error');
+
+    // The give-up is terminal for the backoff loop: a further close does not
+    // schedule another reconnect (shouldReconnect was flipped off).
+    const constructedAtGiveUp = FakeWebSocket.constructed;
+    vi.advanceTimersByTime(5000);
+    expect(FakeWebSocket.constructed).toBe(constructedAtGiveUp);
+  });
+
+  it('resumes reconnection when connect() is called again after giving up', () => {
+    const service = makeService(2);
+    const maxRetries = vi.fn();
+    service.subscribe('connection:max-retries-exceeded', maxRetries);
+
+    service.connect();
+    driveOneOutageCycle();
+    driveOneOutageCycle();
+    driveOneOutageCycle(); // budget exhausted -> gave up
+
+    expect(maxRetries).toHaveBeenCalledTimes(1);
+    const giveUpSocket = FakeWebSocket.lastInstance;
+    const constructedAtGiveUp = FakeWebSocket.constructed;
+
+    // Resume: an explicit connect() must reset the budget and open a fresh
+    // socket (this is the online-event / manual-reconnect entry point).
+    service.connect();
+    expect(FakeWebSocket.constructed).toBe(constructedAtGiveUp + 1);
+    expect(FakeWebSocket.lastInstance).not.toBe(giveUpSocket);
+    expect(service.getConnectionState()).toBe('connecting');
+
+    // And because the budget was reset, the very next unclean close must NOT
+    // immediately re-trigger give-up: it schedules another retry instead.
+    // (Without the reset, attempts would still be at the cap and this would
+    // fire max-retries a second time.)
+    driveOneOutageCycle();
+    expect(maxRetries).toHaveBeenCalledTimes(1);
+    expect(FakeWebSocket.constructed).toBeGreaterThan(constructedAtGiveUp + 1);
+  });
+
+  it('resetReconnectAttempts() lets a fresh backoff run reach the cap again', () => {
+    const service = makeService(1);
+    const maxRetries = vi.fn();
+    service.subscribe('connection:max-retries-exceeded', maxRetries);
+
+    service.connect();
+    driveOneOutageCycle(); // attempts 0->1 reopen
+    driveOneOutageCycle(); // 1>=1 -> give up (1st)
+    expect(maxRetries).toHaveBeenCalledTimes(1);
+
+    service.resetReconnectAttempts();
+    // Re-arm the loop the way connect() would, then exhaust it again.
+    service.connect();
+    driveOneOutageCycle(); // attempts 0->1 reopen
+    driveOneOutageCycle(); // 1>=1 -> give up (2nd)
+    expect(maxRetries).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/apps/ppt-web/src/lib/websocket.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.ts
@@ -320,8 +320,28 @@ export class WebSocketService {
 
   /**
    * Connect to the WebSocket server.
+   *
+   * An explicit `connect()` is a fresh (re)start request, so it resets the
+   * reconnect-attempt budget via {@link resetReconnectAttempts}. This is what
+   * makes a resume after a previous give-up work: once
+   * {@link scheduleReconnect} has hit `maxReconnectAttempts` and flipped
+   * `shouldReconnect` off, the budget is stuck at the cap; without the reset a
+   * subsequent `connect()` would open one socket and then immediately give up
+   * again on the first unclean close. The internal backoff loop deliberately
+   * calls {@link openConnection} directly (NOT `connect()`) so a mid-backoff
+   * retry does not reset the budget — otherwise the cap could never be reached.
    */
   connect(): void {
+    this.resetReconnectAttempts();
+    this.openConnection();
+  }
+
+  /**
+   * Open (or re-open) the underlying socket without touching the reconnect
+   * budget. Shared by the public {@link connect} entry point and the internal
+   * exponential-backoff reconnect loop.
+   */
+  private openConnection(): void {
     const token = this.getToken();
     if (!token) {
       this.setConnectionState('error', new Error('No auth token available'));
@@ -622,7 +642,9 @@ export class WebSocketService {
     this.reconnectAttempts++;
 
     this.reconnectTimeoutId = setTimeout(() => {
-      this.connect();
+      // Continue the backoff loop via openConnection() so this retry does NOT
+      // reset the attempt budget — only an explicit connect() does that.
+      this.openConnection();
     }, delay);
   }
 


### PR DESCRIPTION
## Task
`frontend/apps/ppt-web/src/lib/websocket.ts:600-612` — once `reconnectAttempts` reaches `maxReconnectAttempts` (default 10), `scheduleReconnect()` sets `shouldReconnect=false` and gives up permanently. Nothing re-arms reconnection: `onclose` only reconnects when `shouldReconnect` is true (:507); `reconnectAttempts` only resets on a successful `onopen` (:489); the public `resetReconnectAttempts()` (:479-481) is dead code. The default backoff budget is only ~3 min, so any longer outage (sleep, VPN drop, redeploy) permanently kills the notification socket for the session. `contexts/WebSocketContext.tsx` (:246-256) only connects on auth change and never subscribes to `connection:max-retries-exceeded`, and is not wired to `hooks/useNetworkStatus.ts` (which already detects online/offline, :96-121). Fix: on the browser `online` event (via `useNetworkStatus`) call `service.connect()` to resume, and have `connect()` reset the reconnect attempt budget (call `resetReconnectAttempts()`); optionally surface the max-retries-exceeded state in `WebSocketContext`. Add a regression test for the resume-after-give-up path.

## Owner
pm-backend (specialist: react-web / frontend)

## What changed
- **`lib/websocket.ts`** — Split the public `connect()` (which now calls `resetReconnectAttempts()`) from a new private `openConnection()`. `connect()` resets the budget then opens; the internal exponential-backoff loop (`scheduleReconnect` timeout) calls `openConnection()` directly so a mid-backoff retry does **not** reset the budget — the cap can still be reached on a continuous outage. This is what makes resume-after-give-up work: previously a `connect()` after give-up would open one socket and immediately re-give-up because the budget was still pinned at the cap.
- **`contexts/WebSocketContext.tsx`** — Resume the socket on the browser `online` event via `useNetworkStatusEffect` (only while authenticated). Subscribe to `connection:max-retries-exceeded` and expose a new `maxRetriesExceeded` context flag (additive; cleared on the next successful `connected` transition) so the UI can offer an explicit reconnect affordance.
- **`lib/websocket.reconnect.test.ts`** (new) — Regression coverage: (1) give-up after a continuous outage exhausts the budget; (2) an explicit `connect()` after give-up resets the budget and resumes without immediately re-firing max-retries; (3) `resetReconnectAttempts()` lets a fresh backoff run reach the cap again (proving the previously-dead method is now live).

Verified the new test **fails against pre-fix `websocket.ts`** (1 failed / 2 passed) and passes with the fix — a genuine failing-on-main regression test.

## Verification
```
VERIFY-PLAN base=e092fc5dc58928bcd58515bae3abbc1e82ca7d13 files=3
  cd frontend && pnpm exec biome check apps/ppt-web/src/contexts/WebSocketContext.tsx apps/ppt-web/src/lib/websocket.reconnect.test.ts apps/ppt-web/src/lib/websocket.ts
  cd frontend && pnpm --filter "...[e092fc5dc58928bcd58515bae3abbc1e82ca7d13]" typecheck
  cd frontend && pnpm --filter "...[e092fc5dc58928bcd58515bae3abbc1e82ca7d13]" test
```
```
VERIFY OK a602a7fb8714228adb747817365927cb15951672
```
(First gate run had 2 load-induced 5s timeouts in an unrelated file, `reports.create-schedule.route.test.tsx`; that file passes 5/5 in isolation and the re-run was fully green — 2145/2145.)

IG goal-check: IG3 (test:+fix: pair) ok, IG7 (verify) ok. IG1/IG2 report FAIL only because this is a dispatcher code-review finding, not a `.research/plans/` task (no plan file) and uses the dispatcher-chosen `auto-impl/…` branch name — neither is a code/quality issue.

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 because `owner_role=pm-backend` maps to `backend/`, but the finding is a ppt-web frontend fix (as the dispatcher noted: specialist react-web / frontend). All three changed paths are under `frontend/apps/ppt-web/src/`:
- `frontend/apps/ppt-web/src/lib/websocket.ts`
- `frontend/apps/ppt-web/src/contexts/WebSocketContext.tsx`
- `frontend/apps/ppt-web/src/lib/websocket.reconnect.test.ts`

The drift is the owner-role label, not the change — no backend code touched.

## Code-reuse review
`reuse-grep.sh --specialist react-web` — no warnings. The fix reuses the existing public `resetReconnectAttempts()` and the existing `useNetworkStatusEffect` hook rather than adding new helpers.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- `maxRetriesExceeded` is an additive field on `WebSocketContextValue`; existing consumers (`hooks/useWebSocket.ts`) are unaffected.
- No API/route/screen-map changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfykegraQZePjUduG7kNGd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfykegraQZePjUduG7kNGd)_