### PR TITLE
code-review-reality-web-comparison-share-all-or-nothing: tolerate bad listing ids in shared comparison URLs

### DIFF
--- a/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.test.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.test.tsx
@@ -95,4 +95,38 @@ describe('ComparisonUrlHandler', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
     expect(addToComparison).not.toHaveBeenCalled();
   });
+
+  it('degrades gracefully: one bad id is dropped, the good ones still load', async () => {
+    // Regression bar for the all-or-nothing bug: `Promise.all` used to reject
+    // on the first failure, so a single stale/missing id blanked the entire
+    // shared comparison. The good listings must survive.
+    const goodA = { ...mockListing, id: 'good-a', slug: 'good-a' };
+    const goodB = { ...mockListing, id: 'good-b', slug: 'good-b' };
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/bad')) {
+        return { ok: false, status: 404, json: async () => ({}) };
+      }
+      const id = url.endsWith('/good-a') ? goodA : goodB;
+      return { ok: true, status: 200, json: async () => id };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<ComparisonUrlHandler sharedIds={['good-a', 'bad', 'good-b']} />);
+
+    // Both good listings are added despite the bad id in the middle.
+    await waitFor(() => expect(addToComparison).toHaveBeenCalledWith(goodA));
+    await waitFor(() => expect(addToComparison).toHaveBeenCalledWith(goodB));
+
+    // The bad id is dropped — it is never handed to the comparison. Every
+    // added listing is one of the two good ones (guard against the harness
+    // re-running the effect since the mocked context stays empty).
+    for (const [added] of addToComparison.mock.calls) {
+      expect(['good-a', 'good-b']).toContain(added.id);
+    }
+
+    // The comparison is usable, so the error state must NOT blank it out.
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
 });

--- a/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
@@ -47,13 +47,33 @@ export function ComparisonUrlHandler({ sharedIds }: ComparisonUrlHandlerProps) {
           return response.json() as Promise<ListingSummary>;
         });
 
-        const loadedListings = await Promise.all(fetchPromises);
+        // Resolve every id independently so one bad/missing listing degrades
+        // gracefully (it is dropped) instead of blanking the whole shared
+        // comparison. `Promise.all` used to reject on the first failure, so a
+        // single stale/invalid id in a shared URL wiped out every listing.
+        const results = await Promise.allSettled(fetchPromises);
 
-        // Add each listing to comparison
-        for (const listing of loadedListings) {
-          if (listing) {
-            addToComparison(listing);
+        const loadedListings: ListingSummary[] = [];
+        for (const result of results) {
+          if (result.status === 'fulfilled') {
+            if (result.value) {
+              loadedListings.push(result.value);
+            }
+          } else {
+            // Skip the bad id but keep the rest of the comparison intact.
+            console.error('Error loading shared listing:', result.reason);
           }
+        }
+
+        // Add each successfully loaded listing to comparison.
+        for (const listing of loadedListings) {
+          addToComparison(listing);
+        }
+
+        // Only surface the error state when NOTHING could be loaded — a
+        // partial success still yields a usable comparison.
+        if (loadedListings.length === 0) {
+          setError(t('loadError'));
         }
       } catch (err) {
         setError(t('loadError'));


### PR DESCRIPTION
## Task
reality-web `ComparisonUrlHandler` uses `Promise.all` to resolve listing ids for a shared comparison URL — if ONE listing id is bad/missing, `Promise.all` rejects and the WHOLE shared comparison URL blanks out. Change to a fault-tolerant resolution (e.g. `Promise.allSettled`) so a single bad id degrades gracefully (drop/skip the bad listing) instead of blanking the entire comparison. Add a regression test.

## Change
- `ComparisonUrlHandler.tsx`: replaced `Promise.all` with `Promise.allSettled`. Fulfilled listings are added to the comparison; rejected ids are dropped with a `console.error`. The error state is now shown **only when nothing at all could be loaded** — a partial success yields a usable comparison instead of a blank page.
- Preserves existing behavior: a fully-failing shared URL (every id 404s) still renders the error alert.

## Owner
`pm-backend` (hint only — this is frontend-only reality-web/Next.js work; specialist = `nextjs-web`).

## Verification
```
VERIFY-PLAN base=0637cc7d1e1d75fd173b70ef816d8bedee14b795 files=2
  cd frontend && pnpm exec biome check apps/reality-web/src/components/comparison/ComparisonUrlHandler.test.tsx apps/reality-web/src/components/comparison/ComparisonUrlHandler.tsx
  cd frontend && pnpm --filter "...[0637cc7d1e1d75fd173b70ef816d8bedee14b795]" typecheck
  cd frontend && pnpm --filter "...[0637cc7d1e1d75fd173b70ef816d8bedee14b795]" test
```
```
VERIFY OK 9135286492034904f2a5c0ac0b836ac31b7dccfc
```
- biome check: clean (2 files)
- reality-web typecheck: exit 0
- reality-web vitest: 24 files / 236 tests passed

### IG3 regression evidence
The new test `degrades gracefully: one bad id is dropped, the good ones still load` **fails against the old `Promise.all` code** (both good listings never load, error alert shown) and **passes on the fix**. Confirmed by stashing the component fix and re-running the single test.

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 because the `owner_role` hint is `pm-backend` while the change is entirely frontend. Re-running with the correct owner — `scope-check.sh --owner pm-frontend` — exits 0 (clean). No genuine drift: both touched files are within `frontend/apps/reality-web/src/components/comparison/`.

## Code-reuse review
`reuse-grep.sh --specialist nextjs-web`: no warnings.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- Frontend-only; unaffected by the dev migration-collision CI hostage. `frontend.yml` (biome + typecheck + vitest + build) gates normally.
- No new i18n keys added (reuses existing `comparison.loadError`), so no messages/*.json changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123W1ca3wM4FWiMv6ezQu56

---
_Generated by [Claude Code](https://claude.ai/code/session_0123W1ca3wM4FWiMv6ezQu56)_