### PR TITLE
code-review-reality-server-listing-viewcount-hardcoded-zero: report real listing view_count instead of hardcoded 0

### DIFF
--- a/backend/crates/db/migrations/00220_portal_get_listing_view_count.sql
+++ b/backend/crates/db/migrations/00220_portal_get_listing_view_count.sql
@@ -1,0 +1,64 @@
+-- Epic 15 follow-up: fix the public listing-detail **view-count read** for
+-- portal-owned listings (the read-back counterpart of the write fix in
+-- migration 00214 / #2244).
+--
+-- Background
+-- ----------
+-- `GET /api/v1/listings/{id}` (the public listing-detail handler) records a
+-- view via the SECURITY DEFINER `portal_track_listing_view` (00214), so views
+-- ARE persisted into `listing_analytics`. But the handler built its response
+-- with a hardcoded `view_count: 0` — the read side was never wired up, so the
+-- public listing page and analytics under-reported every listing's views to
+-- zero.
+--
+-- A naive read fix (a plain `SELECT SUM(views) FROM listing_analytics` on the
+-- reality-server pool) does not work: `listing_analytics` is
+-- `FORCE ROW LEVEL SECURITY` (migration 00113) with an org-only policy and no
+-- portal-owner branch. Portal listings carry `organization_id = NULL`
+-- (migration 00186) and the public reality-server pool is RLS-subject with no
+-- org context, so a direct SELECT reads back zero rows for portal listings —
+-- exactly the RLS trap documented in 00213 (read) and 00214 (write).
+--
+-- Fix
+-- ---
+-- Mirror the portal SECURITY DEFINER pattern (migrations 00186 / 00213 / 00214).
+-- Add `portal_get_listing_view_count(p_listing_id)`, a SECURITY DEFINER function
+-- that runs as the definer (a superuser) and thus bypasses the org-scoped
+-- `listing_analytics` RLS policy, returning the listing's aggregate view total.
+--
+-- No ownership gate is applied (unlike the per-owner read function 00213):
+-- the total view count of a public listing is itself public — any visitor of
+-- the public listing-detail page legitimately sees it. The function only ever
+-- aggregates the `views` counter of the single requested listing; it exposes no
+-- per-tenant rows and lets the caller read no other tenant's data. This matches
+-- the public, ownership-free contract of the write path 00214.
+
+CREATE OR REPLACE FUNCTION portal_get_listing_view_count(
+    p_listing_id UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_total BIGINT;
+BEGIN
+    SELECT COALESCE(SUM(la.views), 0)::bigint
+    INTO v_total
+    FROM listing_analytics la
+    WHERE la.listing_id = p_listing_id;
+
+    RETURN v_total;
+END;
+$$;
+
+COMMENT ON FUNCTION portal_get_listing_view_count IS
+    'Return the aggregate view total for a listing from listing_analytics. '
+    'SECURITY DEFINER bypasses the org-scoped listing_analytics RLS policy '
+    '(which has no portal-owner branch), so the public listing-detail read '
+    'reports real recorded views for portal listings (organization_id IS NULL) '
+    'instead of a hardcoded zero. No ownership gate — a public listing''s total '
+    'view count is public (read-side counterpart of portal_track_listing_view, '
+    'migration 00214).';

--- a/backend/crates/db/src/repositories/reality_portal/listings.rs
+++ b/backend/crates/db/src/repositories/reality_portal/listings.rs
@@ -221,6 +221,26 @@ impl RealityPortalRepository {
         Ok(())
     }
 
+    /// Get the aggregate view total for a listing (public read).
+    ///
+    /// Routes through the SECURITY DEFINER `portal_get_listing_view_count`
+    /// function (migration 00220), **not** a direct `SELECT SUM(views)`. A plain
+    /// select on the RLS-subject reality-server pool reads back zero for
+    /// portal-owned listings (`organization_id IS NULL`): `listing_analytics` is
+    /// `FORCE ROW LEVEL SECURITY` (migration 00113) with an org-only policy and
+    /// no portal-owner branch, and the public pool has no org context — the same
+    /// RLS trap that broke the write path (#2244) and the per-owner read (#2199).
+    /// The definer function bypasses that policy and only ever aggregates the
+    /// requested listing's `views` counter. There is no ownership gate — a public
+    /// listing's total view count is itself public (read-side counterpart of
+    /// [`track_view`](Self::track_view)).
+    pub async fn get_view_count(&self, listing_id: Uuid) -> Result<i64, SqlxError> {
+        sqlx::query_scalar::<_, i64>("SELECT portal_get_listing_view_count($1)")
+            .bind(listing_id)
+            .fetch_one(&self.pool)
+            .await
+    }
+
     /// Get listing analytics (org-scoped path).
     ///
     /// This runs a direct `SELECT` on the RLS-subject pool, so it only returns

--- a/backend/crates/db/tests/suite_3.rs
+++ b/backend/crates/db/tests/suite_3.rs
@@ -19,6 +19,8 @@ mod payment_reminder_dedup_tests;
 mod portal_imports_cross_org_idor_tests;
 #[path = "suites/portal_listing_analytics_force_rls_tests.rs"]
 mod portal_listing_analytics_force_rls_tests;
+#[path = "suites/portal_listing_view_count_force_rls_tests.rs"]
+mod portal_listing_view_count_force_rls_tests;
 #[path = "suites/portal_track_listing_view_force_rls_tests.rs"]
 mod portal_track_listing_view_force_rls_tests;
 #[path = "suites/portal_user_merge_tests.rs"]

--- a/backend/crates/db/tests/suites/portal_listing_view_count_force_rls_tests.rs
+++ b/backend/crates/db/tests/suites/portal_listing_view_count_force_rls_tests.rs
@@ -1,0 +1,185 @@
+//! Repo/DB-level FORCE-RLS regression test for the public listing-detail
+//! **view-count read** on **portal-owned** listings — the read-back counterpart
+//! of the write test in `portal_track_listing_view_force_rls_tests.rs` (#2244).
+//!
+//! Background
+//! ----------
+//! The public listing-detail handler (`GET /api/v1/listings/{id}`) records views
+//! via the SECURITY DEFINER `portal_track_listing_view` (00214), so views ARE
+//! persisted. But it built its response with a hardcoded `view_count: 0` — the
+//! read side was never wired, so the public page under-reported every listing's
+//! views to zero.
+//!
+//! A naive read fix (`SELECT SUM(views) FROM listing_analytics`) does not work
+//! for portal listings: `listing_analytics` is `FORCE ROW LEVEL SECURITY`
+//! (migration 00113) with an org-only policy and no portal-owner branch. Portal
+//! listings carry `organization_id = NULL` (migration 00186) and the public
+//! reality-server pool is RLS-subject with no org context, so a direct SELECT
+//! reads back zero — the same RLS trap as the write path (#2244).
+//!
+//! Migration 00220 adds `portal_get_listing_view_count`, a SECURITY DEFINER
+//! aggregate that bypasses the org-only policy so the public read reports the
+//! real recorded total.
+//!
+//! This test binds a real `NOSUPERUSER NOBYPASSRLS` role — the way the
+//! production reality-server role experiences FORCE RLS — and proves:
+//!
+//! 1. **Bug proof** — a direct `SELECT SUM(views)` reads back 0 for the portal
+//!    listing under the bound role even though views were recorded.
+//! 2. **Fix** — `RealityPortalRepository::get_view_count` (routing through the
+//!    SECURITY DEFINER `portal_get_listing_view_count`) reads the real total.
+//!
+//! Assertion (2) fails on `main` (no definer read path existed there); it is the
+//! regression lock for the read fix.
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn seed_portal_user(pool: &PgPool, tag: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind) \
+         VALUES ($1, 'test_hash', $2, 'active', NOW(), 'public') RETURNING id",
+    )
+    .bind(format!("{tag}@portal-viewcount-rls.test"))
+    .bind(format!("PortalViewCountRls {tag}"))
+    .fetch_one(pool)
+    .await
+    .unwrap_or_else(|e| panic!("seed_portal_user({tag}): {e}"))
+}
+
+/// Create a portal-owned listing (`organization_id IS NULL`,
+/// `portal_owner_id = user_id`) via the SECURITY DEFINER repo path.
+async fn seed_portal_listing(pool: &PgPool, user_id: Uuid, title: &str) -> Uuid {
+    let repo = db::repositories::RealityPortalRepository::new(pool.clone());
+    repo.create_portal_listing(
+        user_id,
+        title,
+        Some("desc"),
+        "apartment",
+        "sale",
+        rust_decimal::Decimal::new(100_000, 0),
+        "EUR",
+        "Test Street 1",
+        "Bratislava",
+        "81101",
+        "SK",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("seed_portal_listing")
+    .id
+}
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn portal_view_count_read_via_security_definer_under_force_rls(pool: PgPool) {
+    let owner = seed_portal_user(&pool, "owner").await;
+    let listing_id = seed_portal_listing(&pool, owner, "viewcount-force-rls").await;
+
+    // Record three views through the SECURITY DEFINER write path (00214).
+    let repo = db::repositories::RealityPortalRepository::new(pool.clone());
+    for _ in 0..3 {
+        repo.track_view(listing_id, "website")
+            .await
+            .expect("track_view must record a portal view");
+    }
+
+    let role = format!("portal_vc_rls_{}", &Uuid::new_v4().to_string()[..8]);
+
+    // --- NOSUPERUSER NOBYPASSRLS role so FORCE RLS actually binds. ---
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "CREATE ROLE \"{role}\" NOSUPERUSER NOBYPASSRLS"
+    )))
+    .execute(&pool)
+    .await
+    .expect("create test role");
+
+    // Grant everything the reads would legitimately need, so the ONLY barrier
+    // left standing is the FORCE-RLS policy itself.
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT SELECT ON listing_analytics, listings TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant select privileges");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!(
+        "GRANT EXECUTE ON FUNCTION \
+         portal_get_listing_view_count(UUID), \
+         is_super_admin(), get_current_org_id() TO \"{role}\""
+    )))
+    .execute(&pool)
+    .await
+    .expect("grant execute");
+
+    // All role-bound work runs on ONE dedicated connection.
+    let mut conn = pool.acquire().await.expect("acquire connection");
+
+    sqlx::query(sqlx::AssertSqlSafe(format!("SET ROLE \"{role}\"")))
+        .execute(&mut *conn)
+        .await
+        .expect("set role");
+
+    // --- 1. Bug proof: a direct SUM is filtered to zero by FORCE RLS. ---
+    let direct_total: i64 = sqlx::query_scalar(
+        "SELECT COALESCE(SUM(views), 0)::bigint FROM listing_analytics WHERE listing_id = $1",
+    )
+    .bind(listing_id)
+    .fetch_one(&mut *conn)
+    .await
+    .expect("direct sum query");
+    assert_eq!(
+        direct_total, 0,
+        "a direct SELECT SUM(views) on the RLS-subject role must read back 0 \
+         for a portal listing (org-only listing_analytics policy has no \
+         portal-owner branch) — this is the hardcoded-zero bug's root cause"
+    );
+
+    // --- 2. Fix: the SECURITY DEFINER path reads the real recorded total. ---
+    let definer_total: i64 = sqlx::query_scalar("SELECT portal_get_listing_view_count($1)")
+        .bind(listing_id)
+        .fetch_one(&mut *conn)
+        .await
+        .expect("portal_get_listing_view_count must succeed under FORCE RLS");
+    assert_eq!(
+        definer_total, 3,
+        "portal_get_listing_view_count must bypass the org-only RLS policy and \
+         return the real recorded view total for a portal listing (read-side \
+         regression lock for the hardcoded view_count: 0)"
+    );
+
+    sqlx::query("RESET ROLE")
+        .execute(&mut *conn)
+        .await
+        .expect("reset role");
+    drop(conn);
+
+    // --- 3. Repo method reads the same total on the superuser test pool. ---
+    let repo_total = repo
+        .get_view_count(listing_id)
+        .await
+        .expect("get_view_count repo method");
+    assert_eq!(
+        repo_total, 3,
+        "RealityPortalRepository::get_view_count must return the recorded total"
+    );
+
+    // --- Cleanup ---
+    for stmt in [
+        format!("REVOKE ALL ON listing_analytics, listings FROM \"{role}\""),
+        format!(
+            "REVOKE EXECUTE ON FUNCTION \
+             portal_get_listing_view_count(UUID), \
+             is_super_admin(), get_current_org_id() FROM \"{role}\""
+        ),
+        format!("DROP OWNED BY \"{role}\""),
+        format!("DROP ROLE IF EXISTS \"{role}\""),
+    ] {
+        sqlx::query(sqlx::AssertSqlSafe(stmt))
+            .execute(&pool)
+            .await
+            .ok();
+    }
+}

--- a/backend/servers/reality-server/src/routes/listings.rs
+++ b/backend/servers/reality-server/src/routes/listings.rs
@@ -379,6 +379,19 @@ pub async fn get_listing(
             // Track the view
             let _ = state.reality_portal_repo.track_view(id, "website").await;
 
+            // Read back the aggregate view total via the SECURITY DEFINER path
+            // (a direct SELECT on this RLS-subject public pool reads zero for
+            // portal-owned listings — see get_view_count / migration 00220).
+            // Best-effort: degrade to 0 rather than failing the public detail
+            // page if analytics are momentarily unavailable.
+            let view_count = match state.reality_portal_repo.get_view_count(id).await {
+                Ok(count) => count,
+                Err(e) => {
+                    tracing::warn!(%id, error = %e, "Failed to read listing view count; defaulting to 0");
+                    0
+                }
+            };
+
             // Get photos for the listing
             let photos: Vec<String> = sqlx::query_scalar(
                 "SELECT url FROM listing_photos WHERE listing_id = $1 ORDER BY display_order",
@@ -429,7 +442,7 @@ pub async fn get_listing(
                 photos,
                 features,
                 published_at: l.published_at.map(|dt| dt.to_rfc3339()).unwrap_or_default(),
-                view_count: 0, // Would need analytics query
+                view_count,
             }))
         }
         None => Err((


### PR DESCRIPTION
Auto: reality-server public listing-detail handler `get_listing()` reports the real `view_count` instead of a hardcoded 0, via a new `SECURITY DEFINER` migration `00220_portal_get_listing_view_count.sql` and FORCE-RLS regression tests.

Reviewed (dispatcher Phase 5): verdict=approve. Migration/RLS/tests correct. An earlier auto-created note about `.research/**` scope drift was a false positive (a two-dot local-diff artifact — the branch is behind dev on those files; GitHub's merge-base diff contains only the 5 code files). No `.research/**` changes are in this PR.