### PR TITLE
churn-hotspot-backend-servers-api-server-src-routes-ai-llm-rs: fail closed on partial RAG embedding batch

### DIFF
--- a/backend/servers/api-server/src/routes/ai/llm.rs
+++ b/backend/servers/api-server/src/routes/ai/llm.rs
@@ -112,6 +112,21 @@ struct IndexDocumentResponse {
 /// and connection hold time.
 const MAX_INDEX_CHUNKS: usize = 512;
 
+/// Whether an embedding batch is well-formed for indexing: the provider must
+/// return exactly one vector per submitted chunk.
+///
+/// The [`EmbeddingProvider::embed_batch`] contract is one vector per input, but
+/// the production OpenAI backend fulfils it via a remote batch call whose `data`
+/// array length is not guaranteed by the type system. If the provider returns
+/// *fewer* vectors than chunks (a truncated / partial batch response), the write
+/// loop's `chunks.iter().zip(embeddings.iter())` silently drops the surplus
+/// chunks — only a prefix of the document is indexed while the caller still gets
+/// a 201 success, corrupting later similarity retrieval. Verify the counts match
+/// and fail closed instead.
+fn embedding_batch_is_complete(chunk_count: usize, embedding_count: usize) -> bool {
+    chunk_count == embedding_count
+}
+
 /// Index a document into the pgvector RAG store (Story 84.5 / 103.5).
 ///
 /// This is the missing application-side embedding-write flow: it generates an
@@ -269,6 +284,27 @@ async fn index_document(
             ));
         }
     };
+
+    // partial-batch guard: the write loop below zips chunks with embeddings, so a
+    // provider that returns fewer vectors than chunks would silently index only a
+    // prefix of the document and still report success. Fail closed on any
+    // count mismatch rather than persisting a partially-embedded document.
+    if !embedding_batch_is_complete(chunks.len(), embeddings.len()) {
+        tracing::error!(
+            organization_id = %tenant_id,
+            document_id = %req.document_id,
+            chunks = chunks.len(),
+            embeddings = embeddings.len(),
+            "RAG embedding provider returned a mismatched vector count — refusing partial index"
+        );
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            Json(ErrorResponse::new(
+                "EMBEDDING_FAILED",
+                "Embedding provider returned an incomplete result",
+            )),
+        ));
+    }
 
     // Base metadata: caller-provided object (if any) plus an optional title.
     // Per-vector provenance (`embedding_model`) is folded in by the repository's
@@ -1484,5 +1520,40 @@ mod tests {
             "client error body still interpolates the upstream error: {body}"
         );
         assert_eq!(response.message, LEASE_GENERATION_FAILED_MESSAGE);
+    }
+
+    /// Regression guard for the RAG partial-index gap: a provider that returns
+    /// fewer embedding vectors than submitted chunks must be rejected, because
+    /// the `index_document` write loop zips chunks with embeddings and would
+    /// otherwise silently persist only a prefix of the document.
+    #[test]
+    fn embedding_batch_mismatch_is_rejected_before_write() {
+        let chunks = ["a", "b", "c"];
+        // Provider dropped one vector (truncated / partial batch response).
+        let embeddings = [vec![0.0f32], vec![0.0f32]];
+
+        // Demonstrate the silent-truncation hazard the guard exists to prevent:
+        // zip stops at the shorter side, so only 2 of the 3 chunks would be
+        // written while the caller still gets a success response.
+        let written = chunks.iter().zip(embeddings.iter()).count();
+        assert_eq!(
+            written, 2,
+            "zip truncates to the shorter side — 1 chunk would be silently dropped"
+        );
+
+        // The guard catches the mismatch...
+        assert!(
+            !embedding_batch_is_complete(chunks.len(), embeddings.len()),
+            "mismatched vector count must be treated as incomplete"
+        );
+        // ...and accepts the well-formed 1-vector-per-chunk case.
+        assert!(
+            embedding_batch_is_complete(chunks.len(), chunks.len()),
+            "one vector per chunk is a complete batch"
+        );
+        assert!(
+            embedding_batch_is_complete(0, 0),
+            "an empty batch is trivially complete"
+        );
     }
 }


### PR DESCRIPTION
## Task
Churn hotspot: backend/servers/api-server/src/routes/ai/llm.rs (fail-closed enhanced_chat #2688 + upstream error masking #2694). Review the recently-churned file and land one concrete correctness/robustness/security hardening change.

## Finding
`index_document` (`POST /api/v1/ai/llm/rag/index`) generates embeddings via `EmbeddingProvider::embed_batch`, then writes them with:

```rust
for (idx, (chunk, emb)) in chunks.iter().zip(embeddings.iter()).enumerate() { ... }
```

The "one vector per input chunk" contract is honoured by the default trait impl, but the **production OpenAI backend** fulfils it through a remote batch call (`generate_embeddings_batch`) whose returned `data`-array length is not guaranteed by the type system. If the provider returns **fewer** vectors than chunks (truncated / partial batch response), `zip` stops at the shorter side and **silently drops the surplus chunks** — only a prefix of the document is indexed, `chunks_indexed` under-reports, and the caller still receives `201 Created`. The document then looks indexed but is partial, corrupting later pgvector similarity retrieval. This is the same fail-open class as the #2688 enhanced_chat stub (success returned over incomplete/fabricated data).

## Change
- Add `embedding_batch_is_complete(chunk_count, embedding_count) -> bool`.
- After `embed_batch` succeeds, reject any count mismatch with `502 EMBEDDING_FAILED` ("Embedding provider returned an incomplete result") **before** the write loop — fail closed rather than persist a partially-embedded document. Logs org/document/counts server-side.
- Pure regression test `embedding_batch_mismatch_is_rejected_before_write` that demonstrates the zip-truncation hazard (3 chunks + 2 vectors → only 2 written) and asserts the guard rejects it, accepts the 1:1 case, and treats an empty batch as complete.

No SQL changed → no `.sqlx` regeneration needed. Diff is confined to the single file named in the task.

## Owner
pm-tech-lead

## Scope drift
`scope-check.sh --owner pm-tech-lead` exits 2: `pm-tech-lead` maps only to `docs/**`, `.research/**`, `_bmad-output/**`, so any backend change registers as drift. This is a benign owner_role/area mismatch — the dispatcher assigned a backend churn-hotspot task under a non-backend owner_role. The diff vs `origin/dev` is exactly the one file the task targets:
- `backend/servers/api-server/src/routes/ai/llm.rs`

## Verification
Local backend compile is unavailable in this environment (rustup channel sync / utoipa-swagger-ui egress block — `cargo` component "not applicable to the 1.94.1 toolchain"). `just verify` / `cargo test -p api-server --no-run` cannot run here by design; the change is a self-contained free function + a guard using only already-in-scope bindings (`chunks`, `embeddings`, `tenant_id`, `req.document_id`, `StatusCode`, `ErrorResponse`) plus a std-only unit test. Verification is delegated to CI `backend.yml` (`cargo fmt` / `clippy` / `cargo test`). Opened as **draft** pending CI green.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no auth/billing/data-integrity contract change; a robustness fail-closed guard on an existing endpoint).

## Remote-tested
skipped

## Notes
`embedding_batch_is_complete` returns `false` for any inequality (including the theoretical over-count) — over-count would also mean the provider misbehaved, so rejecting it is correct and conservative.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHjeW1j6rBHy5HB3RD7YaV)_