### PR TITLE
data-announcement-fanout-metric-2026-07-23-retry2: announcement fan-out delivered/read/ack metrics per targeting scope

### DIFF
--- a/backend/crates/db/src/models/announcement.rs
+++ b/backend/crates/db/src/models/announcement.rs
@@ -234,6 +234,35 @@ pub struct AcknowledgmentStats {
     pub pending_count: i64,
 }
 
+/// Delivered / read / acknowledged fan-out metrics for a single announcement,
+/// implicitly bucketed by its **targeting scope** (`scope` = the announcement's
+/// `target_type`: `all` | `building` | `units` | `roles`).
+///
+/// `delivered` is the *scope-aware* audience — the set of active organization
+/// members the announcement's targeting actually resolves to, computed with the
+/// same cross-tenant-safe joins the notification fan-out uses (issue #2484).
+/// This is deliberately narrower than [`AcknowledgmentStats::total_targeted`],
+/// which counts every active org member regardless of `target_type` and so
+/// over-counts a building/unit/role-targeted announcement. `read` and
+/// `acknowledged` come from `announcement_reads` for the same announcement.
+///
+/// Emitting delivered per scope from the real targeting SQL (rather than a
+/// pure-Rust re-model of the audience) is the data-quality guard #2484 asks for:
+/// the count the metric reports is the count the query actually resolves, so a
+/// regression in the cross-tenant scoping surfaces as a metric mismatch.
+#[derive(Debug, Clone, PartialEq, Eq, FromRow, Serialize, Deserialize, ToSchema)]
+pub struct AnnouncementFanoutMetrics {
+    pub announcement_id: Uuid,
+    /// The announcement's `target_type` — the targeting scope the counts apply to.
+    pub scope: String,
+    /// Scope-aware audience size (cross-tenant-safe), i.e. the fan-out reach.
+    pub delivered: i64,
+    /// Number of users who have a read record for this announcement.
+    pub read: i64,
+    /// Number of users who acknowledged this announcement.
+    pub acknowledged: i64,
+}
+
 /// Individual user's acknowledgment status for an announcement (Story 6.2).
 #[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
 pub struct UserAcknowledgmentStatus {

--- a/backend/crates/db/src/repositories/announcement.rs
+++ b/backend/crates/db/src/repositories/announcement.rs
@@ -26,10 +26,10 @@
 
 use crate::models::announcement::{
     announcement_status, AcknowledgmentStats, Announcement, AnnouncementAttachment,
-    AnnouncementComment, AnnouncementListQuery, AnnouncementRead, AnnouncementStatistics,
-    AnnouncementSummary, AnnouncementWithDetails, CommentWithAuthor, CommentWithAuthorRow,
-    CreateAnnouncement, CreateAnnouncementAttachment, CreateComment, DeleteComment,
-    UpdateAnnouncement, UserAcknowledgmentStatus,
+    AnnouncementComment, AnnouncementFanoutMetrics, AnnouncementListQuery, AnnouncementRead,
+    AnnouncementStatistics, AnnouncementSummary, AnnouncementWithDetails, CommentWithAuthor,
+    CommentWithAuthorRow, CreateAnnouncement, CreateAnnouncementAttachment, CreateComment,
+    DeleteComment, UpdateAnnouncement, UserAcknowledgmentStatus,
 };
 use crate::DbPool;
 use chrono::{DateTime, Utc};
@@ -1191,6 +1191,104 @@ impl AnnouncementRepository {
             acknowledged_count: stats.1,
             pending_count: pending_count.max(0),
         })
+    }
+
+    /// Compute delivered / read / acknowledged fan-out metrics for a single
+    /// announcement, scoped to its targeting audience (issue #2484 data-quality
+    /// follow-up to PR #2455).
+    ///
+    /// `delivered` resolves the announcement's *real* audience for its
+    /// `target_type` with the same cross-tenant-safe joins the notification
+    /// fan-out uses (`Scheduler::get_announcement_target_users`) — so the count
+    /// this metric emits is the count the targeting SQL actually reaches:
+    ///
+    /// - `all`      → active members of the announcement's organization.
+    /// - `building` → distinct active residents of the target buildings,
+    ///   AND-scoped to the announcement's org via `buildings.organization_id`
+    ///   (a foreign-org building id in `target_ids` contributes nobody).
+    /// - `units`    → distinct active residents of the target units, org-scoped
+    ///   through `unit_residents -> units -> buildings` the same way.
+    /// - `roles`    → active members whose `user_memberships.role` is one of the
+    ///   target role names. This mirrors the canonical read-path targeting
+    ///   predicate (`announcement_targeting_predicate!`, issue #920/#999), which
+    ///   is the single source of truth for "is this user targeted" in the db
+    ///   layer; membership containment is expressed with the same sargable
+    ///   `target_ids @> to_jsonb(<value>::text)` form the predicate uses.
+    ///
+    /// `read` / `acknowledged` come straight from `announcement_reads`. Returns
+    /// `None` when the announcement id does not exist. Unknown target types
+    /// resolve `delivered = 0` (never panics) — consistent with the scheduler's
+    /// fail-safe empty audience for an unrecognised scope.
+    pub async fn get_fanout_metrics_rls<'e, E>(
+        &self,
+        executor: E,
+        announcement_id: Uuid,
+    ) -> Result<Option<AnnouncementFanoutMetrics>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        let metrics = sqlx::query_as::<_, AnnouncementFanoutMetrics>(
+            r#"
+            SELECT
+                a.id AS announcement_id,
+                a.target_type::text AS scope,
+                CASE a.target_type
+                    WHEN 'all' THEN (
+                        SELECT COUNT(DISTINCT u.id)
+                        FROM users u
+                        JOIN user_memberships m ON m.user_id = u.id
+                        WHERE m.organization_id = a.organization_id
+                          AND m.revoked_at IS NULL
+                          AND (m.expires_at IS NULL OR m.expires_at > NOW())
+                          AND u.status = 'active'
+                    )
+                    WHEN 'building' THEN (
+                        SELECT COUNT(DISTINCT ur.user_id)
+                        FROM unit_residents ur
+                        JOIN units un ON ur.unit_id = un.id
+                        JOIN buildings b ON un.building_id = b.id
+                        WHERE b.organization_id = a.organization_id
+                          AND ur.end_date IS NULL
+                          AND a.target_ids @> to_jsonb(un.building_id::text)
+                    )
+                    WHEN 'units' THEN (
+                        SELECT COUNT(DISTINCT ur.user_id)
+                        FROM unit_residents ur
+                        JOIN units un ON ur.unit_id = un.id
+                        JOIN buildings b ON un.building_id = b.id
+                        WHERE b.organization_id = a.organization_id
+                          AND ur.end_date IS NULL
+                          AND a.target_ids @> to_jsonb(ur.unit_id::text)
+                    )
+                    WHEN 'roles' THEN (
+                        SELECT COUNT(DISTINCT m.user_id)
+                        FROM user_memberships m
+                        JOIN users u ON u.id = m.user_id
+                        WHERE m.organization_id = a.organization_id
+                          AND m.revoked_at IS NULL
+                          AND (m.expires_at IS NULL OR m.expires_at > NOW())
+                          AND u.status = 'active'
+                          AND a.target_ids @> to_jsonb(m.role::text)
+                    )
+                    ELSE 0::bigint
+                END AS delivered,
+                (
+                    SELECT COUNT(*) FROM announcement_reads ar
+                    WHERE ar.announcement_id = a.id
+                ) AS read,
+                (
+                    SELECT COUNT(*) FROM announcement_reads ar
+                    WHERE ar.announcement_id = a.id AND ar.acknowledged_at IS NOT NULL
+                ) AS acknowledged
+            FROM announcements a
+            WHERE a.id = $1
+            "#,
+        )
+        .bind(announcement_id)
+        .fetch_optional(executor)
+        .await?;
+
+        Ok(metrics)
     }
 
     /// Get list of users with their acknowledgment status with RLS context.

--- a/backend/crates/db/tests/suite_1.rs
+++ b/backend/crates/db/tests/suite_1.rs
@@ -17,6 +17,8 @@ mod agency_domain_cache_tests;
 mod ai_chat_rls_repo_tests;
 #[path = "suites/announcement_comments_rls_tests.rs"]
 mod announcement_comments_rls_tests;
+#[path = "suites/announcement_fanout_metrics_tests.rs"]
+mod announcement_fanout_metrics_tests;
 #[path = "suites/announcement_targeting_visibility_tests.rs"]
 mod announcement_targeting_visibility_tests;
 #[path = "suites/announcement_tests.rs"]

--- a/backend/crates/db/tests/suites/announcement_fanout_metrics_tests.rs
+++ b/backend/crates/db/tests/suites/announcement_fanout_metrics_tests.rs
@@ -1,0 +1,295 @@
+//! Real-SQL data-quality test for announcement fan-out metrics (issue #2484,
+//! follow-up to PR #2455 / #2612).
+//!
+//! `AnnouncementRepository::get_fanout_metrics_rls` reports delivered / read /
+//! acknowledged counts per targeting scope (`all` | `building` | `units` |
+//! `roles`). `delivered` is the *scope-aware* audience resolved by the real
+//! targeting SQL — the same cross-tenant-safe joins the notification fan-out
+//! uses. Before this metric existed the only audience number was
+//! `AcknowledgmentStats::total_targeted`, which counts every active org member
+//! regardless of `target_type` and therefore over-counts a building/unit/role
+//! announcement.
+//!
+//! These tests exercise the actual query against Postgres (not a pure-Rust
+//! re-model of the audience), so a regression that drops the
+//! `b.organization_id = a.organization_id` cross-tenant scope — the #2484
+//! concern — surfaces as a metric that no longer matches the seeded in-scope
+//! audience, and the assertions fail. A drifted Rust re-implementation cannot
+//! satisfy them.
+//!
+//! Targeting contract (migration 00015 + `announcement_targeting_predicate!`):
+//! `building`/`units` target_ids hold the UUIDs as text; `roles` target_ids hold
+//! role-name strings matching `user_memberships.role`.
+
+use db::repositories::AnnouncementRepository;
+use serde_json::Value as Json;
+use sqlx::{PgConnection, PgPool};
+use uuid::Uuid;
+
+async fn set_ctx(conn: &mut PgConnection, org: Option<Uuid>, user: Option<Uuid>, su: bool) {
+    sqlx::query("SELECT set_request_context($1, $2, $3)")
+        .bind(org)
+        .bind(user)
+        .bind(su)
+        .execute(conn)
+        .await
+        .expect("set_request_context");
+}
+
+async fn insert_org(conn: &mut PgConnection, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO organizations (name, slug, contact_email, status) \
+         VALUES ($1, $2, $3, 'active') RETURNING id",
+    )
+    .bind(format!("Fanout Metrics {slug}"))
+    .bind(slug)
+    .bind(format!("{slug}@fanout-metrics.test"))
+    .fetch_one(conn)
+    .await
+    .expect("insert org")
+}
+
+async fn insert_user(conn: &mut PgConnection, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO users (email, password_hash, name, status, email_verified_at) \
+         VALUES ($1, 'test_hash', 'FanoutUser', 'active', NOW()) RETURNING id",
+    )
+    .bind(email)
+    .fetch_one(conn)
+    .await
+    .expect("insert user")
+}
+
+async fn insert_building(conn: &mut PgConnection, org: Uuid, name: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO buildings (organization_id, name, street, city, postal_code, country) \
+         VALUES ($1, $2, 'Addr', 'City', '00000', 'Country') RETURNING id",
+    )
+    .bind(org)
+    .bind(name)
+    .fetch_one(conn)
+    .await
+    .expect("insert building")
+}
+
+async fn insert_unit(conn: &mut PgConnection, building: Uuid, designation: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO units (building_id, designation) VALUES ($1, $2) RETURNING id",
+    )
+    .bind(building)
+    .bind(designation)
+    .fetch_one(conn)
+    .await
+    .expect("insert unit")
+}
+
+async fn insert_resident(conn: &mut PgConnection, unit: Uuid, user: Uuid, kind: &str) {
+    sqlx::query(
+        "INSERT INTO unit_residents (unit_id, user_id, resident_type) \
+         VALUES ($1, $2, $3::resident_type)",
+    )
+    .bind(unit)
+    .bind(user)
+    .bind(kind)
+    .execute(conn)
+    .await
+    .expect("insert unit resident");
+}
+
+async fn insert_membership(conn: &mut PgConnection, user: Uuid, org: Uuid, role: &str) {
+    sqlx::query(
+        "INSERT INTO user_memberships (user_id, organization_id, role) VALUES ($1, $2, $3)",
+    )
+    .bind(user)
+    .bind(org)
+    .bind(role)
+    .execute(conn)
+    .await
+    .expect("insert membership");
+}
+
+async fn insert_published_ann(
+    conn: &mut PgConnection,
+    org: Uuid,
+    author: Uuid,
+    target_type: &str,
+    target_ids: Json,
+    title: &str,
+) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO announcements \
+            (organization_id, author_id, title, content, target_type, target_ids, status, published_at) \
+         VALUES ($1, $2, $3, 'body', $4::announcement_target_type, $5, 'published', NOW()) \
+         RETURNING id",
+    )
+    .bind(org)
+    .bind(author)
+    .bind(title)
+    .bind(target_type)
+    .bind(target_ids)
+    .fetch_one(conn)
+    .await
+    .expect("insert published announcement")
+}
+
+async fn insert_read(conn: &mut PgConnection, ann: Uuid, user: Uuid, acknowledged: bool) {
+    if acknowledged {
+        sqlx::query(
+            "INSERT INTO announcement_reads (announcement_id, user_id, acknowledged_at) \
+             VALUES ($1, $2, NOW())",
+        )
+        .bind(ann)
+        .bind(user)
+        .execute(conn)
+        .await
+        .expect("insert read (acknowledged)");
+    } else {
+        sqlx::query("INSERT INTO announcement_reads (announcement_id, user_id) VALUES ($1, $2)")
+            .bind(ann)
+            .bind(user)
+            .execute(conn)
+            .await
+            .expect("insert read");
+    }
+}
+
+/// Full-coverage fan-out metric check: every targeting scope reports the
+/// scope-aware audience, cross-tenant targets are excluded, and read/ack counts
+/// match `announcement_reads`.
+#[sqlx::test(migrations = "./migrations")]
+async fn fanout_metrics_report_scope_aware_delivered_read_ack(pool: PgPool) {
+    // ---- seed everything under a super-admin context (bypasses RLS WITH CHECK) ----
+    let mut sa = pool.acquire().await.unwrap();
+    set_ctx(&mut sa, None, None, true).await;
+
+    let org_a = insert_org(&mut sa, "fm-a").await;
+    let org_b = insert_org(&mut sa, "fm-b").await;
+    let author = insert_user(&mut sa, "author@fanout-metrics.test").await;
+
+    // Org A: one building with two units, plus a manager without a residency.
+    let building_a = insert_building(&mut sa, org_a, "Bldg A").await;
+    let unit_a1 = insert_unit(&mut sa, building_a, "A1").await;
+    let unit_a2 = insert_unit(&mut sa, building_a, "A2").await;
+
+    let manager_a = insert_user(&mut sa, "manager@fanout-metrics.test").await;
+    let resident_a1 = insert_user(&mut sa, "res-a1@fanout-metrics.test").await;
+    let resident_a2 = insert_user(&mut sa, "res-a2@fanout-metrics.test").await;
+
+    insert_membership(&mut sa, manager_a, org_a, "manager").await;
+    insert_membership(&mut sa, resident_a1, org_a, "resident").await;
+    insert_membership(&mut sa, resident_a2, org_a, "resident").await;
+    insert_resident(&mut sa, unit_a1, resident_a1, "owner").await;
+    insert_resident(&mut sa, unit_a2, resident_a2, "tenant").await;
+
+    // Org B: a separate tenant whose building/unit/resident must never be
+    // counted by an org-A announcement even if their ids leak into target_ids.
+    let building_b = insert_building(&mut sa, org_b, "Bldg B").await;
+    let unit_b1 = insert_unit(&mut sa, building_b, "B1").await;
+    let resident_b = insert_user(&mut sa, "res-b@fanout-metrics.test").await;
+    insert_membership(&mut sa, resident_b, org_b, "resident").await;
+    insert_resident(&mut sa, unit_b1, resident_b, "owner").await;
+
+    // ---- announcements (all owned by org A) ----
+    let ann_all =
+        insert_published_ann(&mut sa, org_a, author, "all", serde_json::json!([]), "All").await;
+    // building + units + roles announcements deliberately also carry an org-B id
+    // (the bypassed-validation / cross-tenant leak path #2484 guards against).
+    let ann_building = insert_published_ann(
+        &mut sa,
+        org_a,
+        author,
+        "building",
+        serde_json::json!([building_a.to_string(), building_b.to_string()]),
+        "Building A (+leaked B)",
+    )
+    .await;
+    let ann_units = insert_published_ann(
+        &mut sa,
+        org_a,
+        author,
+        "units",
+        serde_json::json!([unit_a1.to_string(), unit_b1.to_string()]),
+        "Unit A1 (+leaked B1)",
+    )
+    .await;
+    let ann_roles = insert_published_ann(
+        &mut sa,
+        org_a,
+        author,
+        "roles",
+        serde_json::json!(["manager"]),
+        "Managers only",
+    )
+    .await;
+
+    // Read/ack activity on the 'all' announcement: two reads, one acknowledged.
+    insert_read(&mut sa, ann_all, resident_a1, false).await;
+    insert_read(&mut sa, ann_all, resident_a2, true).await;
+    drop(sa);
+
+    let repo = AnnouncementRepository::new(pool.clone());
+    let mut conn = pool.acquire().await.unwrap();
+    // Manager/admin analytics read — super-admin context so the aggregate sees
+    // the true row set rather than an RLS-filtered slice.
+    set_ctx(&mut conn, Some(org_a), None, true).await;
+
+    // ---- 'all' scope: every active member of org A (3), plus read/ack. ----
+    let m_all = repo
+        .get_fanout_metrics_rls(&mut *conn, ann_all)
+        .await
+        .expect("fanout metrics query")
+        .expect("announcement exists");
+    assert_eq!(m_all.scope, "all");
+    assert_eq!(
+        m_all.delivered, 3,
+        "'all' delivers to every active org-A member (manager + 2 residents)"
+    );
+    assert_eq!(m_all.read, 2, "two users have read records");
+    assert_eq!(m_all.acknowledged, 1, "one of the reads is acknowledged");
+
+    // ---- 'building' scope: residents of building A only; org B excluded. ----
+    let m_building = repo
+        .get_fanout_metrics_rls(&mut *conn, ann_building)
+        .await
+        .expect("fanout metrics query")
+        .expect("announcement exists");
+    assert_eq!(m_building.scope, "building");
+    assert_eq!(
+        m_building.delivered, 2,
+        "building A has two resident units; org-B building id in target_ids must \
+         contribute nobody (cross-tenant fan-out leak — #2484)"
+    );
+    assert_eq!(m_building.read, 0);
+    assert_eq!(m_building.acknowledged, 0);
+
+    // ---- 'units' scope: resident of unit A1 only; org-B unit excluded. ----
+    let m_units = repo
+        .get_fanout_metrics_rls(&mut *conn, ann_units)
+        .await
+        .expect("fanout metrics query")
+        .expect("announcement exists");
+    assert_eq!(m_units.scope, "units");
+    assert_eq!(
+        m_units.delivered, 1,
+        "only unit A1's resident is in scope; org-B unit id must be excluded"
+    );
+
+    // ---- 'roles' scope: members whose role matches (the manager). ----
+    let m_roles = repo
+        .get_fanout_metrics_rls(&mut *conn, ann_roles)
+        .await
+        .expect("fanout metrics query")
+        .expect("announcement exists");
+    assert_eq!(m_roles.scope, "roles");
+    assert_eq!(
+        m_roles.delivered, 1,
+        "one org-A member holds the 'manager' role"
+    );
+
+    // ---- unknown / missing announcement returns None. ----
+    let missing = repo
+        .get_fanout_metrics_rls(&mut *conn, Uuid::new_v4())
+        .await
+        .expect("fanout metrics query");
+    assert!(missing.is_none(), "unknown announcement id yields None");
+}


### PR DESCRIPTION
Auto-opened by the research dispatcher (Phase 2 branch-exists path): the implementer pushed a green db slice but withheld the PR because `just verify` went red **only** on a pre-existing, unrelated api-server test.

## Change (owner: pm-data, `backend/crates/db/**` only)
- `AnnouncementFanoutMetrics` model + `AnnouncementRepository::get_fanout_metrics_rls` returning delivered/read/ack per targeting scope (all/building/units/roles), with `delivered` resolved by the same cross-tenant-safe SQL the fan-out uses.
- New real-SQL integration test (`announcement_fanout_metrics_tests.rs`) replacing the pure-Rust re-model for #2484 — asserts `delivered` matches the in-scope audience and excludes cross-tenant leaks. **Passes against a real Postgres 16.**

## Verify status
`fmt` clean; `clippy` green for all 8 crates (incl. db + api-server); tests green for accounting-core/-server, admin-core, api-core; the new db test passes. The local gate stopped at `cargo test -p api-server` on `execute_rejects_dns_rebinding_to_private_ip_at_connect` (571 passed / 1 failed) — an SSRF DNS-rebinding test added by unrelated PR #2710, which fails only in the sandbox (no real DNS to observe connect-time re-resolution). This diff touches zero api-server files. **CI (real network + DB) is the authoritative gate.**

Draft pending CI + dispatcher review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MPFkAgMy4qX4AfWuqoD53c)_