### PR TITLE
code-review-reality-server-orphan-schedule-viewing-stub: remove orphaned schedule_viewing stub

### DIFF
--- a/backend/servers/reality-server/src/handlers/inquiries/mod.rs
+++ b/backend/servers/reality-server/src/handlers/inquiries/mod.rs
@@ -3,7 +3,7 @@
 //! Implements contact validation, email notifications,
 //! and viewing scheduling functionality.
 
-use db::models::{CreateListingInquiry, ListingInquiry, ScheduleViewing, ViewingSchedule};
+use db::models::{CreateListingInquiry, ListingInquiry, ViewingSchedule};
 use db::repositories::RealityPortalRepository;
 use uuid::Uuid;
 
@@ -34,21 +34,6 @@ pub enum InquiryResult {
     RealtorNotFound,
     /// Rate limited (too many inquiries)
     RateLimited,
-    /// Database error
-    DatabaseError(String),
-}
-
-/// Viewing scheduling result.
-#[derive(Debug)]
-pub enum ViewingResult {
-    /// Viewing scheduled successfully
-    Scheduled(Box<ViewingSchedule>),
-    /// Inquiry not found
-    InquiryNotFound,
-    /// Time slot unavailable
-    TimeSlotUnavailable,
-    /// Validation failed
-    ValidationFailed(Vec<ValidationError>),
     /// Database error
     DatabaseError(String),
 }
@@ -286,54 +271,6 @@ impl InquiriesHandler {
         Self::send_response_notification(inquiry_id).await;
 
         Ok(response)
-    }
-
-    /// Schedule a viewing for an inquiry.
-    pub async fn schedule_viewing(
-        &self,
-        _inquiry_id: Uuid,
-        _realtor_id: Uuid,
-        data: ScheduleViewing,
-    ) -> ViewingResult {
-        // Validate scheduled time
-        let now = chrono::Utc::now();
-        if data.scheduled_at <= now {
-            return ViewingResult::ValidationFailed(vec![ValidationError {
-                field: "scheduled_at".to_string(),
-                message: "Viewing must be scheduled in the future".to_string(),
-            }]);
-        }
-
-        // Check if within reasonable timeframe (next 90 days)
-        let max_date = now + chrono::Duration::days(90);
-        if data.scheduled_at > max_date {
-            return ViewingResult::ValidationFailed(vec![ValidationError {
-                field: "scheduled_at".to_string(),
-                message: "Viewing must be within the next 90 days".to_string(),
-            }]);
-        }
-
-        // Validate duration
-        let duration = data.duration_minutes.unwrap_or(30);
-        if !(15..=120).contains(&duration) {
-            return ViewingResult::ValidationFailed(vec![ValidationError {
-                field: "duration_minutes".to_string(),
-                message: "Duration must be between 15 and 120 minutes".to_string(),
-            }]);
-        }
-
-        // For now, return a placeholder since we don't have the full viewing scheduling in repo
-        // In production, this would create the viewing record
-        tracing::info!(
-            inquiry_id = %_inquiry_id,
-            scheduled_at = %data.scheduled_at,
-            "Viewing scheduling requested"
-        );
-
-        ViewingResult::ValidationFailed(vec![ValidationError {
-            field: "viewing".to_string(),
-            message: "Viewing scheduling not yet implemented".to_string(),
-        }])
     }
 
     /// Send notification email for new inquiry.


### PR DESCRIPTION
## Task
`backend/servers/reality-server/src/handlers/inquiries/mod.rs` — `schedule_viewing()` runs full input validation then unconditionally returns `ViewingResult::ValidationFailed([{ field: "viewing", message: "Viewing scheduling not yet implemented" }])` after only a `tracing::info!`. It creates no record, and reporting a not-implemented feature as a *field validation* error is a wrong contract. The method is DEAD/ORPHANED: the live viewing route `POST /api/v1/inquiries/viewing/{listing_id}` (`routes/inquiries.rs` → `request_viewing`) does NOT call `schedule_viewing` — it builds a message embedding preferred times and creates a normal inquiry via `InquiriesHandler::validate_contact` + `create`. A grep for `schedule_viewing(` call sites finds only its own definition.

**Fix applied (preferred path — deletion):**
- Deleted the orphaned `schedule_viewing` method.
- Deleted the `ViewingResult` enum (used exclusively by that method).
- Removed the now-unused `ScheduleViewing` import.
- `ViewingSchedule` import retained — still used by `send_viewing_reminder` (out of finding scope, untouched).

Verified via call-site greps before removal: `schedule_viewing` and `ViewingResult` have no references anywhere else in `backend/`. `ScheduleViewing` had only this file's import + the deleted parameter (the model type itself lives in `crates/db` and is unaffected).

Net: 1 file changed, 1 insertion, 64 deletions.

## Owner
pm-backend

## Verification
```
VERIFY-PLAN base=a5cbc079ca8be84c4791dccba55306b7adafa347 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo test -p reality-server
```

- `cargo fmt --all -- --check` → exit 0 (clean).
- `cargo clippy -p reality-server` / `cargo test -p reality-server` → could not complete locally: the `utoipa-swagger-ui v9.0.2` build script fails downloading the Swagger UI zip from github.com (`InvalidArchive("Could not find EOCD")`) due to the sandbox github-egress block — a build-dependency failure unrelated to this diff. Opening as **draft pending CI**; `backend.yml` is authoritative for the clippy + test steps (same approach as prior PRs under this constraint).

Deterministic gate checks that do not require the full compile:
- fmt check: exit 0
- `scope-check.sh --owner pm-backend`: exit 0 (in-area) → `scope_drift=false`
- `reuse-grep.sh --specialist rust-backend`: no warnings → `code_reuse_warn=none`

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (dead-code removal; no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- Pure dead-code deletion; no behavioral change to any live route, so no regression test is applicable (IG3 N/A).
- The misleading "Viewing scheduling not yet implemented" as a field-validation error was never reachable in production — this only removes the orphaned code path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Crrafx77LGYGuvAT1NhWFW)_