### PR TITLE
code-review-api-core-voice-actions-fabricated-empty: voice check-announcements/check-meter fail honestly instead of fabricating empty success

### DIFF
--- a/backend/servers/api-server/src/services/voice_commands.rs
+++ b/backend/servers/api-server/src/services/voice_commands.rs
@@ -387,28 +387,27 @@ impl VoiceCommandProcessor {
         _device: &VoiceAssistantDevice,
         parsed: &ParsedVoiceCommand,
     ) -> Result<VoiceActionResult, VoiceCommandError> {
-        // In a real implementation, this would query the announcement repository
+        // No announcement repository is wired into the voice processor yet, so
+        // there is nothing to query. This used to fabricate a "you have no new
+        // announcements" success response with an empty `data` payload on this
+        // live webhook path (code review: fabricated success) — a resident
+        // could be told there is nothing new when announcements were never
+        // actually queried. Fail honestly instead: tell the caller the feature
+        // isn't available via voice yet rather than asserting an empty inbox.
         let response = match parsed.language.as_str() {
-            "sk" => "Nemate ziadne nove oznamy.",
-            "cs" => "Nemate zadne nove oznameni.",
-            _ => "You have no new announcements.",
+            "sk" => "Kontrola oznamov hlasom momentalne nie je dostupna. Prosim, pouzite mobilnu aplikaciu alebo webovy portal.",
+            "cs" => "Kontrola oznameni hlasem momentalne neni dostupna. Prosim, pouzijte mobilni aplikaci nebo webovy portal.",
+            _ => "Checking announcements is not yet available via voice assistant. Please use the mobile app or web portal.",
         };
 
         Ok(VoiceActionResult {
-            success: true,
+            success: false,
             action_type: voice_intent::CHECK_ANNOUNCEMENTS.to_string(),
             response_text: response.to_string(),
             ssml: Some(format!("<speak>{}</speak>", response)),
-            card: Some(VoiceCard {
-                title: self.localize("Announcements", &parsed.language),
-                content: response.to_string(),
-                image_url: None,
-            }),
+            card: None,
             should_end_session: true,
-            data: Some(json!({
-                "count": 0,
-                "announcements": []
-            })),
+            data: None,
         })
     }
 
@@ -439,29 +438,28 @@ impl VoiceCommandProcessor {
         _device: &VoiceAssistantDevice,
         parsed: &ParsedVoiceCommand,
     ) -> Result<VoiceActionResult, VoiceCommandError> {
-        // In a real implementation, this would query the meter repository
+        // No meter repository is wired into the voice processor yet, so there
+        // is nothing to query. This used to fabricate a "there are no pending
+        // readings" success response with an empty `data` payload on this live
+        // webhook path (code review: fabricated success) — a resident could be
+        // told their readings are up to date when the meter state was never
+        // actually queried. Fail honestly instead: tell the caller the feature
+        // isn't available via voice yet rather than asserting there is nothing
+        // pending.
         let response = match parsed.language.as_str() {
-            "sk" => {
-                "Vase posledne odcitanie meracov bolo zaznamenane. Nemam ziadne cakajuce odcitania."
-            }
-            "cs" => "Vase posledni odecty meracu byly zaznamenany. Nemam zadne cekajici odecty.",
-            _ => "Your latest meter readings have been recorded. There are no pending readings.",
+            "sk" => "Kontrola odcitania meracov hlasom momentalne nie je dostupna. Prosim, pouzite mobilnu aplikaciu alebo webovy portal.",
+            "cs" => "Kontrola odectu meracu hlasem momentalne neni dostupna. Prosim, pouzijte mobilni aplikaci nebo webovy portal.",
+            _ => "Checking meter readings is not yet available via voice assistant. Please use the mobile app or web portal.",
         };
 
         Ok(VoiceActionResult {
-            success: true,
+            success: false,
             action_type: voice_intent::CHECK_METER.to_string(),
             response_text: response.to_string(),
             ssml: Some(format!("<speak>{}</speak>", response)),
-            card: Some(VoiceCard {
-                title: self.localize("Meter Readings", &parsed.language),
-                content: response.to_string(),
-                image_url: None,
-            }),
+            card: None,
             should_end_session: true,
-            data: Some(json!({
-                "pending_readings": 0
-            })),
+            data: None,
         })
     }
 
@@ -783,6 +781,84 @@ mod tests {
         assert!(
             !result.response_text.to_lowercase().contains("zero"),
             "response must not claim a fabricated zero balance"
+        );
+    }
+
+    /// Regression (code-review: voice check-announcements fabricated empty
+    /// success): the handler used to unconditionally report `success: true`
+    /// with a hardcoded "you have no new announcements" response and an empty
+    /// `data` payload on this live webhook path, without ever consulting an
+    /// announcement repository. No announcement service is wired in yet, so it
+    /// must now fail honestly — `success: false`, no fabricated `data`, and a
+    /// response that tells the caller the feature isn't available rather than
+    /// asserting an empty inbox.
+    #[tokio::test]
+    async fn test_check_announcements_fails_honestly_instead_of_fabricating_empty() {
+        let processor = create_test_processor();
+        let device = make_device(Uuid::new_v4(), Uuid::new_v4(), Some(Uuid::new_v4()));
+        let parsed = processor.parse_command("Any new announcements?", "en-US");
+        assert_eq!(parsed.intent, voice_intent::CHECK_ANNOUNCEMENTS);
+
+        // action_check_announcements doesn't touch the database, so it can be
+        // called directly without acquiring a real connection.
+        let result = processor
+            .action_check_announcements(&device, &parsed)
+            .await
+            .expect("check-announcements must not error, it must fail honestly in-band");
+
+        assert!(
+            !result.success,
+            "check-announcements must not report fabricated success"
+        );
+        assert!(
+            result.data.is_none(),
+            "no announcement data must be fabricated when no repository was queried"
+        );
+        assert!(
+            !result
+                .response_text
+                .to_lowercase()
+                .contains("no new announcements"),
+            "response must not claim a fabricated empty inbox"
+        );
+    }
+
+    /// Regression (code-review: voice check-meter fabricated empty success):
+    /// the handler used to unconditionally report `success: true` with a
+    /// hardcoded "there are no pending readings" response and an empty `data`
+    /// payload on this live webhook path, without ever consulting a meter
+    /// repository. No meter service is wired in yet, so it must now fail
+    /// honestly — `success: false`, no fabricated `data`, and a response that
+    /// tells the caller the feature isn't available rather than asserting
+    /// nothing is pending.
+    #[tokio::test]
+    async fn test_check_meter_fails_honestly_instead_of_fabricating_empty() {
+        let processor = create_test_processor();
+        let device = make_device(Uuid::new_v4(), Uuid::new_v4(), Some(Uuid::new_v4()));
+        let parsed = processor.parse_command("Do I have any pending meter readings?", "en-US");
+        assert_eq!(parsed.intent, voice_intent::CHECK_METER);
+
+        // action_check_meter doesn't touch the database, so it can be called
+        // directly without acquiring a real connection.
+        let result = processor
+            .action_check_meter(&device, &parsed)
+            .await
+            .expect("check-meter must not error, it must fail honestly in-band");
+
+        assert!(
+            !result.success,
+            "check-meter must not report fabricated success"
+        );
+        assert!(
+            result.data.is_none(),
+            "no meter data must be fabricated when no repository was queried"
+        );
+        assert!(
+            !result
+                .response_text
+                .to_lowercase()
+                .contains("no pending readings"),
+            "response must not claim fabricated absence of pending readings"
         );
     }
 


### PR DESCRIPTION
## Summary
Voice check-announcements & check-meter actions fabricated a `success:true` response with empty data — residents were told "You have no new announcements" / "There are no pending readings" without any announcement or meter repository ever being queried, on the live voice-webhook path.

This mirrors the already-merged **check-balance** fix for the identical "fabricated success" finding: since no announcement/meter service is wired into the voice processor yet, the actions now **fail honestly** (`success:false`, `card:None`, `data:None`) and steer the caller to the mobile app / web portal, instead of asserting an empty inbox / no pending readings that was never actually checked.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Related Issues
Code-review finding: `code-review-api-core-voice-actions-fabricated-empty`

## Changes Made
- `action_check_announcements`: no longer returns `success:true` + `{count:0, announcements:[]}`; returns `success:false`, no card, no data, with an sk/cs/en "not yet available via voice" response.
- `action_check_meter`: no longer returns `success:true` + `{pending_readings:0}`; returns `success:false`, no card, no data, with an sk/cs/en "not yet available via voice" response.
- Consistent with the existing `action_check_balance` precedent in the same file.

## Testing
- [x] Unit tests added (2 regression tests)

Added `test_check_announcements_fails_honestly_instead_of_fabricating_empty` and `test_check_meter_fails_honestly_instead_of_fabricating_empty` — each asserts `!success`, `data.is_none()`, and that the response does not claim a fabricated empty result. Both PASS locally.

## Owner
pm-backend (specialist: rust-backend)

## Scope drift
None. Diff (against merge-base) is a single file: `backend/servers/api-server/src/services/voice_commands.rs`. `scope-check.sh --owner pm-backend` → exit 0.

## Code-reuse review
None. `reuse-grep.sh --specialist rust-backend` → no warnings (no new security/auth/crypto/http helpers introduced).

## Verification
```
VERIFY-PLAN base=773e00f4fe1cd8d4fcd42a8891093ac2c9a3d28d files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```
- `cargo fmt --all -- --check` → **PASS**
- `cargo clippy -p api-server --all-targets -- -D warnings` → **PASS** (clean, no warnings)
- `cargo test -p api-server` → **563 passed; 11 failed** — all 11 failures are environmental, none reachable by this single-file change:
  - 10× `#[sqlx::test]` tests panicking with `DATABASE_URL must be set: EnvVar(NotPresent)` — the dispatcher sandbox has no Postgres and no Docker daemon. These are CI-gated by design (see the in-file comment on `test_report_fault_persists_fault`: "Skipped by the offline verify gate (no DATABASE_URL); runs under backend.yml CI"). Affected: voice_webhooks auth (1), scheduler (7), voice_commands report_fault (2).
  - 1× `services::actions::api_call::tests::execute_rejects_dns_rebinding_to_private_ip_at_connect` — a DNS-rebinding network test in `api_call.rs`, a file this PR does not touch; fails due to sandbox network behavior.
  - The **two new regression tests for this fix both PASS**, and compilation fully succeeded (all 574 tests ran). backend.yml CI (with its Postgres service + GitHub egress) is the environment that runs the DB tests green.

Note: local clippy/test compile required a one-off env workaround for a blocked transitive build dependency — `utoipa-swagger-ui`'s build script downloads the swagger-ui zip from GitHub, which is egress-policy-blocked in the sandbox; supplied the identical swagger-ui 5.17.14 dist from npm via `SWAGGER_UI_DOWNLOAD_URL=file://…` (env only, no repo change). CI is unaffected.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Backend CI (`backend.yml`) runs the full gate with a DB on this PR.

## Remote-tested
Skipped (no ppt-bridge MCP in session).

## Notes
Low-priority code-review fix. Draft — merge is gated by backend.yml CI, which provisions Postgres and will exercise the `#[sqlx::test]` tests that cannot run in the local DB-less sandbox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGNVbTC8D4DeRDoMc2UmMb)_