### PR TITLE
code-review-mobile-rn-biometric-prompt-i18n: i18n the RN biometric OS-dialog copy

### DIFF
--- a/frontend/apps/mobile/src/contexts/AuthContext.tsx
+++ b/frontend/apps/mobile/src/contexts/AuthContext.tsx
@@ -5,6 +5,7 @@ import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 import type { ReactNode } from 'react';
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { resetLocalData } from '../services/resetLocalData';
 
 // Token storage keys
@@ -59,6 +60,7 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
   const queryClient = useQueryClient();
+  const { t } = useTranslation();
   const [state, setState] = useState<AuthState>({
     isLoading: true,
     isAuthenticated: false,
@@ -252,9 +254,9 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
 
     try {
       const result = await LocalAuthentication.authenticateAsync({
-        promptMessage: 'Enable biometric login',
-        cancelLabel: 'Cancel',
-        fallbackLabel: 'Use passcode',
+        promptMessage: t('auth.biometric.enablePrompt'),
+        cancelLabel: t('auth.biometric.cancel'),
+        fallbackLabel: t('auth.biometric.usePasscode'),
       });
 
       if (result.success) {
@@ -268,7 +270,7 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
       console.error('Failed to enable biometric:', error);
       return false;
     }
-  }, [state.biometricAvailable]);
+  }, [state.biometricAvailable, t]);
 
   const disableBiometric = useCallback(async () => {
     await SecureStore.deleteItemAsync(BIOMETRIC_ENABLED_KEY);
@@ -282,9 +284,9 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
 
     try {
       const result = await LocalAuthentication.authenticateAsync({
-        promptMessage: 'Login to Property Management',
-        cancelLabel: 'Cancel',
-        fallbackLabel: 'Use password',
+        promptMessage: t('auth.biometric.authenticatePrompt'),
+        cancelLabel: t('auth.biometric.cancel'),
+        fallbackLabel: t('auth.biometric.usePassword'),
       });
 
       if (result.success) {
@@ -314,7 +316,7 @@ export function AuthProvider({ children, apiBaseUrl }: AuthProviderProps) {
       console.error('Biometric authentication failed:', error);
       return false;
     }
-  }, [state.biometricEnabled, state.biometricAvailable]);
+  }, [state.biometricEnabled, state.biometricAvailable, t]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -54,7 +54,14 @@
     "biometricNotSuccessful": "Biometricke overeni nebylo uspesne",
     "signInWith": "Prihlasit se pomoci {{provider}}",
     "faceIdTouchId": "Face ID / Touch ID",
-    "biometrics": "Biometrie"
+    "biometrics": "Biometrie",
+    "biometric": {
+      "enablePrompt": "Zapnout biometricke prihlaseni",
+      "authenticatePrompt": "Prihlaseni do Spravy nemovitosti",
+      "cancel": "Zrusit",
+      "usePasscode": "Pouzit pristupovy kod",
+      "usePassword": "Pouzit heslo"
+    }
   },
   "dashboard": {
     "title": "Prehled",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -54,7 +54,14 @@
     "biometricNotSuccessful": "Biometrische Authentifizierung war nicht erfolgreich",
     "signInWith": "Anmelden mit {{provider}}",
     "faceIdTouchId": "Face ID / Touch ID",
-    "biometrics": "Biometrie"
+    "biometrics": "Biometrie",
+    "biometric": {
+      "enablePrompt": "Biometrische Anmeldung aktivieren",
+      "authenticatePrompt": "Bei der Hausverwaltung anmelden",
+      "cancel": "Abbrechen",
+      "usePasscode": "Passcode verwenden",
+      "usePassword": "Passwort verwenden"
+    }
   },
   "dashboard": {
     "title": "Dashboard",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -54,7 +54,14 @@
     "biometricNotSuccessful": "Biometric authentication was not successful",
     "signInWith": "Sign in with {{provider}}",
     "faceIdTouchId": "Face ID / Touch ID",
-    "biometrics": "Biometrics"
+    "biometrics": "Biometrics",
+    "biometric": {
+      "enablePrompt": "Enable biometric login",
+      "authenticatePrompt": "Login to Property Management",
+      "cancel": "Cancel",
+      "usePasscode": "Use passcode",
+      "usePassword": "Use password"
+    }
   },
   "dashboard": {
     "title": "Dashboard",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -54,7 +54,14 @@
     "biometricNotSuccessful": "A biometrikus hitelesites nem sikerult",
     "signInWith": "Bejelentkezes ezzel: {{provider}}",
     "faceIdTouchId": "Face ID / Touch ID",
-    "biometrics": "Biometria"
+    "biometrics": "Biometria",
+    "biometric": {
+      "enablePrompt": "Biometrikus bejelentkezes engedelyezese",
+      "authenticatePrompt": "Bejelentkezes az Ingatlankezelesbe",
+      "cancel": "Megse",
+      "usePasscode": "Jelkod hasznalata",
+      "usePassword": "Jelszo hasznalata"
+    }
   },
   "dashboard": {
     "title": "Iranyitopult",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -54,7 +54,14 @@
     "biometricNotSuccessful": "Uwierzytelnianie biometryczne nie bylo udane",
     "signInWith": "Zaloguj sie przez {{provider}}",
     "faceIdTouchId": "Face ID / Touch ID",
-    "biometrics": "Biometria"
+    "biometrics": "Biometria",
+    "biometric": {
+      "enablePrompt": "Wlacz logowanie biometryczne",
+      "authenticatePrompt": "Zaloguj sie do Zarzadzania nieruchomosciami",
+      "cancel": "Anuluj",
+      "usePasscode": "Uzyj kodu dostepu",
+      "usePassword": "Uzyj hasla"
+    }
   },
   "dashboard": {
     "title": "Panel",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -54,7 +54,14 @@
     "biometricNotSuccessful": "Biometricke overenie nebolo uspesne",
     "signInWith": "Prihlasit sa pomocou {{provider}}",
     "faceIdTouchId": "Face ID / Touch ID",
-    "biometrics": "Biometria"
+    "biometrics": "Biometria",
+    "biometric": {
+      "enablePrompt": "Zapnut biometricke prihlasenie",
+      "authenticatePrompt": "Prihlasenie do Spravy nehnutelnosti",
+      "cancel": "Zrusit",
+      "usePasscode": "Pouzit pristupovy kod",
+      "usePassword": "Pouzit heslo"
+    }
   },
   "dashboard": {
     "title": "Prehlad",

--- a/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
+++ b/frontend/apps/mobile/src/test/integration/auth.integration.test.tsx
@@ -25,6 +25,12 @@ import * as LocalAuthentication from 'expo-local-authentication';
 import * as SecureStore from 'expo-secure-store';
 import type { ReactNode } from 'react';
 import { AuthProvider, useAuth } from '../../contexts/AuthContext';
+import csLocale from '../../locales/cs.json';
+import deLocale from '../../locales/de.json';
+import enLocale from '../../locales/en.json';
+import huLocale from '../../locales/hu.json';
+import plLocale from '../../locales/pl.json';
+import skLocale from '../../locales/sk.json';
 
 // AuthProvider now purges the AsyncStorage-backed tenant caches on
 // login/logout (issue #2399), so swap the shared jest stub for a real
@@ -479,6 +485,19 @@ describe('AuthContext integration', () => {
       expect(enabled).toBe(true);
       expect(result.current.biometricEnabled).toBe(true);
       expect(store.get('ppt_biometric_enabled')).toBe('true');
+
+      // The OS biometric dialog copy must come from i18n, not hardcoded
+      // English (code-review-mobile-rn-biometric-prompt-i18n). The shared
+      // react-i18next mock returns the key verbatim (`t(key) => key`), so we
+      // assert on the keys and that the old literals are gone.
+      expect(mockedLocalAuth.authenticateAsync).toHaveBeenCalledWith({
+        promptMessage: 'auth.biometric.enablePrompt',
+        cancelLabel: 'auth.biometric.cancel',
+        fallbackLabel: 'auth.biometric.usePasscode',
+      });
+      const enableArg = mockedLocalAuth.authenticateAsync.mock.calls[0][0];
+      expect(enableArg.promptMessage).not.toBe('Enable biometric login');
+      expect(enableArg.fallbackLabel).not.toBe('Use passcode');
     });
 
     it('enableBiometric returns false when prompt is cancelled', async () => {
@@ -549,6 +568,17 @@ describe('AuthContext integration', () => {
       expect(ok).toBe(true);
       expect(result.current.isAuthenticated).toBe(true);
       expect(result.current.user).toEqual(sampleUser);
+
+      // Unlock dialog copy is i18n-sourced, not hardcoded English
+      // (code-review-mobile-rn-biometric-prompt-i18n).
+      expect(mockedLocalAuth.authenticateAsync).toHaveBeenCalledWith({
+        promptMessage: 'auth.biometric.authenticatePrompt',
+        cancelLabel: 'auth.biometric.cancel',
+        fallbackLabel: 'auth.biometric.usePassword',
+      });
+      const authArg = mockedLocalAuth.authenticateAsync.mock.calls[0][0];
+      expect(authArg.promptMessage).not.toBe('Login to Property Management');
+      expect(authArg.fallbackLabel).not.toBe('Use password');
     });
 
     it('authenticateWithBiometric deliberately preserves persisted caches (issue #2399)', async () => {
@@ -588,5 +618,48 @@ describe('AuthContext integration', () => {
       expect(ok).toBe(false);
       expect(mockedLocalAuth.authenticateAsync).not.toHaveBeenCalled();
     });
+  });
+});
+
+// Resource-layer guard: the biometric prompt keys referenced by AuthContext
+// must exist in every shipped locale and carry a real, non-English translation
+// (code-review-mobile-rn-biometric-prompt-i18n). Mirrors the pattern in
+// FaultsListScreen.i18n.test.tsx.
+describe('auth.biometric prompt keys resolve to real, locale-distinct translations', () => {
+  const BIOMETRIC_KEYS = [
+    'enablePrompt',
+    'authenticatePrompt',
+    'cancel',
+    'usePasscode',
+    'usePassword',
+  ] as const;
+
+  it('en carries the expected English copy', () => {
+    expect(enLocale.auth.biometric.enablePrompt).toBe('Enable biometric login');
+    expect(enLocale.auth.biometric.authenticatePrompt).toBe('Login to Property Management');
+    expect(enLocale.auth.biometric.cancel).toBe('Cancel');
+    expect(enLocale.auth.biometric.usePasscode).toBe('Use passcode');
+    expect(enLocale.auth.biometric.usePassword).toBe('Use password');
+  });
+
+  it('every shipped locale defines all biometric keys as non-empty strings', () => {
+    for (const locale of [enLocale, skLocale, csLocale, deLocale, plLocale, huLocale]) {
+      for (const key of BIOMETRIC_KEYS) {
+        const value = locale.auth.biometric[key];
+        expect(typeof value).toBe('string');
+        expect(value.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('non-English locales translate the prompt copy away from English', () => {
+    // `cancel` is a proper noun-ish UI word that can legitimately collide in
+    // some languages, so only assert divergence on the descriptive prompts.
+    for (const locale of [skLocale, csLocale, deLocale, plLocale, huLocale]) {
+      expect(locale.auth.biometric.enablePrompt).not.toBe(enLocale.auth.biometric.enablePrompt);
+      expect(locale.auth.biometric.authenticatePrompt).not.toBe(
+        enLocale.auth.biometric.authenticatePrompt
+      );
+    }
   });
 });


### PR DESCRIPTION
## Task
i18n bug — the app ships sk/cs/de/en (+pl/hu) but the OS biometric dialog strings in `frontend/apps/mobile/src/contexts/AuthContext.tsx` were hardcoded English:
- `enableBiometric` (was lines 252-256): `promptMessage: 'Enable biometric login'`, `cancelLabel: 'Cancel'`, `fallbackLabel: 'Use passcode'`.
- `authenticateWithBiometric` (was lines 284-287): `promptMessage: 'Login to Property Management'`, `cancelLabel: 'Cancel'`, `fallbackLabel: 'Use password'`.

All six strings are now routed through `t('auth.biometric.*')` keys, added to every locale file (sk/cs/de/en/pl/hu). Scope kept to `AuthContext.tsx` + the locale JSON files (+ test coverage).

### Keys added under `auth.biometric`
`enablePrompt`, `authenticatePrompt`, `cancel` (shared), `usePasscode`, `usePassword` — 5 keys covering the 6 call sites, translated per-locale (matching the existing ASCII/no-diacritics convention already used in these files).

### Implementation notes
- Used the `useTranslation()` hook (`const { t } = useTranslation()`) rather than the i18n singleton — the app's jest `setup.ts` mocks `react-i18next`'s hook (`t(key) => key`) but mocks `../i18n` as a plain object with no `t`, so the hook path is the test-safe and idiomatic choice. `t` added to the two `useCallback` dependency arrays so the callbacks pick up a language change.

## Owner
pm-backend (hint only — actual work is `frontend/apps/mobile`, so the `react-native` specialist ran).

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 because every changed path is under `frontend/apps/mobile` (the `react-native` area), not a pm-backend area. This is expected: the task's `owner_role` is a routing hint; the finding is a React Native i18n bug. No files outside `frontend/apps/mobile` were touched. Reviewer to confirm the drift is justified (it is, by the task text).

## Code-reuse review
`reuse-grep.sh --specialist react-native` → clean (no new helper introduced; change only swaps string literals for `t()` calls).

## Verification
```
VERIFY-PLAN base=a5cbc079ca8be84c4791dccba55306b7adafa347 files=8
  cd frontend && pnpm exec biome check apps/mobile/src/contexts/AuthContext.tsx apps/mobile/src/locales/cs.json apps/mobile/src/locales/de.json apps/mobile/src/locales/en.json apps/mobile/src/locales/hu.json apps/mobile/src/locales/pl.json apps/mobile/src/locales/sk.json apps/mobile/src/test/integration/auth.integration.test.tsx
  cd frontend && pnpm --filter "...[a5cbc079ca8be84c4791dccba55306b7adafa347]" typecheck
  cd frontend && pnpm --filter "...[a5cbc079ca8be84c4791dccba55306b7adafa347]" test
```
```
VERIFY OK 471374daa6b9e1a507f3853f243c1faf39621cba
```
(mobile suite: 49 suites / 615 tests passed; typecheck clean; Biome clean.)

## Tests
Extended `src/test/integration/auth.integration.test.tsx`:
- The two success-path biometric tests now assert `LocalAuthentication.authenticateAsync` is called with the i18n keys (`auth.biometric.*`) and that the old hardcoded English literals are gone.
- New resource-layer `describe` verifies every shipped locale defines all five keys as non-empty strings, `en` carries the expected English copy, and non-English locales translate the two descriptive prompts away from English (mirrors `FaultsListScreen.i18n.test.tsx`).

These assertions fail on `dev` (hardcoded literals) and pass here — IG3 regression coverage.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (UI copy / i18n only; no auth-logic, security, billing, or data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- `just verify` was run via `scripts/verify-impact.sh --base origin/dev` (the worktree's local `dev` ref is stale / has no merge-base with `origin/dev`; the branch was cut from `origin/dev` @ a5cbc07).
- The `hu`/`pl` locales were included for completeness even though the task named only sk/cs/de/en — leaving them out would silently fall back to English on the OS dialog.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Crrafx77LGYGuvAT1NhWFW)_