### PR TITLE
code-review-reality-web-listingform-nan-validation: guard area/rooms against NaN & negative input

### DIFF
--- a/frontend/apps/reality-web/src/components/realtor/ListingForm.test.tsx
+++ b/frontend/apps/reality-web/src/components/realtor/ListingForm.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * ListingForm validation tests.
+ *
+ * Regression for the bug where numeric fields (area / rooms) were submitted
+ * via `area ? Number(area) : undefined`, which silently forwarded `NaN` for
+ * non-numeric input and let negative values pass through. The form must now
+ * reject non-numeric / negative area & rooms with an inline error and never
+ * call onSubmit with a `NaN` or negative measure.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ListingForm } from './ListingForm';
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByLabelText(/Title/i), { target: { value: 'Nice flat' } });
+  fireEvent.change(screen.getByLabelText(/Description/i), {
+    target: { value: 'A lovely place to live' },
+  });
+  fireEvent.change(screen.getByLabelText(/City/i), { target: { value: 'Bratislava' } });
+  fireEvent.change(screen.getByLabelText(/Price/i), { target: { value: '120000' } });
+}
+
+function submit() {
+  fireEvent.click(screen.getByRole('button', { name: /save/i }));
+}
+
+describe('ListingForm — numeric field validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a negative area and does not submit', () => {
+    const onSubmit = vi.fn();
+    render(<ListingForm submitLabel="Save" onSubmit={onSubmit} />);
+
+    fillRequiredFields();
+    fireEvent.change(screen.getByLabelText(/Area/i), { target: { value: '-5' } });
+    submit();
+
+    expect(screen.getByText(/Area must not be negative/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('rejects a negative room count and does not submit', () => {
+    const onSubmit = vi.fn();
+    render(<ListingForm submitLabel="Save" onSubmit={onSubmit} />);
+
+    fillRequiredFields();
+    fireEvent.change(screen.getByLabelText(/Rooms/i), { target: { value: '-2' } });
+    submit();
+
+    expect(screen.getByText(/Rooms must not be negative/i)).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('never forwards NaN for a non-numeric area value', () => {
+    const onSubmit = vi.fn();
+    render(<ListingForm submitLabel="Save" onSubmit={onSubmit} />);
+
+    fillRequiredFields();
+    // Simulate a value `Number()` would coerce to NaN reaching the field.
+    fireEvent.change(screen.getByLabelText(/Area/i), { target: { value: 'not-a-number' } });
+    submit();
+
+    // Either it is rejected (error shown, no submit) or the field was
+    // sanitized to empty — in both cases NaN must never reach onSubmit.
+    if (onSubmit.mock.calls.length > 0) {
+      const draft = onSubmit.mock.calls[0][0];
+      expect(draft.area === undefined || Number.isFinite(draft.area)).toBe(true);
+    } else {
+      expect(onSubmit).not.toHaveBeenCalled();
+    }
+  });
+
+  it('submits valid numeric area & rooms as finite numbers (no NaN)', () => {
+    const onSubmit = vi.fn();
+    render(<ListingForm submitLabel="Save" onSubmit={onSubmit} />);
+
+    fillRequiredFields();
+    fireEvent.change(screen.getByLabelText(/Area/i), { target: { value: '85' } });
+    fireEvent.change(screen.getByLabelText(/Rooms/i), { target: { value: '3' } });
+    submit();
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const draft = onSubmit.mock.calls[0][0];
+    expect(draft.area).toBe(85);
+    expect(draft.rooms).toBe(3);
+    expect(Number.isNaN(draft.area)).toBe(false);
+    expect(Number.isNaN(draft.rooms)).toBe(false);
+  });
+
+  it('omits empty optional numeric fields (undefined, not NaN)', () => {
+    const onSubmit = vi.fn();
+    render(<ListingForm submitLabel="Save" onSubmit={onSubmit} />);
+
+    fillRequiredFields();
+    submit();
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const draft = onSubmit.mock.calls[0][0];
+    expect(draft.area).toBeUndefined();
+    expect(draft.rooms).toBeUndefined();
+  });
+});

--- a/frontend/apps/reality-web/src/components/realtor/ListingForm.tsx
+++ b/frontend/apps/reality-web/src/components/realtor/ListingForm.tsx
@@ -37,6 +37,24 @@ interface FieldErrors {
   description?: string;
   price?: string;
   city?: string;
+  area?: string;
+  rooms?: string;
+}
+
+/**
+ * Parse an optional numeric field from raw input.
+ *
+ * Empty input is valid and yields `undefined` (the field is optional).
+ * Non-numeric input (which `Number()` would coerce to `NaN`) and negative
+ * values are rejected so the form never submits `NaN` or a negative measure.
+ */
+function parseOptionalNonNegative(raw: string): { value?: number; error?: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { value: undefined };
+  const num = Number(trimmed);
+  if (!Number.isFinite(num)) return { error: 'must be a valid number' };
+  if (num < 0) return { error: 'must not be negative' };
+  return { value: num };
 }
 
 export function ListingForm({
@@ -71,6 +89,10 @@ export function ListingForm({
     if (!city.trim()) next.city = 'City is required';
     const priceNum = Number(price);
     if (!Number.isFinite(priceNum) || priceNum <= 0) next.price = 'Price must be a positive number';
+    const areaResult = parseOptionalNonNegative(area);
+    if (areaResult.error) next.area = `Area ${areaResult.error}`;
+    const roomsResult = parseOptionalNonNegative(rooms);
+    if (roomsResult.error) next.rooms = `Rooms ${roomsResult.error}`;
     setErrors(next);
     if (Object.keys(next).length > 0) return;
 
@@ -84,8 +106,8 @@ export function ListingForm({
       city: city.trim(),
       street: street.trim() || undefined,
       postalCode: postalCode.trim() || undefined,
-      area: area ? Number(area) : undefined,
-      rooms: rooms ? Number(rooms) : undefined,
+      area: areaResult.value,
+      rooms: roomsResult.value,
     });
   };
 
@@ -225,8 +247,9 @@ export function ListingForm({
             value={area}
             onChange={(e) => setArea(e.target.value)}
             disabled={isSubmitting}
-            className="input"
+            className={`input ${errors.area ? 'input-error' : ''}`}
           />
+          {errors.area && <span className="error">{errors.area}</span>}
         </label>
         <label className="field">
           <span className="label">Rooms</span>
@@ -236,8 +259,9 @@ export function ListingForm({
             value={rooms}
             onChange={(e) => setRooms(e.target.value)}
             disabled={isSubmitting}
-            className="input"
+            className={`input ${errors.rooms ? 'input-error' : ''}`}
           />
+          {errors.rooms && <span className="error">{errors.rooms}</span>}
         </label>
       </div>
 


### PR DESCRIPTION
## Task
reality-web `ListingForm` posts `NaN` for numeric fields (area/rooms) — non-numeric or negative input is silently coerced (e.g. `Number(input)` producing `NaN`, or a negative value passing through). Add proper validation: reject/guard non-numeric and negative input for area/rooms so the form never submits `NaN` (surface a validation error to the user instead). Add a regression test.

## Owner
`pm-backend` (hint only — this is FRONTEND reality-web work; specialist selected: `nextjs-web`).

## What changed
`frontend/apps/reality-web/src/components/realtor/ListingForm.tsx`
- Root cause: on submit, optional numerics were forwarded via `area ? Number(area) : undefined` / `rooms ? Number(rooms) : undefined`. Non-numeric input coerced to `NaN` (and was truthy as a string, so it passed through), and negative values passed straight through.
- Added `parseOptionalNonNegative(raw)`: empty → `undefined` (field is optional); non-finite (`NaN`) → error `must be a valid number`; negative → error `must not be negative`; otherwise the parsed number.
- Extended `FieldErrors` with `area` / `rooms`; both fields now block submit and render an inline error (`input-error` class + `.error` span), consistent with the existing `price` validation.
- Submit now forwards the validated `areaResult.value` / `roomsResult.value` (guaranteed finite & non-negative, or `undefined`) — never `NaN`.

`frontend/apps/reality-web/src/components/realtor/ListingForm.test.tsx` (new)
- Regression coverage: negative area rejected + no submit; negative rooms rejected + no submit; non-numeric area never forwards `NaN`; valid area/rooms submit as finite numbers; empty optionals submit as `undefined`.
- IG3 confirmed: with the source fix reverted (test kept), the two negative-input cases FAIL on pre-fix code; all 5 pass with the fix.

## Verification
```
VERIFY-PLAN base=0637cc7d1e1d75fd173b70ef816d8bedee14b795 files=2
  cd frontend && pnpm exec biome check apps/reality-web/src/components/realtor/ListingForm.test.tsx apps/reality-web/src/components/realtor/ListingForm.tsx
  cd frontend && pnpm --filter "...[0637cc7d1e1d75fd173b70ef816d8bedee14b795]" typecheck
  cd frontend && pnpm --filter "...[0637cc7d1e1d75fd173b70ef816d8bedee14b795]" test
```
```
VERIFY OK d413aea9d848b61171222d18f511e489701a4059
```
- biome check: clean (2 files). typecheck: exit 0. reality-web tests: 240 passed (25 files), incl. 5 new ListingForm cases.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
True only against the `pm-backend` owner hint (the task explicitly notes this is reality-web frontend work, so the correct area is `frontend/apps/reality-web/**`). The actual diff vs `origin/dev` is exactly the two `ListingForm` files — tightly scoped, no sibling-i18n overlap. `scope-check.sh`'s extra listed paths were false positives from a stale local `dev` ref; `git diff --name-only origin/dev...HEAD` shows only the two files.

## Code-reuse review
`reuse-grep.sh` (nextjs-web): no warnings. `parseOptionalNonNegative` is a small local helper mirroring the existing inline `price` validation pattern.

## Notes
- Diff kept intentionally minimal — a sibling task edits `ListingForm` for i18n but is not claimed this run, so this change avoids touching labels/strings to prevent future conflicts.
- The `goal-check.sh` helper timed out on its internal re-verification pass (tooling, not a goal failure); IG3 and IG7 were verified directly (regression fail-on-base + green verify gate above).


---
_Generated by [Claude Code](https://claude.ai/code/session_0123W1ca3wM4FWiMv6ezQu56)_