### PR TITLE
gh-issue-2612-retry1: decouple scheduled notification dispatch from publish/activate/close (Closes #2612)

### DIFF
--- a/backend/crates/db/migrations/00228_announcement_vote_notified_at.sql
+++ b/backend/crates/db/migrations/00228_announcement_vote_notified_at.sql
@@ -1,0 +1,92 @@
+-- Migration: 00228_announcement_vote_notified_at
+-- Decouple "published/activated" from "notified" for the scheduler's
+-- announcement / vote notification triggers (issue #2612, follow-up to PR #2608).
+--
+-- Background
+-- ----------
+-- `Scheduler::publish_scheduled_announcements` and the vote-lifecycle jobs did
+-- two committed-but-decoupled things in one tick: (1) flip the row to
+-- published/active/closed and COMMIT, then (2) resolve notification targets and
+-- dispatch. After PR #2608 a failure in step (2) is logged, but because step (1)
+-- already committed, the row is never re-selected — a single transient
+-- target-resolution / dispatch blip permanently DROPS the notification
+-- (fire-once).
+--
+-- Fix: add a nullable "notified" watermark to each notifiable transition so the
+-- state change (published/active/closed) is decoupled from the notification.
+-- The scheduler selects rows in the target state whose watermark IS NULL,
+-- dispatches, and stamps the watermark ONLY on success — mirroring the
+-- "stamp only after a successful run" pattern already used by the retention
+-- prunes (`last_*_prune_at`) and `fire_due_report_schedules`. A transient error
+-- simply leaves the watermark NULL and the next ~60s tick retries.
+--
+-- Semantics of the watermark (NULL = "needs notification"):
+--   * The scheduler's automated transition (publish_scheduled / activate_scheduled
+--     / close_expired) leaves the watermark NULL so the dispatch pass picks the
+--     row up.
+--   * Manual transitions (announcement publish, vote publish→active, vote close
+--     from the manager route) stamp the watermark = NOW() so they are NOT picked
+--     up by the scheduler dispatch pass — preserving the pre-existing behaviour
+--     that manual publish/close did not fan out a scheduler notification.
+--
+-- Backfill: every row that has ALREADY transitioned past its notifiable moment
+-- is stamped NOW() so this additive column does not cause a one-time mass
+-- re-notification of the entire historical backlog on deploy. Rows still in the
+-- pre-notification state (announcements/votes that are still `scheduled`, and
+-- not-yet-closed votes) keep a NULL closed-watermark so their eventual scheduler
+-- transition still notifies.
+
+-- ---------------------------------------------------------------------------
+-- Announcements: single "published" notification.
+-- ---------------------------------------------------------------------------
+ALTER TABLE announcements
+    ADD COLUMN IF NOT EXISTS notified_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN announcements.notified_at IS
+    'Scheduler notification watermark (issue #2612). NULL = the published-announcement notification still needs to be dispatched; stamped only after a successful dispatch so a transient failure is retried instead of dropped.';
+
+-- Suppress a mass re-notification: everything that is not still `scheduled` has
+-- already had (or will never get) its published notification.
+UPDATE announcements
+SET notified_at = COALESCE(published_at, updated_at, created_at)
+WHERE status <> 'scheduled'
+  AND notified_at IS NULL;
+
+-- Cheap lookup for the dispatch pass (`published AND notified_at IS NULL`).
+CREATE INDEX IF NOT EXISTS idx_announcements_pending_notification
+    ON announcements (scheduled_at)
+    WHERE status = 'published' AND notified_at IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- Votes: two distinct notifiable transitions — vote-started (activation) and
+-- vote-closed (result). Each needs its own watermark.
+-- ---------------------------------------------------------------------------
+ALTER TABLE votes
+    ADD COLUMN IF NOT EXISTS started_notified_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS closed_notified_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN votes.started_notified_at IS
+    'Scheduler notification watermark for the vote-started notification (issue #2612). NULL = still needs dispatch; stamped only after a successful dispatch.';
+COMMENT ON COLUMN votes.closed_notified_at IS
+    'Scheduler notification watermark for the closed-vote result notification (issue #2612). NULL = still needs dispatch; stamped only after a successful dispatch.';
+
+-- Started watermark: any vote past `scheduled` has already had (or bypassed via
+-- manual publish) its started moment.
+UPDATE votes
+SET started_notified_at = COALESCE(published_at, updated_at, created_at)
+WHERE status <> 'scheduled'
+  AND started_notified_at IS NULL;
+
+-- Closed watermark: only already-closed votes have had their result moment.
+UPDATE votes
+SET closed_notified_at = COALESCE(results_calculated_at, updated_at, created_at)
+WHERE status = 'closed'
+  AND closed_notified_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_votes_pending_started_notification
+    ON votes (start_at)
+    WHERE status = 'active' AND started_notified_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_votes_pending_closed_notification
+    ON votes (end_at)
+    WHERE status = 'closed' AND closed_notified_at IS NULL;

--- a/backend/crates/db/src/repositories/announcement.rs
+++ b/backend/crates/db/src/repositories/announcement.rs
@@ -608,13 +608,21 @@ impl AnnouncementRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
+        // A manual publish stamps `notified_at = NOW()` (issue #2612) so the
+        // scheduler's decoupled notification pass — which selects
+        // `published AND notified_at IS NULL` — does NOT fan out a
+        // published-announcement notification for it. This preserves the
+        // pre-existing behaviour that a manager-driven publish did not trigger a
+        // scheduler notification (only auto-published *scheduled* announcements
+        // did). Auto-publish (`publish_scheduled_rls`) leaves it NULL instead.
         let announcement = sqlx::query_as::<_, Announcement>(
             r#"
             UPDATE announcements
             SET
                 status = 'published',
                 published_at = NOW(),
-                updated_at = NOW()
+                updated_at = NOW(),
+                notified_at = NOW()
             WHERE id = $1 AND status IN ('draft', 'scheduled')
             RETURNING
                 id, organization_id, author_id, title, content,
@@ -699,10 +707,18 @@ impl AnnouncementRepository {
     where
         E: Executor<'e, Database = Postgres>,
     {
+        // `notified_at = NULL` is the "needs notification" marker (issue #2612):
+        // publishing only flips the state, leaving the dispatch to a separate
+        // scheduler pass that resolves targets, notifies, and stamps
+        // `notified_at` only on success. Set explicitly (not merely relying on
+        // the column default) so a row that carried a stale non-NULL watermark
+        // — e.g. a draft backfilled to NOW() by migration 00228 that was later
+        // scheduled — is reset to "needs notification" when it publishes.
         let announcements = sqlx::query_as::<_, Announcement>(
             r#"
             UPDATE announcements
-            SET status = 'published', published_at = NOW(), updated_at = NOW()
+            SET status = 'published', published_at = NOW(), updated_at = NOW(),
+                notified_at = NULL
             WHERE status = 'scheduled' AND scheduled_at <= NOW()
             RETURNING
                 id, organization_id, author_id, title, content,
@@ -716,6 +732,55 @@ impl AnnouncementRepository {
         .await?;
 
         Ok(announcements)
+    }
+
+    /// Announcements that are published but whose scheduler notification has not
+    /// yet been dispatched (`status = 'published' AND notified_at IS NULL`).
+    ///
+    /// Backs the decoupled dispatch pass added for issue #2612: publishing and
+    /// notifying are separate steps, so a transient target-resolution/dispatch
+    /// failure leaves `notified_at` NULL and the row is re-selected here on the
+    /// next tick instead of being dropped fire-once. Ordered oldest-first so a
+    /// backlog drains in publish order.
+    pub async fn find_published_pending_notification(
+        &self,
+    ) -> Result<Vec<Announcement>, SqlxError> {
+        let announcements = sqlx::query_as::<_, Announcement>(
+            r#"
+            SELECT
+                id, organization_id, author_id, title, content,
+                target_type::text as target_type, target_ids,
+                status::text as status, scheduled_at, published_at,
+                pinned, pinned_at, pinned_by, comments_enabled,
+                acknowledgment_required, created_at, updated_at
+            FROM announcements
+            WHERE status = 'published' AND notified_at IS NULL
+            ORDER BY published_at ASC NULLS FIRST
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(announcements)
+    }
+
+    /// Stamp an announcement's notification watermark after a successful
+    /// dispatch (issue #2612). Idempotent guard on `notified_at IS NULL` so a
+    /// concurrent stamp cannot double-count. Returns the number of rows stamped
+    /// (0 or 1).
+    pub async fn mark_notified(&self, id: Uuid) -> Result<u64, SqlxError> {
+        let result = sqlx::query(
+            r#"
+            UPDATE announcements
+            SET notified_at = NOW()
+            WHERE id = $1 AND notified_at IS NULL
+            "#,
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected())
     }
 
     // ------------------------------------------------------------------------

--- a/backend/crates/db/src/repositories/vote.rs
+++ b/backend/crates/db/src/repositories/vote.rs
@@ -808,7 +808,18 @@ impl VoteRepository {
                 eligible_count = $4,
                 published_by = $5,
                 published_at = NOW(),
-                updated_at = NOW()
+                updated_at = NOW(),
+                -- A manual publish straight to `active` stamps the started
+                -- watermark = NOW() (issue #2612) so the scheduler's decoupled
+                -- vote-started dispatch pass (selects `active AND
+                -- started_notified_at IS NULL`) does NOT re-notify it —
+                -- preserving the pre-existing behaviour that manual publish did
+                -- not fan out a vote-started notification. Publishing to
+                -- `scheduled` leaves it NULL so activation notifies later.
+                started_notified_at = CASE
+                    WHEN $2::vote_status = 'active'::vote_status THEN NOW()
+                    ELSE NULL
+                END
             WHERE id = $1 AND status = 'draft'
             RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
@@ -893,7 +904,15 @@ impl VoteRepository {
                 quorum_met = $3,
                 results = $4,
                 results_calculated_at = NOW(),
-                updated_at = NOW()
+                updated_at = NOW(),
+                -- Stamp the closed watermark = NOW() (issue #2612). This is the
+                -- shared close path (manager route AND the scheduler's
+                -- `close_expired_votes`). A manual close is thereby suppressed
+                -- from the scheduler's closed-vote dispatch pass, preserving the
+                -- pre-existing behaviour that manual close did not fan out a
+                -- result notification. `close_expired_votes` re-clears this to
+                -- NULL for the votes IT closes so the scheduler still notifies.
+                closed_notified_at = NOW()
             WHERE id = $1
             RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
@@ -924,10 +943,15 @@ impl VoteRepository {
 
     /// Activate scheduled votes that have reached their start time.
     pub async fn activate_scheduled_votes(&self) -> Result<Vec<Vote>, SqlxError> {
+        // `started_notified_at = NULL` marks the activated vote as "needs a
+        // vote-started notification" (issue #2612). Activation only flips the
+        // state; the scheduler's decoupled dispatch pass resolves eligible
+        // voters, notifies, and stamps the watermark only on success — so a
+        // transient failure retries instead of dropping the notification.
         let votes = sqlx::query_as::<_, Vote>(
             r#"
             UPDATE votes
-            SET status = 'active', updated_at = NOW()
+            SET status = 'active', updated_at = NOW(), started_notified_at = NULL
             WHERE status = 'scheduled' AND start_at <= NOW()
             RETURNING id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
             "#,
@@ -955,7 +979,80 @@ impl VoteRepository {
             closed.push(id);
         }
 
+        // `close()` (shared with the manager route) stamps `closed_notified_at`
+        // = NOW() to suppress manual closes from the dispatch pass. Re-clear it
+        // to NULL for the votes the SCHEDULER just closed, marking them "needs a
+        // closed-vote result notification" (issue #2612). The dispatch pass then
+        // notifies and re-stamps on success.
+        if !closed.is_empty() {
+            sqlx::query("UPDATE votes SET closed_notified_at = NULL WHERE id = ANY($1)")
+                .bind(&closed)
+                .execute(&self.pool)
+                .await?;
+        }
+
         Ok(closed)
+    }
+
+    /// Active votes whose vote-started notification has not yet been dispatched
+    /// (`status = 'active' AND started_notified_at IS NULL`). Backs the
+    /// decoupled dispatch pass (issue #2612): activation and notification are
+    /// separate, so a transient failure leaves the watermark NULL and the vote
+    /// is re-selected here next tick. Oldest-first so a backlog drains in order.
+    pub async fn find_active_pending_started_notification(&self) -> Result<Vec<Vote>, SqlxError> {
+        let votes = sqlx::query_as::<_, Vote>(
+            r#"
+            SELECT id, organization_id, building_id, title, description, start_at, end_at, status::text AS status, quorum_type::text AS quorum_type, quorum_percentage, allow_delegation, anonymous_voting, participation_count, eligible_count, quorum_met, results, results_calculated_at, created_by, published_by, published_at, cancelled_by, cancelled_at, cancellation_reason, created_at, updated_at
+            FROM votes
+            WHERE status = 'active' AND started_notified_at IS NULL
+            ORDER BY start_at ASC NULLS FIRST
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(votes)
+    }
+
+    /// Stamp a vote's started-notification watermark after a successful dispatch
+    /// (issue #2612). Guarded on `started_notified_at IS NULL` (idempotent).
+    /// Returns rows stamped (0 or 1).
+    pub async fn mark_started_notified(&self, id: Uuid) -> Result<u64, SqlxError> {
+        let result =
+            sqlx::query("UPDATE votes SET started_notified_at = NOW() WHERE id = $1 AND started_notified_at IS NULL")
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Ids of closed votes whose result notification has not yet been dispatched
+    /// (`status = 'closed' AND closed_notified_at IS NULL`). Only votes closed
+    /// by the scheduler (`close_expired_votes` cleared the watermark) qualify;
+    /// manual closes keep the NOW() stamp `close()` set. Oldest-first.
+    pub async fn find_closed_pending_notification(&self) -> Result<Vec<Uuid>, SqlxError> {
+        let rows: Vec<(Uuid,)> = sqlx::query_as(
+            r#"
+            SELECT id FROM votes
+            WHERE status = 'closed' AND closed_notified_at IS NULL
+            ORDER BY end_at ASC NULLS FIRST
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
+    /// Stamp a vote's closed-notification watermark after a successful dispatch
+    /// (issue #2612). Guarded on `closed_notified_at IS NULL` (idempotent).
+    /// Returns rows stamped (0 or 1).
+    pub async fn mark_closed_notified(&self, id: Uuid) -> Result<u64, SqlxError> {
+        let result =
+            sqlx::query("UPDATE votes SET closed_notified_at = NOW() WHERE id = $1 AND closed_notified_at IS NULL")
+                .bind(id)
+                .execute(&self.pool)
+                .await?;
+        Ok(result.rows_affected())
     }
 
     // ========================================================================

--- a/backend/servers/api-server/src/services/scheduler/mod.rs
+++ b/backend/servers/api-server/src/services/scheduler/mod.rs
@@ -289,9 +289,16 @@ impl Scheduler {
 
     /// Run all scheduled tasks.
     async fn run_scheduled_tasks(&self) {
-        // Story 106.1: Publish scheduled announcements and send notifications
+        // Story 106.1: Publish scheduled announcements (state flip only).
         if let Err(e) = self.publish_scheduled_announcements().await {
             tracing::error!("Failed to publish scheduled announcements: {}", e);
+            self.increment_errors();
+        }
+
+        // Issue #2612: dispatch pending published-announcement notifications
+        // (decoupled from publishing so a transient failure retries next tick).
+        if let Err(e) = self.dispatch_announcement_notifications().await {
+            tracing::error!("Failed to dispatch announcement notifications: {}", e);
             self.increment_errors();
         }
 
@@ -301,15 +308,29 @@ impl Scheduler {
             self.increment_errors();
         }
 
-        // Story 106.2: Activate scheduled votes
+        // Story 106.2: Activate scheduled votes (state flip only).
         if let Err(e) = self.activate_scheduled_votes().await {
             tracing::error!("Failed to activate scheduled votes: {}", e);
             self.increment_errors();
         }
 
-        // Story 106.2: Close expired votes and notify results
+        // Issue #2612: dispatch pending vote-started notifications (decoupled
+        // from activation so a transient failure retries next tick).
+        if let Err(e) = self.dispatch_vote_started_notifications().await {
+            tracing::error!("Failed to dispatch vote-started notifications: {}", e);
+            self.increment_errors();
+        }
+
+        // Story 106.2: Close expired votes (state flip only).
         if let Err(e) = self.close_expired_votes().await {
             tracing::error!("Failed to close expired votes: {}", e);
+            self.increment_errors();
+        }
+
+        // Issue #2612: dispatch pending closed-vote result notifications
+        // (decoupled from closing so a transient failure retries next tick).
+        if let Err(e) = self.dispatch_vote_closed_notifications().await {
+            tracing::error!("Failed to dispatch vote-closed notifications: {}", e);
             self.increment_errors();
         }
 
@@ -384,7 +405,16 @@ impl Scheduler {
     // Story 106.1: Announcement Notification Triggers
     // ========================================================================
 
-    /// Publish all scheduled announcements that are due and send notifications.
+    /// Publish all scheduled announcements that are due.
+    ///
+    /// Issue #2612: this now ONLY flips due announcements to `published`
+    /// (leaving `notified_at = NULL`). Notification dispatch is decoupled into
+    /// [`Self::dispatch_announcement_notifications`], which selects
+    /// `published AND notified_at IS NULL`, resolves targets, dispatches, and
+    /// stamps `notified_at` only on success. Previously publish + notify shared
+    /// one loop, so a transient target-resolution/dispatch failure permanently
+    /// dropped the notification (the row was already committed as published and
+    /// never re-selected). Decoupling lets the next tick retry.
     async fn publish_scheduled_announcements(&self) -> Result<(), sqlx::Error> {
         // Note: Scheduler runs in background without user context.
         // These operations are privileged/admin-level and don't need RLS enforcement.
@@ -403,69 +433,104 @@ impl Scheduler {
                 let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
                 metrics.announcements_published += published.len() as u64;
             }
+        }
 
-            // Send notifications for each published announcement
-            for announcement in &published {
-                // Get target users based on target_type and target_ids.
-                //
-                // A query error here is NOT the same thing as "no target
-                // users" (a legitimately empty audience, e.g. an unpopulated
-                // building). Coercing it into an empty Vec would let the loop
-                // fall through to the `if !target_user_ids.is_empty()` guard
-                // below and silently treat a transient DB failure as "zero
-                // recipients, nothing to send" — the announcement is already
-                // marked published (see `publish_scheduled()` above) but
-                // nobody is ever notified, and nothing signals the failure.
-                //
-                // Log with full context here (announcement id / target type —
-                // detail the caller's generic log line below doesn't have),
-                // then propagate so `run_scheduled_tasks` observes the error,
-                // increments the scheduler error metric, and the failure is
-                // never mistaken for a successful zero-recipient dispatch.
-                let target_user_ids = match self.get_announcement_target_users(announcement).await {
-                    Ok(ids) => ids,
+        Ok(())
+    }
+
+    /// Dispatch published-announcement notifications that have not yet been sent
+    /// (issue #2612 — the durability half of the decoupled publish/notify flow).
+    ///
+    /// Selects `published AND notified_at IS NULL`, resolves targets, dispatches,
+    /// and stamps `notified_at` ONLY on success — mirroring the "stamp only after
+    /// a successful run" pattern of the retention prunes and
+    /// `fire_due_report_schedules`. A transient failure (target resolution OR
+    /// dispatch) is logged and the row is LEFT unstamped, so the next ~60s tick
+    /// retries it instead of dropping the notification fire-once.
+    ///
+    /// A legitimately empty audience (`Ok(vec![])` — e.g. an unpopulated
+    /// building) IS stamped: there is genuinely nobody to notify, so the row is
+    /// "handled" and must not retry forever. Only a target-resolution `Err` or a
+    /// dispatch `Err` leaves it unstamped for retry.
+    async fn dispatch_announcement_notifications(&self) -> Result<(), sqlx::Error> {
+        let pending = self
+            .announcement_repo
+            .find_published_pending_notification()
+            .await?;
+
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            count = pending.len(),
+            "Dispatching pending announcement notifications"
+        );
+
+        for announcement in &pending {
+            // A query error resolving targets is NOT an empty audience — leave
+            // the row unstamped so it retries rather than being silently marked
+            // notified with zero recipients.
+            let target_user_ids = match self.get_announcement_target_users(announcement).await {
+                Ok(ids) => ids,
+                Err(e) => {
+                    tracing::error!(
+                        announcement_id = %announcement.id,
+                        target_type = %announcement.target_type,
+                        error = %e,
+                        "Failed to resolve announcement notification targets; \
+                         leaving notified_at NULL so the next tick retries"
+                    );
+                    continue;
+                }
+            };
+
+            if !target_user_ids.is_empty() {
+                match self
+                    .notification_service
+                    .notify_announcement_published(announcement, &target_user_ids)
+                    .await
+                {
+                    Ok(sent) => {
+                        tracing::info!(
+                            announcement_id = %announcement.id,
+                            sent_count = sent,
+                            "Sent announcement notifications"
+                        );
+                    }
                     Err(e) => {
                         tracing::error!(
                             announcement_id = %announcement.id,
-                            target_type = %announcement.target_type,
                             error = %e,
-                            "Failed to resolve announcement notification targets; \
-                             propagating so the failure is observable instead of \
-                             silently notifying zero users"
+                            "Failed to send announcement notifications; \
+                             leaving notified_at NULL so the next tick retries"
                         );
-                        return Err(e);
-                    }
-                };
-
-                if !target_user_ids.is_empty() {
-                    match self
-                        .notification_service
-                        .notify_announcement_published(announcement, &target_user_ids)
-                        .await
-                    {
-                        Ok(sent) => {
-                            tracing::info!(
-                                announcement_id = %announcement.id,
-                                sent_count = sent,
-                                "Sent announcement notifications"
-                            );
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                announcement_id = %announcement.id,
-                                error = %e,
-                                "Failed to send announcement notifications"
-                            );
-                        }
+                        continue;
                     }
                 }
+            }
 
-                tracing::info!(
-                    announcement_id = %announcement.id,
-                    title = %announcement.title,
-                    target_type = %announcement.target_type,
-                    "Scheduled announcement published"
-                );
+            // Stamp only after a successful dispatch (or a legitimately empty
+            // audience). A failed stamp is logged but not fatal — the row stays
+            // unstamped and the next tick re-dispatches (at worst a duplicate
+            // send, never a lost one).
+            match self.announcement_repo.mark_notified(announcement.id).await {
+                Ok(_) => {
+                    tracing::info!(
+                        announcement_id = %announcement.id,
+                        title = %announcement.title,
+                        target_type = %announcement.target_type,
+                        "Announcement notification dispatched and stamped"
+                    );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        announcement_id = %announcement.id,
+                        error = %e,
+                        "Failed to stamp announcement notified_at after dispatch; \
+                         next tick may resend"
+                    );
+                }
             }
         }
 
@@ -1763,29 +1828,137 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // IG3 regression (code-review-api-core-sched-notify-swallow): a target-
-    // resolution DB error must propagate out of
-    // `publish_scheduled_announcements`, not collapse into an empty target
-    // Vec.
+    // IG3 regression (issue #2612): a transient target-resolution error on the
+    // announcement notification dispatch must NOT drop the notification
+    // fire-once. Publishing and notifying are decoupled — publishing only flips
+    // `status = 'published'` (leaving `notified_at = NULL`); a separate dispatch
+    // pass resolves targets, notifies, and stamps `notified_at` ONLY on success.
     //
-    // Before the fix, `get_announcement_target_users` errors were logged and
-    // then swallowed into `Vec::new()`; the loop's
-    // `if !target_user_ids.is_empty()` guard then skipped
-    // `notify_announcement_published` entirely and `publish_scheduled_announcements`
-    // still returned `Ok(())`. The announcement was already flipped to
-    // `status = 'published'` by `publish_scheduled()`, so the net effect of a
-    // transient query error was: announcement marked published, zero
-    // notifications sent, function reports success. This test sabotages the
-    // "all" leg's `user_memberships` join (drops the table after seeding, so
-    // `publish_scheduled()` itself still succeeds) and asserts the error
-    // surfaces as `Err` rather than a silent `Ok(())`.
+    // Before the fix the two shared one loop: the announcement was committed as
+    // published, and a target-resolution/dispatch failure (post-#2608: logged,
+    // not retried) left it published-but-never-notified with no way to re-select
+    // it. This test forces a target-resolution error on the FIRST dispatch tick
+    // (by transiently renaming `buildings` away, breaking the `"building"` leg's
+    // JOIN) and asserts `notified_at` stays NULL — i.e. the row is NOT stamped
+    // and remains eligible for retry. It then restores the table and asserts a
+    // LATER tick resolves targets, dispatches, and stamps `notified_at`.
+    //
+    // The pre-fix code cannot satisfy this: it never had a `notified_at`
+    // watermark nor a re-selecting dispatch pass, so the notification was gone
+    // after the first failed tick.
     // ------------------------------------------------------------------
     #[sqlx::test(migrator = "db::MIGRATOR")]
-    async fn test_publish_scheduled_announcements_propagates_target_resolution_error(
-        pool: sqlx::PgPool,
-    ) {
-        let org = seed_org(&pool, "swallow-guard").await;
-        let author = seed_user(&pool, "author@swallow-guard.test").await;
+    async fn test_announcement_notification_retries_after_transient_error(pool: sqlx::PgPool) {
+        let org = seed_org(&pool, "retry-guard").await;
+        let author = seed_user(&pool, "author@retry-guard.test").await;
+        let building = seed_building(&pool, org, "RETRY").await;
+        let unit = seed_unit(&pool, building, "RETRY-1").await;
+        let resident = seed_user(&pool, "resident@retry-guard.test").await;
+        seed_resident(&pool, unit, resident).await;
+
+        // A scheduled, due announcement targeting the building above.
+        let scheduled_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+        let announcement_id: Uuid = sqlx::query_scalar(
+            r#"
+            INSERT INTO announcements (
+                organization_id, author_id, title, content,
+                target_type, target_ids, status, scheduled_at
+            )
+            VALUES ($1, $2, $3, $4, 'building'::announcement_target_type, $5, 'scheduled'::announcement_status, $6)
+            RETURNING id
+            "#,
+        )
+        .bind(org)
+        .bind(author)
+        .bind("Retry guard")
+        .bind("body")
+        .bind(serde_json::json!([building]))
+        .bind(scheduled_at)
+        .fetch_one(&pool)
+        .await
+        .expect("seed scheduled announcement");
+
+        let scheduler = test_scheduler(pool.clone());
+
+        // Publish: flips to `published`, leaves `notified_at = NULL`.
+        scheduler
+            .publish_scheduled_announcements()
+            .await
+            .expect("publish scheduled announcements");
+        let (status, notified): (String, Option<chrono::DateTime<chrono::Utc>>) =
+            sqlx::query_as("SELECT status::text, notified_at FROM announcements WHERE id = $1")
+                .bind(announcement_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read status/notified_at after publish");
+        assert_eq!(status, "published", "publish must flip status to published");
+        assert!(
+            notified.is_none(),
+            "publish must leave notified_at NULL (needs notification)"
+        );
+
+        // Tick 1 — sabotage ONLY target resolution: rename `buildings` away so
+        // the `"building"` leg's JOIN fails. `find_published_pending_notification`
+        // (announcements-only) still succeeds, so the failure is isolated to the
+        // dispatch's target resolution — the transient blip the fix defends.
+        sqlx::query("ALTER TABLE buildings RENAME TO buildings_hidden")
+            .execute(&pool)
+            .await
+            .expect("rename buildings away");
+
+        scheduler
+            .dispatch_announcement_notifications()
+            .await
+            .expect("dispatch tolerates a per-row target-resolution error");
+
+        let notified_after_fail: Option<chrono::DateTime<chrono::Utc>> =
+            sqlx::query_scalar("SELECT notified_at FROM announcements WHERE id = $1")
+                .bind(announcement_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read notified_at after failed tick");
+        assert!(
+            notified_after_fail.is_none(),
+            "a transient target-resolution error must leave notified_at NULL so the \
+             announcement is retried, not dropped fire-once"
+        );
+
+        // Restore and re-tick: resolution now succeeds → dispatch → stamp.
+        sqlx::query("ALTER TABLE buildings_hidden RENAME TO buildings")
+            .execute(&pool)
+            .await
+            .expect("restore buildings");
+
+        scheduler
+            .dispatch_announcement_notifications()
+            .await
+            .expect("dispatch succeeds on retry");
+
+        let notified_after_retry: Option<chrono::DateTime<chrono::Utc>> =
+            sqlx::query_scalar("SELECT notified_at FROM announcements WHERE id = $1")
+                .bind(announcement_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read notified_at after retry");
+        assert!(
+            notified_after_retry.is_some(),
+            "a later tick must re-attempt and stamp notified_at once dispatch succeeds"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Issue #2612: a legitimately EMPTY audience (Ok(vec![]) — e.g. a target
+    // building with no residents) must be stamped as notified, NOT retried
+    // forever. This distinguishes "nobody to notify" (handled) from a
+    // target-resolution error (retry), which the dispatch pass treats
+    // differently.
+    // ------------------------------------------------------------------
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_announcement_notification_stamps_empty_audience(pool: sqlx::PgPool) {
+        let org = seed_org(&pool, "empty-aud").await;
+        let author = seed_user(&pool, "author@empty-aud.test").await;
+        // Building targeted but with NO residents → resolves to an empty set.
+        let building = seed_building(&pool, org, "EMPTY").await;
 
         let scheduled_at = chrono::Utc::now() - chrono::Duration::minutes(1);
         let announcement_id: Uuid = sqlx::query_scalar(
@@ -1794,55 +1967,40 @@ mod tests {
                 organization_id, author_id, title, content,
                 target_type, target_ids, status, scheduled_at
             )
-            VALUES ($1, $2, $3, $4, 'all'::announcement_target_type, $5, 'scheduled'::announcement_status, $6)
+            VALUES ($1, $2, $3, $4, 'building'::announcement_target_type, $5, 'scheduled'::announcement_status, $6)
             RETURNING id
             "#,
         )
         .bind(org)
         .bind(author)
-        .bind("Swallow guard")
+        .bind("Empty audience")
         .bind("body")
-        .bind(serde_json::json!([]))
+        .bind(serde_json::json!([building]))
         .bind(scheduled_at)
         .fetch_one(&pool)
         .await
         .expect("seed scheduled announcement");
 
-        // Sabotage ONLY the target-resolution query's dependency. The `"all"`
-        // leg joins `user_memberships`; dropping it after the announcement is
-        // seeded leaves `publish_scheduled()` (an UPDATE against
-        // `announcements` alone) unaffected, so the failure is isolated to
-        // target resolution — exactly the "transient failure mid-fanout"
-        // scenario the fix defends against.
-        sqlx::query("DROP TABLE user_memberships CASCADE")
-            .execute(&pool)
-            .await
-            .expect("sabotage user_memberships");
-
         let scheduler = test_scheduler(pool.clone());
-        let result = scheduler.publish_scheduled_announcements().await;
+        scheduler
+            .publish_scheduled_announcements()
+            .await
+            .expect("publish scheduled announcements");
+        scheduler
+            .dispatch_announcement_notifications()
+            .await
+            .expect("dispatch empty-audience announcement");
 
-        assert!(
-            result.is_err(),
-            "a target-resolution query error must propagate as Err — coercing it \
-             into an empty target Vec makes `publish_scheduled_announcements` \
-             report Ok(()) while silently sending zero notifications for an \
-             announcement that is already marked published"
-        );
-
-        // The announcement was already flipped to `published` by
-        // `publish_scheduled()` before the sabotaged query ran — confirming
-        // that, so the test genuinely exercises "published but notification
-        // targets failed to resolve" rather than "publish itself failed".
-        let status: String =
-            sqlx::query_scalar("SELECT status::text FROM announcements WHERE id = $1")
+        let notified: Option<chrono::DateTime<chrono::Utc>> =
+            sqlx::query_scalar("SELECT notified_at FROM announcements WHERE id = $1")
                 .bind(announcement_id)
                 .fetch_one(&pool)
                 .await
-                .expect("read announcement status");
-        assert_eq!(
-            status, "published",
-            "announcement must already be published when target resolution fails"
+                .expect("read notified_at");
+        assert!(
+            notified.is_some(),
+            "an announcement with a legitimately empty audience must be stamped \
+             notified so it is not retried on every tick forever"
         );
     }
 
@@ -2043,6 +2201,116 @@ mod tests {
             scheduler.get_metrics().support_tooling_events_pruned,
             1,
             "a gated (skipped) prune must not advance the metric"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // IG3 regression (issue #2612): the vote-started notification path has the
+    // same fire-once shape as the announcement path — activation was committed
+    // in one tick and a transient target-resolution failure dropped the
+    // notification. Decoupling means activation only flips the vote to `active`
+    // (leaving `started_notified_at = NULL`) and a separate dispatch pass
+    // notifies + stamps only on success. This test activates a due vote, forces
+    // a target-resolution error on the first dispatch tick (renaming `units`
+    // away, breaking `get_vote_eligible_users`), asserts the watermark stays
+    // NULL (retryable), then restores and asserts a later tick stamps it.
+    // ------------------------------------------------------------------
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_vote_started_notification_retries_after_transient_error(pool: sqlx::PgPool) {
+        let org = seed_org(&pool, "vote-retry").await;
+        let author = seed_user(&pool, "author@vote-retry.test").await;
+        let building = seed_building(&pool, org, "VR").await;
+        let unit = seed_unit(&pool, building, "VR-1").await;
+        let owner = seed_user(&pool, "owner@vote-retry.test").await;
+        // get_vote_eligible_users only counts `resident_type = 'owner'`.
+        sqlx::query(
+            "INSERT INTO unit_residents (unit_id, user_id, resident_type) VALUES ($1, $2, 'owner')",
+        )
+        .bind(unit)
+        .bind(owner)
+        .execute(&pool)
+        .await
+        .expect("seed owner resident");
+
+        // A scheduled, due vote (start_at in the past, end_at in the future).
+        let start_at = chrono::Utc::now() - chrono::Duration::minutes(1);
+        let end_at = chrono::Utc::now() + chrono::Duration::days(1);
+        let vote_id: Uuid = sqlx::query_scalar(
+            r#"
+            INSERT INTO votes (organization_id, building_id, title, end_at, start_at, status, created_by)
+            VALUES ($1, $2, $3, $4, $5, 'scheduled'::vote_status, $6)
+            RETURNING id
+            "#,
+        )
+        .bind(org)
+        .bind(building)
+        .bind("Vote retry")
+        .bind(end_at)
+        .bind(start_at)
+        .bind(author)
+        .fetch_one(&pool)
+        .await
+        .expect("seed scheduled vote");
+
+        let scheduler = test_scheduler(pool.clone());
+
+        // Activate: flips to `active`, leaves started_notified_at NULL.
+        scheduler
+            .activate_scheduled_votes()
+            .await
+            .expect("activate scheduled votes");
+        let (status, started): (String, Option<chrono::DateTime<chrono::Utc>>) =
+            sqlx::query_as("SELECT status::text, started_notified_at FROM votes WHERE id = $1")
+                .bind(vote_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read status/started_notified_at after activate");
+        assert_eq!(status, "active", "activation must flip status to active");
+        assert!(
+            started.is_none(),
+            "activation must leave started_notified_at NULL (needs notification)"
+        );
+
+        // Tick 1 — sabotage target resolution: rename `units` away so
+        // `get_vote_eligible_users` (JOIN units) fails.
+        sqlx::query("ALTER TABLE units RENAME TO units_hidden")
+            .execute(&pool)
+            .await
+            .expect("rename units away");
+        scheduler
+            .dispatch_vote_started_notifications()
+            .await
+            .expect("dispatch tolerates a per-vote target-resolution error");
+        let started_after_fail: Option<chrono::DateTime<chrono::Utc>> =
+            sqlx::query_scalar("SELECT started_notified_at FROM votes WHERE id = $1")
+                .bind(vote_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read started_notified_at after failed tick");
+        assert!(
+            started_after_fail.is_none(),
+            "a transient target-resolution error must leave started_notified_at NULL \
+             so the vote-started notification is retried, not dropped fire-once"
+        );
+
+        // Restore and re-tick: resolution succeeds → dispatch → stamp.
+        sqlx::query("ALTER TABLE units_hidden RENAME TO units")
+            .execute(&pool)
+            .await
+            .expect("restore units");
+        scheduler
+            .dispatch_vote_started_notifications()
+            .await
+            .expect("dispatch succeeds on retry");
+        let started_after_retry: Option<chrono::DateTime<chrono::Utc>> =
+            sqlx::query_scalar("SELECT started_notified_at FROM votes WHERE id = $1")
+                .bind(vote_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read started_notified_at after retry");
+        assert!(
+            started_after_retry.is_some(),
+            "a later tick must re-attempt and stamp started_notified_at once dispatch succeeds"
         );
     }
 

--- a/backend/servers/api-server/src/services/scheduler/votes.rs
+++ b/backend/servers/api-server/src/services/scheduler/votes.rs
@@ -24,6 +24,12 @@ impl Scheduler {
     // ========================================================================
 
     /// Activate scheduled votes that have reached their start time.
+    ///
+    /// Issue #2612: this now ONLY flips due votes to `active` (leaving
+    /// `started_notified_at = NULL`). Dispatch is decoupled into
+    /// [`Self::dispatch_vote_started_notifications`] so a transient
+    /// target-resolution/dispatch failure retries on the next tick instead of
+    /// permanently dropping the vote-started notification.
     pub(super) async fn activate_scheduled_votes(&self) -> Result<(), sqlx::Error> {
         let activated = self.vote_repo.activate_scheduled_votes().await?;
 
@@ -35,59 +41,99 @@ impl Scheduler {
             );
 
             // Update metrics
-            {
-                let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
-                metrics.votes_activated += activated.len() as u64;
-            }
+            let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
+            metrics.votes_activated += activated.len() as u64;
+        }
 
-            // Send notifications for each activated vote
-            for vote in &activated {
-                // A DB error resolving the eligible voters must be surfaced
-                // (not coerced into an empty target set) so a failed dispatch
-                // is observable — mirrors `send_vote_reminders`.
-                let eligible_user_ids = match self.get_vote_eligible_users(vote.building_id).await {
-                    Ok(ids) => ids,
+        Ok(())
+    }
+
+    /// Dispatch vote-started notifications that have not yet been sent
+    /// (issue #2612 — durability half of the decoupled activate/notify flow).
+    ///
+    /// Selects `active AND started_notified_at IS NULL`, resolves eligible
+    /// owners, dispatches, and stamps `started_notified_at` ONLY on success. A
+    /// transient failure (target resolution OR dispatch) leaves the watermark
+    /// NULL so the next ~60s tick retries. An `Ok(vec![])` audience (building
+    /// with no eligible owners) IS stamped — there is nobody to notify, so the
+    /// vote is handled and must not retry forever.
+    pub(super) async fn dispatch_vote_started_notifications(&self) -> Result<(), sqlx::Error> {
+        let pending = self
+            .vote_repo
+            .find_active_pending_started_notification()
+            .await?;
+
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            count = pending.len(),
+            "Dispatching pending vote-started notifications"
+        );
+
+        for vote in &pending {
+            // A DB error resolving eligible voters is NOT an empty audience —
+            // leave the watermark NULL so it retries rather than being stamped
+            // with zero recipients.
+            let eligible_user_ids = match self.get_vote_eligible_users(vote.building_id).await {
+                Ok(ids) => ids,
+                Err(e) => {
+                    tracing::error!(
+                        vote_id = %vote.id,
+                        building_id = %vote.building_id,
+                        error = %e,
+                        "Failed to resolve vote-started notification targets; \
+                         leaving started_notified_at NULL so the next tick retries"
+                    );
+                    continue;
+                }
+            };
+
+            if !eligible_user_ids.is_empty() {
+                match self
+                    .notification_service
+                    .notify_vote_started(vote, &eligible_user_ids)
+                    .await
+                {
+                    Ok(sent) => {
+                        tracing::info!(
+                            vote_id = %vote.id,
+                            sent_count = sent,
+                            "Sent vote started notifications"
+                        );
+                    }
                     Err(e) => {
                         tracing::error!(
                             vote_id = %vote.id,
-                            building_id = %vote.building_id,
                             error = %e,
-                            "Failed to resolve vote-started notification targets; \
-                             skipping dispatch for this vote"
+                            "Failed to send vote started notifications; \
+                             leaving started_notified_at NULL so the next tick retries"
                         );
-                        Vec::new()
-                    }
-                };
-
-                if !eligible_user_ids.is_empty() {
-                    match self
-                        .notification_service
-                        .notify_vote_started(vote, &eligible_user_ids)
-                        .await
-                    {
-                        Ok(sent) => {
-                            tracing::info!(
-                                vote_id = %vote.id,
-                                sent_count = sent,
-                                "Sent vote started notifications"
-                            );
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                vote_id = %vote.id,
-                                error = %e,
-                                "Failed to send vote started notifications"
-                            );
-                        }
+                        continue;
                     }
                 }
+            }
+
+            if let Err(e) = self.vote_repo.mark_started_notified(vote.id).await {
+                tracing::error!(
+                    vote_id = %vote.id,
+                    error = %e,
+                    "Failed to stamp vote started_notified_at after dispatch; \
+                     next tick may resend"
+                );
             }
         }
 
         Ok(())
     }
 
-    /// Close expired votes and send result notifications.
+    /// Close expired votes (state flip only).
+    ///
+    /// Issue #2612: result-notification dispatch is decoupled into
+    /// [`Self::dispatch_vote_closed_notifications`]. `close_expired_votes` (repo)
+    /// clears `closed_notified_at` to NULL for the votes it closes so the
+    /// dispatch pass picks them up and can retry on a transient failure.
     pub(super) async fn close_expired_votes(&self) -> Result<(), sqlx::Error> {
         let closed_ids = self.vote_repo.close_expired_votes().await?;
 
@@ -99,86 +145,143 @@ impl Scheduler {
             );
 
             // Update metrics
-            {
-                let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
-                metrics.votes_closed += closed_ids.len() as u64;
-            }
+            let mut metrics = self.metrics.lock().unwrap_or_else(|e| e.into_inner());
+            metrics.votes_closed += closed_ids.len() as u64;
+        }
 
-            // Batch-fetch participants for all closed votes in a single query
-            // (was N+1: one SELECT per closed vote). Group by vote_id so each
-            // iteration below has its participant list ready in memory.
-            let participants_by_vote: std::collections::HashMap<uuid::Uuid, Vec<uuid::Uuid>> =
-                match self.get_vote_participants_batch(&closed_ids).await {
-                    Ok(map) => map,
-                    Err(e) => {
-                        tracing::error!(
-                            error = %e,
-                            "Failed to batch-fetch vote participants; falling back to empty map"
-                        );
-                        std::collections::HashMap::new()
+        Ok(())
+    }
+
+    /// Dispatch closed-vote result notifications that have not yet been sent
+    /// (issue #2612 — durability half of the decoupled close/notify flow).
+    ///
+    /// Selects `closed AND closed_notified_at IS NULL`, loads each vote +
+    /// results + participants, dispatches, and stamps `closed_notified_at` ONLY
+    /// on success. A transient failure at any step (vote/result load, dispatch)
+    /// leaves the watermark NULL so the next ~60s tick retries. `Ok(None)` on
+    /// the vote/result load (row genuinely gone) IS stamped so the pass does not
+    /// spin on a permanently-missing row.
+    pub(super) async fn dispatch_vote_closed_notifications(&self) -> Result<(), sqlx::Error> {
+        let pending_ids = self.vote_repo.find_closed_pending_notification().await?;
+
+        if pending_ids.is_empty() {
+            return Ok(());
+        }
+
+        tracing::info!(
+            count = pending_ids.len(),
+            "Dispatching pending closed-vote result notifications"
+        );
+
+        // Batch-fetch participants for all pending votes in a single query
+        // (avoids N+1). A batch error leaves the whole set unstamped for retry.
+        let participants_by_vote: std::collections::HashMap<uuid::Uuid, Vec<uuid::Uuid>> =
+            match self.get_vote_participants_batch(&pending_ids).await {
+                Ok(map) => map,
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        "Failed to batch-fetch vote participants; leaving \
+                         closed_notified_at NULL so the next tick retries"
+                    );
+                    return Ok(());
+                }
+            };
+
+        for vote_id in &pending_ids {
+            // Note: Scheduler runs in background without user context - RLS not applicable
+            #[allow(deprecated)]
+            let vote_result = self.vote_repo.find_by_id(*vote_id).await;
+            #[allow(deprecated)]
+            let results_result = self.vote_repo.get_results(*vote_id).await;
+
+            // A DB error loading the vote or its results leaves the watermark
+            // NULL for retry. `Ok(None)` (row genuinely gone) is stamped below
+            // so the pass does not spin forever on a missing row.
+            let vote = match vote_result {
+                Ok(Some(vote)) => vote,
+                Ok(None) => {
+                    tracing::warn!(
+                        vote_id = %vote_id,
+                        "Closed vote missing for result notification; stamping to \
+                         stop retrying a permanently-absent row"
+                    );
+                    if let Err(e) = self.vote_repo.mark_closed_notified(*vote_id).await {
+                        tracing::error!(vote_id = %vote_id, error = %e, "Failed to stamp closed_notified_at for missing vote");
                     }
-                };
-
-            // Send notifications for each closed vote
-            for vote_id in &closed_ids {
-                // Get the vote with results
-                // Note: Scheduler runs in background without user context - RLS not applicable
-                #[allow(deprecated)]
-                let vote_result = self.vote_repo.find_by_id(*vote_id).await;
-                #[allow(deprecated)]
-                let results_result = self.vote_repo.get_results(*vote_id).await;
-                // Surface DB errors on the vote/result lookups instead of
-                // letting `if let Ok(Some(..))` silently drop the `Err` arm —
-                // otherwise a failed closed-vote dispatch is invisible.
-                // `Ok(None)` (vote genuinely gone) stays a silent skip.
-                if let Err(e) = &vote_result {
+                    continue;
+                }
+                Err(e) => {
                     tracing::error!(
                         vote_id = %vote_id,
                         error = %e,
                         "Failed to load closed vote for result notification; \
-                         skipping dispatch for this vote"
+                         leaving closed_notified_at NULL so the next tick retries"
                     );
+                    continue;
                 }
-                if let Err(e) = &results_result {
+            };
+            let results = match results_result {
+                Ok(Some(results)) => results,
+                Ok(None) => {
+                    tracing::warn!(
+                        vote_id = %vote_id,
+                        "Closed vote results missing for result notification; \
+                         stamping to stop retrying a permanently-absent row"
+                    );
+                    if let Err(e) = self.vote_repo.mark_closed_notified(*vote_id).await {
+                        tracing::error!(vote_id = %vote_id, error = %e, "Failed to stamp closed_notified_at for missing results");
+                    }
+                    continue;
+                }
+                Err(e) => {
                     tracing::error!(
                         vote_id = %vote_id,
                         error = %e,
                         "Failed to load vote results for result notification; \
-                         skipping dispatch for this vote"
+                         leaving closed_notified_at NULL so the next tick retries"
                     );
+                    continue;
                 }
-                if let Ok(Some(vote)) = vote_result {
-                    if let Ok(Some(results)) = results_result {
-                        // Participants pre-fetched by batch query above.
-                        let participant_ids = participants_by_vote
-                            .get(vote_id)
-                            .cloned()
-                            .unwrap_or_default();
+            };
 
-                        if !participant_ids.is_empty() {
-                            match self
-                                .notification_service
-                                .notify_vote_closed(&vote, &results, &participant_ids)
-                                .await
-                            {
-                                Ok(sent) => {
-                                    tracing::info!(
-                                        vote_id = %vote_id,
-                                        sent_count = sent,
-                                        "Sent vote closed notifications"
-                                    );
-                                }
-                                Err(e) => {
-                                    tracing::error!(
-                                        vote_id = %vote_id,
-                                        error = %e,
-                                        "Failed to send vote closed notifications"
-                                    );
-                                }
-                            }
-                        }
+            let participant_ids = participants_by_vote
+                .get(vote_id)
+                .cloned()
+                .unwrap_or_default();
+
+            if !participant_ids.is_empty() {
+                match self
+                    .notification_service
+                    .notify_vote_closed(&vote, &results, &participant_ids)
+                    .await
+                {
+                    Ok(sent) => {
+                        tracing::info!(
+                            vote_id = %vote_id,
+                            sent_count = sent,
+                            "Sent vote closed notifications"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            vote_id = %vote_id,
+                            error = %e,
+                            "Failed to send vote closed notifications; \
+                             leaving closed_notified_at NULL so the next tick retries"
+                        );
+                        continue;
                     }
                 }
+            }
+
+            if let Err(e) = self.vote_repo.mark_closed_notified(*vote_id).await {
+                tracing::error!(
+                    vote_id = %vote_id,
+                    error = %e,
+                    "Failed to stamp vote closed_notified_at after dispatch; \
+                     next tick may resend"
+                );
             }
         }
 


### PR DESCRIPTION
## Task

Follow-up (Closes #2612): scheduled announcement / vote-started / closed-vote notifications are fire-once — a transient target-resolution error permanently DROPS them. Decouple "published/activated" from "notified": add a `notified_at TIMESTAMPTZ NULL` column (additive migration) to announcements (and the votes equivalent); `publish_scheduled()` sets published state but leaves `notified_at = NULL`; add a scheduler pass that selects `published AND notified_at IS NULL`, resolves targets, dispatches, and stamps `notified_at` only on success (mirror the `last_*_prune_at` / `fire_due_report_schedules` "stamp only after success" pattern). Add an IG3 regression test that forces a target-resolution error on the first tick and asserts the notification is re-attempted (and eventually stamped) on a later tick. Scope: backend (`services/scheduler/mod.rs` + announcement/vote repositories + one additive migration).

## Owner
pm-tech-lead (concrete specialist: rust-backend / pm-backend)

## What changed

**Migration `00228_announcement_vote_notified_at.sql` (additive):**
- `announcements.notified_at TIMESTAMPTZ NULL` (single "published" notification watermark).
- `votes.started_notified_at` + `votes.closed_notified_at` — votes have two distinct notifiable transitions (started / closed), so each gets its own watermark.
- Partial indexes for each `<state> AND <watermark> IS NULL` dispatch select.
- **Backfill** stamps every already-transitioned row `NOW()` so this additive column does NOT trigger a one-time mass re-notification of the historical backlog on deploy; rows still in the pre-notification state keep NULL.

**Watermark semantics (`NULL` = "needs notification"):**
- Scheduler's automated transition (`publish_scheduled` / `activate_scheduled` / `close_expired`) leaves the watermark NULL so the dispatch pass picks the row up.
- Manual transitions (`publish_rls`, vote `publish()`→active, vote `close()` from the manager route) stamp the watermark `NOW()`, so the scheduler does NOT fan out a notification for them — **preserving the pre-existing behaviour** that manual publish/close did not trigger a scheduler notification. `close_expired_votes` re-clears the watermark to NULL for the votes IT closes.

**Scheduler (`services/scheduler/{mod.rs,votes.rs}`):**
- `publish_scheduled_announcements` / `activate_scheduled_votes` / `close_expired_votes` now ONLY flip state.
- New decoupled dispatch passes: `dispatch_announcement_notifications`, `dispatch_vote_started_notifications`, `dispatch_vote_closed_notifications`. Each selects rows in the target state whose watermark IS NULL, resolves targets, dispatches, and stamps **only on success** (mirrors the `last_*_prune_at` / `fire_due_report_schedules` pattern). A transient target-resolution/dispatch error leaves the watermark NULL → next ~60s tick retries. A legitimately empty audience (`Ok(vec[])`) IS stamped so it does not retry forever; only an `Err` retries.
- Wired all three dispatch passes into `run_scheduled_tasks` right after their state-flip counterpart.

**Repositories (`db/repositories/{announcement.rs,vote.rs}`):** new `find_*_pending_notification` selectors + idempotent `mark_*_notified` stampers; `publish_scheduled_rls` now sets `notified_at = NULL` explicitly.

Note: all queries here are runtime `sqlx::query_as::<_, T>` (no compile-time macros; the repo has no `.sqlx` offline dir), so no `cargo sqlx prepare` is needed. Additive columns are safe for the existing `SELECT *` runtime queries (FromRow ignores unknown columns).

## Verification

```
VERIFY-PLAN base=1f2a35151df4e8d2632655dc4cef902878e211c4 files=5
  # WARN: migrations touched — SQL truth needs a live DB (localhost:5433); runtime sqlx compiles without one, so run DB-backed tests before merge
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```

Ran locally:
- `cd backend && cargo fmt --all -- --check` → **exit 0** (clean).
- `cd backend && cargo clippy -p db --lib` → **exit 0** (clean; covers the announcement/vote repository changes).

Deferred to CI `backend.yml` (known limitation: the local backend compile of `api-server` is blocked by `utoipa-swagger-ui` GitHub egress, and the workspace test band needs a live Postgres): full-workspace `cargo clippy` + `cargo test` (including the new `#[sqlx::test]` DB-backed regressions).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## IG3 regression tests (added, `services/scheduler/mod.rs`)
- `test_announcement_notification_retries_after_transient_error` — publishes a due announcement (asserts `notified_at` NULL), forces a target-resolution error on the first dispatch tick (transiently renames `buildings` away), asserts `notified_at` **stays NULL** (retryable, not dropped), then restores and asserts a later tick dispatches and **stamps** `notified_at`.
- `test_vote_started_notification_retries_after_transient_error` — same shape for the vote-started path (renames `units` away to break `get_vote_eligible_users`).
- `test_announcement_notification_stamps_empty_audience` — a legitimately empty audience is stamped (not retried forever).

The previous `test_publish_scheduled_announcements_propagates_target_resolution_error` asserted the now-obsolete pre-decouple semantics (publish loop propagates the target error) and was replaced by the retry tests above.

## Notes
- `scope_drift=false` under the concrete owner `pm-backend` (scope-check exit 0); the diff is entirely within backend scheduler + db repositories + one migration. (The nominal `pm-tech-lead` owner_role does not map these backend paths, but the authoritative area owner is pm-backend per the task.)
- `code_reuse_warn=none`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NT7dxu8pngDSQU3ALGXfVn)_