### PR TITLE
code-review-api-core-quiet-drain-drops-failed-delivery: don't release held notifications on failed quiet-hours drain

### DIFF
--- a/backend/servers/api-server/src/services/notification_pipeline.rs
+++ b/backend/servers/api-server/src/services/notification_pipeline.rs
@@ -687,17 +687,30 @@ impl NotificationPipeline {
     /// Issue #980: deliver a previously held notification on its stored
     /// channels, bypassing the quiet-hours gate (the drain worker only releases
     /// rows whose `release_at` has passed, i.e. quiet hours have ended).
-    /// Returns the number of channels successfully sent.
-    pub async fn deliver_held(&self, held: &HeldNotification) -> usize {
+    ///
+    /// Returns a [`PipelineResult`] summarising the attempt. The drain worker
+    /// keys off `failed`: a non-zero `failed` means at least one channel hit a
+    /// transient error and the held row must be left for the next tick rather
+    /// than marked released (otherwise the notification is permanently dropped
+    /// on a transient failure). A fully-skipped result (`sent == 0 &&
+    /// failed == 0`, e.g. push not configured or unknown user) carries no
+    /// failures and is safe to release — retrying it would never make progress.
+    pub async fn deliver_held(&self, held: &HeldNotification) -> PipelineResult {
         let user = match self.user_repo.find_by_id(held.user_id).await {
             Ok(Some(u)) => u,
             Ok(None) => {
                 tracing::warn!(user_id = %held.user_id, "[#980] Held notification for unknown user; dropping");
-                return 0;
+                // Nothing deliverable and no point retrying — no failure.
+                return PipelineResult::default();
             }
             Err(e) => {
                 tracing::warn!(user_id = %held.user_id, error = %e, "[#980] Failed to resolve user for held notification");
-                return 0;
+                // Transient lookup error — report as a failure so the drain
+                // worker retries on the next tick instead of dropping the row.
+                return PipelineResult {
+                    failed: 1,
+                    ..PipelineResult::default()
+                };
             }
         };
 
@@ -716,7 +729,7 @@ impl NotificationPipeline {
             notification = notification.with_action_url(url);
         }
 
-        let mut sent = 0;
+        let mut result = PipelineResult::default();
         for ch in &held.channels {
             let channel = match ch.as_str() {
                 "push" => NotificationChannel::Push,
@@ -724,17 +737,23 @@ impl NotificationPipeline {
                 "in_app" => NotificationChannel::InApp,
                 other => {
                     tracing::warn!(channel = %other, "[#980] Unknown held channel; skipping");
+                    // Unrecognised channel is a skip, not a failure — it must
+                    // not block the row from being released.
+                    result.skipped += 1;
                     continue;
                 }
             };
             let record = self
                 .deliver_channel(held.user_id, &user, &notification, None, channel)
                 .await;
-            if record.status == DeliveryStatus::Sent {
-                sent += 1;
+            match record.status {
+                DeliveryStatus::Sent => result.sent += 1,
+                DeliveryStatus::Failed => result.failed += 1,
+                DeliveryStatus::Skipped | DeliveryStatus::Pending => result.skipped += 1,
             }
+            result.records.push(record);
         }
-        sent
+        result
     }
 
     // ------------------------------------------------------------------

--- a/backend/servers/api-server/src/services/quiet_hours_drain.rs
+++ b/backend/servers/api-server/src/services/quiet_hours_drain.rs
@@ -10,6 +10,7 @@
 
 use std::time::Duration;
 
+use common::notifications::PipelineResult;
 use db::{repositories::GranularNotificationRepository, DbPool};
 use tokio::time::interval;
 use tracing::Instrument;
@@ -129,20 +130,89 @@ impl QuietHoursDrainWorker {
 
         let mut released = 0usize;
         for held in due.into_iter().take(self.config.batch_limit) {
-            // Deliver first; only mark released if the row is accounted for so a
-            // transient failure can be retried on the next tick. `deliver_held`
+            // Deliver first, then decide. A held row is marked released ONLY
+            // when delivery left nothing to retry (no channel reported a
+            // transient `Failed`). If any channel failed we leave `released_at`
+            // NULL so the next tick re-attempts, rather than permanently
+            // dropping the notification on a transient failure. `deliver_held`
             // is best-effort per channel and never panics.
-            let sent = self.pipeline.deliver_held(&held).await;
+            let outcome = self.pipeline.deliver_held(&held).await;
+            if !should_mark_released(&outcome) {
+                tracing::warn!(
+                    id = %held.id,
+                    sent = outcome.sent,
+                    failed = outcome.failed,
+                    "[#980] Held notification delivery failed on ≥1 channel; leaving held for retry"
+                );
+                continue;
+            }
             if let Err(e) = self.granular_repo.mark_notification_released(held.id).await {
                 tracing::warn!(id = %held.id, error = %e, "[#980] Delivered held notification but failed to mark released; may re-deliver");
                 continue;
             }
             released += 1;
-            tracing::debug!(id = %held.id, sent = sent, "[#980] Released held notification");
+            tracing::debug!(
+                id = %held.id,
+                sent = outcome.sent,
+                skipped = outcome.skipped,
+                "[#980] Released held notification"
+            );
         }
 
         if released > 0 {
             tracing::info!(released = released, "[#980] Drained held notifications");
         }
+    }
+}
+
+/// Decide whether a drained held-notification row may be marked released.
+///
+/// Releasing is permanent (`released_at` is set once and the row is never
+/// re-fetched), so it must only happen when there is nothing left to retry.
+///
+/// - `failed > 0` — at least one channel hit a transient error. Return `false`
+///   so the row stays held and the next tick re-attempts delivery. Releasing
+///   here is the bug this guards against: a `sent == 0` transient failure would
+///   otherwise mark the row released and lose the notification forever.
+/// - `failed == 0` — everything was either sent or skipped (e.g. push not
+///   configured, unknown user, unrecognised channel). Return `true`: the row is
+///   accounted for and retrying it would loop forever with no progress.
+fn should_mark_released(outcome: &PipelineResult) -> bool {
+    outcome.failed == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(sent: usize, skipped: usize, failed: usize) -> PipelineResult {
+        PipelineResult {
+            sent,
+            skipped,
+            failed,
+            ..PipelineResult::default()
+        }
+    }
+
+    #[test]
+    fn releases_when_delivered_cleanly() {
+        assert!(should_mark_released(&result(1, 0, 0)));
+        assert!(should_mark_released(&result(2, 1, 0)));
+    }
+
+    #[test]
+    fn releases_when_fully_skipped_nothing_to_retry() {
+        // e.g. push not configured / unknown user — sent==0 but no failure.
+        assert!(should_mark_released(&result(0, 1, 0)));
+        assert!(should_mark_released(&result(0, 0, 0)));
+    }
+
+    #[test]
+    fn holds_for_retry_when_any_channel_failed() {
+        // Regression: a transient failure (sent==0, failed>0) must NOT be
+        // released — it would permanently drop the held notification.
+        assert!(!should_mark_released(&result(0, 0, 1)));
+        // Partial success with a failed channel still retries.
+        assert!(!should_mark_released(&result(1, 0, 1)));
     }
 }


### PR DESCRIPTION
## Task
Quiet-hours drain marks held push released even when delivery failed (sent=0) — held notification permanently lost on transient failure

## Owner
pm-backend

## Root cause
`QuietHoursDrainWorker::drain_due` (backend/servers/api-server/src/services/quiet_hours_drain.rs) called `pipeline.deliver_held(&held)` and then marked the row released via `mark_notification_released` **unconditionally** — ignoring the `sent` return value. `mark_notification_released` stamps `released_at`, and `get_notifications_to_release` only ever re-fetches rows where `released_at IS NULL`, so a row is fetched exactly once. When delivery failed on every channel (transient error → `sent=0`), the row was still marked released and never retried, permanently dropping the held notification — the opposite of the worker's own comment about retrying on the next tick.

## Fix
- `NotificationPipeline::deliver_held` now returns a `PipelineResult` (sent/skipped/failed counts) instead of a bare `usize` sent count. Transient user-lookup errors are reported as `failed: 1`; unknown user / unrecognised channel are `skipped` (no failure).
- `drain_due` releases a row **only when `failed == 0`** (new `should_mark_released` helper). Any failed channel leaves `released_at` NULL so the next tick re-attempts. A fully-skipped result (push not configured, unknown user — `sent==0, failed==0`) is still released so it cannot loop forever with no progress.
- Unit tests cover the release-decision matrix, including the regression: `sent==0, failed>0` must NOT release.

Only `deliver_held`'s single caller (the drain worker) is affected.

## Verification
Gate: `./scripts/verify-impact.sh` (equivalent to `just verify`), run with `SQLX_OFFLINE=true` and a local `file://` Swagger-UI asset (this offline runner cannot reach the `swagger-api/swagger-ui` GitHub download that `utoipa-swagger-ui`'s build script needs; the asset was sourced from the allowed npm registry — no repo code changed).

```
VERIFY-PLAN base=773e00f4fe1cd8d4fcd42a8891093ac2c9a3d28d files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` — PASS
- `cargo clippy -p api-server --all-targets -- -D warnings` — PASS (`Finished` clean, no warnings)
- `cargo test -p api-server` — 564 passed; **11 failed**, all environmental on this DB-less/sandboxed runner and NOT touched by this change:
  - 10× `DATABASE_URL must be set: EnvVar(NotPresent)` from `#[sqlx::test]` cases (scheduler, voice_webhooks, voice_commands) — need a live Postgres, which this offline dispatcher runner has none of.
  - 1× `services::actions::api_call::tests::execute_rejects_dns_rebinding_to_private_ip_at_connect` — a DNS-rebinding assertion in `api_call.rs` (unrelated file) that depends on sandbox-unavailable resolver behaviour.
  - The tests exercising the changed code all PASS: `services::quiet_hours_drain::tests::{holds_for_retry_when_any_channel_failed, releases_when_delivered_cleanly, releases_when_fully_skipped_nothing_to_retry}`, plus all `notification_pipeline`, `quiet_hours`, and `push_fanout` tests.

The full DB-backed suite runs in CI (`backend.yml`, which provisions Postgres). Reviewer: please confirm CI is green before un-drafting.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change). Notification-delivery reliability only.

## Scope drift
None — `scope-check.sh --owner pm-backend` exit 0. Only the two api-server service files changed.

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` produced no warnings. The fix reuses the existing `common::notifications::PipelineResult` type rather than adding a new counts struct.

## Remote-tested
skipped

## Notes
The `should_mark_released` unit tests are pure-logic (no DB harness available in the verify environment). Full end-to-end drain retry behaviour is not exercised here — it would need a Postgres + adapter harness. The at-least-once retry semantics mean a partial success (one channel sent, another failed) will re-deliver all channels on the next tick; this matches the module's existing best-effort contract and is preferable to dropping the notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QGNVbTC8D4DeRDoMc2UmMb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QGNVbTC8D4DeRDoMc2UmMb)_