### PR TITLE
gh-issue-2703: close SSRF DNS-rebinding TOCTOU in workflow api_call.rs

### DIFF
--- a/backend/crates/common/src/url_validation.rs
+++ b/backend/crates/common/src/url_validation.rs
@@ -23,15 +23,27 @@
 //! returned address against the same forbidden ranges, failing closed
 //! (resolution error, empty result, or any forbidden address => reject).
 //!
-//! Note this still leaves a narrow DNS-rebinding window between the
-//! `validate_resolved_host` lookup and the HTTP client's own connect-time
-//! lookup (TOCTOU) since the underlying HTTP client, not this module, owns
-//! the socket connect. Closing that fully would require pinning the
-//! validated IP for the connection (a custom resolver/connector), which is
-//! out of scope here; re-resolving immediately before the request narrows
-//! the window to the two lookups happening back-to-back.
+//! A one-shot pre-flight [`validate_resolved_host`] on its own still leaves a
+//! narrow DNS-rebinding window between that lookup and the HTTP client's own
+//! connect-time lookup (TOCTOU): the two lookups can disagree, and the client
+//! owns the socket connect. To close that window a caller must ensure the
+//! addresses the client actually *connects to* are the validated ones. Two
+//! building blocks here support that:
+//!
+//! * [`resolve_and_validate_host`] resolves once and returns the concrete,
+//!   validated [`SocketAddr`]s so a caller can pin them into its HTTP client
+//!   (e.g. `reqwest`'s custom resolver / `resolve_to_addrs`), guaranteeing the
+//!   connect targets the exact addresses that passed validation.
+//! * [`validate_resolved_addrs`] validates an already-resolved address set —
+//!   the primitive a connect-time custom resolver calls so that validation and
+//!   connection observe the *same* resolution (no second, unvalidated lookup),
+//!   and so every redirect hop is re-validated too.
+//!
+//! `backend/servers/api-server/src/services/actions/api_call.rs` wires the
+//! workflow HTTP client this way (connect-time SSRF-guard resolver), which is
+//! what actually closes the TOCTOU for that path.
 
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use url::{Host, Url};
 
 /// Structured error returned when a URL fails SSRF validation.
@@ -176,16 +188,64 @@ pub async fn validate_resolved_host(host: &str, port: u16) -> Result<(), UrlVali
     validate_resolved_host_with(host.to_string(), port, resolve_host).await
 }
 
+/// Resolve `host`/`port` and return the **validated** set of socket
+/// addresses. Same policy and fail-closed semantics as
+/// [`validate_resolved_host`], but returns the concrete addresses so a caller
+/// can pin them into its HTTP client and connect only to addresses that
+/// passed validation — closing the DNS-rebinding TOCTOU window that a lookup
+/// which merely returns `Ok(())` leaves open (the client would otherwise
+/// perform its own, second, unvalidated lookup at connect time).
+///
+/// Fails closed: resolution error, empty result set, or any single forbidden
+/// address in the result causes rejection.
+pub async fn resolve_and_validate_host(
+    host: &str,
+    port: u16,
+) -> Result<Vec<SocketAddr>, UrlValidationError> {
+    resolve_and_validate_host_with(host.to_string(), port, resolve_host).await
+}
+
+/// Validate an already-resolved address set against the SSRF forbidden-range
+/// policy, returning the corresponding [`SocketAddr`]s (with `port`) on
+/// success.
+///
+/// This is the primitive a connect-time custom resolver (e.g. `reqwest`'s
+/// [`dns::Resolve`]) calls so that the addresses validated here are *exactly*
+/// the ones the HTTP client connects to — there is no second, unvalidated
+/// lookup between check and use, which is what closes the DNS-rebinding
+/// TOCTOU. Fails closed on an empty set or any forbidden address.
+///
+/// [`dns::Resolve`]: https://docs.rs/reqwest/latest/reqwest/dns/trait.Resolve.html
+pub fn validate_resolved_addrs(
+    host: &str,
+    port: u16,
+    addrs: &[IpAddr],
+) -> Result<Vec<SocketAddr>, UrlValidationError> {
+    if addrs.is_empty() {
+        return Err(UrlValidationError::ResolutionFailed(format!(
+            "no addresses found for host '{}'",
+            host
+        )));
+    }
+
+    let mut out = Vec::with_capacity(addrs.len());
+    for &ip in addrs {
+        if let Err(reason) = is_forbidden_ip(ip) {
+            return Err(UrlValidationError::ResolvedToPrivateIp(format!(
+                "{} resolves to {} ({})",
+                host, ip, reason
+            )));
+        }
+        out.push(SocketAddr::new(ip, port));
+    }
+
+    Ok(out)
+}
+
 /// Same as [`validate_resolved_host`] but with the resolver injected, so
 /// tests can exercise the private-IP-rejection path with a fake resolver
 /// instead of depending on live DNS/network access (which CI/sandbox
 /// runners may not have).
-///
-/// `host` is owned (`String`) rather than borrowed: an `F: FnOnce(&str, ..)
-/// -> Fut` bound ties `Fut` to the elided lifetime of that borrow, which
-/// rustc can't unify with the higher-ranked lifetime the call site needs
-/// (`implementation of FnOnce is not general enough`). Taking ownership
-/// sidesteps the borrow-checker issue entirely.
 async fn validate_resolved_host_with<F, Fut>(
     host: String,
     port: u16,
@@ -195,27 +255,34 @@ where
     F: FnOnce(String, u16) -> Fut,
     Fut: std::future::Future<Output = std::io::Result<Vec<IpAddr>>>,
 {
+    resolve_and_validate_host_with(host, port, resolve)
+        .await
+        .map(|_| ())
+}
+
+/// Resolve-and-validate with the resolver injected (returns the validated
+/// addresses). Backs both [`resolve_and_validate_host`] and, via
+/// [`validate_resolved_host_with`], [`validate_resolved_host`].
+///
+/// `host` is owned (`String`) rather than borrowed: an `F: FnOnce(&str, ..)
+/// -> Fut` bound ties `Fut` to the elided lifetime of that borrow, which
+/// rustc can't unify with the higher-ranked lifetime the call site needs
+/// (`implementation of FnOnce is not general enough`). Taking ownership
+/// sidesteps the borrow-checker issue entirely.
+async fn resolve_and_validate_host_with<F, Fut>(
+    host: String,
+    port: u16,
+    resolve: F,
+) -> Result<Vec<SocketAddr>, UrlValidationError>
+where
+    F: FnOnce(String, u16) -> Fut,
+    Fut: std::future::Future<Output = std::io::Result<Vec<IpAddr>>>,
+{
     let addrs = resolve(host.clone(), port)
         .await
         .map_err(|e| UrlValidationError::ResolutionFailed(e.to_string()))?;
 
-    if addrs.is_empty() {
-        return Err(UrlValidationError::ResolutionFailed(format!(
-            "no addresses found for host '{}'",
-            host
-        )));
-    }
-
-    for ip in addrs {
-        if let Err(reason) = is_forbidden_ip(ip) {
-            return Err(UrlValidationError::ResolvedToPrivateIp(format!(
-                "{} resolves to {} ({})",
-                host, ip, reason
-            )));
-        }
-    }
-
-    Ok(())
+    validate_resolved_addrs(&host, port, &addrs)
 }
 
 /// Default resolver: real DNS via the OS resolver (through Tokio's async
@@ -555,5 +622,47 @@ mod tests {
             result,
             Err(UrlValidationError::ResolutionFailed(_))
         ));
+    }
+
+    /// `validate_resolved_addrs` (the primitive a connect-time custom resolver
+    /// calls) returns the validated `SocketAddr`s — carrying the requested
+    /// port — when every resolved IP is public.
+    #[test]
+    fn validate_resolved_addrs_returns_socket_addrs_for_public_ips() {
+        let ips: Vec<IpAddr> = vec!["93.184.216.34".parse().unwrap()];
+        let out = validate_resolved_addrs("example.com", 8443, &ips).expect("public IP accepted");
+        assert_eq!(out, vec![SocketAddr::new(ips[0], 8443)]);
+    }
+
+    /// Fail-closed for a connect-time resolver too: if any resolved address is
+    /// forbidden, the whole set is rejected so the client never connects.
+    #[test]
+    fn validate_resolved_addrs_rejects_when_any_ip_is_forbidden() {
+        let ips: Vec<IpAddr> = vec![
+            "93.184.216.34".parse().unwrap(),
+            "10.0.0.5".parse().unwrap(),
+        ];
+        assert!(matches!(
+            validate_resolved_addrs("multi.example", 443, &ips),
+            Err(UrlValidationError::ResolvedToPrivateIp(_))
+        ));
+    }
+
+    /// `resolve_and_validate_host` hands back the concrete validated addresses
+    /// (so a caller can pin them into its HTTP client), not just `Ok(())`.
+    #[tokio::test]
+    async fn resolve_and_validate_host_returns_validated_addrs() {
+        async fn fake_resolve(_host: String, port: u16) -> std::io::Result<Vec<IpAddr>> {
+            let _ = port;
+            Ok(vec!["93.184.216.34".parse().unwrap()])
+        }
+
+        let out = resolve_and_validate_host_with("example.com".to_string(), 443, fake_resolve)
+            .await
+            .expect("public IP accepted");
+        assert_eq!(
+            out,
+            vec![SocketAddr::new("93.184.216.34".parse().unwrap(), 443)]
+        );
     }
 }

--- a/backend/servers/api-server/src/services/actions/api_call.rs
+++ b/backend/servers/api-server/src/services/actions/api_call.rs
@@ -7,7 +7,72 @@ use async_trait::async_trait;
 use db::models::action_type;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::future::Future;
+use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+/// Type-erased hostname → IPs resolver used by [`SsrfGuardResolver`].
+///
+/// Injected so the executor's real DNS path and the hermetic
+/// DNS-rebinding regression test share one code path (the test drives a
+/// stateful resolver that returns a public IP first and a private IP on the
+/// connect-time lookup).
+type IpResolver = Arc<
+    dyn Fn(String) -> Pin<Box<dyn Future<Output = std::io::Result<Vec<IpAddr>>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// Connect-time SSRF-guard DNS resolver for the workflow HTTP client.
+///
+/// `reqwest`/`hyper` invoke this at **connect** time for the initial request
+/// **and every redirect hop**. It resolves the hostname and validates every
+/// resulting address against the shared SSRF forbidden-range policy, erroring
+/// out (which aborts the connection) if any address is forbidden. Because the
+/// addresses `reqwest` connects to are exactly the ones validated here —
+/// resolved once, at connect, in the same step — this closes the
+/// DNS-rebinding TOCTOU window that a separate pre-flight lookup left open (a
+/// pre-flight lookup and `reqwest`'s own connect-time lookup could disagree,
+/// letting a hostname that first resolved public rebind to a private address
+/// before the socket is opened). It also re-validates redirects, which a
+/// one-shot pre-flight check never covered.
+struct SsrfGuardResolver {
+    resolve_ips: IpResolver,
+}
+
+impl reqwest::dns::Resolve for SsrfGuardResolver {
+    fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+        let resolve_ips = self.resolve_ips.clone();
+        Box::pin(async move {
+            let host = name.as_str().to_string();
+            // The port is irrelevant to SSRF validation (range checks are on
+            // the IP) and `hyper` overrides it with the real destination port
+            // after resolution, so we resolve/validate with 0.
+            let ips = (resolve_ips)(host.clone())
+                .await
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
+            let addrs = common::url_validation::validate_resolved_addrs(&host, 0, &ips)
+                .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::new(e) })?;
+            let iter: reqwest::dns::Addrs = Box::new(addrs.into_iter());
+            Ok(iter)
+        })
+    }
+}
+
+/// Real DNS resolver used in production: the OS resolver via Tokio's async
+/// wrapper around `getaddrinfo`.
+fn real_ip_resolver() -> IpResolver {
+    Arc::new(
+        |host: String| -> Pin<Box<dyn Future<Output = std::io::Result<Vec<IpAddr>>> + Send>> {
+            Box::pin(async move {
+                let addrs = tokio::net::lookup_host((host.as_str(), 0)).await?;
+                Ok(addrs.map(|sa| sa.ip()).collect::<Vec<IpAddr>>())
+            })
+        },
+    )
+}
 
 /// HTTP method for the API call.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -114,18 +179,56 @@ fn default_true() -> bool {
 /// API call action executor.
 pub struct ApiCallExecutor {
     client: reqwest::Client,
+    /// The same resolver the HTTP client uses at connect time, kept so the
+    /// fail-fast pre-flight check and the connect-time re-validation observe
+    /// one DNS path (and so the rebinding regression test can inject a
+    /// stateful resolver that drives both).
+    resolve_ips: IpResolver,
 }
 
 impl ApiCallExecutor {
-    /// Create a new API call executor.
+    /// Create a new API call executor backed by the real OS DNS resolver.
     pub fn new() -> Self {
+        Self::with_ip_resolver(real_ip_resolver())
+    }
+
+    /// Build an executor whose HTTP client resolves and SSRF-validates every
+    /// connection (initial request + redirects) through `resolve_ips`. The
+    /// connect-time [`SsrfGuardResolver`] is what closes the DNS-rebinding
+    /// TOCTOU: `reqwest` connects only to addresses this resolver validated.
+    fn with_ip_resolver(resolve_ips: IpResolver) -> Self {
+        // Re-validate every redirect hop's URL statically before following it.
+        // The connect-time `SsrfGuardResolver` already blocks any hop that
+        // resolves to a forbidden IP (including rebinds), but the static
+        // `validate_external_url` additionally rejects a redirect that
+        // downgrades to plain `http://`, or targets a blocked hostname /
+        // `.local` / `.internal` TLD, which an IP-range check alone would not
+        // catch. Fail closed: an invalid hop aborts the request.
+        let redirect_policy = reqwest::redirect::Policy::custom(|attempt| {
+            const MAX_REDIRECTS: usize = 10;
+            if attempt.previous().len() >= MAX_REDIRECTS {
+                return attempt.error("too many redirects");
+            }
+            match common::url_validation::validate_external_url(attempt.url().as_str()) {
+                Ok(_) => attempt.follow(),
+                Err(e) => attempt.error(e),
+            }
+        });
+
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(60))
             .user_agent("PPT-Workflow/1.0")
+            .redirect(redirect_policy)
+            .dns_resolver(Arc::new(SsrfGuardResolver {
+                resolve_ips: resolve_ips.clone(),
+            }))
             .build()
             .expect("Failed to create HTTP client");
 
-        Self { client }
+        Self {
+            client,
+            resolve_ips,
+        }
     }
 
     /// Parse and validate the API call configuration.
@@ -241,16 +344,35 @@ impl ActionExecutor for ApiCallExecutor {
         // SSRF via DNS: `validate_external_url` only inspects the literal
         // string — a hostname with no literal-IP form (e.g.
         // "attacker.example.com") that resolves to a private/internal
-        // address at request time sailed straight through it. Resolve now,
-        // right before the request is issued, and reject if *any* resolved
-        // address falls in a forbidden range. Fails closed: a resolution
-        // error also rejects.
+        // address at request time sails straight through it. Two layers guard
+        // the DNS path:
+        //
+        //   1. This fail-fast pre-flight: resolve now and reject if *any*
+        //      resolved address is forbidden, so an obviously-internal or
+        //      unresolvable host is rejected with a clean `ConfigurationError`
+        //      before a request is ever built.
+        //   2. The connect-time `SsrfGuardResolver` wired into `self.client`
+        //      (see `with_ip_resolver`), which re-resolves-and-validates at
+        //      the moment `reqwest` opens the socket, for the initial request
+        //      and every redirect hop. THIS is what actually closes the
+        //      DNS-rebinding TOCTOU: a hostname that resolves public here but
+        //      rebinds to a private address before connect is rejected at
+        //      connect, because the client connects only to addresses the
+        //      resolver validated. Both layers share `self.resolve_ips`, so
+        //      the pre-flight and the connection observe one DNS code path.
+        //
+        // Fails closed: a resolution error also rejects.
         let host = parsed_url.host_str().ok_or_else(|| {
             ActionError::ConfigurationError("API call URL must have a host".to_string())
         })?;
         let port = parsed_url.port_or_known_default().unwrap_or(443);
-        common::url_validation::validate_resolved_host(host, port)
-            .await
+        let resolved_ips = (self.resolve_ips)(host.to_string()).await.map_err(|e| {
+            ActionError::ConfigurationError(
+                common::url_validation::UrlValidationError::ResolutionFailed(e.to_string())
+                    .to_string(),
+            )
+        })?;
+        common::url_validation::validate_resolved_addrs(host, port, &resolved_ips)
             .map_err(|e| ActionError::ConfigurationError(e.to_string()))?;
 
         // Build request
@@ -619,5 +741,73 @@ mod tests {
 
         assert!(!truncated, "a small body must not be flagged truncated");
         assert_eq!(text.as_bytes(), payload.as_slice());
+    }
+
+    /// IG3 regression (SSRF DNS-rebinding TOCTOU, #2703): the pre-fix executor
+    /// resolved+validated the host **once** in a pre-flight lookup, then let
+    /// `reqwest` resolve the same host **again** at connect time. An attacker
+    /// controlling DNS could answer the first lookup with a public IP (passing
+    /// validation) and the second with a private/link-local IP (the socket the
+    /// client actually opens) — a classic time-of-check/time-of-use bypass of
+    /// the anti-SSRF gate.
+    ///
+    /// The fix wires a connect-time `SsrfGuardResolver` into the HTTP client so
+    /// the addresses `reqwest` connects to are exactly the ones re-validated at
+    /// connect. This test models the rebind with a hermetic, stateful resolver
+    /// (no real network): the **first** resolution — the pre-flight — returns a
+    /// public IP so validation passes, and the **second** — `reqwest`'s
+    /// connect-time lookup — returns `10.0.0.5`. The request must be rejected,
+    /// and the resolver must have been consulted at least twice (proving the
+    /// connect-time layer ran and observed the rebind).
+    ///
+    /// Fails on `dev`: there the client uses its own default resolver, so a
+    /// rebind to a private IP at connect is not re-validated and the request
+    /// would proceed to open a socket to the private address rather than being
+    /// rejected here.
+    #[tokio::test]
+    async fn execute_rejects_dns_rebinding_to_private_ip_at_connect() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_in_resolver = calls.clone();
+
+        // Stateful rebinding resolver: lookup #0 (pre-flight validation) →
+        // public; lookup #1+ (connect-time) → private.
+        let resolver: IpResolver = Arc::new(
+            move |_host: String| -> Pin<Box<dyn Future<Output = std::io::Result<Vec<IpAddr>>> + Send>> {
+                let calls = calls_in_resolver.clone();
+                Box::pin(async move {
+                    let n = calls.fetch_add(1, Ordering::SeqCst);
+                    let ip: IpAddr = if n == 0 {
+                        "93.184.216.34".parse().unwrap() // public — first (pre-flight) lookup
+                    } else {
+                        "10.0.0.5".parse().unwrap() // private — connect-time rebind
+                    };
+                    Ok(vec![ip])
+                })
+            },
+        );
+
+        let executor = ApiCallExecutor::with_ip_resolver(resolver);
+        let context = ActionContext::new(
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            uuid::Uuid::new_v4(),
+            serde_json::json!({}),
+        );
+        let config = serde_json::json!({ "url": "https://rebind.attacker.example/webhook" });
+
+        let result = executor.execute(&config, &context).await;
+
+        assert!(
+            result.is_err(),
+            "a host that rebinds to a private IP at connect must be rejected, got: {result:?}"
+        );
+        assert!(
+            calls.load(Ordering::SeqCst) >= 2,
+            "expected the connect-time resolver to re-resolve after the pre-flight \
+             lookup (rebinding observed), but it was consulted {} time(s)",
+            calls.load(Ordering::SeqCst)
+        );
     }
 }

--- a/backend/servers/api-server/src/services/actions/api_call.rs
+++ b/backend/servers/api-server/src/services/actions/api_call.rs
@@ -8,7 +8,7 @@ use db::models::action_type;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::future::Future;
-use std::net::{IpAddr, SocketAddr};
+use std::net::IpAddr;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};


### PR DESCRIPTION
## Task
Security: SSRF DNS-rebinding TOCTOU in workflow action `api_call.rs` — the anti-rebinding gate is bypassable (Closes #2703).

The anti-SSRF gate resolved + validated the webhook host once in a pre-flight lookup (`validate_resolved_host`), then let `reqwest` resolve the same host **again** at connect time. An attacker controlling DNS could answer the first lookup with a public IP (passing validation) and the second with a private/link-local IP (the socket actually opened) — a time-of-check/time-of-use bypass.

## Owner
pm-tech-lead (this is a backend/security fix — see Scope drift below)

## Fix
- **Connect-time SSRF-guard DNS resolver** (`SsrfGuardResolver`, `reqwest::dns::Resolve`) wired into the workflow HTTP client via `ClientBuilder::dns_resolver`. `reqwest`/`hyper` invoke it at **connect** time for the initial request **and every redirect hop**; it resolves and validates every resulting address against the shared SSRF policy and errors out (aborting the connection) on any forbidden address. Because the addresses `reqwest` connects to are exactly the ones validated here — resolved once, at connect, in the same step — the TOCTOU/DNS-rebinding window is closed. This is the `ClientBuilder::resolve()`-family / custom-resolver approach called for in the issue.
- **Redirect re-validation**: a `redirect::Policy::custom` runs `validate_external_url` on every hop before following it, so a redirect that downgrades to plain `http://` or targets a blocked host / `.local` / `.internal` TLD is rejected too (the IP-range resolver alone would not catch those). 10-hop limit preserved.
- **Pre-flight kept** as a fail-fast layer, now sharing the same injected DNS path (`self.resolve_ips`) as the connect-time resolver, so both observe one resolution code path and the regression test can drive both deterministically.
- **`common::url_validation`**: added `resolve_and_validate_host` (resolves once, returns validated `SocketAddr`s to pin) and `validate_resolved_addrs` (the primitive the connect-time resolver calls). `validate_resolved_host` refactored to delegate — behavior unchanged.

## IG3 regression test
`api_call::tests::execute_rejects_dns_rebinding_to_private_ip_at_connect` — a hermetic **stateful** resolver models the rebind: the **first** resolution (pre-flight) returns a public IP so validation passes; the **connect-time** resolution returns `10.0.0.5`. Asserts the request is rejected **and** that the resolver was consulted ≥2 times (proving the connect-time layer ran and observed the rebind). Fails on `dev` (default resolver → no connect-time re-validation → request would open a socket to the private address). No real network.

Supporting hermetic unit tests added in `common::url_validation`: `validate_resolved_addrs_returns_socket_addrs_for_public_ips`, `validate_resolved_addrs_rejects_when_any_ip_is_forbidden`, `resolve_and_validate_host_returns_validated_addrs`.

## Verification
Full `just verify` could not run locally: the `api-server` crate transitively builds `utoipa-swagger-ui`, whose build script downloads Swagger UI from github.com and the sandbox blocks that egress (documented environment limitation). Deferred to CI `backend.yml` (fmt + clippy + test).

Locally verified for the independently-compilable half:

```
cd backend && cargo test -p common url_validation   # 28 passed; 0 failed (incl. 3 new)
cd backend && cargo clippy -p common --all-targets -- -D warnings   # clean
cd backend && cargo fmt --all -- --check   # clean (fmt-check-exit=0)
```

`api_call.rs` (api-server) was written against the verified `reqwest` 0.13.4 API surface (`dns::Resolve`/`Name::as_str`/`Addrs`/`Resolving`, `ClientBuilder::dns_resolver`, `redirect::Policy::custom`/`Attempt::error|follow|previous|url`) — full type-check relies on CI.

## CI parity (Band C — hot-path)
This is a security/SSRF hot-path change. `just verify` could not complete locally (see above); the authoritative gate is CI `backend.yml`. Please do not merge until it is green.

## Scope drift
`scope-check` (owner `pm-tech-lead`) exits 2 — the diff is entirely under `backend/`, outside the tech-lead's docs/research areas. Expected: this is a backend security fix routed with a tech-lead owner hint. Files touched:
- `backend/servers/api-server/src/services/actions/api_call.rs`
- `backend/crates/common/src/url_validation.rs`

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- `common::url_validation::validate_resolved_host` now has no in-repo callers (this executor was its only one) but is kept as tested public API. Other outbound-fetch callers (`workflow_executor.rs`, `signatures.rs`, `webhook.rs`) currently only run the static `validate_external_url`; hardening those the same way is out of scope for #2703 and worth a follow-up.
- Draft pending CI (local backend compile blocked by swagger-ui egress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHjeW1j6rBHy5HB3RD7YaV

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHjeW1j6rBHy5HB3RD7YaV)_