### PR TITLE
refactor-churn-hotspot-api-server-layout-tenant-2026-07-30-retry1: dedupe layout tenant-override handlers

### DIFF
--- a/backend/servers/api-server/src/routes/layout/tenant.rs
+++ b/backend/servers/api-server/src/routes/layout/tenant.rs
@@ -4,8 +4,12 @@ use api_core::AuthUser;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::Json;
+use common::TenantRole;
+use db::models::layout::LayoutConfigRow;
 use db::repositories::LayoutRepository;
 use db::RlsPool;
+use sqlx::{Executor, Postgres};
+use uuid::Uuid;
 
 use super::types::{PutTenantOverrideRequest, ScreenQuery, ValidationErrorsResponse};
 
@@ -45,6 +49,38 @@ fn admin_required_error() -> ErrorResponse {
     error_response(StatusCode::FORBIDDEN, "org admin role required")
 }
 
+/// Org-admin gate shared by both handlers. Rejects the nil-org sentinel
+/// (platform hosts — an override stored under `Uuid::nil()` would leak across
+/// every org) with 400, then non-admin roles with 403. Rails/manifest/config
+/// are org-admin material. A caller still holding an `RlsConnection` must
+/// release it before propagating the returned error (see `get_tenant_override`).
+fn require_org_admin(org_id: Uuid, role: TenantRole) -> Result<(), ErrorResponse> {
+    if org_id.is_nil() {
+        return Err(nil_org_error());
+    }
+    if !role.is_admin() {
+        return Err(admin_required_error());
+    }
+    Ok(())
+}
+
+/// Load a screen's layout config from a public/global (no-RLS) connection,
+/// mapping a missing row to 404 and any sqlx failure to 500. Shared by both
+/// handlers so the fetch + not-found mapping stays in one place.
+async fn load_screen_config<'e, E>(
+    repo: &LayoutRepository,
+    executor: E,
+    screen: &str,
+) -> Result<LayoutConfigRow, ErrorResponse>
+where
+    E: Executor<'e, Database = Postgres>,
+{
+    repo.get_config(executor, screen)
+        .await
+        .map_err(internal_error)?
+        .ok_or_else(|| error_response(StatusCode::NOT_FOUND, "unknown screen"))
+}
+
 #[utoipa::path(get, path = "/api/v1/layout/tenant-override", tag = "Layout",
     security(("bearer_auth" = [])), params(("screen" = String, Query, description = "Screen id")),
     responses((status = 200, description = "Override + rails + published base + web manifest for the org"),
@@ -57,18 +93,13 @@ pub async fn get_tenant_override(
     mut rls: RlsConnection,
     Query(q): Query<ScreenQuery>,
 ) -> Result<Json<serde_json::Value>, ErrorResponse> {
-    // Nil-org sentinel (platform hosts) — an override under Uuid::nil() would
-    // be global, so refuse before touching the DB.
+    // Authz on the DB-validated identity (RlsConnection validates membership),
+    // not the raw JWT claim. Refuse the nil-org sentinel / non-admins before
+    // touching the DB; release the held connection on rejection.
     let org_id = rls.tenant_id();
-    if org_id.is_nil() {
+    if let Err(e) = require_org_admin(org_id, rls.role()) {
         rls.release().await;
-        return Err(nil_org_error());
-    }
-    // Authz on the DB-validated role (RlsConnection validates membership),
-    // not the raw JWT claim. Rails/manifest/config are org-admin material.
-    if !rls.role().is_admin() {
-        rls.release().await;
-        return Err(admin_required_error());
+        return Err(e);
     }
     let repo = LayoutRepository::new();
     let ov = repo
@@ -81,11 +112,7 @@ pub async fn get_tenant_override(
         .acquire_public()
         .await
         .map_err(internal_error)?;
-    let cfg = repo
-        .get_config(&mut **pub_conn, &q.screen)
-        .await
-        .map_err(internal_error)?
-        .ok_or_else(|| error_response(StatusCode::NOT_FOUND, "unknown screen"))?;
+    let cfg = load_screen_config(&repo, &mut **pub_conn, &q.screen).await?;
     let manifest_row = repo
         .get_manifest(&mut **pub_conn, "web")
         .await
@@ -121,12 +148,7 @@ pub async fn put_tenant_override(
     let is_super_admin = rls.is_super_admin();
     rls.release().await;
 
-    if org_id.is_nil() {
-        return Err(nil_org_error());
-    }
-    if !role.is_admin() {
-        return Err(admin_required_error());
-    }
+    require_org_admin(org_id, role)?;
 
     let parse_err = |e: serde_json::Error, what: &str| {
         error_response(
@@ -158,11 +180,7 @@ pub async fn put_tenant_override(
     // Global no-RLS layout tables — sanctioned public connection (clears stale context).
     let (base, rails_value) = {
         let mut pub_conn = rls_pool.acquire_public().await.map_err(internal_error)?;
-        let cfg = repo
-            .get_config(&mut **pub_conn, &req.screen)
-            .await
-            .map_err(internal_error)?
-            .ok_or_else(|| error_response(StatusCode::NOT_FOUND, "unknown screen"))?;
+        let cfg = load_screen_config(&repo, &mut **pub_conn, &req.screen).await?;
         let published = cfg.published.clone().ok_or_else(|| {
             error_response(StatusCode::NOT_FOUND, "screen has no published config")
         })?;


### PR DESCRIPTION
## Task
Churn hotspot — `backend/servers/api-server/src/routes/layout/tenant.rs` accumulated 262 changed lines in the review window (PR #2478). Reduce churn/complexity: extract helpers, dedupe repeated request/response mapping, tighten module structure — WITHOUT changing external behavior or route contracts. (Retry 1/2 of a prior attempt that failed with no PR — sandbox timeout before a PR existed.)

## Owner
pm-tech-lead

## What changed (behavior-preserving)
Two private helpers extracted; both handler bodies now delegate to them. No route paths, status codes, response shapes, ordering of checks, or connection lifecycle changed.

- `require_org_admin(org_id, role)` — the nil-org sentinel (400) + org-admin (403) gate, previously inlined in both `get_tenant_override` and `put_tenant_override`. Same check order and same error values. The GET handler still releases its held `RlsConnection` before propagating the error (unchanged semantics).
- `load_screen_config(repo, executor, screen)` — the `get_config(...) -> 500 on sqlx error -> 404 "unknown screen" on missing row` mapping, previously duplicated across both handlers.

Net effect: less duplicated request/response mapping and simpler handler bodies on the PR #2478 hotspot. Diff is confined to the single target file.

## Verification
```
VERIFY-PLAN base=06f9f5cc2ba7f9abe9fa1e9fda2a9fdda6fd7728 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```
- `cargo fmt --all -- --check` — PASS (locally).
- `cargo clippy -p api-server` / `cargo test -p api-server` — **DEFERRED TO CI (environment-limited).** The api-server dependency tree pulls `utoipa-swagger-ui`, whose build script downloads the Swagger UI zip from `github.com` at compile time. github.com egress is blocked by this sandbox's policy, so the download returns a 378-byte JSON error instead of a zip and the build panics: `failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")`. This is a known limitation of the local sandbox (same as the other backend auto-impl PRs); it is a build-dependency of a transitive crate, not this change. CI has the asset and will run the full clippy + test gate.

No `VERIFY OK` line is emitted because the gate could not complete locally for the reason above; fmt is green and the change is a mechanical, type-checked-by-inspection refactor (all added imports — `common::TenantRole`, `db::models::layout::LayoutConfigRow`, `sqlx::{Executor, Postgres}`, `uuid::Uuid` — resolve; both helpers mirror the original control flow exactly).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity behavior change — the authz gate is unchanged, only relocated into a shared helper).

## Remote-tested
skipped

## Scope drift
`scope-check.sh --owner pm-tech-lead` reported the change touches `backend/servers/api-server/src/routes/layout/tenant.rs`, which is outside the `pm-tech-lead` owner map (`docs/**`, `.research/**`, `_bmad-output/**`). This is expected: the task is a backend code refactor assigned under a PM/tech-lead owner hint. The change stays entirely within the single hotspot file named by the task. Flagging per protocol for reviewer adjudication.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no warnings. The two new helpers are file-local and do not duplicate any existing shared auth/crypto/http helper.

## Notes
- Pure refactor: no regression test added (IG3 exempt for behavior-preserving refactors). The existing api-server tests cover these handlers and run in CI.
- The IG goal-check script is oriented to the `.research/plans/` research flow (expects a plan file, an `impl/*` branch, and a test:+fix: commit pair); those checks are not applicable to a dispatcher-assigned churn-hotspot task and were not used as a gate.


---
_Generated by [Claude Code](https://claude.ai/code/session_014VTaHRHQbC9xAAWNGP82gv)_