### PR TITLE
code-review-api-handlers-ai-upstream-error-leak: stop leaking upstream AI provider errors to clients

### DIFF
--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -28,6 +28,11 @@ use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use uuid::Uuid;
 
+/// Client-facing message returned when lease generation fails. The underlying
+/// LLM-provider error is logged server-side in [`generate_lease`] but is never
+/// forwarded to the client, to avoid leaking upstream provider detail.
+const LEASE_GENERATION_FAILED_MESSAGE: &str = "Lease generation failed";
+
 /// Router for LLM document generation (Epic 64).
 pub fn llm_router() -> Router<AppState> {
     Router::new()
@@ -684,7 +689,9 @@ async fn generate_lease(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(
                     "GENERATION_FAILED",
-                    format!("Failed to generate lease: {}", e),
+                    // Do not leak the upstream LLM-provider error to the client;
+                    // the detail is already logged server-side above.
+                    LEASE_GENERATION_FAILED_MESSAGE,
                 )),
             ))
         }
@@ -1456,5 +1463,34 @@ async fn get_generation_request(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to get")),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression guard for the AI upstream-error leak finding: the client-facing
+    /// body for a failed lease generation must carry only the fixed generic
+    /// message and must never contain the raw upstream LLM-provider error
+    /// (which is logged server-side in `generate_lease`).
+    #[test]
+    fn lease_generation_error_does_not_leak_upstream_detail() {
+        // A representative raw provider error that must not reach the client.
+        let upstream_detail = "provider 503: model overloaded (upstream request id abc123)";
+
+        // Mirror the client body built by `generate_lease`'s error branch.
+        let response = ErrorResponse::new("GENERATION_FAILED", LEASE_GENERATION_FAILED_MESSAGE);
+        let body = serde_json::to_string(&response).expect("serialize ErrorResponse");
+
+        assert!(
+            !body.contains(upstream_detail),
+            "client error body leaked the upstream provider detail: {body}"
+        );
+        assert!(
+            !body.contains("Failed to generate lease:"),
+            "client error body still interpolates the upstream error: {body}"
+        );
+        assert_eq!(response.message, LEASE_GENERATION_FAILED_MESSAGE);
     }
 }

--- a/backend/servers/api-server/src/routes/ai/voice.rs
+++ b/backend/servers/api-server/src/routes/ai/voice.rs
@@ -17,6 +17,11 @@ use common::errors::ErrorResponse;
 use db::models::LinkVoiceDeviceRequest;
 use uuid::Uuid;
 
+/// Client-facing message returned when the voice-device OAuth code exchange
+/// fails. The underlying provider error is logged server-side but is never
+/// forwarded to the client, to avoid leaking upstream OAuth-provider detail.
+const OAUTH_EXCHANGE_FAILED_MESSAGE: &str = "Authorization code exchange failed";
+
 // ============================================================================
 // Story 64.5: Voice Assistant Endpoints
 // ============================================================================
@@ -191,7 +196,9 @@ async fn exchange_voice_oauth_tokens(
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
                     "OAUTH_EXCHANGE_FAILED",
-                    format!("Failed to exchange authorization code: {}", e),
+                    // Do not leak the upstream OAuth-provider error to the client;
+                    // the detail is already logged server-side above.
+                    OAUTH_EXCHANGE_FAILED_MESSAGE,
                 )),
             )
         })?;
@@ -320,5 +327,34 @@ pub(crate) async fn list_voice_commands(
                 Json(ErrorResponse::new("INTERNAL_ERROR", "Failed to list")),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression guard for the AI upstream-error leak finding: the client-facing
+    /// body for a failed voice-device OAuth code exchange must carry only the
+    /// fixed generic message and must never contain the raw upstream provider
+    /// error (which is logged server-side).
+    #[test]
+    fn oauth_exchange_error_does_not_leak_upstream_detail() {
+        // A representative raw provider error that must not reach the client.
+        let upstream_detail = "invalid_grant: authorization code expired (provider trace xyz)";
+
+        // Mirror the client body built by the OAuth exchange error branch.
+        let response = ErrorResponse::new("OAUTH_EXCHANGE_FAILED", OAUTH_EXCHANGE_FAILED_MESSAGE);
+        let body = serde_json::to_string(&response).expect("serialize ErrorResponse");
+
+        assert!(
+            !body.contains(upstream_detail),
+            "client error body leaked the upstream provider detail: {body}"
+        );
+        assert!(
+            !body.contains("Failed to exchange authorization code:"),
+            "client error body still interpolates the upstream error: {body}"
+        );
+        assert_eq!(response.message, OAUTH_EXCHANGE_FAILED_MESSAGE);
     }
 }


### PR DESCRIPTION
## Task

Two AI route handlers forwarded the raw upstream LLM/OAuth-provider error verbatim in the client-facing `ErrorResponse` message:

- `backend/servers/api-server/src/routes/ai/llm.rs` (`generate_lease`) — `format!("Failed to generate lease: {}", e)`. The error is already logged server-side via `tracing::error!("Lease generation failed: {}", e)`.
- `backend/servers/api-server/src/routes/ai/voice.rs` (voice-device OAuth code exchange) — `format!("Failed to exchange authorization code: {}", e)`. Already logged server-side via `tracing::error!("OAuth token exchange failed ...: {}", e)`.

Return stable generic client messages and keep `{e}` only in the tracing calls. Scope kept to these two files.

## Change

- `llm.rs`: client body now uses a module-level `const LEASE_GENERATION_FAILED_MESSAGE = "Lease generation failed"`. The `{e}` detail remains only in `tracing::error!` and in the server-side `update_generation_status` DB record (not returned to the client).
- `voice.rs`: client body now uses `const OAUTH_EXCHANGE_FAILED_MESSAGE = "Authorization code exchange failed"`. `{e}` remains only in the `tracing::error!` call.
- Added a `#[cfg(test)]` regression test in each file that serializes the client `ErrorResponse` and asserts the body does NOT contain a representative upstream detail nor the old interpolated prefix, and that `message` equals the generic const.

## Owner

pm-security

## Verification

```
VERIFY-PLAN base=a5cbc079ca8be84c4791dccba55306b7adafa347 files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` — PASS.
- `cargo clippy -p api-server` / `cargo test -p api-server` — could NOT complete locally: the `utoipa-swagger-ui v9.0.2` build script fails to download the Swagger UI zip from GitHub (`InvalidArchive("Could not find EOCD")`) due to the known github-egress block in this environment. This is infra, not a code failure. Per prior PRs #2684 / #2685, opening as draft and relying on CI `backend.yml` as authoritative.

## Scope drift

`scope-check.sh --owner pm-security` reports exit 2: both changed files are outside `pm-security`'s configured owner-areas (auth/mfa/extractors), but they are exactly the files named in the task and are entirely within `backend/**`. Mapping artifact, not real drift — flagging for reviewer per the deterministic contract.

- `backend/servers/api-server/src/routes/ai/llm.rs`
- `backend/servers/api-server/src/routes/ai/voice.rs`

## Code-reuse review

`reuse-grep.sh --specialist rust-backend` — no warnings. No new auth/crypto/http-client helpers introduced (only two string consts).

## CI parity (Band C — hot-path only)

skipped: error-hygiene message change; no auth/billing/data-integrity logic altered.

## Remote-tested

skipped: no ppt-bridge MCP in session.

## Notes

The upstream error is still persisted server-side in the `llm_document` generation record (`update_generation_status(..., Some(&error_msg), ...)`) and logged — only the HTTP client response is sanitized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Crrafx77LGYGuvAT1NhWFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Crrafx77LGYGuvAT1NhWFW)_