### PR TITLE
refactor-churn-hotspot-api-server-layout-tenant-2026-07-30-retry1: extract acquire_public_conn in layout tenant handlers

### DIFF
--- a/backend/servers/api-server/src/routes/layout/tenant.rs
+++ b/backend/servers/api-server/src/routes/layout/tenant.rs
@@ -7,7 +7,7 @@ use axum::Json;
 use common::TenantRole;
 use db::models::layout::LayoutConfigRow;
 use db::repositories::LayoutRepository;
-use db::RlsPool;
+use db::{PublicConnection, RlsPool};
 use sqlx::{Executor, Postgres};
 use uuid::Uuid;
 
@@ -64,6 +64,18 @@ fn require_org_admin(org_id: Uuid, role: TenantRole) -> Result<(), ErrorResponse
     Ok(())
 }
 
+/// Acquire the sanctioned public/global (no-RLS) connection for the global
+/// layout tables, mapping a pool failure to 500. Acquiring clears any stale RLS
+/// context, so this is safe to call after an org-scoped connection was released.
+/// Mirrors the sibling `admin.rs` helper so both tenant-override handlers share
+/// one acquisition site instead of repeating the pool dance inline.
+async fn acquire_public_conn(state: &AppState) -> Result<PublicConnection, ErrorResponse> {
+    RlsPool::new(state.db.clone())
+        .acquire_public()
+        .await
+        .map_err(internal_error)
+}
+
 /// Load a screen's layout config from a public/global (no-RLS) connection,
 /// mapping a missing row to 404 and any sqlx failure to 500. Shared by both
 /// handlers so the fetch + not-found mapping stays in one place.
@@ -108,10 +120,7 @@ pub async fn get_tenant_override(
     rls.release().await;
     let ov = ov.map_err(internal_error)?;
     // Global no-RLS layout tables — sanctioned public connection (clears stale context).
-    let mut pub_conn = RlsPool::new(state.db.clone())
-        .acquire_public()
-        .await
-        .map_err(internal_error)?;
+    let mut pub_conn = acquire_public_conn(&state).await?;
     let cfg = load_screen_config(&repo, &mut **pub_conn, &q.screen).await?;
     let manifest_row = repo
         .get_manifest(&mut **pub_conn, "web")
@@ -179,7 +188,7 @@ pub async fn put_tenant_override(
     // Phase 1: public/global reads (config + rails), no RLS connection held.
     // Global no-RLS layout tables — sanctioned public connection (clears stale context).
     let (base, rails_value) = {
-        let mut pub_conn = rls_pool.acquire_public().await.map_err(internal_error)?;
+        let mut pub_conn = acquire_public_conn(&state).await?;
         let cfg = load_screen_config(&repo, &mut **pub_conn, &req.screen).await?;
         let published = cfg.published.clone().ok_or_else(|| {
             error_response(StatusCode::NOT_FOUND, "screen has no published config")


### PR DESCRIPTION
## Task
Churn hotspot: backend/servers/api-server/src/routes/layout/tenant.rs — 262 lines this window (PR #2478) [retry 1/2 of failed refactor-churn-hotspot-api-server-layout-tenant-2026-07-30]

Behavior-preserving structural cleanup. The prior dedup (`require_org_admin` + `load_screen_config`, PR #2711) already landed on `dev`; this PR removes the remaining duplication in the same hotspot: both `get_tenant_override` and `put_tenant_override` repeated the `RlsPool::new(state.db.clone()).acquire_public().await.map_err(internal_error)` acquisition inline. Hoisted into a local `acquire_public_conn(&state)` helper that mirrors the sibling `admin.rs::acquire_public_conn` pattern, so the module now acquires its public/global connection through one site per file.

No route contract or response-shape change. Acquisition semantics are identical (fresh pool, clears stale RLS context, 500 on pool failure). `rls_pool` is still constructed in the PUT handler for the org-scoped RLS write.

## Owner
pm-tech-lead (api-server Rust backend work — see Scope drift)

## Verification
```
VERIFY-PLAN base=7c73ec332c6ffa2c585b6479349ee3654c271a1f files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` — **PASS** (exit 0).
- `cargo clippy -p api-server` / `cargo test -p api-server` — **cannot run in this sandbox**: the `utoipa-swagger-ui v9.0.2` build script panics because it cannot download the Swagger UI zip (egress-blocked): `failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")`. Zero code errors (`error[E…]` count = 0) were produced before that infra failure; `common` and dependencies checked clean. Per the task brief, CI `backend.yml` is the authoritative gate for api-server here, so this draft relies on CI for the clippy+test bands.

No `VERIFY OK` line is emitted because the gate could not complete locally (infra-only failure, not a code failure).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change; pure structural refactor)

## Remote-tested
skipped

## Scope drift
The mechanical `scope-check.sh --owner pm-tech-lead` flags `backend/servers/api-server/src/routes/layout/tenant.rs` (exit 2) because `pm-tech-lead`'s owner-areas map to `docs/** / .research/** / _bmad-output/**`, not backend code. This is an owner-hint/area mismatch, not real drift — the task itself states this is api-server Rust backend work (its natural owner is `pm-backend`, whose area is `backend/**`). The single changed file is exactly the task's target hotspot.

## Code-reuse review
`reuse-grep.sh` reported no warnings. The new `acquire_public_conn` intentionally mirrors the existing private `admin.rs::acquire_public_conn` — the established per-file pattern in this module (each file keeps its own copy bound to its own `internal_error` log tag: "layout tenant" vs "layout admin"). Consolidating both into a shared module-level helper would require hoisting the per-file `ErrorResponse`/`internal_error` too, expanding scope beyond this tightly-scoped hotspot; left as a possible module-wide follow-up.

## Notes
- Single-file diff: +14 −10 in `tenant.rs`.
- The branch previously carried the (now-merged) PR #2711 tip; it was force-updated to this new commit after #2711 landed on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHv9Pjcn1a5xz6WSiTNTXw

---
_Generated by [Claude Code](https://claude.ai/code/session_01LHv9Pjcn1a5xz6WSiTNTXw)_