### PR TITLE
dx-fixme-admin-web-platform-settings-patch-endpoint-retry1: add PATCH/GET /api/v1/platform-admin/settings

### DIFF
--- a/backend/crates/db/migrations/00228_create_platform_settings.sql
+++ b/backend/crates/db/migrations/00228_create_platform_settings.sql
@@ -1,0 +1,31 @@
+-- Migration: 00228_create_platform_settings.sql
+--
+-- Global, operator-controlled platform settings backing the admin-web
+-- `/admin/platform` page (`PATCH /api/v1/platform-admin/settings`).
+--
+-- Unlike `tenant_settings` (00137), which is per-organization and RLS-isolated,
+-- these settings are platform-wide: a single row shared across the whole
+-- deployment. Access is gated entirely at the application layer by the
+-- platform-admin capability middleware (`RequireCapability(SiteSettingsWrite)`
+-- + a validated super-admin token), so this table follows the same no-RLS
+-- pattern as the other platform-operator tables (e.g. health monitoring,
+-- 00074): there is no per-tenant row to isolate.
+
+CREATE TABLE IF NOT EXISTS platform_settings (
+    -- Singleton guard: exactly one row, always id = 1.
+    id INTEGER PRIMARY KEY DEFAULT 1,
+    maintenance_mode BOOLEAN NOT NULL DEFAULT false,
+    signup_enabled BOOLEAN NOT NULL DEFAULT true,
+    support_email TEXT NOT NULL DEFAULT '',
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- `updated_by` references users(id); `ON DELETE SET NULL` so a removed
+    -- operator does not cascade-delete the settings row.
+    updated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    CONSTRAINT platform_settings_singleton CHECK (id = 1)
+);
+
+-- Seed the singleton row so reads always return defaults before the first write.
+INSERT INTO platform_settings (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+COMMENT ON TABLE platform_settings IS
+    'Global operator-controlled platform settings (singleton row). Written via PATCH /api/v1/platform-admin/settings.';

--- a/backend/crates/db/migrations/00229_create_platform_settings.sql
+++ b/backend/crates/db/migrations/00229_create_platform_settings.sql
@@ -1,4 +1,4 @@
--- Migration: 00228_create_platform_settings.sql
+-- Migration: 00229_create_platform_settings.sql
 --
 -- Global, operator-controlled platform settings backing the admin-web
 -- `/admin/platform` page (`PATCH /api/v1/platform-admin/settings`).

--- a/backend/crates/db/src/models/platform_admin.rs
+++ b/backend/crates/db/src/models/platform_admin.rs
@@ -99,6 +99,27 @@ pub struct ReactivateOrganizationRequest {
     pub note: Option<String>,
 }
 
+// ==================== Platform Settings Models ====================
+
+/// Global, operator-controlled platform settings (singleton).
+///
+/// Backs the `platform_settings` table (migration 00228). Unlike the
+/// per-tenant `tenant_settings` store, this is a single row shared across the
+/// whole deployment, written via `PATCH /api/v1/platform-admin/settings`.
+#[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
+pub struct PlatformSettings {
+    /// Whether the platform is in maintenance mode.
+    pub maintenance_mode: bool,
+    /// Whether public sign-up is enabled.
+    pub signup_enabled: bool,
+    /// Operator support contact email (may be empty).
+    pub support_email: String,
+    /// When the settings were last written.
+    pub updated_at: DateTime<Utc>,
+    /// Operator who last wrote the settings (null after operator deletion).
+    pub updated_by: Option<Uuid>,
+}
+
 // ==================== Feature Flag Models ====================
 
 /// Feature flag entity.

--- a/backend/crates/db/src/models/platform_admin.rs
+++ b/backend/crates/db/src/models/platform_admin.rs
@@ -103,7 +103,7 @@ pub struct ReactivateOrganizationRequest {
 
 /// Global, operator-controlled platform settings (singleton).
 ///
-/// Backs the `platform_settings` table (migration 00228). Unlike the
+/// Backs the `platform_settings` table (migration 00229). Unlike the
 /// per-tenant `tenant_settings` store, this is a single row shared across the
 /// whole deployment, written via `PATCH /api/v1/platform-admin/settings`.
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]

--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -28,7 +28,7 @@
 
 use crate::models::fault::StatusCount as FaultStatusCount;
 use crate::models::platform_admin::{
-    AdminOrganizationDetail, OrganizationDetailMetrics, OrganizationMetrics,
+    AdminOrganizationDetail, OrganizationDetailMetrics, OrganizationMetrics, PlatformSettings,
 };
 use crate::models::Organization;
 use crate::repositories::fault::fault_counts_by_status;
@@ -47,6 +47,51 @@ impl PlatformAdminRepository {
     /// Create a new PlatformAdminRepository.
     pub fn new(pool: DbPool) -> Self {
         Self { pool }
+    }
+
+    /// Read the singleton platform settings row (migration 00228).
+    ///
+    /// The row is seeded by the migration, so this always returns a row on a
+    /// migrated database.
+    pub async fn get_platform_settings(&self) -> Result<PlatformSettings, SqlxError> {
+        sqlx::query_as::<_, PlatformSettings>(
+            r#"
+            SELECT maintenance_mode, signup_enabled, support_email, updated_at, updated_by
+            FROM platform_settings
+            WHERE id = 1
+            "#,
+        )
+        .fetch_one(&self.pool)
+        .await
+    }
+
+    /// Patch the singleton platform settings row. `None` fields are left
+    /// unchanged (partial `PATCH` semantics). Returns the updated row.
+    pub async fn update_platform_settings(
+        &self,
+        maintenance_mode: Option<bool>,
+        signup_enabled: Option<bool>,
+        support_email: Option<String>,
+        actor: Uuid,
+    ) -> Result<PlatformSettings, SqlxError> {
+        sqlx::query_as::<_, PlatformSettings>(
+            r#"
+            UPDATE platform_settings
+            SET maintenance_mode = COALESCE($1, maintenance_mode),
+                signup_enabled   = COALESCE($2, signup_enabled),
+                support_email    = COALESCE($3, support_email),
+                updated_by       = $4,
+                updated_at       = NOW()
+            WHERE id = 1
+            RETURNING maintenance_mode, signup_enabled, support_email, updated_at, updated_by
+            "#,
+        )
+        .bind(maintenance_mode)
+        .bind(signup_enabled)
+        .bind(support_email)
+        .bind(actor)
+        .fetch_one(&self.pool)
+        .await
     }
 
     /// List all organizations with metrics (platform admin view).

--- a/backend/crates/db/src/repositories/platform_admin.rs
+++ b/backend/crates/db/src/repositories/platform_admin.rs
@@ -49,7 +49,7 @@ impl PlatformAdminRepository {
         Self { pool }
     }
 
-    /// Read the singleton platform settings row (migration 00228).
+    /// Read the singleton platform settings row (migration 00229).
     ///
     /// The row is seeded by the migration, so this always returns a row on a
     /// migrated database.

--- a/backend/servers/api-server/src/routes/platform_admin/mod.rs
+++ b/backend/servers/api-server/src/routes/platform_admin/mod.rs
@@ -17,12 +17,13 @@ pub mod audit;
 pub mod features;
 pub mod oauth;
 pub mod ops;
+pub mod settings;
 pub mod tenants;
 
 use admin_core::{require_capability, Capability};
 use axum::{
     http::StatusCode,
-    routing::{delete, get, post, put},
+    routing::{delete, get, patch, post, put},
     Json, Router,
 };
 use common::errors::ErrorResponse;
@@ -50,6 +51,7 @@ pub use ops::{
     get_thresholds, get_upcoming_maintenance, get_upcoming_maintenance_admin,
     list_system_announcements, schedule_maintenance, update_system_announcement, update_threshold,
 };
+pub use settings::{get_platform_settings, update_platform_settings};
 pub use tenants::{
     get_organization, get_platform_stats, list_organizations, reactivate_organization,
     suspend_organization,
@@ -220,6 +222,16 @@ pub fn router() -> Router<AppState> {
         .route(
             "/onboarding-config",
             get(get_onboarding_config).layer(require_capability(Capability::SiteSettingsRead)),
+        )
+        // Platform settings (global operator settings — admin-web /admin/platform)
+        .route(
+            "/settings",
+            get(get_platform_settings).layer(require_capability(Capability::SiteSettingsRead)),
+        )
+        .route(
+            "/settings",
+            patch(update_platform_settings)
+                .layer(require_capability(Capability::SiteSettingsWrite)),
         )
         // Agency provisioning (Phase 1: Tenant Resolution).
         // Merged in from `agency_provisioning` so the new

--- a/backend/servers/api-server/src/routes/platform_admin/settings.rs
+++ b/backend/servers/api-server/src/routes/platform_admin/settings.rs
@@ -1,0 +1,139 @@
+//! Platform settings handlers.
+//!
+//! Backs the admin-web `/admin/platform` page. These are global,
+//! operator-controlled settings (never tenant-facing) persisted in the
+//! `platform_settings` singleton table (migration 00228).
+//!
+//! Both handlers are gated by the platform-admin capability middleware
+//! (`RequireCapability(SiteSettingsWrite)` on the route) plus the
+//! [`extract_super_admin_token`] JWT-role check as defence in depth.
+
+use admin_core::RequireCapability;
+use axum::{extract::State, http::StatusCode, Json};
+use common::errors::ErrorResponse;
+use db::models::platform_admin::PlatformSettings;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::extract_super_admin_token;
+use crate::state::AppState;
+
+/// Platform settings payload.
+///
+/// The JSON keys are the dotted keys used by the admin-web `SettingsForm`
+/// (`platform.maintenance_mode`, …), so the response round-trips directly into
+/// the form and the request accepts what the form submits.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PlatformSettingsResponse {
+    /// Whether the platform is in maintenance mode.
+    #[serde(rename = "platform.maintenance_mode")]
+    pub maintenance_mode: bool,
+    /// Whether public sign-up is enabled.
+    #[serde(rename = "platform.signup_enabled")]
+    pub signup_enabled: bool,
+    /// Operator support contact email.
+    #[serde(rename = "platform.support_email")]
+    pub support_email: String,
+}
+
+impl From<PlatformSettings> for PlatformSettingsResponse {
+    fn from(s: PlatformSettings) -> Self {
+        Self {
+            maintenance_mode: s.maintenance_mode,
+            signup_enabled: s.signup_enabled,
+            support_email: s.support_email,
+        }
+    }
+}
+
+/// `PATCH` request body. Every field is optional — omitted fields are left
+/// unchanged (partial update).
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdatePlatformSettingsRequest {
+    /// Whether the platform is in maintenance mode.
+    #[serde(rename = "platform.maintenance_mode", default)]
+    pub maintenance_mode: Option<bool>,
+    /// Whether public sign-up is enabled.
+    #[serde(rename = "platform.signup_enabled", default)]
+    pub signup_enabled: Option<bool>,
+    /// Operator support contact email.
+    #[serde(rename = "platform.support_email", default)]
+    pub support_email: Option<String>,
+}
+
+fn db_error(context: &str) -> impl Fn(sqlx::Error) -> (StatusCode, Json<ErrorResponse>) + '_ {
+    move |e| {
+        tracing::error!(error = %e, "{context}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("DATABASE_ERROR", context)),
+        )
+    }
+}
+
+/// Get the current platform settings.
+#[utoipa::path(
+    get,
+    path = "/api/v1/platform-admin/settings",
+    responses(
+        (status = 200, description = "Platform settings retrieved", body = PlatformSettingsResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - requires SuperAdmin role"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("bearer_auth" = [])),
+    tag = "Platform Admin - Settings"
+)]
+pub async fn get_platform_settings(
+    _cap: RequireCapability,
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<PlatformSettingsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    extract_super_admin_token(&headers, &state)?;
+
+    let settings = state
+        .platform_admin_repo
+        .get_platform_settings()
+        .await
+        .map_err(db_error("Failed to read platform settings"))?;
+
+    Ok(Json(settings.into()))
+}
+
+/// Update (patch) the platform settings.
+#[utoipa::path(
+    patch,
+    path = "/api/v1/platform-admin/settings",
+    request_body = UpdatePlatformSettingsRequest,
+    responses(
+        (status = 200, description = "Platform settings updated", body = PlatformSettingsResponse),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden - requires SuperAdmin role"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("bearer_auth" = [])),
+    tag = "Platform Admin - Settings"
+)]
+pub async fn update_platform_settings(
+    _cap: RequireCapability,
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Json(request): Json<UpdatePlatformSettingsRequest>,
+) -> Result<Json<PlatformSettingsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let (user_id, _email) = extract_super_admin_token(&headers, &state)?;
+
+    let settings = state
+        .platform_admin_repo
+        .update_platform_settings(
+            request.maintenance_mode,
+            request.signup_enabled,
+            request.support_email,
+            user_id,
+        )
+        .await
+        .map_err(db_error("Failed to update platform settings"))?;
+
+    tracing::info!(actor = %user_id, "Platform settings updated");
+
+    Ok(Json(settings.into()))
+}

--- a/backend/servers/api-server/src/routes/platform_admin/settings.rs
+++ b/backend/servers/api-server/src/routes/platform_admin/settings.rs
@@ -2,7 +2,7 @@
 //!
 //! Backs the admin-web `/admin/platform` page. These are global,
 //! operator-controlled settings (never tenant-facing) persisted in the
-//! `platform_settings` singleton table (migration 00228).
+//! `platform_settings` singleton table (migration 00229).
 //!
 //! Both handlers are gated by the platform-admin capability middleware
 //! (`RequireCapability(SiteSettingsWrite)` on the route) plus the

--- a/backend/servers/api-server/tests/suite_7.rs
+++ b/backend/servers/api-server/tests/suite_7.rs
@@ -17,6 +17,8 @@ mod platform_admin_authz_batch2_tests;
 mod platform_admin_authz_batch3_tests;
 #[path = "suites/platform_admin_authz_tests.rs"]
 mod platform_admin_authz_tests;
+#[path = "suites/platform_settings_patch_tests.rs"]
+mod platform_settings_patch_tests;
 #[path = "suites/portal_webhook_signature_tests.rs"]
 mod portal_webhook_signature_tests;
 #[path = "suites/predictive_maintenance_happy_path_tests.rs"]

--- a/backend/servers/api-server/tests/suites/platform_settings_patch_tests.rs
+++ b/backend/servers/api-server/tests/suites/platform_settings_patch_tests.rs
@@ -122,8 +122,16 @@ async fn patch_platform_settings_persists(pool: PgPool) {
     );
 
     let body = resp.json_value();
-    assert_eq!(body["platform.maintenance_mode"], json!(true), "body: {body}");
-    assert_eq!(body["platform.signup_enabled"], json!(false), "body: {body}");
+    assert_eq!(
+        body["platform.maintenance_mode"],
+        json!(true),
+        "body: {body}"
+    );
+    assert_eq!(
+        body["platform.signup_enabled"],
+        json!(false),
+        "body: {body}"
+    );
     assert_eq!(
         body["platform.support_email"],
         json!("ops@example.com"),
@@ -187,7 +195,11 @@ async fn patch_platform_settings_partial_update(pool: PgPool) {
     );
     let body = resp.json_value();
     // Untouched fields keep their prior values.
-    assert_eq!(body["platform.maintenance_mode"], json!(true), "body: {body}");
+    assert_eq!(
+        body["platform.maintenance_mode"],
+        json!(true),
+        "body: {body}"
+    );
     assert_eq!(body["platform.signup_enabled"], json!(true), "body: {body}");
     // The patched field changed.
     assert_eq!(

--- a/backend/servers/api-server/tests/suites/platform_settings_patch_tests.rs
+++ b/backend/servers/api-server/tests/suites/platform_settings_patch_tests.rs
@@ -1,0 +1,198 @@
+//! Regression test for `PATCH /api/v1/platform-admin/settings`.
+//!
+//! Guards the platform-settings write endpoint that unblocks the admin-web
+//! `/admin/platform` Save button. Before this endpoint existed the route was
+//! absent from the router, so a `PATCH` (and the sibling `GET`) returned
+//! `404 Not Found` — this suite fails on that baseline (IG3) and passes once
+//! the route + handler + repository land.
+//!
+//! Provisioning mirrors `admin_platform_happy_path_tests.rs`: a platform
+//! principal, MFA-enrolled, holding a single non-MFA-gated capability grant.
+
+#![allow(dead_code)]
+
+use api_server::services::JwtService;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::common::TestApp;
+
+const TEST_JWT_SECRET: &str =
+    "test-secret-key-that-is-at-least-64-characters-long-for-testing-purposes";
+
+/// Seed a platform-principal user and return its id.
+async fn seed_platform_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at, principal_kind)
+        VALUES ($1, 'h', 'Platform Settings Test', 'active', NOW(), 'platform')
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed platform user")
+}
+
+/// Mark the user as MFA-enrolled (the capability gate's step-2.5 wall).
+async fn enroll_mfa(pool: &PgPool, user_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO user_2fa (user_id, secret, enabled, enabled_at, backup_codes, backup_codes_remaining)
+        VALUES ($1, 'unused-secret', true, NOW(), '[]'::jsonb, 0)
+        ON CONFLICT (user_id) DO UPDATE SET enabled = true, enabled_at = NOW()
+        "#,
+    )
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("enroll mfa");
+}
+
+/// Grant a single named `capability` with `mfa_required = false` so the
+/// extractor's recent-MFA recency check is skipped. `granted_by` must
+/// reference a distinct real user (FK + app-layer no-self-grant rule).
+async fn grant_capability(pool: &PgPool, user_id: Uuid, granted_by: Uuid, capability: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO capability_grants
+            (user_id, capability, granted_by, expires_at, mfa_required, note)
+        VALUES ($1, $2, $3, NULL, false, 'platform-settings-patch-test')
+        "#,
+    )
+    .bind(user_id)
+    .bind(capability)
+    .bind(granted_by)
+    .execute(pool)
+    .await
+    .expect("grant capability");
+}
+
+/// Mint a platform-kind bearer JWT validated by `TestApp`'s JWT secret.
+fn mint_platform_token(user_id: Uuid, email: &str) -> String {
+    let svc = JwtService::new(TEST_JWT_SECRET).expect("jwt service");
+    svc.generate_access_token_with_kind(
+        user_id,
+        email,
+        "Platform Settings Test",
+        None,
+        Some(vec!["super_admin".to_string()]),
+        Some("platform".to_string()),
+    )
+    .expect("mint token")
+}
+
+/// Provision a fully-authorized platform admin holding `capability` and return
+/// its bearer token.
+async fn authorized_admin_token(pool: &PgPool, label: &str, capability: &str) -> String {
+    let email = format!("psp-admin-{label}-{}@test.local", Uuid::new_v4());
+    let granter_email = format!("psp-granter-{label}-{}@test.local", Uuid::new_v4());
+    let admin = seed_platform_user(pool, &email).await;
+    let granter = seed_platform_user(pool, &granter_email).await;
+    enroll_mfa(pool, admin).await;
+    grant_capability(pool, admin, granter, capability).await;
+    mint_platform_token(admin, &email)
+}
+
+/// PATCH the platform settings, then read them back — asserting the write took
+/// effect and persisted. Fails on the pre-endpoint baseline (404).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn patch_platform_settings_persists(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let write_token = authorized_admin_token(&pool, "write", "site_settings_write").await;
+
+    let resp = app
+        .patch("/api/v1/platform-admin/settings")
+        .bearer(&write_token)
+        .json(json!({
+            "platform.maintenance_mode": true,
+            "platform.signup_enabled": false,
+            "platform.support_email": "ops@example.com",
+        }))
+        .send()
+        .await;
+
+    assert!(
+        resp.status.is_success(),
+        "PATCH platform settings: expected 2xx, got {} — body: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let body = resp.json_value();
+    assert_eq!(body["platform.maintenance_mode"], json!(true), "body: {body}");
+    assert_eq!(body["platform.signup_enabled"], json!(false), "body: {body}");
+    assert_eq!(
+        body["platform.support_email"],
+        json!("ops@example.com"),
+        "body: {body}"
+    );
+
+    // Read back via GET to confirm the write persisted.
+    let read_token = authorized_admin_token(&pool, "read", "site_settings_read").await;
+    let get_resp = app
+        .get("/api/v1/platform-admin/settings")
+        .bearer(&read_token)
+        .send()
+        .await;
+
+    assert!(
+        get_resp.status.is_success(),
+        "GET platform settings: expected 2xx, got {} — body: {}",
+        get_resp.status,
+        get_resp.text()
+    );
+    let got = get_resp.json_value();
+    assert_eq!(got["platform.maintenance_mode"], json!(true), "got: {got}");
+    assert_eq!(got["platform.signup_enabled"], json!(false), "got: {got}");
+    assert_eq!(
+        got["platform.support_email"],
+        json!("ops@example.com"),
+        "got: {got}"
+    );
+}
+
+/// A partial PATCH leaves omitted fields unchanged.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn patch_platform_settings_partial_update(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+    let write_token = authorized_admin_token(&pool, "partial", "site_settings_write").await;
+
+    // Seed a known state.
+    app.patch("/api/v1/platform-admin/settings")
+        .bearer(&write_token)
+        .json(json!({
+            "platform.maintenance_mode": true,
+            "platform.signup_enabled": true,
+            "platform.support_email": "first@example.com",
+        }))
+        .send()
+        .await;
+
+    // Patch only one field.
+    let resp = app
+        .patch("/api/v1/platform-admin/settings")
+        .bearer(&write_token)
+        .json(json!({ "platform.support_email": "second@example.com" }))
+        .send()
+        .await;
+
+    assert!(
+        resp.status.is_success(),
+        "partial PATCH: expected 2xx, got {} — body: {}",
+        resp.status,
+        resp.text()
+    );
+    let body = resp.json_value();
+    // Untouched fields keep their prior values.
+    assert_eq!(body["platform.maintenance_mode"], json!(true), "body: {body}");
+    assert_eq!(body["platform.signup_enabled"], json!(true), "body: {body}");
+    // The patched field changed.
+    assert_eq!(
+        body["platform.support_email"],
+        json!("second@example.com"),
+        "body: {body}"
+    );
+}


### PR DESCRIPTION
## Task
admin-web platform-settings Save blocked: PATCH /api/v1/platform-admin/settings endpoint missing. Implement the missing endpoint (route + handler + repository update as needed) so Save works, plus a failing-on-dev regression test (IG3). Keep scope tight to this endpoint.

## Owner
pm-devops (hint only — this is backend api-server work; see Scope drift)

## What landed
- **Migration `00228_create_platform_settings.sql`** — global, operator-controlled `platform_settings` singleton table (one row, `id = 1`, seeded with defaults). Unlike per-tenant `tenant_settings` (00137) these settings are platform-wide, so the table follows the no-RLS pattern of the other platform-operator tables (health monitoring, 00074); access is gated entirely at the app layer.
- **Model** `PlatformSettings` (`db::models::platform_admin`).
- **Repository** `PlatformAdminRepository::get_platform_settings` + `update_platform_settings` (partial `COALESCE` patch). Runtime `sqlx::query_as` — the repo-wide convention (no `.sqlx/` offline cache), so no `cargo sqlx prepare` needed.
- **Handlers + routes** `GET`/`PATCH /api/v1/platform-admin/settings` in `routes/platform_admin/settings.rs`, gated by `SiteSettingsRead` / `SiteSettingsWrite` capabilities + the `extract_super_admin_token` JWT check. Request/response JSON uses the dotted keys the admin-web `SettingsForm` already emits (`platform.maintenance_mode`, `platform.signup_enabled`, `platform.support_email`), so the payloads round-trip without a client change.

Scope kept to the endpoint: the admin-web `platform.tsx` re-enable (flip `readOnly` → real Save) is a separate frontend follow-up (needs api-client regen); this PR unblocks it.

## Verification
```
VERIFY-PLAN base=8f3dff5104b4d06d857471e584cdee66fa84a558 files=7
  # WARN: migrations touched — SQL truth needs a live DB (localhost:5433); runtime sqlx compiles without one, so run DB-backed tests before merge
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```

Local results (cloud sandbox):
- `cargo fmt --all -- --check` — **PASS** (full workspace).
- `cargo clippy -p db --lib` — **PASS** (model + repository compile clean).
- `cargo clippy --workspace` / `cargo test --workspace` — **could not run locally**: the `utoipa-swagger-ui` build script must download Swagger UI from `github.com/swagger-api`, which this session's egress policy returns **403** for (verified via proxy), so `api-server` cannot be compiled in the sandbox; there is also no local Postgres (`:5433` down, no Docker daemon). These are environment limits, not code failures.
- **Draft** so CI (`backend.yml`, which has GitHub + a Postgres service) is the authoritative gate: it compiles `api-server` and runs the regression test below. Do not merge until CI is green.

## IG3 — failing-on-dev regression test
`backend/servers/api-server/tests/suites/platform_settings_patch_tests.rs` (2 `#[sqlx::test]` cases). On `dev` the route is absent, so `PATCH`/`GET /api/v1/platform-admin/settings` return `404` and the tests fail; with this endpoint they pass (200 + persisted round-trip, and a partial-update case). Committed test-first (`test:` then `feat:`).

## Scope drift
`owner_role=pm-devops` maps to `.github/**`, `scripts/**`, `docker/**`, `infra/**` — so `scope-check.sh` flags every path here (exit 2). The drift is the whole task: this is api-server + db work, not devops. Paths: migration 00228, `db/models/platform_admin.rs`, `db/repositories/platform_admin.rs`, `routes/platform_admin/{mod,settings}.rs`, api-server test suite. `reuse-grep.sh` clean.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; a platform-admin operator settings CRUD gated by existing capability middleware).

## Remote-tested
skipped (no ppt-bridge MCP in this session).

## Notes
- No `.sqlx/` regen needed (runtime queries).
- Follow-up: re-enable admin-web `platform.tsx` Save (frontend, `pm-frontend`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkKGRjXbUcpTiMMenCrAno

---
_Generated by [Claude Code](https://claude.ai/code/session_01UkKGRjXbUcpTiMMenCrAno)_