### PR TITLE
data-audit-add-evidence-idor-fix-2026-07-23-retry2: emit dispute add_evidence access-audit event

### DIFF
--- a/backend/crates/db/src/repositories/dispute.rs
+++ b/backend/crates/db/src/repositories/dispute.rs
@@ -693,6 +693,36 @@ impl DisputeRepository {
         )
         .await?;
 
+        // Access-audit event (who added evidence to which dispute) on the
+        // platform-admin `audit_logs` stream — the same append-only,
+        // AuditRead-gated table the platform_admin support flow reads (see
+        // `membership.rs`, which emits `org_member_added`/`org_member_removed`
+        // the same way). Mirrors the support-data audit-emission pattern so a
+        // support engineer can trace evidence attachment across tenants. A
+        // generic `resource_created` action over `resource_type =
+        // 'dispute_evidence'` keeps this in the existing enum — no new
+        // `audit_action` value / migration is required.
+        sqlx::query(
+            r#"
+            INSERT INTO audit_logs (
+                user_id, action, resource_type, resource_id, org_id, details
+            )
+            VALUES ($1, 'resource_created'::audit_action, 'dispute_evidence', $2, $3, $4)
+            "#,
+        )
+        .bind(req.uploaded_by)
+        .bind(evidence.id)
+        .bind(org_id)
+        .bind(serde_json::json!({
+            "dispute_id":        req.dispute_id,
+            "evidence_id":       evidence.id,
+            "filename":          req.filename,
+            "original_filename": req.original_filename,
+        }))
+        .execute(&self.pool)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
         Ok(evidence)
     }
 

--- a/backend/crates/db/tests/suites/dispute_lifecycle_tests.rs
+++ b/backend/crates/db/tests/suites/dispute_lifecycle_tests.rs
@@ -387,3 +387,83 @@ async fn add_evidence_persists_and_records_activity(pool: PgPool) {
         .expect("delete query ok");
     assert!(right_scope, "evidence is deletable via its own dispute id");
 }
+
+/// Regression: attaching evidence must emit an access-audit event on the
+/// platform-admin `audit_logs` stream — who (`user_id`) added evidence
+/// (`resource_id` = evidence id, `resource_type = 'dispute_evidence'`) to
+/// which dispute (`details.dispute_id`), scoped to the owning org.
+///
+/// Fails on `dev` (pre-fix `add_evidence` writes the evidence row + activity
+/// but NO `audit_logs` row, so the SELECT returns zero rows). Passes once the
+/// repo emits the `resource_created`/`dispute_evidence` audit row, mirroring
+/// the `membership.rs` / support-data audit-emission pattern. Sibling to the
+/// support-tooling `support_data_viewed` emission on the read path.
+#[sqlx::test]
+async fn add_evidence_writes_access_audit_event(pool: PgPool) {
+    let org = seed_org(&pool, "evaudit").await;
+    let user = seed_user(&pool, "evaudit@dispute-lifecycle.test").await;
+    let repo = DisputeRepository::new(pool.clone());
+
+    let dispute = repo
+        .file_dispute(org, file_req(org, user, vec![]))
+        .await
+        .expect("file dispute");
+
+    let evidence = repo
+        .add_evidence(
+            AddEvidence {
+                dispute_id: dispute.id,
+                uploaded_by: user,
+                filename: "lease-scan.pdf".into(),
+                original_filename: "Lease Scan.pdf".into(),
+                content_type: "application/pdf".into(),
+                size_bytes: 2048,
+                storage_url: "s3://evidence/lease-scan.pdf".into(),
+                description: None,
+            },
+            org,
+        )
+        .await
+        .expect("add evidence");
+
+    // Exactly one access-audit row for this evidence attachment, carrying the
+    // actor, the org, and the parent dispute in `details`.
+    #[derive(sqlx::FromRow)]
+    struct AuditRow {
+        user_id: Option<Uuid>,
+        resource_id: Option<Uuid>,
+        org_id: Option<Uuid>,
+        details: serde_json::Value,
+    }
+
+    let row: AuditRow = sqlx::query_as(
+        r#"
+        SELECT user_id, resource_id, org_id, details
+        FROM audit_logs
+        WHERE action = 'resource_created'::audit_action
+          AND resource_type = 'dispute_evidence'
+          AND resource_id = $1
+        "#,
+    )
+    .bind(evidence.id)
+    .fetch_one(&pool)
+    .await
+    .expect("add_evidence must write a dispute_evidence access-audit row");
+
+    assert_eq!(row.user_id, Some(user), "audit actor is the uploader");
+    assert_eq!(
+        row.resource_id,
+        Some(evidence.id),
+        "audit targets the evidence"
+    );
+    assert_eq!(
+        row.org_id,
+        Some(org),
+        "audit row is scoped to the owning org"
+    );
+    assert_eq!(
+        row.details["dispute_id"],
+        serde_json::json!(dispute.id),
+        "audit details record which dispute the evidence was added to"
+    );
+}


### PR DESCRIPTION
## Task
Backfill a dispute `add_evidence` access-audit event (who added evidence to which dispute) to the platform-admin support-data event stream, mirroring the existing support-data audit-read pattern. Locate the dispute add_evidence handler and the support-data audit event emission pattern in the backend, and add a parallel audit event on evidence add. Retry 2/2 (final) of a prior attempt that failed with no PR (sandbox timeout). Prerequisite: `#2483`/PR `#2490` — verified already landed on `dev`.

## Owner
pm-data

## What changed
`DisputeRepository::add_evidence` (`backend/crates/db/src/repositories/dispute.rs`) now emits an access-audit event on the append-only, `AuditRead`-gated `audit_logs` stream — the same table the platform-admin support flow reads (see `membership.rs`, which emits `org_member_added`/`org_member_removed` the same way; migration `00163` explicitly documents `audit_logs` as "the generic audit_logs table that is gated by AuditRead"). The row records **who** (`user_id` = uploader), **which evidence** (`resource_id`, `resource_type = 'dispute_evidence'`), **which dispute** (`details.dispute_id`), scoped to the owning org — mirroring the `support_data_viewed` fire-and-forget emission on the support-data read path.

### Why `audit_logs`, not `support_tooling_events`
The literal "support-data event stream" (`support_tooling_events`) was considered and rejected: (a) its `event_kind` is pinned by a CHECK constraint (migration `00163`) so a new kind needs a **migration** — out of the pm-data route-layer scope and cross-specialist; (b) its `admin_user_id` column models a platform-admin actor, a semantic mismatch for a tenant user attaching evidence. `audit_logs` is the generic AuditRead-gated append-only stream, needs **no migration** (reuses the existing `resource_created` `audit_action` value), and matches the established repo-layer precedent. This keeps the change entirely inside `backend/crates/db/**` (pm-data owner area).

## Regression test (IG3)
`add_evidence_writes_access_audit_event` in `backend/crates/db/tests/suites/dispute_lifecycle_tests.rs` (`#[sqlx::test]`, DB-backed, not ignored — the sibling `add_evidence_persists_and_records_activity` is quarantined under BIT-351). Files a dispute, adds evidence, then asserts exactly one `resource_created`/`dispute_evidence` `audit_logs` row exists with the uploader, evidence id, org, and `details.dispute_id`. **Fails on `dev`** (pre-fix `add_evidence` writes the evidence + activity rows but no audit row → `fetch_one` returns no row). Runs in CI `backend.yml` (has Postgres); skipped in the local no-DB gate.

## Verification
```
VERIFY-PLAN base=06f9f5cc2ba7f9abe9fa1e9fda2a9fdda6fd7728 files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p db --all-targets -- -D warnings
  ... (+ db reverse-dependents: accounting-*, api-core, api-server, admin-core, reality-server, tenant-ops)
```
Locally green on the crate actually changed:
- `cargo fmt --all -- --check` — exit 0
- `cargo clippy -p db --all-targets -- -D warnings` — exit 0 (compiles the new regression test)

The db reverse-dependent **server** crates (`accounting-server`, `api-server`, `reality-server`) fail the local gate solely on the KNOWN `utoipa-swagger-ui` build-script egress block (`SWAGGER_UI_DOWNLOAD_URL` download → `InvalidArchive("Could not find EOCD")`) — unrelated to this diff. Deferred to CI, consistent with the other backend auto-impl PRs. `add_evidence`'s signature is unchanged, so callers are source-compatible.

## Scope drift
None — diff is limited to `backend/crates/db/**` (pm-data owner area). `scope-check.sh --owner pm-data --base origin/dev` → exit 0.

## Code-reuse review
None — `reuse-grep.sh` clean. Reuses the existing `AuditAction::ResourceCreated` enum value and the `audit_logs` INSERT pattern already used by `membership.rs`.

## CI parity (Band C — hot-path)
This is a data-integrity/audit change. Full CI parity (`backend.yml` with Postgres) is required to execute the `#[sqlx::test]` regression — deferred to CI, which is also where the swagger-ui-blocked server crates compile.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- No migration required. No handler change (`routes/disputes.rs` untouched) — emission lives in the db-crate repo method, atomic with the existing evidence write path.
- Prerequisite `#2483`/PR `#2490` (org-scoped `add_evidence` write) confirmed present on `dev` (commit `747af7a1f`).


---
_Generated by [Claude Code](https://claude.ai/code/session_014VTaHRHQbC9xAAWNGP82gv)_