### PR TITLE
code-review-reality-server-db-error-leak: route raw DB errors through util::errors::db_error

### DIFF
--- a/backend/servers/reality-server/src/routes/agencies.rs
+++ b/backend/servers/reality-server/src/routes/agencies.rs
@@ -259,12 +259,10 @@ pub async fn update_agency(
     // SECURITY (H2): membership check via the shared helper in
     // `super::agency_imports` — single source of truth for "is this user
     // allowed to mutate this agency's data?".
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("acquire db connection", e))?;
     super::agency_imports::check_agency_membership(&mut conn, id, principal.user_id).await?;
     drop(conn);
 
@@ -313,12 +311,10 @@ pub async fn update_branding(
     Path(id): Path<Uuid>,
     Json(data): Json<UpdateAgencyBranding>,
 ) -> Result<Json<AgencyResponse>, (axum::http::StatusCode, String)> {
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("acquire db connection", e))?;
     super::agency_imports::check_agency_membership(&mut conn, id, principal.user_id).await?;
     drop(conn);
 
@@ -392,12 +388,10 @@ pub async fn create_invitation(
     // via the shared helper — single source of truth for "is this user allowed
     // to mutate this agency's data?". Returns 404 (unknown agency) / 403
     // (non-member) before any invitation is created.
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("acquire db connection", e))?;
     super::agency_imports::check_agency_membership(&mut conn, agency_id, principal.user_id).await?;
     drop(conn);
 
@@ -463,12 +457,10 @@ pub async fn accept_invitation(
     // SECURITY (invite-email-match): gate on recipient identity before adding
     // membership. See the handler doc-comment above for the escalation this
     // prevents.
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("acquire db connection", e))?;
     verify_invitation_recipient(&mut conn, &token, principal.user_id).await?;
     drop(conn);
 

--- a/backend/servers/reality-server/src/routes/imports.rs
+++ b/backend/servers/reality-server/src/routes/imports.rs
@@ -58,12 +58,7 @@ async fn resolve_agency(
         .reality_portal_repo
         .get_active_agency_for_user(user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to resolve agency: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("resolve agency", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::FORBIDDEN,
@@ -131,12 +126,7 @@ pub async fn list_import_jobs(
             query.offset.unwrap_or(0),
         )
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list import jobs: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("list import jobs", e))?;
 
     let total = jobs.len() as i64;
 
@@ -164,12 +154,7 @@ pub async fn create_import_job(
         .reality_portal_repo
         .create_import_job(principal.user_id, data)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to create import job: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("create import job", e))?;
 
     Ok(Json(ImportJobResponse { job }))
 }
@@ -194,12 +179,7 @@ pub async fn get_import_job(
         .reality_portal_repo
         .get_import_job(id, principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get import job: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("get import job", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::NOT_FOUND,
@@ -337,12 +317,7 @@ pub async fn list_feeds(
         .reality_portal_repo
         .list_feed_subscriptions(agency_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to list feeds: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("list feed subscriptions", e))?;
 
     let total = feeds.len() as i64;
 
@@ -371,12 +346,7 @@ pub async fn create_feed(
         .reality_portal_repo
         .create_feed_subscription(agency_id, data)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to create feed: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("create feed subscription", e))?;
 
     Ok(Json(FeedResponse { feed }))
 }
@@ -402,12 +372,7 @@ pub async fn get_feed(
         .reality_portal_repo
         .get_feed_subscription(id, agency_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get feed: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("get feed subscription", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::NOT_FOUND,

--- a/backend/servers/reality-server/src/routes/layout.rs
+++ b/backend/servers/reality-server/src/routes/layout.rs
@@ -58,24 +58,20 @@ pub async fn get_resolved(
     let mut conn = state
         .acquire_public_conn()
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")))?;
+        .map_err(|e| crate::util::errors::db_error("acquire db connection", e))?;
     let repo = LayoutRepository::new();
 
     let cfg = repo
         .get_config(&mut *conn, &screen)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")))?
+        .map_err(|e| crate::util::errors::db_error("get layout config", e))?
         .ok_or((StatusCode::NOT_FOUND, "unknown screen".to_string()))?;
     let published = cfg.published.ok_or((
         StatusCode::NOT_FOUND,
         "screen has no published config".to_string(),
     ))?;
-    let base: layout_core::ScreenConfig = serde_json::from_value(published).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("stored config invalid: {e}"),
-        )
-    })?;
+    let base: layout_core::ScreenConfig = serde_json::from_value(published)
+        .map_err(|e| crate::util::errors::db_error("parse stored layout config", e))?;
 
     let platform_key = match platform {
         layout_core::Platform::Web => "web",
@@ -84,23 +80,18 @@ pub async fn get_resolved(
     let manifest_row = repo
         .get_manifest(&mut *conn, platform_key)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")))?
+        .map_err(|e| crate::util::errors::db_error("get layout manifest", e))?
         .ok_or((
             StatusCode::NOT_FOUND,
             "no registry manifest for platform".to_string(),
         ))?;
     let manifest: layout_core::RegistryManifest = serde_json::from_value(manifest_row.manifest)
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("stored manifest invalid: {e}"),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("parse stored layout manifest", e))?;
 
     let kills: BTreeSet<layout_core::SectionType> = repo
         .list_kills(&mut *conn, &screen)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("db error: {e}")))?
+        .map_err(|e| crate::util::errors::db_error("list layout kills", e))?
         .into_iter()
         .map(|k| layout_core::SectionType(k.section_type))
         .collect();

--- a/backend/servers/reality-server/src/routes/listings.rs
+++ b/backend/servers/reality-server/src/routes/listings.rs
@@ -283,24 +283,14 @@ pub async fn search(
         .portal_repo
         .search_listings(&query)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to search listings: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("search listings", e))?;
 
     // Count total
     let total = state
         .portal_repo
         .count_listings(&query)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to count listings: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("count listings", e))?;
 
     // Convert to response types
     let listings: Vec<ListingSummary> = listings.into_iter().map(Into::into).collect();
@@ -477,12 +467,7 @@ pub async fn get_suggestions(
         .portal_repo
         .get_nearby_cities(city, 10)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get cities: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("get nearby cities", e))?;
 
     Ok(Json(SuggestionsResponse {
         cities,

--- a/backend/servers/reality-server/src/routes/price_map.rs
+++ b/backend/servers/reality-server/src/routes/price_map.rs
@@ -147,12 +147,10 @@ pub async fn get_price_map(
         }
     }
 
-    let mut conn = state.acquire_public_conn().await.map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-    })?;
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("acquire db connection", e))?;
 
     // Aggregate current-period avg price/m² by city.
     // size_sqm is the listings column; price/size_sqm gives €/m².
@@ -211,12 +209,7 @@ pub async fn get_price_map(
         .bind(&city_pattern)
         .fetch_all(&mut *conn)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to aggregate price map data: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("aggregate price map data", e))?;
 
     let districts: Vec<DistrictPriceData> = rows
         .into_iter()

--- a/backend/servers/reality-server/src/routes/realtors.rs
+++ b/backend/servers/reality-server/src/routes/realtors.rs
@@ -69,12 +69,7 @@ pub async fn get_my_profile(
         .reality_portal_repo
         .get_realtor_profile(principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get profile: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("get realtor profile", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::NOT_FOUND,
@@ -104,12 +99,7 @@ pub async fn get_profile(
         .reality_portal_repo
         .get_realtor_profile(user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to get profile: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("get realtor profile", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::NOT_FOUND,
@@ -149,10 +139,7 @@ pub async fn create_profile(
                     "Profile already exists".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to create profile: {}", e),
-                )
+                crate::util::errors::db_error("create realtor profile", e)
             }
         })?;
 
@@ -188,10 +175,7 @@ pub async fn update_profile(
                     "Profile not found".to_string(),
                 )
             } else {
-                (
-                    axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Failed to update profile: {}", e),
-                )
+                crate::util::errors::db_error("update realtor profile", e)
             }
         })?;
 
@@ -234,12 +218,7 @@ pub async fn list_inquiries(
             .reality_portal_repo
             .count_realtor_inquiries(principal.user_id, status_filter),
     )
-    .map_err(|e| {
-        (
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to list inquiries: {}", e),
-        )
-    })?;
+    .map_err(|e| crate::util::errors::db_error("list realtor inquiries", e))?;
 
     Ok(Json(InquiriesResponse { inquiries, total }))
 }
@@ -267,12 +246,7 @@ pub async fn mark_inquiry_read(
         .reality_portal_repo
         .mark_inquiry_read_for_realtor(id, principal.user_id)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to mark inquiry read: {}", e),
-            )
-        })?;
+        .map_err(|e| crate::util::errors::db_error("mark inquiry read", e))?;
 
     if !updated {
         return Err((
@@ -307,12 +281,7 @@ pub async fn respond_to_inquiry(
         .reality_portal_repo
         .respond_to_inquiry(id, principal.user_id, &data.message)
         .await
-        .map_err(|e| {
-            (
-                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to respond to inquiry: {}", e),
-            )
-        })?
+        .map_err(|e| crate::util::errors::db_error("respond to inquiry", e))?
         .ok_or_else(|| {
             (
                 axum::http::StatusCode::NOT_FOUND,

--- a/backend/servers/reality-server/src/util/errors.rs
+++ b/backend/servers/reality-server/src/util/errors.rs
@@ -30,3 +30,63 @@ pub fn db_error(ctx: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
         "Internal server error".to_string(),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The client-facing body must be a fixed generic string and a 500 — never
+    /// the underlying error. This is the security contract reality-server relies
+    /// on: raw `sqlx::Error` / `serde` / connection strings can expose column
+    /// names, constraint names, and pool/TLS state to internet clients.
+    #[test]
+    fn db_error_returns_generic_500_body() {
+        let (status, body) = db_error("acquire db connection", "boom");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "Internal server error");
+    }
+
+    /// The returned body must not carry any fragment of the source error, even
+    /// when that error string contains schema/constraint/connection detail that
+    /// a raw `format!("...: {e}")` boundary would have leaked.
+    #[test]
+    fn db_error_body_leaks_no_source_detail() {
+        // Mimics the kind of text a raw sqlx::Error can surface.
+        let sensitive = "error returned from database: duplicate key value \
+             violates unique constraint \"realtor_profiles_user_id_key\" \
+             DETAIL: Key (user_id)=(...) already exists; \
+             host=db.internal port=5432 dbname=reality sslmode=require";
+        let (status, body) = db_error("create realtor profile", sensitive);
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "Internal server error");
+        // None of the sensitive tokens may appear in the client-facing body.
+        for needle in [
+            "constraint",
+            "realtor_profiles_user_id_key",
+            "DETAIL",
+            "user_id",
+            "host=",
+            "dbname=",
+            "sslmode",
+            "duplicate key",
+        ] {
+            assert!(
+                !body.contains(needle),
+                "client body leaked DB detail: found `{needle}` in `{body}`"
+            );
+        }
+    }
+
+    /// The `Display` bound (not `sqlx::Error`) keeps the helper reusable for
+    /// anyhow / serde / repository-wrapped errors — all of which must be
+    /// scrubbed identically.
+    #[test]
+    fn db_error_accepts_any_display_error() {
+        let serde_err = serde_json::from_str::<serde_json::Value>("{ not json")
+            .expect_err("invalid json should fail to parse");
+        let (status, body) = db_error("parse stored layout config", serde_err);
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body, "Internal server error");
+    }
+}


### PR DESCRIPTION
## Task
reality-server leaks raw sqlx::Error strings to internet-facing clients, bypassing util::errors::db_error [retry 1/2 of failed code-review-reality-server-db-error-leak].

reality-server is internet-facing. Several route handlers serialized the raw error via `format!("...: {e}")` straight into the client-facing `(StatusCode, String)` body, leaking `sqlx::Error` / serde detail: column and constraint names, and connection `host=`/`dbname=`/`sslmode=` fragments. This routes every such `map_err` boundary through the **existing** `util::errors::db_error` helper (reused, not duplicated) — it logs the full detail server-side and returns a generic `500 "Internal server error"` to the caller.

### Leak sites converted (23 across 6 route files)
- `listings.rs` — search, count, get-nearby-cities (3)
- `realtors.rs` — get/create/update profile, list/mark/respond inquiries (7; the `already exists`/`not found` classification branches are preserved, only the leaking `else` fallbacks changed)
- `imports.rs` — resolve agency, list/create/get import jobs, list/create/get feeds (7)
- `agencies.rs` — 4 `acquire_public_conn` `Database error: {e}` leaks
- `price_map.rs` — acquire conn + aggregate query (2)
- `layout.rs` — acquire conn, get config/manifest, list kills, and the two `serde_json::from_value` "stored config/manifest invalid: {e}" parse-error leaks (6)

### Intentionally left alone (not `map_err`→client DB leaks, out of scope)
- `health.rs:151` — health-check component-status struct field; a deliberate ops diagnostic surface, not a `?`-boundary DB error to a normal client, and a different shape than `db_error`.
- `sso.rs:153` — URL-parse error on a config value, not a DB error.
- The pre-existing inline `db_error` fn / `db_err` closure in `listings.rs` (get_listing, featured) already emit generic "Internal server error" — they do not leak; left as-is to keep the diff scoped to the security bug.

## Owner
pm-security

## Verification
fmt: clean — `cd backend && cargo fmt --all -- --check` passed.

The impact-scoped gate (`scripts/verify-impact.sh`) planned:
```
VERIFY-PLAN base=d5639a5cc6913c6c80f96800748faf4142921ac6 files=7
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo test -p reality-server
```

**clippy + tests could NOT complete in this sandbox** — but NOT due to this change. The backend workspace build fails in the `utoipa-swagger-ui v9.0.2` build-dependency, whose build script downloads `github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip`. That host is blocked by the session's egress policy (verified: `curl` returns HTTP 403 with body `{"message":"GitHub access to this repository is not enabled for this session..."}`; utoipa then panics `InvalidArchive("Could not find EOCD")`). Per proxy policy, the blocked host is reported, not retried. Compilation never reached `reality-server` or my edited files. `SQLX_OFFLINE=true` was set; the blocker is unrelated to sqlx/DB.

**CI must run `cargo clippy -p reality-server` and `cargo test -p reality-server` (incl. the new unit tests) to confirm green.** The change is a mechanical refactor onto an already widely-used helper (`db_error` is called ~60× elsewhere in reality-server with the same `map_err(|e| crate::util::errors::db_error("ctx", e))` shape and `impl Display` bound), so the risk is low.

## Tests added
`backend/servers/reality-server/src/util/errors.rs` — 3 pure unit tests (no DB required):
- `db_error_returns_generic_500_body` — asserts `(500, "Internal server error")`.
- `db_error_body_leaks_no_source_detail` — feeds a string containing constraint names, `DETAIL:`, `host=`/`dbname=`/`sslmode`, "duplicate key" and asserts none appear in the client body.
- `db_error_accepts_any_display_error` — passes a real `serde_json` parse error to confirm the `impl Display` bound covers serde/anyhow/repo-wrapped errors, all scrubbed identically.

## Scope drift
`scope-check.sh --owner pm-security` reports drift (exit 2): pm-security's declared globs are auth-only (`backend/crates/auth/**`, extractors, auth handlers/pages, migrations). This task deliberately directs a security fix inside `backend/servers/reality-server/src/routes/**` + `util/errors.rs`, which fall outside those globs. Drift is expected and justified by the task itself. `reuse-grep` clean (no new helper added — the existing `db_error` is reused).

## Code-reuse review
none — no new helper introduced; the fix consolidates onto the existing `crate::util::errors::db_error`.

## Notes
Retry 1/2 of a task that previously died before producing a PR. Draft pending CI confirmation of clippy + unit tests (blocked locally only by the swagger-ui egress denial described above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TH7pu5CpvxF6YxezZUmmXC)_