### PR TITLE
sec-layout-webhook-hmac-verify-2026-07-23-retry2: verify layout webhook HMAC parity + pin body-binding test

### DIFF
--- a/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
+++ b/frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts
@@ -258,6 +258,29 @@ describe('POST /api/layout-revalidate', () => {
     expect(revalidateTag).not.toHaveBeenCalled();
   });
 
+  it('returns 401 when a valid signature is presented over a DIFFERENT body (HMAC binds the body)', async () => {
+    vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
+    // Parity documentation (sec-layout-webhook-hmac-verify): the receiver's
+    // HMAC must cover the whole request body, exactly like the esignature
+    // token's MAC binds every field (`test_tampered_*_rejected`) and the
+    // portal receiver's `verify_slice` over "{timestamp}.{body}". An attacker
+    // who captures a valid (timestamp, signature) for one body and swaps in a
+    // different body must be rejected — otherwise the signature would not
+    // authenticate the payload that is actually acted on.
+    const ts = nowTs();
+    const signedBody = JSON.stringify({ screen: 'reality/listing-detail', event: 'published' });
+    const tamperedBody = JSON.stringify({ screen: 'reality/pricing', event: 'published' });
+    const req = makeRequest(tamperedBody, {
+      'X-Webhook-Timestamp': String(ts),
+      // Signature is valid for `signedBody`, but a different body is sent.
+      'X-Webhook-Signature': makeSignature(SECRET, ts, signedBody),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'invalid signature' });
+    expect(revalidateTag).not.toHaveBeenCalled();
+  });
+
   it('returns 413 for bodies larger than 16 KiB before verifying', async () => {
     vi.stubEnv('LAYOUT_WEBHOOK_SECRET', SECRET);
     // Correctly signed, but oversized — the size cap must fire first so an


### PR DESCRIPTION
## Task
SECURITY — verify the layout publish webhook uses HMAC signature verification (parity with the esignature webhook); feeds the #2485 fix design. Investigate whether the layout publish webhook validates an HMAC signature the way the esignature webhook does; if it does NOT, add HMAC verification parity (constant-time compare, shared secret, reject on mismatch) with an IG3 regression test proving an unsigned/badly-signed request is rejected. If it already verifies correctly, produce the verification finding/test that documents parity. Retry (round 2/2) of a prior attempt that failed with no PR.

## Owner
pm-security

## Verification finding — parity CONFIRMED (no fix required)

The layout publish webhook **already validates HMAC signatures correctly, with full parity to (and exceeding) the esignature/portal webhook baseline.** The webhook is a two-sided pipeline:

**1. Outbound signer — `backend/servers/api-server/src/routes/layout/webhook.rs`**
- Signs `"{timestamp}.{body}"` with HMAC-SHA256 keyed on `LAYOUT_WEBHOOK_SECRET` (`sign_timestamped_payload`), ships `X-Webhook-Timestamp` + `X-Webhook-Signature`.
- Empty secret is treated as unconfigured (`.filter(|s| !s.is_empty())`) — matches the portal `#2263` fix.
- Covered by unit known-vector tests + the HTTP integration test `layout_webhook_outbound_replay_tests.rs`.

**2. Inbound verifier — `frontend/apps/reality-web/src/app/api/layout-revalidate/route.ts`** (this is where "verification" actually happens)
- **Shared secret**: reads `LAYOUT_WEBHOOK_SECRET`; **fails closed** with 503 when unset (parity with portal `require_portal_webhook_verification` / `#833`).
- **Constant-time compare**: `crypto.timingSafeEqual` over `sha256=<base64(HMAC-SHA256("{timestamp}.{body}"))>`, length-guarded first — equivalent to the esignature token's `mac.verify_slice` and the portal receiver's `verify_slice` (both constant-time).
- **Reject on mismatch**: 401 on missing sig, wrong sig, and swapped-timestamp replay.
- **Exceeds baseline**: adds `#2485` replay protection (signed timestamp folded into the HMAC + ±300s freshness window) and a 16 KiB pre-auth body cap.

**esignature comparison** (`backend/crates/integrations/src/esignature.rs`): its HMAC token `verify()` uses constant-time `verify_slice`, binds every field into the MAC, and rejects tampering (`test_tampered_*_rejected`). The layout receiver matches this contract; the layout receiver's timestamp-binding is the analogue of the esignature token's `expires_at` binding.

**Conclusion:** nothing to fix — the layout publish webhook verifies HMAC with constant-time compare, a shared secret, and reject-on-mismatch. Existing tests already prove unsigned (missing sig → 401) and badly-signed (garbage sig → 401) requests are rejected.

## Change (verification test documenting parity)
Added the one parity property not already pinned: **a signature validly computed over a DIFFERENT body is rejected** (proves the HMAC binds the whole payload, not just the timestamp). This mirrors the esignature tamper-rejection suite and the portal `verify_slice` over `"{timestamp}.{body}"`. One focused test in `route.test.ts` (42 → 43 tests in that file; 243 pass across reality-web).

This is a pinning/documentation test (passes on `dev` because the code is already correct), not a failing-on-main fix — hence IG3 is legitimately skipped (verification vector, no code-fix).

## Verification
```
VERIFY-PLAN base=72a3d9fbba7e7c341d6281007908e6d138de3438 files=1
  cd frontend && pnpm exec biome check apps/reality-web/src/app/api/layout-revalidate/route.test.ts
  cd frontend && pnpm --filter "...[72a3d9fbba7e7c341d6281007908e6d138de3438]" typecheck
  cd frontend && pnpm --filter "...[72a3d9fbba7e7c341d6281007908e6d138de3438]" test
```
```
VERIFY OK 1fe4b3068c2097209d6ac742e90ec462f2d7db79
```
(biome check + reality-web typecheck + 243 tests all green. The 2 biome "infos" are pre-existing — `routeModule['GET']` on an existing test line — not part of this change.)

## CI parity (Band C — hot-path)
The impact-scoped gate replicated `frontend.yml`'s substantive checks for the changed package: `biome check`, `reality-web typecheck`, `pnpm test`. The change is test-only (no runtime code touched), so the `frontend.yml` build step cannot regress from it. `act`/`gh workflow` not available in this environment.

## Scope drift
`scope-check.sh --owner pm-security` reports drift (exit 2) on:
- `frontend/apps/reality-web/src/app/api/layout-revalidate/route.test.ts`

This is expected and justified: pm-security's owner-areas cover auth/mfa/migrations, but the layout webhook's HMAC **verification** lives in reality-web. The security-relevant code for this task is exactly there, so the parity test necessarily lands in reality-web. Reviewer to adjudicate.

## Remote-tested
skipped

## Notes
- No code fix was warranted; the deliverable is the verification finding above plus the parity-pinning test.
- Goal-check (`goal-check.sh`) reports IG1/IG2/IG5/IG6/IG8 failures — all artifacts of the `ppt-research-flow` plan-file lifecycle, which this dispatcher ad-hoc task does not use (no `.research/plans/<slug>.md`; the preamble forbids writing `.research/**`; the branch name is dispatcher-mandated `auto-impl/...`, not renamable to `impl/...`). The substantive IG7 (verify) passed and IG3 is legitimately skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLXqfKBAWBP4XtZLDhd74f)_