### PR TITLE
code-review-reality-server-agency-members-unauth-idor-retry1: require agency membership to list members

### DIFF
--- a/backend/servers/reality-server/src/routes/agencies.rs
+++ b/backend/servers/reality-server/src/routes/agencies.rs
@@ -328,6 +328,17 @@ pub async fn update_branding(
 }
 
 /// List agency members.
+///
+/// SECURITY (members-idor audit): the member roster is agency-internal PII
+/// (names, emails, roles). Previously this handler had no auth extractor and
+/// no membership gate, so anyone on the internet could enumerate any agency's
+/// members via `GET /api/v1/agencies/{id}/members` — unauthenticated
+/// cross-agency member enumeration (IDOR). We now require an authenticated
+/// principal who is an active member of the target agency, using the same
+/// shared `check_agency_membership` gate the sibling mutators
+/// (`update_agency`, `update_branding`, `create_invitation`) apply: `404` when
+/// the agency doesn't exist and `403` for a non-member (never leaks
+/// cross-agency membership).
 #[utoipa::path(
     get,
     path = "/api/v1/agencies/{id}/members",
@@ -335,13 +346,28 @@ pub async fn update_branding(
     params(("id" = Uuid, Path, description = "Agency ID")),
     responses(
         (status = 200, description = "List of members", body = MembersResponse),
-        (status = 401, description = "Unauthorized")
-    )
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Not a member of this agency"),
+        (status = 404, description = "Agency not found")
+    ),
+    security(("session_token" = []))
 )]
 pub async fn list_members(
     State(state): State<AppState>,
+    principal: RequestPrincipal,
     Path(id): Path<Uuid>,
 ) -> Result<Json<MembersResponse>, (axum::http::StatusCode, String)> {
+    // SECURITY (members-idor): gate on active membership of the target agency
+    // via the shared helper — single source of truth for "is this user allowed
+    // to see this agency's internal data?". Returns 404 (unknown agency) / 403
+    // (non-member) before any member data is read.
+    let mut conn = state
+        .acquire_public_conn()
+        .await
+        .map_err(|e| crate::util::errors::db_error("acquire db connection", e))?;
+    super::agency_imports::check_agency_membership(&mut conn, id, principal.user_id).await?;
+    drop(conn);
+
     let members = state
         .reality_portal_repo
         .get_agency_members(id)

--- a/backend/servers/reality-server/tests/suites/agencies_authz_tests.rs
+++ b/backend/servers/reality-server/tests/suites/agencies_authz_tests.rs
@@ -3,11 +3,11 @@
 //! Drives the real Axum router (routes::agencies) end-to-end via `oneshot`.
 //!
 //! Public endpoints (no RequestPrincipal): list_agencies, get_agency,
-//! get_agency_by_slug, list_members — return non-401 without a token.
+//! get_agency_by_slug — return non-401 without a token.
 //!
 //! Protected endpoints (RequestPrincipal): create_agency, update_agency,
-//! create_invitation, accept_invitation — return 401 without a token and
-//! non-401 with a seeded user token.
+//! list_members, create_invitation, accept_invitation — return 401 without a
+//! token and non-401 with a seeded user token.
 
 use crate::common::{make_app_state, mint_token, send, send_json};
 use axum::{http::Method, Router};
@@ -161,10 +161,14 @@ async fn get_agency_by_slug_unauthenticated_returns_non_401(pool: PgPool) {
     );
 }
 
-// ── list_members (public) ─────────────────────────────────────────────────────
+// ── list_members (protected) ──────────────────────────────────────────────────
 
+// SECURITY regression (members-idor audit): the member roster is agency-internal
+// PII. `list_members` had NO auth extractor and NO membership gate, so anyone on
+// the internet could enumerate any agency's members. An unauthenticated request
+// must now be rejected with 401 (auth required), not served the roster.
 #[sqlx::test(migrator = "db::MIGRATOR")]
-async fn list_members_unauthenticated_returns_non_401(pool: PgPool) {
+async fn list_members_unauthenticated_returns_401(pool: PgPool) {
     let id = Uuid::new_v4();
     let app = agencies_router(pool);
     let status = send(
@@ -174,9 +178,56 @@ async fn list_members_unauthenticated_returns_non_401(pool: PgPool) {
         None,
     )
     .await;
-    assert_ne!(
+    assert_eq!(
         status, 401,
-        "list_members must not require auth (may return empty list or 404)"
+        "list_members must require auth (member roster is agency-internal PII), got {status}"
+    );
+}
+
+// SECURITY regression (members-idor audit): an authenticated user who is NOT a
+// member of the target agency must NOT be able to enumerate its members — the
+// cross-agency IDOR. Uses a `platform` caller so the request clears the
+// `RequestPrincipal` extractor and the 403 can only come from the handler's own
+// `check_agency_membership` gate.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_members_non_member_returns_403(pool: PgPool) {
+    let outsider = seed_platform_user(&pool, "members-outsider").await;
+    let agency_id = seed_agency(&pool, "members-403").await;
+    // NB: no membership seeded for `outsider` in this agency.
+    let token = mint_token(outsider);
+    let app = agencies_router(pool);
+    let status = send(
+        &app,
+        Method::GET,
+        &format!("/api/v1/agencies/{agency_id}/members"),
+        Some(&token),
+    )
+    .await;
+    assert_eq!(
+        status, 403,
+        "a non-member must NOT be able to enumerate an agency's members, got {status}"
+    );
+}
+
+// Companion: the gate must not over-reject — an active member of the agency is
+// allowed past the membership check and receives the roster (200).
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn list_members_member_returns_200(pool: PgPool) {
+    let member = seed_platform_user(&pool, "members-member").await;
+    let agency_id = seed_agency(&pool, "members-ok").await;
+    seed_membership(&pool, agency_id, member).await;
+    let token = mint_token(member);
+    let app = agencies_router(pool);
+    let status = send(
+        &app,
+        Method::GET,
+        &format!("/api/v1/agencies/{agency_id}/members"),
+        Some(&token),
+    )
+    .await;
+    assert_eq!(
+        status, 200,
+        "an active member must be able to list the agency's members, got {status}"
     );
 }
 

--- a/backend/servers/reality-server/tests/suites/agencies_happy_path_tests.rs
+++ b/backend/servers/reality-server/tests/suites/agencies_happy_path_tests.rs
@@ -1,12 +1,13 @@
 //! Happy-path 2xx tests for the agencies surface
 //! (`reality-server/src/routes/agencies.rs`) — BIT-344 Wave 6.
 //!
-//! Public reads (`list_agencies`, `get_agency`, `get_agency_by_slug`,
-//! `list_members`) need only a seeded `reality_agencies` row. The authenticated
-//! writes (`create_agency`, `update_agency`) use `RequestPrincipal`, so the
-//! caller is seeded `principal_kind = 'platform'` to clear the tenant gate;
-//! `update_agency` additionally needs an active `reality_agency_members` row
-//! (FK → `users` after migration 00148).
+//! Public reads (`list_agencies`, `get_agency`, `get_agency_by_slug`) need only
+//! a seeded `reality_agencies` row. The authenticated calls (`create_agency`,
+//! `update_agency`, `list_members`) use `RequestPrincipal`, so the caller is
+//! seeded `principal_kind = 'platform'` to clear the tenant gate; `update_agency`
+//! and `list_members` additionally need an active `reality_agency_members` row
+//! (FK → `users` after migration 00148) — the member roster is agency-internal
+//! PII, gated by `check_agency_membership` (members-idor audit).
 
 use crate::common::{make_app_state, mint_token, send, send_json};
 use axum::{http::Method, Router};
@@ -109,13 +110,18 @@ async fn get_agency_by_slug_returns_2xx(pool: PgPool) {
 
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn list_members_returns_2xx(pool: PgPool) {
+    // members-idor audit: listing members now requires an authenticated,
+    // active member of the target agency.
+    let member = seed_user(&pool, "members-caller").await;
     let agency_id = seed_agency(&pool, "members").await;
+    seed_membership(&pool, agency_id, member).await;
+    let token = mint_token(member);
     let app = agencies_router(pool);
     let status = send(
         &app,
         Method::GET,
         &format!("/api/v1/agencies/{agency_id}/members"),
-        None,
+        Some(&token),
     )
     .await;
     assert!(status.is_success(), "expected 2xx, got {status}");


### PR DESCRIPTION
## Task
reality-server `GET /api/v1/agencies/{id}/members` has no auth or membership check — unauthenticated cross-agency member enumeration (IDOR). Add proper authentication + agency-membership authorization so only members of agency `{id}` (or appropriately privileged roles) can enumerate its members; unauthenticated/cross-agency requests must be rejected (401/403), matching how other authenticated reality-server endpoints guard tenant scope.

## Owner
pm-backend

## Fix
`list_members` (`backend/servers/reality-server/src/routes/agencies.rs`) previously took no `RequestPrincipal` extractor and no membership gate, so anyone on the internet could enumerate any agency's member roster (names, emails, roles) — an IDOR. It now:

- requires an authenticated `RequestPrincipal` → **401** unauthenticated;
- calls the shared `super::agency_imports::check_agency_membership` gate — the same single-source-of-truth guard the sibling mutators (`update_agency`, `update_branding`, `create_invitation`) already use → **404** unknown agency, **403** non-member (never leaks cross-agency membership);
- OpenAPI annotation updated (adds 403/404 + `security(session_token)`).

Tests (`test:` commit lands the failing-on-main regression first, then `fix:`):
- `agencies_authz_tests.rs`: `list_members_unauthenticated_returns_401` (flipped from the old `_returns_non_401`), `list_members_non_member_returns_403` (cross-agency IDOR), `list_members_member_returns_200` (no over-rejection).
- `agencies_happy_path_tests.rs`: `list_members_returns_2xx` now seeds + authenticates an active member.

## Verification
```
VERIFY-PLAN base=d20fd9e5cfb1985988268f35bf4af7e07bb0a20c files=3
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p reality-server --all-targets -- -D warnings
  cd backend && cargo test -p reality-server
```
- `cargo fmt --all -- --check` — **PASS** (exit 0)
- `cargo clippy -p reality-server --all-targets -- -D warnings` — **PASS** (exit 0; compiles the new test targets too)
- `cargo test -p reality-server` — **could not run locally**: no Postgres in this sandbox (`#[sqlx::test]` needs a live DB) and `utoipa-swagger-ui`'s build script downloads swagger-ui from github.com, which is egress-blocked (403). Clippy `--all-targets` was made to pass by seeding a local synthetic swagger-ui zip so the crate + tests type-check; **CI `backend.yml` is the authoritative gate** for the DB-backed test run. PR kept as **draft** accordingly.

## IG goal-check
`goal-check.sh --skip IG7,IG8`: IG3 **ok** (separate `test:`+`fix:` commits). IG1 (plan file) and IG2 (`impl/<slug>` branch) FAIL only because this is a plan-less dispatcher code-review task on the dispatcher-mandated `auto-impl/…` branch — structural, not code defects. IG4/5/6 skip (no plan → no OOS).

## Scope drift
None — diff is 3 files, all under `backend/servers/reality-server/` (pm-backend). `scope-check.sh --owner pm-backend --base origin/dev` → exit 0.

## Code-reuse review
None — `reuse-grep.sh` clean. The fix reuses the existing `check_agency_membership` helper rather than adding a new one.

## CI parity (Band C — hot-path)
Security/auth change. `just`/`act` not installed in-sandbox; relying on CI `backend.yml` (fmt + clippy + `cargo test`) as the authoritative hot-path gate. fmt + clippy replicated locally (green); DB tests deferred to CI.

## Remote-tested
skipped (ppt-bridge MCP not connected)

## Notes
- The member roster is agency-internal PII; this matches the round-9 H2 audit pattern already applied to the sibling agency mutators.
- Frontend/mobile clients that call this endpoint are already authenticated agency members, so no client change is required; if any surface called it unauthenticated it must now send the session token (follow-up for pm-frontend if observed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCMsdPS8UaeYTJ2iJw4DAq)_