### PR TITLE
code-review-reality-web-listingform-no-i18n: i18n ListingForm via next-intl catalogs

### DIFF
--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -963,5 +963,34 @@
         "cancelled": "Zrušeno"
       }
     }
+  },
+  "listingForm": {
+    "labelTitle": "Název",
+    "labelDescription": "Popis",
+    "labelPropertyType": "Typ nemovitosti",
+    "labelTransaction": "Transakce",
+    "labelPrice": "Cena",
+    "labelCurrency": "Měna",
+    "labelCity": "Město",
+    "labelPostalCode": "PSČ",
+    "labelStreet": "Ulice",
+    "labelArea": "Plocha (m²)",
+    "labelRooms": "Pokoje",
+    "propertyTypeApartment": "Byt",
+    "propertyTypeHouse": "Dům",
+    "propertyTypeLand": "Pozemek",
+    "propertyTypeCommercial": "Komerční prostory",
+    "propertyTypeOther": "Jiné",
+    "transactionSale": "Na prodej",
+    "transactionRent": "K pronájmu",
+    "saving": "Ukládání…",
+    "errorTitleRequired": "Název je povinný",
+    "errorDescriptionRequired": "Popis je povinný",
+    "errorCityRequired": "Město je povinné",
+    "errorPricePositive": "Cena musí být kladné číslo",
+    "errorAreaInvalid": "Plocha musí být platné číslo",
+    "errorAreaNegative": "Plocha nesmí být záporná",
+    "errorRoomsInvalid": "Počet pokojů musí být platné číslo",
+    "errorRoomsNegative": "Počet pokojů nesmí být záporný"
   }
 }

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -963,5 +963,34 @@
         "cancelled": "Abgebrochen"
       }
     }
+  },
+  "listingForm": {
+    "labelTitle": "Titel",
+    "labelDescription": "Beschreibung",
+    "labelPropertyType": "Immobilientyp",
+    "labelTransaction": "Transaktion",
+    "labelPrice": "Preis",
+    "labelCurrency": "Währung",
+    "labelCity": "Stadt",
+    "labelPostalCode": "Postleitzahl",
+    "labelStreet": "Straße",
+    "labelArea": "Fläche (m²)",
+    "labelRooms": "Zimmer",
+    "propertyTypeApartment": "Wohnung",
+    "propertyTypeHouse": "Haus",
+    "propertyTypeLand": "Grundstück",
+    "propertyTypeCommercial": "Gewerbe",
+    "propertyTypeOther": "Sonstiges",
+    "transactionSale": "Zu verkaufen",
+    "transactionRent": "Zu vermieten",
+    "saving": "Wird gespeichert…",
+    "errorTitleRequired": "Titel ist erforderlich",
+    "errorDescriptionRequired": "Beschreibung ist erforderlich",
+    "errorCityRequired": "Stadt ist erforderlich",
+    "errorPricePositive": "Preis muss eine positive Zahl sein",
+    "errorAreaInvalid": "Fläche muss eine gültige Zahl sein",
+    "errorAreaNegative": "Fläche darf nicht negativ sein",
+    "errorRoomsInvalid": "Zimmeranzahl muss eine gültige Zahl sein",
+    "errorRoomsNegative": "Zimmeranzahl darf nicht negativ sein"
   }
 }

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -963,5 +963,34 @@
         "cancelled": "Cancelled"
       }
     }
+  },
+  "listingForm": {
+    "labelTitle": "Title",
+    "labelDescription": "Description",
+    "labelPropertyType": "Property type",
+    "labelTransaction": "Transaction",
+    "labelPrice": "Price",
+    "labelCurrency": "Currency",
+    "labelCity": "City",
+    "labelPostalCode": "Postal code",
+    "labelStreet": "Street",
+    "labelArea": "Area (m²)",
+    "labelRooms": "Rooms",
+    "propertyTypeApartment": "Apartment",
+    "propertyTypeHouse": "House",
+    "propertyTypeLand": "Land",
+    "propertyTypeCommercial": "Commercial",
+    "propertyTypeOther": "Other",
+    "transactionSale": "For sale",
+    "transactionRent": "For rent",
+    "saving": "Saving…",
+    "errorTitleRequired": "Title is required",
+    "errorDescriptionRequired": "Description is required",
+    "errorCityRequired": "City is required",
+    "errorPricePositive": "Price must be a positive number",
+    "errorAreaInvalid": "Area must be a valid number",
+    "errorAreaNegative": "Area must not be negative",
+    "errorRoomsInvalid": "Rooms must be a valid number",
+    "errorRoomsNegative": "Rooms must not be negative"
   }
 }

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -956,5 +956,34 @@
         "cancelled": "Törölve"
       }
     }
+  },
+  "listingForm": {
+    "labelTitle": "Cím",
+    "labelDescription": "Leírás",
+    "labelPropertyType": "Ingatlan típusa",
+    "labelTransaction": "Tranzakció",
+    "labelPrice": "Ár",
+    "labelCurrency": "Pénznem",
+    "labelCity": "Város",
+    "labelPostalCode": "Irányítószám",
+    "labelStreet": "Utca",
+    "labelArea": "Terület (m²)",
+    "labelRooms": "Szobák",
+    "propertyTypeApartment": "Lakás",
+    "propertyTypeHouse": "Ház",
+    "propertyTypeLand": "Telek",
+    "propertyTypeCommercial": "Üzlethelyiség",
+    "propertyTypeOther": "Egyéb",
+    "transactionSale": "Eladó",
+    "transactionRent": "Kiadó",
+    "saving": "Mentés…",
+    "errorTitleRequired": "A cím megadása kötelező",
+    "errorDescriptionRequired": "A leírás megadása kötelező",
+    "errorCityRequired": "A város megadása kötelező",
+    "errorPricePositive": "Az árnak pozitív számnak kell lennie",
+    "errorAreaInvalid": "A területnek érvényes számnak kell lennie",
+    "errorAreaNegative": "A terület nem lehet negatív",
+    "errorRoomsInvalid": "A szobák számának érvényes számnak kell lennie",
+    "errorRoomsNegative": "A szobák száma nem lehet negatív"
   }
 }

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -956,5 +956,34 @@
         "cancelled": "Anulowane"
       }
     }
+  },
+  "listingForm": {
+    "labelTitle": "Tytuł",
+    "labelDescription": "Opis",
+    "labelPropertyType": "Typ nieruchomości",
+    "labelTransaction": "Transakcja",
+    "labelPrice": "Cena",
+    "labelCurrency": "Waluta",
+    "labelCity": "Miasto",
+    "labelPostalCode": "Kod pocztowy",
+    "labelStreet": "Ulica",
+    "labelArea": "Powierzchnia (m²)",
+    "labelRooms": "Pokoje",
+    "propertyTypeApartment": "Mieszkanie",
+    "propertyTypeHouse": "Dom",
+    "propertyTypeLand": "Działka",
+    "propertyTypeCommercial": "Lokal komercyjny",
+    "propertyTypeOther": "Inne",
+    "transactionSale": "Na sprzedaż",
+    "transactionRent": "Na wynajem",
+    "saving": "Zapisywanie…",
+    "errorTitleRequired": "Tytuł jest wymagany",
+    "errorDescriptionRequired": "Opis jest wymagany",
+    "errorCityRequired": "Miasto jest wymagane",
+    "errorPricePositive": "Cena musi być liczbą dodatnią",
+    "errorAreaInvalid": "Powierzchnia musi być prawidłową liczbą",
+    "errorAreaNegative": "Powierzchnia nie może być ujemna",
+    "errorRoomsInvalid": "Liczba pokoi musi być prawidłową liczbą",
+    "errorRoomsNegative": "Liczba pokoi nie może być ujemna"
   }
 }

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -963,5 +963,34 @@
         "cancelled": "Zrušené"
       }
     }
+  },
+  "listingForm": {
+    "labelTitle": "Názov",
+    "labelDescription": "Popis",
+    "labelPropertyType": "Typ nehnuteľnosti",
+    "labelTransaction": "Transakcia",
+    "labelPrice": "Cena",
+    "labelCurrency": "Mena",
+    "labelCity": "Mesto",
+    "labelPostalCode": "PSČ",
+    "labelStreet": "Ulica",
+    "labelArea": "Plocha (m²)",
+    "labelRooms": "Izby",
+    "propertyTypeApartment": "Byt",
+    "propertyTypeHouse": "Dom",
+    "propertyTypeLand": "Pozemok",
+    "propertyTypeCommercial": "Komerčné priestory",
+    "propertyTypeOther": "Iné",
+    "transactionSale": "Na predaj",
+    "transactionRent": "Na prenájom",
+    "saving": "Ukladá sa…",
+    "errorTitleRequired": "Názov je povinný",
+    "errorDescriptionRequired": "Popis je povinný",
+    "errorCityRequired": "Mesto je povinné",
+    "errorPricePositive": "Cena musí byť kladné číslo",
+    "errorAreaInvalid": "Plocha musí byť platné číslo",
+    "errorAreaNegative": "Plocha nesmie byť záporná",
+    "errorRoomsInvalid": "Počet izieb musí byť platné číslo",
+    "errorRoomsNegative": "Počet izieb nesmie byť záporný"
   }
 }

--- a/frontend/apps/reality-web/src/components/realtor/ListingForm.test.tsx
+++ b/frontend/apps/reality-web/src/components/realtor/ListingForm.test.tsx
@@ -38,7 +38,7 @@ describe('ListingForm — numeric field validation', () => {
     fireEvent.change(screen.getByLabelText(/Area/i), { target: { value: '-5' } });
     submit();
 
-    expect(screen.getByText(/Area must not be negative/i)).toBeInTheDocument();
+    expect(screen.getByText('errorAreaNegative')).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -50,7 +50,7 @@ describe('ListingForm — numeric field validation', () => {
     fireEvent.change(screen.getByLabelText(/Rooms/i), { target: { value: '-2' } });
     submit();
 
-    expect(screen.getByText(/Rooms must not be negative/i)).toBeInTheDocument();
+    expect(screen.getByText('errorRoomsNegative')).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
@@ -88,6 +88,19 @@ describe('ListingForm — numeric field validation', () => {
     expect(draft.rooms).toBe(3);
     expect(Number.isNaN(draft.area)).toBe(false);
     expect(Number.isNaN(draft.rooms)).toBe(false);
+  });
+
+  it('renders field labels via next-intl translation keys (no hardcoded English)', () => {
+    // The next-intl mock (src/test/setup.tsx) returns the key verbatim, so a
+    // component wired to useTranslations renders the key. This asserts the
+    // form pulls its labels from the `listingForm` catalog rather than a
+    // hardcoded English literal.
+    render(<ListingForm submitLabel="Save" onSubmit={vi.fn()} />);
+
+    expect(screen.getByText('labelTitle')).toBeInTheDocument();
+    expect(screen.getByText('labelPropertyType')).toBeInTheDocument();
+    expect(screen.getByText('propertyTypeApartment')).toBeInTheDocument();
+    expect(screen.getByText('transactionSale')).toBeInTheDocument();
   });
 
   it('omits empty optional numeric fields (undefined, not NaN)', () => {

--- a/frontend/apps/reality-web/src/components/realtor/ListingForm.tsx
+++ b/frontend/apps/reality-web/src/components/realtor/ListingForm.tsx
@@ -7,6 +7,7 @@
  * the submit handler and any post-submit navigation.
  */
 
+import { useTranslations } from 'next-intl';
 import { type FormEvent, useState } from 'react';
 import type { ListingDraft } from '@/lib/realtor-api';
 
@@ -18,19 +19,21 @@ interface ListingFormProps {
   onSubmit: (draft: ListingDraft) => void | Promise<void>;
 }
 
-const PROPERTY_TYPES: ReadonlyArray<{ value: ListingDraft['propertyType']; label: string }> = [
-  { value: 'apartment', label: 'Apartment' },
-  { value: 'house', label: 'House' },
-  { value: 'land', label: 'Land' },
-  { value: 'commercial', label: 'Commercial' },
-  { value: 'other', label: 'Other' },
+const PROPERTY_TYPES: ReadonlyArray<{ value: ListingDraft['propertyType']; labelKey: string }> = [
+  { value: 'apartment', labelKey: 'propertyTypeApartment' },
+  { value: 'house', labelKey: 'propertyTypeHouse' },
+  { value: 'land', labelKey: 'propertyTypeLand' },
+  { value: 'commercial', labelKey: 'propertyTypeCommercial' },
+  { value: 'other', labelKey: 'propertyTypeOther' },
 ];
 
-const TRANSACTION_TYPES: ReadonlyArray<{ value: ListingDraft['transactionType']; label: string }> =
-  [
-    { value: 'sale', label: 'For sale' },
-    { value: 'rent', label: 'For rent' },
-  ];
+const TRANSACTION_TYPES: ReadonlyArray<{
+  value: ListingDraft['transactionType'];
+  labelKey: string;
+}> = [
+  { value: 'sale', labelKey: 'transactionSale' },
+  { value: 'rent', labelKey: 'transactionRent' },
+];
 
 interface FieldErrors {
   title?: string;
@@ -48,12 +51,15 @@ interface FieldErrors {
  * Non-numeric input (which `Number()` would coerce to `NaN`) and negative
  * values are rejected so the form never submits `NaN` or a negative measure.
  */
-function parseOptionalNonNegative(raw: string): { value?: number; error?: string } {
+function parseOptionalNonNegative(raw: string): {
+  value?: number;
+  error?: 'invalid' | 'negative';
+} {
   const trimmed = raw.trim();
   if (!trimmed) return { value: undefined };
   const num = Number(trimmed);
-  if (!Number.isFinite(num)) return { error: 'must be a valid number' };
-  if (num < 0) return { error: 'must not be negative' };
+  if (!Number.isFinite(num)) return { error: 'invalid' };
+  if (num < 0) return { error: 'negative' };
   return { value: num };
 }
 
@@ -64,6 +70,7 @@ export function ListingForm({
   generalError,
   onSubmit,
 }: ListingFormProps) {
+  const t = useTranslations('listingForm');
   const [title, setTitle] = useState(initialValue?.title ?? '');
   const [description, setDescription] = useState(initialValue?.description ?? '');
   const [propertyType, setPropertyType] = useState<ListingDraft['propertyType']>(
@@ -84,15 +91,17 @@ export function ListingForm({
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const next: FieldErrors = {};
-    if (!title.trim()) next.title = 'Title is required';
-    if (!description.trim()) next.description = 'Description is required';
-    if (!city.trim()) next.city = 'City is required';
+    if (!title.trim()) next.title = t('errorTitleRequired');
+    if (!description.trim()) next.description = t('errorDescriptionRequired');
+    if (!city.trim()) next.city = t('errorCityRequired');
     const priceNum = Number(price);
-    if (!Number.isFinite(priceNum) || priceNum <= 0) next.price = 'Price must be a positive number';
+    if (!Number.isFinite(priceNum) || priceNum <= 0) next.price = t('errorPricePositive');
     const areaResult = parseOptionalNonNegative(area);
-    if (areaResult.error) next.area = `Area ${areaResult.error}`;
+    if (areaResult.error)
+      next.area = t(areaResult.error === 'negative' ? 'errorAreaNegative' : 'errorAreaInvalid');
     const roomsResult = parseOptionalNonNegative(rooms);
-    if (roomsResult.error) next.rooms = `Rooms ${roomsResult.error}`;
+    if (roomsResult.error)
+      next.rooms = t(roomsResult.error === 'negative' ? 'errorRoomsNegative' : 'errorRoomsInvalid');
     setErrors(next);
     if (Object.keys(next).length > 0) return;
 
@@ -120,7 +129,7 @@ export function ListingForm({
       )}
 
       <label className="field">
-        <span className="label">Title</span>
+        <span className="label">{t('labelTitle')}</span>
         <input
           type="text"
           value={title}
@@ -132,7 +141,7 @@ export function ListingForm({
       </label>
 
       <label className="field">
-        <span className="label">Description</span>
+        <span className="label">{t('labelDescription')}</span>
         <textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
@@ -145,7 +154,7 @@ export function ListingForm({
 
       <div className="row">
         <label className="field">
-          <span className="label">Property type</span>
+          <span className="label">{t('labelPropertyType')}</span>
           <select
             value={propertyType}
             onChange={(e) => setPropertyType(e.target.value as ListingDraft['propertyType'])}
@@ -154,14 +163,14 @@ export function ListingForm({
           >
             {PROPERTY_TYPES.map((opt) => (
               <option key={opt.value} value={opt.value}>
-                {opt.label}
+                {t(opt.labelKey)}
               </option>
             ))}
           </select>
         </label>
 
         <label className="field">
-          <span className="label">Transaction</span>
+          <span className="label">{t('labelTransaction')}</span>
           <select
             value={transactionType}
             onChange={(e) => setTransactionType(e.target.value as ListingDraft['transactionType'])}
@@ -170,7 +179,7 @@ export function ListingForm({
           >
             {TRANSACTION_TYPES.map((opt) => (
               <option key={opt.value} value={opt.value}>
-                {opt.label}
+                {t(opt.labelKey)}
               </option>
             ))}
           </select>
@@ -179,7 +188,7 @@ export function ListingForm({
 
       <div className="row">
         <label className="field">
-          <span className="label">Price</span>
+          <span className="label">{t('labelPrice')}</span>
           <input
             type="number"
             min="0"
@@ -192,7 +201,7 @@ export function ListingForm({
           {errors.price && <span className="error">{errors.price}</span>}
         </label>
         <label className="field">
-          <span className="label">Currency</span>
+          <span className="label">{t('labelCurrency')}</span>
           <input
             type="text"
             value={currency}
@@ -205,7 +214,7 @@ export function ListingForm({
 
       <div className="row">
         <label className="field">
-          <span className="label">City</span>
+          <span className="label">{t('labelCity')}</span>
           <input
             type="text"
             value={city}
@@ -216,7 +225,7 @@ export function ListingForm({
           {errors.city && <span className="error">{errors.city}</span>}
         </label>
         <label className="field">
-          <span className="label">Postal code</span>
+          <span className="label">{t('labelPostalCode')}</span>
           <input
             type="text"
             value={postalCode}
@@ -228,7 +237,7 @@ export function ListingForm({
       </div>
 
       <label className="field">
-        <span className="label">Street</span>
+        <span className="label">{t('labelStreet')}</span>
         <input
           type="text"
           value={street}
@@ -240,7 +249,7 @@ export function ListingForm({
 
       <div className="row">
         <label className="field">
-          <span className="label">Area (m²)</span>
+          <span className="label">{t('labelArea')}</span>
           <input
             type="number"
             min="0"
@@ -252,7 +261,7 @@ export function ListingForm({
           {errors.area && <span className="error">{errors.area}</span>}
         </label>
         <label className="field">
-          <span className="label">Rooms</span>
+          <span className="label">{t('labelRooms')}</span>
           <input
             type="number"
             min="0"
@@ -266,7 +275,7 @@ export function ListingForm({
       </div>
 
       <button type="submit" className="submit" disabled={isSubmitting}>
-        {isSubmitting ? 'Saving…' : submitLabel}
+        {isSubmitting ? t('saving') : submitLabel}
       </button>
 
       <style jsx>{`


### PR DESCRIPTION
## Task
reality-web ListingForm hardcodes English throughout a next-intl sk/cs/de/en app. Extract the hardcoded strings into next-intl message catalogs (all locales) and consume them via the translation hook, matching the existing i18n pattern in the reality-web app. Add/adjust a test if the app has i18n test coverage.

## Owner
pm-backend (hint only — this is a `nextjs-web` / reality-web frontend task)

## What changed
- Added a `listingForm` namespace (27 keys) to all six message catalogs: `en, sk, cs, de, pl, hu` (the app ships 6 locales, not 4 — real translations provided for every locale). Keys cover field labels, property-type / transaction select options, the "Saving…" state, and all inline validation errors.
- `ListingForm.tsx`: consumes the catalog via `useTranslations('listingForm')`, matching the existing pattern in `agency/RealtorManagement.tsx`. Select-option constants now carry `labelKey` resolved through `t()`; `parseOptionalNonNegative` returns an `'invalid' | 'negative'` error code mapped to translation keys instead of building English strings. `submitLabel` and `generalError` remain caller-owned props (unchanged contract).
- `ListingForm.test.tsx`: updated the two error-text assertions to the new translation keys (the next-intl test mock returns the key verbatim) and added one test asserting labels/options render from the `listingForm` catalog rather than hardcoded English.

## Verification
```
VERIFY-PLAN base=27d35158a7ea5fd38c182ddded5985acef3d7233 files=8
  cd frontend && pnpm exec biome check <8 files>
  cd frontend && pnpm --filter "...[27d3515]" typecheck
  cd frontend && pnpm --filter "...[27d3515]" test
```
```
VERIFY OK 5c14f7ac11642b8ffd5eb41fc50c5280b5590612
```
biome clean, `tsc --noEmit` clean, reality-web vitest 242 passed (25 files) — including the adjusted ListingForm suite (6 tests).

Locale parity confirmed: all 6 catalogs at 25 top-level keys, `listingForm` at 27 keys each.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
`scope-check.sh` exits 2 only because `owner_role=pm-backend` maps to the backend area while every changed file is under `frontend/apps/reality-web/` — an owner-hint mismatch, not off-task drift. All 8 changed files are exactly the ListingForm i18n work:
```
frontend/apps/reality-web/messages/{en,sk,cs,de,pl,hu}.json
frontend/apps/reality-web/src/components/realtor/ListingForm.tsx
frontend/apps/reality-web/src/components/realtor/ListingForm.test.tsx
```

## Notes
- Scope kept to the ListingForm component. The two parent pages (`realtor/listings/new`, `.../[id]/edit`) still pass English `submitLabel` / page-title literals — a separate finding, out of scope here.
- goal-check.sh reports IG1/IG2/IG3 FAIL — all plan-flow structural mismatches, not correctness: no `.research/plans/*` file exists for a dispatcher code-review task (IG1/IG4/IG5/IG6); the dispatcher pre-chose the `auto-impl/*` branch rather than `impl/*` (IG2); and this i18n refactor folds its test into the single `fix:` commit rather than a separate `test:` commit (IG3). The real correctness gate (IG7 / `just verify`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHjeW1j6rBHy5HB3RD7YaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHjeW1j6rBHy5HB3RD7YaV)_