### PR TITLE
code-review-reality-server-sso-session-invalidate-swallowed: surface portal session invalidation failure in sync_session

### DIFF
--- a/backend/servers/reality-server/src/routes/sso.rs
+++ b/backend/servers/reality-server/src/routes/sso.rs
@@ -1020,6 +1020,44 @@ pub struct SyncSessionResponse {
         (status = 401, description = "PM session invalid", body = SsoError)
     )
 )]
+/// Decide the response when a PM token is found inactive during session sync,
+/// given the outcome of the portal-session invalidation attempt.
+///
+/// * `None` — no portal session was supplied, so there was nothing to
+///   invalidate: report the PM session as expired (`401`).
+/// * `Some(Ok(()))` — the portal session was invalidated: report the PM
+///   session as expired (`401`).
+/// * `Some(Err(_))` — invalidation FAILED. We must not claim the session was
+///   invalidated; surface a `500` so the caller treats the portal session as
+///   still live (and can retry) rather than trusting a false "invalidated"
+///   signal.
+fn inactive_pm_token_response(
+    invalidate_result: Option<Result<(), anyhow::Error>>,
+) -> (StatusCode, SsoError) {
+    match invalidate_result {
+        Some(Err(e)) => {
+            tracing::error!(
+                error = %e,
+                "Failed to invalidate portal session after PM token went inactive"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                SsoError::new(
+                    "session_invalidation_failed",
+                    "PM session is inactive but the portal session could not be invalidated",
+                ),
+            )
+        }
+        Some(Ok(())) | None => (
+            StatusCode::UNAUTHORIZED,
+            SsoError::new(
+                "pm_session_expired",
+                "PM session has expired, portal session invalidated",
+            ),
+        ),
+    }
+}
+
 pub async fn sync_session(
     State(state): State<AppState>,
     Json(request): Json<SyncSessionRequest>,
@@ -1037,23 +1075,29 @@ pub async fn sync_session(
             )
         })?;
 
-    // If PM token is inactive, invalidate portal session
+    // If PM token is inactive, invalidate the portal session. The
+    // invalidation error MUST NOT be swallowed: if the portal session cannot
+    // be torn down we must surface that failure instead of falsely reporting
+    // it as invalidated — otherwise the portal session outlives the
+    // deactivated PM token and the caller is lulled into believing the SSO
+    // session is dead when it is still usable (security regression).
     if !token_info.active {
-        if let Some(portal_session) = &request.portal_session {
-            let _ = state
-                .session_service
-                .invalidate_session(portal_session)
-                .await;
+        let invalidate_result = match &request.portal_session {
+            Some(portal_session) => Some(
+                state
+                    .session_service
+                    .invalidate_session(portal_session)
+                    .await,
+            ),
+            None => None,
+        };
+
+        if matches!(invalidate_result, Some(Ok(()))) {
             tracing::info!("Invalidated portal session due to inactive PM token");
         }
 
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            Json(SsoError::new(
-                "pm_session_expired",
-                "PM session has expired, portal session invalidated",
-            )),
-        ));
+        let (status, err) = inactive_pm_token_response(invalidate_result);
+        return Err((status, Json(err)));
     }
 
     // Get current user info
@@ -1435,6 +1479,44 @@ mod pm_role_derivation_tests {
         let derived = derive_pm_roles(Some(&token_scope), Some(&requested));
         assert!(derived.is_empty(), "empty filter must intersect to nothing");
         assert_eq!(portal_role_for(&derived), portal_roles::USER);
+    }
+}
+
+#[cfg(test)]
+mod sync_session_invalidation_tests {
+    use super::inactive_pm_token_response;
+    use axum::http::StatusCode;
+
+    /// Security regression: when the PM token is inactive and the portal
+    /// session invalidation FAILS, the handler must NOT report the session as
+    /// invalidated. It must surface a 500 so the caller does not trust a false
+    /// "portal session invalidated" signal while the session is still live.
+    #[test]
+    fn invalidation_failure_is_surfaced_not_swallowed() {
+        let result = Some(Err(anyhow::anyhow!("redis down")));
+        let (status, err) = inactive_pm_token_response(result);
+        assert_eq!(
+            status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a failed invalidation must not masquerade as a successful 401"
+        );
+        assert_eq!(err.error, "session_invalidation_failed");
+    }
+
+    /// A successful invalidation reports the PM session as expired (401).
+    #[test]
+    fn successful_invalidation_reports_pm_session_expired() {
+        let (status, err) = inactive_pm_token_response(Some(Ok(())));
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.error, "pm_session_expired");
+    }
+
+    /// No portal session supplied: nothing to invalidate, still a 401.
+    #[test]
+    fn no_portal_session_reports_pm_session_expired() {
+        let (status, err) = inactive_pm_token_response(None);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(err.error, "pm_session_expired");
     }
 }
 

--- a/backend/servers/reality-server/src/routes/sso.rs
+++ b/backend/servers/reality-server/src/routes/sso.rs
@@ -1006,20 +1006,6 @@ pub struct SyncSessionResponse {
     pub status: String,
 }
 
-/// Synchronize session state between PM and Reality Portal.
-///
-/// This ensures that logout in PM invalidates the Reality Portal session,
-/// and that role changes are propagated.
-#[utoipa::path(
-    post,
-    path = "/api/v1/sso/sync",
-    tag = "SSO",
-    request_body = SyncSessionRequest,
-    responses(
-        (status = 200, description = "Session synchronized", body = SyncSessionResponse),
-        (status = 401, description = "PM session invalid", body = SsoError)
-    )
-)]
 /// Decide the response when a PM token is found inactive during session sync,
 /// given the outcome of the portal-session invalidation attempt.
 ///
@@ -1058,6 +1044,20 @@ fn inactive_pm_token_response(
     }
 }
 
+/// Synchronize session state between PM and Reality Portal.
+///
+/// This ensures that logout in PM invalidates the Reality Portal session,
+/// and that role changes are propagated.
+#[utoipa::path(
+    post,
+    path = "/api/v1/sso/sync",
+    tag = "SSO",
+    request_body = SyncSessionRequest,
+    responses(
+        (status = 200, description = "Session synchronized", body = SyncSessionResponse),
+        (status = 401, description = "PM session invalid", body = SsoError)
+    )
+)]
 pub async fn sync_session(
     State(state): State<AppState>,
     Json(request): Json<SyncSessionRequest>,


### PR DESCRIPTION
## Task
reality-server sync_session swallows invalidate_session error — portal session survives after PM token goes inactive.

When a PM token is found inactive during SSO session sync (`POST /api/v1/sso/sync`), the portal-session invalidation error was swallowed with `let _ = ...await;`. The handler then unconditionally logged "Invalidated portal session due to inactive PM token" and returned a `401 pm_session_expired` claiming the portal session had been invalidated — **even when the invalidation actually failed**. Result: the portal session outlives the deactivated PM token (a session-survival security regression), while the caller is told the session is dead.

## Fix
- Capture the `invalidate_session` result instead of discarding it.
- Extract a pure, unit-testable helper `inactive_pm_token_response(Option<Result<(), anyhow::Error>>)` that maps the outcome to the response:
  - `None` (no portal session supplied) or `Some(Ok(()))` → `401 pm_session_expired` (nothing to invalidate / invalidated successfully).
  - `Some(Err(_))` → `500 session_invalidation_failed` with an `error!` log — the failure is **surfaced**, never masked. The caller must treat the portal session as still live and retry, rather than trusting a false "invalidated" signal.
- The success log line is now emitted only when invalidation actually succeeded.

## Owner
pm-security

## Scope drift
`scope-check.sh --owner pm-security` reports **exit 2** for the single changed file:
- `backend/servers/reality-server/src/routes/sso.rs`

This is expected/justified: `pm-security`'s declared owner-areas globs cover `api-server` auth/mfa + `api-core` extractors, and do not list `backend/servers/reality-server/**`. The task itself is a pm-security-owned reality-server SSO fix and directed this exact file. No other files are touched.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` → no warnings. The fix reuses the existing `SessionService::invalidate_session` and `SsoError::new`; the new helper is local decision logic, not a duplicated utility. It mirrors the existing swallow-and-log pattern used in `routes/users.rs::logout`, but intentionally diverges to *surface* (not just log) the failure, because unlike voluntary logout, an inactive-PM-token sync must not report success on a failed teardown.

## Verification
```
VERIFY-PLAN base=d5639a5cc6913c6c80f96800748faf4142921ac6 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo test -p reality-server
```

Local results (cloud sandbox — no Postgres/Redis, `SQLX_OFFLINE=true`):
- `cargo fmt --all -- --check` → **PASS**
- `cargo clippy -p reality-server --all-targets -- -D warnings` → **PASS** (clean)
- `cargo test -p reality-server --lib` → **PASS** (3 new `sync_session_invalidation_tests` + 84 existing unit tests):
  - `invalidation_failure_is_surfaced_not_swallowed` — asserts `Some(Err(_))` → `500 session_invalidation_failed` (the regression guard).
  - `successful_invalidation_reports_pm_session_expired` — `Some(Ok(()))` → `401 pm_session_expired`.
  - `no_portal_session_reports_pm_session_expired` — `None` → `401 pm_session_expired`.
- Full `cargo test -p reality-server` → **could NOT complete locally**: the DB-backed integration suites use `#[sqlx::test(migrator = "db::MIGRATOR")]`, which panics with `DATABASE_URL must be set` (no Postgres in this sandbox). The only failures are these DB-dependent tests (e.g. `layout_namespace_tests`), all unrelated to this change. **No `VERIFY OK` line is claimed** — the DB-backed portion is deferred to CI (`backend.yml`), which runs against a live Postgres.

Note: `utoipa-swagger-ui`'s build script downloads its asset from github.com, which is blocked by this sandbox's egress policy; the crate was built by pointing `SWAGGER_UI_DOWNLOAD_URL` at a locally-reconstructed zip. This is a local-build accommodation only and does not affect the committed code or CI.

## CI parity (Band C — hot-path)
This is a security/auth change. Local Band-C replication (`act` / full workflow job) was not possible in-sandbox due to the no-DB / egress constraints above; the draft PR relies on CI's `backend.yml` (fmt + clippy + `cargo test` against Postgres) for the DB-backed gate. Reviewer: please confirm CI green before un-drafting.

## Remote-tested
skipped (no ppt-bridge MCP this session)

## Notes
- Retry (1/2) of `code-review-reality-server-sso-session-invalidate-swallowed`, which died before producing a PR.
- The fix is intentionally minimal and self-contained (one file, one handler branch + one pure helper + unit tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TH7pu5CpvxF6YxezZUmmXC)_