### PR TITLE
code-review-reality-server-password-reset-no-transport: wire real reset email transport + not-configured guard

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -5374,6 +5374,7 @@ dependencies = [
  "hex",
  "jsonwebtoken",
  "layout-core",
+ "lettre",
  "metrics 0.24.6",
  "metrics-exporter-prometheus",
  "opentelemetry",

--- a/backend/servers/reality-server/Cargo.toml
+++ b/backend/servers/reality-server/Cargo.toml
@@ -47,6 +47,10 @@ argon2 = { workspace = true }
 sqlx = { workspace = true }
 rust_decimal = { workspace = true }
 
+# Password-reset email transport (UC-44.3). Version/features mirror api-server's
+# declaration so the workspace resolves a single lettre build.
+lettre = { version = "0.11", features = ["tokio1-native-tls", "builder", "hostname", "smtp-transport"] }
+
 # Observability (Epic 95)
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }

--- a/backend/servers/reality-server/src/handlers/users/mod.rs
+++ b/backend/servers/reality-server/src/handlers/users/mod.rs
@@ -23,8 +23,15 @@ const PASSWORD_RESET_TTL_MINUTES: i64 = 30;
 #[derive(Debug)]
 pub enum PasswordResetRequestResult {
     /// A reset token was generated. The plaintext token is returned so the
-    /// caller can dispatch the email; it is NOT persisted in plaintext.
-    Sent { plaintext_token: String },
+    /// caller can dispatch the email; it is NOT persisted in plaintext. The
+    /// user's `name` and `locale` travel alongside it so the route handler can
+    /// render a properly addressed, localized reset email without a second
+    /// lookup.
+    Sent {
+        plaintext_token: String,
+        name: String,
+        locale: String,
+    },
     /// No such user exists. Returned to the handler so it can log internally
     /// while still returning HTTP 200 to the client.
     UserNotFound,
@@ -563,7 +570,11 @@ impl UserHandler {
             .await
             .map_err(|e| e.to_string())?;
 
-        Ok(PasswordResetRequestResult::Sent { plaintext_token })
+        Ok(PasswordResetRequestResult::Sent {
+            plaintext_token,
+            name: user.name,
+            locale: user.locale,
+        })
     }
 
     /// Verify a reset token and replace the user's password hash.

--- a/backend/servers/reality-server/src/routes/users.rs
+++ b/backend/servers/reality-server/src/routes/users.rs
@@ -7,6 +7,7 @@ use crate::extractors::auth::extract_session_token;
 use crate::handlers::users::{
     PasswordResetConfirmResult, PasswordResetRequestResult, RegistrationResult, UserHandler,
 };
+use crate::services::{delivery_decision, ResetDelivery};
 use crate::state::AppState;
 use api_core::extractors::RequestPrincipal;
 use axum::{
@@ -14,6 +15,7 @@ use axum::{
     routing::{get, post, put},
     Json, Router,
 };
+use db::models::user::Locale;
 use db::models::PortalUser;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -417,21 +419,24 @@ pub struct PasswordResetConfirmResponse {
     pub message: String,
 }
 
-/// Issue a password-reset token and (in production) email it to the user.
+/// Issue a password-reset token and email the reset link to the user.
 ///
-/// The endpoint always returns 200 with the same generic body so callers
-/// can't distinguish "user found" from "user not found" by status or
-/// timing alone. The plaintext token is logged at INFO in development
-/// builds so the dev flow remains testable without an email transport.
+/// On 200 the endpoint returns the same generic body whether or not the account
+/// exists, so callers can't distinguish "user found" from "user not found" by
+/// status or timing alone. When a real email transport is configured the reset
+/// link is delivered; in development builds it falls back to logging the link so
+/// the flow stays testable. If NO transport is configured in a release build the
+/// endpoint returns 503 rather than falsely claiming a link was sent.
 #[utoipa::path(
     post,
     path = "/api/v1/users/password-reset",
     tag = "Users",
     request_body = PasswordResetRequestBody,
     responses(
-        (status = 200, description = "Reset email queued (or user does not exist)",
+        (status = 200, description = "Reset email sent (or user does not exist)",
                        body = PasswordResetRequestResponse),
-        (status = 400, description = "Invalid email format")
+        (status = 400, description = "Invalid email format"),
+        (status = 503, description = "Email transport not configured — reset unavailable")
     )
 )]
 pub async fn request_password_reset(
@@ -445,29 +450,66 @@ pub async fn request_password_reset(
         ));
     }
 
+    // Guard: decide how to answer BEFORE issuing a token. The decision uses
+    // global server state only (transport configured? dev fallback allowed?),
+    // so it never leaks whether the account exists.
+    //
+    // This closes the prod bug where the endpoint always returned
+    // "a reset link has been sent" even though no email transport was wired —
+    // the token was persisted, then discarded, and the user was permanently
+    // stuck with no way to recover their account.
+    let mailer = state.password_reset_mailer.clone();
+    match delivery_decision(mailer.is_configured(), cfg!(debug_assertions)) {
+        ResetDelivery::Unavailable => {
+            // No transport and no dev fallback (release build): refuse rather
+            // than lie. Enumeration-safe — the answer does not depend on the
+            // email argument.
+            tracing::error!(
+                "Password reset requested but no email transport is configured; \
+                 refusing to falsely claim a link was sent (set SMTP_* to enable)"
+            );
+            return Err((
+                axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                "Password reset is temporarily unavailable. Please contact support.".to_string(),
+            ));
+        }
+        // Send (real transport) and LogFallback (dev) both issue the token and
+        // hand it to the mailer; the mailer decides whether it actually leaves
+        // the process.
+        ResetDelivery::Send | ResetDelivery::LogFallback => {}
+    }
+
     let handler = UserHandler::new(state.portal_repo.clone());
     match handler
         .request_password_reset(&state.portal_password_reset_repo, &req.email)
         .await
     {
-        Ok(PasswordResetRequestResult::Sent { plaintext_token }) => {
-            // Email transport hasn't been wired yet for the reality
-            // server. Until it is, surface the token via the tracing
-            // pipeline at INFO so dev/test flows can grab it; production
-            // builds should not log this.
-            #[cfg(debug_assertions)]
-            tracing::info!(
-                email_hash = %common::email_log_hash(&req.email),
-                token = %plaintext_token,
-                "Password reset token issued (dev: token logged for testing)"
-            );
-            #[cfg(not(debug_assertions))]
+        Ok(PasswordResetRequestResult::Sent {
+            plaintext_token,
+            name,
+            locale,
+        }) => {
+            let locale = Locale::parse(&locale);
+            match mailer
+                .send_reset_link(&req.email, &name, &plaintext_token, locale)
+                .await
             {
-                let _ = plaintext_token;
-                tracing::info!(
-                    email_hash = %common::email_log_hash(&req.email),
-                    "Password reset token issued"
-                );
+                Ok(()) => {
+                    tracing::info!(
+                        email_hash = %common::email_log_hash(&req.email),
+                        "Password reset link dispatched"
+                    );
+                }
+                Err(e) => {
+                    // Delivery failed at the transport. Keep the response
+                    // enumeration-safe (generic 200) but log loudly so
+                    // operators notice — we no longer silently drop the token.
+                    tracing::error!(
+                        error = %e,
+                        email_hash = %common::email_log_hash(&req.email),
+                        "Failed to send password reset email"
+                    );
+                }
             }
         }
         Ok(PasswordResetRequestResult::UserNotFound) => {

--- a/backend/servers/reality-server/src/services/email.rs
+++ b/backend/servers/reality-server/src/services/email.rs
@@ -1,0 +1,368 @@
+//! Password-reset email transport for reality-server (UC-44.3).
+//!
+//! ## The bug this closes
+//!
+//! reality-server issued a reset token, persisted its SHA-256 hash, then
+//! **discarded the plaintext token** and unconditionally responded
+//! *"a reset link has been sent"*. In production that was a lie — no email
+//! transport was ever wired, so the link never reached the user and the account
+//! had no working self-service recovery path.
+//!
+//! ## The fix
+//!
+//! A real transport lives behind the [`PasswordResetMailer`] seam:
+//! - [`SmtpPasswordResetMailer`] delivers via SMTP (lettre), configured from the
+//!   same `SMTP_*` environment variables api-server already uses.
+//! - [`LogPasswordResetMailer`] is the local/dev fallback — it logs instead of
+//!   sending and reports `is_configured() == false`.
+//!
+//! [`build_password_reset_mailer`] selects the transport from the environment,
+//! and [`delivery_decision`] is the pure guard the request handler uses so the
+//! endpoint no longer falsely claims delivery when no transport exists.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use db::models::user::Locale;
+use lettre::{
+    message::{header::ContentType, Mailbox},
+    transport::smtp::authentication::Credentials,
+    AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
+};
+
+/// How a password-reset request should be handled given the transport state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResetDelivery {
+    /// A real transport is configured — issue the token and send the email.
+    Send,
+    /// No transport is configured, but a dev/log fallback is permitted — issue
+    /// the token and log it (local/dev only).
+    LogFallback,
+    /// No transport is configured and no fallback is allowed — the endpoint must
+    /// report the feature as unavailable rather than claim a link was sent.
+    Unavailable,
+}
+
+/// Pure guard used by the request handler to decide how to answer a reset
+/// request without leaking whether the account exists (the inputs are global
+/// server state, not per-user).
+///
+/// * `configured` — whether a real delivery transport exists.
+/// * `allow_log_fallback` — whether the caller permits the dev/log fallback
+///   (true in debug/local builds, false in release/production).
+pub fn delivery_decision(configured: bool, allow_log_fallback: bool) -> ResetDelivery {
+    if configured {
+        ResetDelivery::Send
+    } else if allow_log_fallback {
+        ResetDelivery::LogFallback
+    } else {
+        ResetDelivery::Unavailable
+    }
+}
+
+/// Transport seam for delivering a password-reset link.
+#[async_trait]
+pub trait PasswordResetMailer: Send + Sync {
+    /// `true` when a real delivery transport is configured. When `false`, the
+    /// request handler must NOT claim a link was sent (see [`delivery_decision`]).
+    fn is_configured(&self) -> bool;
+
+    /// Deliver a reset link carrying `token` to `to_email`.
+    async fn send_reset_link(
+        &self,
+        to_email: &str,
+        name: &str,
+        token: &str,
+        locale: Locale,
+    ) -> Result<()>;
+}
+
+/// Base URL of the portal web front-end that hosts the reset-password page.
+/// Loaded from `PORTAL_WEB_BASE_URL` (or legacy `REALITY_WEB_BASE_URL`), with a
+/// local-dev fallback. Any trailing slash is trimmed so link building is stable.
+fn reset_base_url_from_env() -> String {
+    let raw = std::env::var("PORTAL_WEB_BASE_URL")
+        .or_else(|_| std::env::var("REALITY_WEB_BASE_URL"))
+        .unwrap_or_else(|_| "http://localhost:3000".to_string());
+    raw.trim_end_matches('/').to_string()
+}
+
+/// Build the localized reset-password link. Matches the reality-web route
+/// `/{locale}/auth/reset-password` and URL-encodes the token.
+fn build_reset_url(base_url: &str, token: &str, locale: &Locale) -> String {
+    format!(
+        "{}/{}/auth/reset-password?token={}",
+        base_url,
+        locale.as_str(),
+        urlencoding::encode(token)
+    )
+}
+
+fn reset_subject(locale: &Locale) -> &'static str {
+    match locale {
+        Locale::Slovak => "Obnovenie hesla",
+        Locale::Czech => "Obnovení hesla",
+        Locale::German => "Passwort zurücksetzen",
+        Locale::English => "Reset your password",
+    }
+}
+
+fn reset_body(name: &str, url: &str, locale: &Locale) -> String {
+    match locale {
+        Locale::Slovak => format!(
+            "Dobrý deň {name},\n\nDostali sme žiadosť o obnovenie vášho hesla. Kliknutím na odkaz nižšie ho obnovte:\n\n{url}\n\nOdkaz je platný 30 minút. Ak ste o obnovenie hesla nežiadali, túto správu ignorujte.\n\nS pozdravom,\nTím Reality Portál",
+        ),
+        Locale::Czech => format!(
+            "Dobrý den {name},\n\nObdrželi jsme žádost o obnovení vašeho hesla. Kliknutím na odkaz níže ho obnovte:\n\n{url}\n\nOdkaz je platný 30 minut. Pokud jste o obnovení hesla nežádali, tuto zprávu ignorujte.\n\nS pozdravem,\nTým Reality Portál",
+        ),
+        Locale::German => format!(
+            "Guten Tag {name},\n\nWir haben eine Anfrage zum Zurücksetzen Ihres Passworts erhalten. Klicken Sie auf den Link unten:\n\n{url}\n\nDer Link ist 30 Minuten gültig. Wenn Sie kein Zurücksetzen angefordert haben, ignorieren Sie diese Nachricht.\n\nMit freundlichen Grüßen,\nDas Reality-Portal-Team",
+        ),
+        Locale::English => format!(
+            "Hello {name},\n\nWe received a request to reset your password. Click the link below:\n\n{url}\n\nThis link is valid for 30 minutes. If you didn't request a password reset, please ignore this email.\n\nBest regards,\nThe Reality Portal Team",
+        ),
+    }
+}
+
+/// SMTP settings loaded from the environment (mirrors api-server's `SMTP_*`).
+struct SmtpSettings {
+    host: String,
+    port: u16,
+    username: String,
+    password: String,
+    from_address: String,
+    from_name: String,
+    use_tls: bool,
+}
+
+impl SmtpSettings {
+    /// Returns `None` unless the mandatory SMTP variables are all present.
+    fn from_env() -> Option<Self> {
+        let host = std::env::var("SMTP_HOST").ok()?;
+        let username = std::env::var("SMTP_USERNAME").ok()?;
+        let password = std::env::var("SMTP_PASSWORD").ok()?;
+        let from_address = std::env::var("SMTP_FROM").ok()?;
+        let port = std::env::var("SMTP_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(587);
+        let from_name =
+            std::env::var("SMTP_FROM_NAME").unwrap_or_else(|_| "Reality Portal".to_string());
+        let use_tls = std::env::var("SMTP_TLS")
+            .map(|v| v != "false" && v != "0")
+            .unwrap_or(true);
+
+        Some(Self {
+            host,
+            port,
+            username,
+            password,
+            from_address,
+            from_name,
+            use_tls,
+        })
+    }
+}
+
+/// Production transport: delivers the reset link over SMTP.
+pub struct SmtpPasswordResetMailer {
+    transport: AsyncSmtpTransport<Tokio1Executor>,
+    /// Pre-rendered `Name <address>` sender mailbox source string.
+    from: String,
+    base_url: String,
+}
+
+impl SmtpPasswordResetMailer {
+    fn new(settings: SmtpSettings, base_url: String) -> Result<Self> {
+        let creds = Credentials::new(settings.username.clone(), settings.password.clone());
+        let builder = if settings.use_tls {
+            AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&settings.host)?
+        } else {
+            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(&settings.host)
+        };
+        let transport = builder.port(settings.port).credentials(creds).build();
+        let from = format!("{} <{}>", settings.from_name, settings.from_address);
+        Ok(Self {
+            transport,
+            from,
+            base_url,
+        })
+    }
+}
+
+#[async_trait]
+impl PasswordResetMailer for SmtpPasswordResetMailer {
+    fn is_configured(&self) -> bool {
+        true
+    }
+
+    async fn send_reset_link(
+        &self,
+        to_email: &str,
+        name: &str,
+        token: &str,
+        locale: Locale,
+    ) -> Result<()> {
+        let url = build_reset_url(&self.base_url, token, &locale);
+        let from: Mailbox = self
+            .from
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid SMTP from address: {e}"))?;
+        let to: Mailbox = to_email
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid recipient address: {e}"))?;
+
+        let email = Message::builder()
+            .from(from)
+            .to(to)
+            .subject(reset_subject(&locale))
+            .header(ContentType::TEXT_PLAIN)
+            .body(reset_body(name, &url, &locale))?;
+
+        self.transport.send(email).await?;
+        Ok(())
+    }
+}
+
+/// Local/dev fallback: logs the reset link instead of sending it, and reports
+/// itself as **not** configured so the request handler never claims delivery.
+pub struct LogPasswordResetMailer {
+    base_url: String,
+}
+
+impl LogPasswordResetMailer {
+    pub fn new(base_url: String) -> Self {
+        Self { base_url }
+    }
+}
+
+#[async_trait]
+impl PasswordResetMailer for LogPasswordResetMailer {
+    fn is_configured(&self) -> bool {
+        false
+    }
+
+    async fn send_reset_link(
+        &self,
+        to_email: &str,
+        _name: &str,
+        token: &str,
+        locale: Locale,
+    ) -> Result<()> {
+        // The reset URL embeds the plaintext token — only surface it in debug
+        // builds so a mis-wired production deployment can never leak it to logs.
+        #[cfg(debug_assertions)]
+        {
+            let url = build_reset_url(&self.base_url, token, &locale);
+            tracing::info!(
+                email_hash = %common::email_log_hash(to_email),
+                reset_url = %url,
+                "Password-reset email (logging fallback — NOT delivered; configure SMTP_* to enable delivery)"
+            );
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let _ = (token, locale);
+            tracing::warn!(
+                email_hash = %common::email_log_hash(to_email),
+                "Password-reset requested but no email transport is configured — link NOT delivered"
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Select the password-reset transport from the environment.
+///
+/// Prefers a real SMTP transport when the `SMTP_*` variables are present; falls
+/// back to [`LogPasswordResetMailer`] (delivery disabled) otherwise.
+pub fn build_password_reset_mailer() -> Arc<dyn PasswordResetMailer> {
+    let base_url = reset_base_url_from_env();
+    match SmtpSettings::from_env() {
+        Some(settings) => match SmtpPasswordResetMailer::new(settings, base_url.clone()) {
+            Ok(mailer) => {
+                tracing::info!("Password-reset SMTP transport configured");
+                Arc::new(mailer)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to build SMTP transport for password reset; using logging fallback (delivery disabled)"
+                );
+                Arc::new(LogPasswordResetMailer::new(base_url))
+            }
+        },
+        None => {
+            tracing::info!(
+                "SMTP not configured; password reset uses the logging fallback (delivery disabled)"
+            );
+            Arc::new(LogPasswordResetMailer::new(base_url))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delivery_decision_truth_table() {
+        // Configured transport always sends, regardless of the fallback flag.
+        assert_eq!(delivery_decision(true, false), ResetDelivery::Send);
+        assert_eq!(delivery_decision(true, true), ResetDelivery::Send);
+        // Unconfigured + fallback allowed (dev) → log the token locally.
+        assert_eq!(delivery_decision(false, true), ResetDelivery::LogFallback);
+        // Unconfigured + no fallback (prod) → must report unavailable, never
+        // claim a link was sent. This is the regression the bug produced.
+        assert_eq!(delivery_decision(false, false), ResetDelivery::Unavailable);
+    }
+
+    #[test]
+    fn log_mailer_reports_not_configured() {
+        let mailer = LogPasswordResetMailer::new("http://localhost:3000".to_string());
+        assert!(!mailer.is_configured());
+    }
+
+    #[tokio::test]
+    async fn log_mailer_send_is_ok_and_never_delivers() {
+        let mailer = LogPasswordResetMailer::new("http://localhost:3000".to_string());
+        let res = mailer
+            .send_reset_link("user@example.com", "User", "tok-123", Locale::English)
+            .await;
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn reset_url_is_locale_prefixed_and_token_encoded() {
+        let url = build_reset_url("https://portal.example.sk", "a b/c+d", &Locale::Slovak);
+        assert_eq!(
+            url,
+            "https://portal.example.sk/sk/auth/reset-password?token=a%20b%2Fc%2Bd"
+        );
+    }
+
+    #[test]
+    fn base_url_trailing_slash_trimmed_in_link() {
+        let url = build_reset_url("https://portal.example.sk/", "tok", &Locale::English);
+        assert_eq!(
+            url, "https://portal.example.sk//en/auth/reset-password?token=tok",
+            "build_reset_url does not itself trim — reset_base_url_from_env does"
+        );
+    }
+
+    #[test]
+    fn reset_subject_is_localized() {
+        assert_eq!(reset_subject(&Locale::English), "Reset your password");
+        assert_eq!(reset_subject(&Locale::Slovak), "Obnovenie hesla");
+        assert_eq!(reset_subject(&Locale::Czech), "Obnovení hesla");
+        assert_eq!(reset_subject(&Locale::German), "Passwort zurücksetzen");
+    }
+
+    #[test]
+    fn reset_body_contains_name_and_link() {
+        let body = reset_body("Jane", "https://x/reset?token=t", &Locale::English);
+        assert!(body.contains("Jane"));
+        assert!(body.contains("https://x/reset?token=t"));
+    }
+}

--- a/backend/servers/reality-server/src/services/mod.rs
+++ b/backend/servers/reality-server/src/services/mod.rs
@@ -1,9 +1,13 @@
 //! Background services for reality-server.
 
+pub mod email;
 pub mod favorite_alerts;
 pub mod saved_search_alerts;
 pub mod search_alert_drainer;
 
+pub use email::{
+    build_password_reset_mailer, delivery_decision, PasswordResetMailer, ResetDelivery,
+};
 pub use favorite_alerts::{FavoriteAlertConfig, FavoriteAlertWorker};
 pub use saved_search_alerts::{SavedSearchAlertConfig, SavedSearchAlertWorker};
 pub use search_alert_drainer::{SearchAlertDrainerConfig, SearchAlertDrainerWorker};

--- a/backend/servers/reality-server/src/state.rs
+++ b/backend/servers/reality-server/src/state.rs
@@ -844,6 +844,11 @@ pub struct AppState {
     pub inquiries_handler: InquiriesHandler,
     /// Portal password-reset token repository (UC-44.3)
     pub portal_password_reset_repo: PortalPasswordResetRepository,
+    /// Password-reset email transport (UC-44.3). Selected from the environment:
+    /// a real SMTP transport when `SMTP_*` is configured, otherwise a logging
+    /// fallback that reports `is_configured() == false` so the request handler
+    /// never falsely claims a reset link was delivered.
+    pub password_reset_mailer: Arc<dyn crate::services::PasswordResetMailer>,
     /// Application configuration
     pub config: AppConfig,
     /// Pending SSO sessions (OAuth flow state)
@@ -917,6 +922,10 @@ impl AppState {
         let portal_repo = PortalRepository::new(db.clone());
         let reality_portal_repo = RealityPortalRepository::new(db.clone());
         let portal_password_reset_repo = PortalPasswordResetRepository::new(db.clone());
+        // UC-44.3: pick the reset email transport from the environment. Without
+        // SMTP_* this returns a logging fallback (delivery disabled) so the
+        // request handler can refuse to claim a link was sent in production.
+        let password_reset_mailer = crate::services::build_password_reset_mailer();
 
         // Public inquiry POSTs go through this handler so the best-effort realtor
         // notification fires. `with_notifier` makes the transport injectable:
@@ -977,6 +986,7 @@ impl AppState {
             reality_portal_repo,
             inquiries_handler,
             portal_password_reset_repo,
+            password_reset_mailer,
             config,
             sso_sessions: Arc::new(Mutex::new(HashMap::new())),
             user_service,


### PR DESCRIPTION
## Task
reality-server password reset is non-functional in prod — token discarded, no email transport, endpoint claims a link was sent.

The endpoint issued a reset token, persisted its SHA-256 hash, then **discarded the plaintext token** and unconditionally responded *"a reset link has been sent"*. In production no email transport was ever wired, so the link never reached the user and accounts had no working self-service recovery.

## Owner
pm-backend

## What changed
- **`services/email.rs` (new)** — a `PasswordResetMailer` transport seam:
  - `SmtpPasswordResetMailer` delivers the reset link over SMTP (lettre), configured from the same `SMTP_*` env vars api-server already uses; localized bodies (sk/cs/de/en); link points at reality-web `/{locale}/auth/reset-password?token=…`.
  - `LogPasswordResetMailer` — dev/log fallback that reports `is_configured() == false` so the handler never claims delivery. The token-bearing URL is only logged under `debug_assertions`.
  - `build_password_reset_mailer()` selects the transport from the environment (SMTP when configured, else logging fallback).
  - `delivery_decision(configured, allow_log_fallback)` — a pure guard.
- **`state.rs`** — `AppState.password_reset_mailer: Arc<dyn PasswordResetMailer>`, built in `AppState::new`.
- **`handlers/users/mod.rs`** — `PasswordResetRequestResult::Sent` now carries the user's `name` + `locale` so the route renders a properly addressed, localized email without a second lookup.
- **`routes/users.rs`** — the request handler now:
  - Returns **503** when no transport is configured and no dev fallback is allowed (release builds) — it no longer falsely claims a link was sent. The decision depends only on global server state, so **user-enumeration safety is preserved**.
  - Actually **sends** the email when configured; on transport failure it keeps the generic 200 but logs loudly (no more silent token drop).
  - Documents the new 503 in the OpenAPI annotation.

## Verification
> [!WARNING]
> **The impact-scoped `just verify` gate could NOT be executed in this cloud session.** Compiling the `reality-server` crate requires the `utoipa-swagger-ui` build script to download `swagger-ui` from `github.com`, and GitHub archive egress is blocked by this session's org policy (returns a policy-denial JSON instead of the zip → `InvalidArchive("Could not find EOCD")`). This is a pre-existing environment limitation unrelated to this change; there is no cached target to reuse. DB-backed integration tests are likewise unavailable (no local Postgres).

What *was* run locally:
- `cargo fmt -p reality-server -- --check` → clean (exit 0).
- Code reviewed by hand for compile-correctness against the api-server email-service and inquiry-notifier-seam patterns (`Locale` is `Clone` not `Copy`, so all template helpers take `&Locale`; trait is object-safe via `async_trait`; multi-arm `Arc::new` unsizes to `Arc<dyn PasswordResetMailer>`).

**CI must run `backend.yml` (clippy + `cargo test`) to close the gate** — CI has the GitHub access the swagger-ui build script needs. New unit tests added in `services/email.rs`: guard truth table, `is_configured`, locale-prefixed/token-encoded URL building, and localized subject/body.

## CI parity (Band C — hot-path)
This is an auth-adjacent (account-recovery) change. `just verify` / `act` could not be replicated locally due to the compile blocker above — deferring the hot-path CI-parity run to `backend.yml` on this PR.

## Remote-tested
skipped — no ppt-bridge MCP in this session.

## Notes
- `SMTP_*` env vars (host/port/username/password/from) enable delivery; `PORTAL_WEB_BASE_URL` (or legacy `REALITY_WEB_BASE_URL`) sets the reset-link origin. Without SMTP, prod returns 503 and dev logs the link.
- `Cargo.lock` change is minimal: adds `lettre` (already locked at 0.11.22 via api-server) to reality-server's dependency list.
- The quarantined `request_password_reset_returns_2xx` integration test stays 2xx: CI builds in debug, so the log fallback path issues a token and returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TH7pu5CpvxF6YxezZUmmXC

---
_Generated by [Claude Code](https://claude.ai/code/session_01TH7pu5CpvxF6YxezZUmmXC)_