### PR TITLE
gh-issue-2704: cap unbounded workflow api_call response-body read (memory DoS)

### DIFF
--- a/backend/servers/api-server/src/services/actions/api_call.rs
+++ b/backend/servers/api-server/src/services/actions/api_call.rs
@@ -83,6 +83,22 @@ pub struct ApiCallConfig {
     pub include_response: bool,
 }
 
+/// Maximum number of response-body bytes the API-call action will buffer into
+/// memory. A workflow action issues one small outbound request but then reads
+/// the *entire* upstream response with `response.text()`, which buffers with no
+/// ceiling — a malicious or misbehaving endpoint can reply with a multi-GB (or,
+/// via chunked transfer with no `Content-Length`, effectively unbounded) body
+/// and amplify a trivial request into an out-of-memory DoS on the worker. We
+/// cap the read at this many bytes; anything beyond is dropped and the stored
+/// body is marked truncated. 8 MiB comfortably covers legitimate JSON webhook
+/// responses while bounding worst-case allocation per in-flight action.
+const MAX_RESPONSE_BODY_BYTES: usize = 8 * 1024 * 1024;
+
+/// Appended to a response body that was cut off at `MAX_RESPONSE_BODY_BYTES`,
+/// so the persisted workflow-execution record makes the truncation explicit
+/// instead of silently storing a partial payload.
+const RESPONSE_TRUNCATION_MARKER: &str = "\u{2026}[truncated: response exceeded 8 MiB cap]";
+
 fn default_timeout_seconds() -> u64 {
     30
 }
@@ -138,6 +154,56 @@ impl ApiCallExecutor {
             ),
             other => other.clone(),
         }
+    }
+
+    /// Read an upstream response body while hard-capping how many bytes are
+    /// buffered, defending against a memory-amplification DoS (a small request
+    /// provoking an enormous reply). Returns `(body_text, truncated)`.
+    ///
+    /// Two layers of defence:
+    /// 1. **`Content-Length` pre-check** — if the upstream already advertises a
+    ///    body larger than the cap, refuse to buffer any of it.
+    /// 2. **Streaming bounded read** — otherwise pull the body chunk-by-chunk
+    ///    and stop the moment the accumulated size would exceed the cap. This
+    ///    is what protects against a chunked-transfer body with no (or a lying)
+    ///    `Content-Length`, which the pre-check alone cannot catch.
+    ///
+    /// A mid-stream network error keeps whatever was read so far (best-effort),
+    /// mirroring the previous `unwrap_or_default()` behaviour.
+    async fn read_capped_body(mut response: reqwest::Response) -> (String, bool) {
+        // Layer 1: honest oversized Content-Length — never start buffering.
+        if let Some(len) = response.content_length() {
+            if len > MAX_RESPONSE_BODY_BYTES as u64 {
+                return (RESPONSE_TRUNCATION_MARKER.to_string(), true);
+            }
+        }
+
+        // Layer 2: bounded streaming read.
+        let mut buf: Vec<u8> = Vec::new();
+        let mut truncated = false;
+        loop {
+            match response.chunk().await {
+                Ok(Some(chunk)) => {
+                    let remaining = MAX_RESPONSE_BODY_BYTES.saturating_sub(buf.len());
+                    if chunk.len() > remaining {
+                        buf.extend_from_slice(&chunk[..remaining]);
+                        truncated = true;
+                        break;
+                    }
+                    buf.extend_from_slice(&chunk);
+                }
+                Ok(None) => break,
+                // Network error mid-read: keep the partial body, don't fail the
+                // whole action on it (matches prior best-effort semantics).
+                Err(_) => break,
+            }
+        }
+
+        let mut text = String::from_utf8_lossy(&buf).into_owned();
+        if truncated {
+            text.push_str(RESPONSE_TRUNCATION_MARKER);
+        }
+        (text, truncated)
     }
 }
 
@@ -253,9 +319,18 @@ impl ActionExecutor for ApiCallExecutor {
         // Check if status code indicates success
         let is_success = api_config.success_codes.contains(&status);
 
-        // Get response body
+        // Get response body — capped read so an oversized/unbounded upstream
+        // reply cannot amplify into an out-of-memory DoS on the worker.
         let response_body = if api_config.include_response {
-            let text = response.text().await.unwrap_or_default();
+            let (text, truncated) = Self::read_capped_body(response).await;
+            if truncated {
+                tracing::warn!(
+                    workflow_id = %context.workflow_id,
+                    execution_id = %context.execution_id,
+                    cap_bytes = MAX_RESPONSE_BODY_BYTES,
+                    "Workflow API-call response body exceeded cap; truncated before persisting"
+                );
+            }
             if api_config.parse_json_response {
                 serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text))
             } else {
@@ -484,5 +559,65 @@ mod tests {
                  unresolvable host, got: {other:?}"
             ),
         }
+    }
+
+    /// Regression (memory-amplification DoS): the executor used to buffer the
+    /// *entire* upstream response with `response.text().await` and no ceiling,
+    /// so a small outbound request could provoke a multi-GB (or, via chunked
+    /// transfer, effectively unbounded) reply and OOM the worker. `read_capped_body`
+    /// now hard-caps the buffered bytes at `MAX_RESPONSE_BODY_BYTES` and marks
+    /// the result truncated.
+    ///
+    /// Hermetic: we hand `read_capped_body` a synthesized over-limit response
+    /// (built via `http::Response` → `reqwest::Response`) instead of standing
+    /// up a network server — the SSRF validator would reject a `127.0.0.1`
+    /// loopback server anyway, so a real request is not an option here.
+    /// Fails on `dev` (the old code returned the full body, so the non-marker
+    /// payload length would exceed the cap and `truncated` would be false).
+    #[tokio::test]
+    async fn read_capped_body_truncates_oversized_response() {
+        use axum::http;
+
+        // A body deliberately larger than the cap.
+        let oversized = vec![b'a'; MAX_RESPONSE_BODY_BYTES + 4096];
+        let http_response = http::Response::builder()
+            .status(200)
+            .body(oversized)
+            .expect("build synthetic http::Response");
+        let response = reqwest::Response::from(http_response);
+
+        let (text, truncated) = ApiCallExecutor::read_capped_body(response).await;
+
+        assert!(truncated, "an over-limit body must be reported truncated");
+        assert!(
+            text.ends_with(RESPONSE_TRUNCATION_MARKER),
+            "truncated body must carry the truncation marker"
+        );
+        // The retained payload (excluding the marker) must never exceed the cap
+        // — i.e. the full body was NOT buffered.
+        let payload_len = text.len() - RESPONSE_TRUNCATION_MARKER.len();
+        assert!(
+            payload_len <= MAX_RESPONSE_BODY_BYTES,
+            "buffered payload {payload_len} must not exceed cap {MAX_RESPONSE_BODY_BYTES}"
+        );
+    }
+
+    /// Companion: a body comfortably under the cap is returned verbatim and is
+    /// not flagged truncated (guards against an over-eager cap).
+    #[tokio::test]
+    async fn read_capped_body_passes_small_response_through() {
+        use axum::http;
+
+        let payload = b"{\"ok\":true}".to_vec();
+        let http_response = http::Response::builder()
+            .status(200)
+            .body(payload.clone())
+            .expect("build synthetic http::Response");
+        let response = reqwest::Response::from(http_response);
+
+        let (text, truncated) = ApiCallExecutor::read_capped_body(response).await;
+
+        assert!(!truncated, "a small body must not be flagged truncated");
+        assert_eq!(text.as_bytes(), payload.as_slice());
     }
 }


### PR DESCRIPTION
## Task
Unbounded response-body read in workflow action `api_call.rs` — memory-amplification DoS (Closes #2704)

The API-call workflow action (`backend/servers/api-server/src/services/actions/api_call.rs`) buffered the **entire** upstream response with `response.text().await` and no ceiling. A single small outbound request could provoke a multi-GB — or, via chunked transfer with no `Content-Length`, effectively unbounded — reply and amplify into an out-of-memory DoS on the worker.

## Fix
- New `read_capped_body(response) -> (String, bool)` helper with two defence layers:
  1. **`Content-Length` pre-check** — an honestly-advertised over-limit body is never buffered at all.
  2. **Bounded streaming read** — otherwise the body is pulled chunk-by-chunk via `response.chunk()` and the read stops the instant the accumulated size would exceed the cap. This is what protects against a chunked/lying-`Content-Length` body that the pre-check cannot catch.
- Cap = `MAX_RESPONSE_BODY_BYTES` = 8 MiB (comfortably covers legitimate JSON webhook replies; bounds worst-case allocation per in-flight action).
- **Truncate-with-marker**: an over-limit body is stored with `RESPONSE_TRUNCATION_MARKER` appended, so the persisted workflow-execution record makes truncation explicit instead of silently storing a partial payload. A `tracing::warn!` is emitted on truncation.
- Mid-stream network error keeps the partial body (preserves the prior best-effort `unwrap_or_default()` semantics).

## Owner
pm-tech-lead (advisory hint only)

## Scope drift
`scope-check.sh` reports exit 2: `pm-tech-lead` owns `docs/** / .research/** / _bmad-output/**`, but this is a backend security fix that correctly lives in `backend/servers/api-server/src/services/actions/api_call.rs`. The owner_role is a non-authoritative hint; the change is confined to the single file named in the issue. Reviewer to confirm the drift is justified (it is — the fix must live where the vulnerable code is).

## Code-reuse review
`reuse-grep.sh` (rust-backend): no warnings. `read_capped_body` is a new, local helper with no existing equivalent.

## Verification
`just verify` / `cargo` cannot run in this environment (utoipa-swagger-ui egress is blocked — documented repo constraint). Relying on CI `backend.yml` (`cargo fmt`, `clippy`, `cargo test`) — PR opened as **draft** until green.

- `scope-check.sh --owner pm-tech-lead --base origin/dev` → exit 2 (drift documented above; single-file diff).
- `reuse-grep.sh --specialist rust-backend` → exit 0 (no warnings).

## CI parity (Band C — hot-path)
This is a security/DoS fix. Local `act`/`gh workflow` run not possible (no cargo locally). CI `backend.yml` on this PR is the parity gate — must be green before this leaves draft.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Tests
Two hermetic `#[tokio::test]`s added (no network — the SSRF validator would reject a loopback test server, so responses are synthesized via `http::Response` → `reqwest::Response`):
- `read_capped_body_truncates_oversized_response` — an over-cap body is reported `truncated`, carries the marker, and the retained payload never exceeds the cap (proves the full body is NOT buffered). Fails on `dev` (old code returned the whole body).
- `read_capped_body_passes_small_response_through` — an under-cap body is returned verbatim and not flagged truncated (guards against an over-eager cap).

## Notes
- Kept tightly scoped to the response-body-size concern. This file is also targeted by sibling SSRF task gh-issue-2703; the SSRF/DNS validation blocks (lines ~165-188) are untouched to minimize conflict — only the body-read section and new helper/constants/tests were added.
- 8 MiB cap chosen as a conservative default; can be lifted to a config knob in a follow-up if any legitimate workflow needs larger webhook responses.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MHjeW1j6rBHy5HB3RD7YaV)_