### PR TITLE
code-review-api-handlers-reports-csv-injection: sanitize vote titles in reports CSV export

### DIFF
--- a/backend/servers/api-server/src/routes/admin/audit.rs
+++ b/backend/servers/api-server/src/routes/admin/audit.rs
@@ -57,7 +57,11 @@ pub fn router() -> Router<AppState> {
 /// spreadsheet UIs. False positives (a legit cell containing `-`) are
 /// acceptable for an audit export — the prefix is harmless when pasted
 /// into a viewer and the operator can strip it.
-fn sanitize_csv_cell(value: &str) -> String {
+///
+/// `pub(crate)` so other CSV exporters (e.g. the reports export in
+/// [`crate::routes::reports`]) reuse this single implementation instead of
+/// re-deriving their own formula-injection guard.
+pub(crate) fn sanitize_csv_cell(value: &str) -> String {
     let dangerous = value.chars().any(|c| matches!(c, '=' | '+' | '-' | '@'));
     if dangerous {
         let mut out = String::with_capacity(value.len() + 1);

--- a/backend/servers/api-server/src/routes/reports/helpers.rs
+++ b/backend/servers/api-server/src/routes/reports/helpers.rs
@@ -9,8 +9,10 @@ use api_core::extractors::RlsConnection;
 use axum::{http::StatusCode, Json};
 use chrono::NaiveDate;
 use common::errors::ErrorResponse;
+use db::models::VoteParticipationDetail;
 use uuid::Uuid;
 
+use crate::routes::admin::audit::sanitize_csv_cell;
 use crate::state::AppState;
 
 /// Get building name by ID if provided.
@@ -89,6 +91,34 @@ pub(super) async fn estimate_report_row_count(
         }
         _ => 0,
     }
+}
+
+/// Render a single voting-participation row for the CSV export.
+///
+/// The vote `title` is the only user-authored, free-form string in the row
+/// (every other column is a UUID, a system enum, a date, or a number), so it
+/// is routed through the shared [`sanitize_csv_cell`] guard to neutralize
+/// spreadsheet formula injection: a title beginning with `=`, `+`, `-`, or
+/// `@` is prefixed with `'` so Excel/Sheets treat it as text rather than a
+/// formula. Commas are then replaced with `;` so the cell cannot spill into
+/// adjacent columns (this hand-rolled export does not use the `csv` crate's
+/// quoting). Extracted into its own function so the neutralization is unit
+/// testable without a database.
+fn voting_csv_row(v: &VoteParticipationDetail) -> String {
+    format!(
+        "{},{},{},{},{},{},{},{:.1}%,{},{}\n",
+        v.vote_id,
+        sanitize_csv_cell(&v.title).replace(',', ";"),
+        v.status,
+        v.start_at.as_deref().unwrap_or("N/A"),
+        v.end_at,
+        v.eligible_count,
+        v.response_count,
+        v.participation_rate,
+        v.quorum_required
+            .map_or("N/A".to_string(), |q| format!("{:.0}%", q)),
+        if v.quorum_reached { "Yes" } else { "No" }
+    )
 }
 
 /// Generate CSV content for a report synchronously (Story 88.5).
@@ -185,20 +215,7 @@ pub(super) async fn generate_sync_csv_report(
             // Generate CSV
             let mut csv = String::from("Vote ID,Title,Status,Start Date,End Date,Eligible Count,Response Count,Participation Rate,Quorum Required,Quorum Reached\n");
             for v in &votes {
-                csv.push_str(&format!(
-                    "{},{},{},{},{},{},{},{:.1}%,{},{}\n",
-                    v.vote_id,
-                    v.title.replace(',', ";"),
-                    v.status,
-                    v.start_at.as_deref().unwrap_or("N/A"),
-                    v.end_at,
-                    v.eligible_count,
-                    v.response_count,
-                    v.participation_rate,
-                    v.quorum_required
-                        .map_or("N/A".to_string(), |q| format!("{:.0}%", q)),
-                    if v.quorum_reached { "Yes" } else { "No" }
-                ));
+                csv.push_str(&voting_csv_row(v));
             }
 
             Ok(csv)
@@ -294,5 +311,70 @@ pub(super) fn get_content_type_for_format(format: &str) -> &'static str {
         "excel" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         "csv" => "text/csv",
         _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_vote(title: &str) -> VoteParticipationDetail {
+        VoteParticipationDetail {
+            vote_id: Uuid::nil(),
+            title: title.to_string(),
+            status: "closed".to_string(),
+            start_at: Some("2026-01-01".to_string()),
+            end_at: "2026-01-31".to_string(),
+            eligible_count: 10,
+            response_count: 8,
+            participation_rate: 80.0,
+            quorum_required: Some(50),
+            quorum_reached: true,
+        }
+    }
+
+    /// The title cell is the 2nd comma-separated field of the row.
+    fn title_cell(row: &str) -> String {
+        row.trim_end_matches('\n')
+            .splitn(3, ',')
+            .nth(1)
+            .expect("row has a title cell")
+            .to_string()
+    }
+
+    /// Regression: a user-authored vote title that begins with a spreadsheet
+    /// formula trigger must be neutralized in the exported CSV (leading `'`
+    /// prefix) instead of being written verbatim, closing the CSV/formula
+    /// injection vector that bypassed the repo's `sanitize_csv_cell`.
+    #[test]
+    fn voting_csv_row_neutralizes_formula_trigger_titles() {
+        for trigger in ["=cmd|'/c calc'!A1", "+1+1", "-2+3", "@SUM(A1)"] {
+            let row = voting_csv_row(&sample_vote(trigger));
+            let cell = title_cell(&row);
+            assert!(
+                cell.starts_with('\''),
+                "title {trigger:?} must be prefixed with a quote in cell {cell:?}"
+            );
+            // The dangerous payload must not appear as a leading formula.
+            assert!(
+                !cell.starts_with(trigger.chars().next().unwrap()),
+                "cell {cell:?} still begins with the formula trigger"
+            );
+        }
+    }
+
+    /// A plain title is written through unchanged (aside from comma escaping).
+    #[test]
+    fn voting_csv_row_leaves_plain_titles_untouched() {
+        let row = voting_csv_row(&sample_vote("Annual Budget Vote"));
+        assert_eq!(title_cell(&row), "Annual Budget Vote");
+    }
+
+    /// Commas in a title are escaped to `;` so the cell cannot spill into
+    /// adjacent CSV columns.
+    #[test]
+    fn voting_csv_row_escapes_commas_in_title() {
+        let row = voting_csv_row(&sample_vote("Roof, Facade, Windows"));
+        assert_eq!(title_cell(&row), "Roof; Facade; Windows");
     }
 }

--- a/backend/servers/api-server/src/routes/reports/helpers.rs
+++ b/backend/servers/api-server/src/routes/reports/helpers.rs
@@ -336,7 +336,7 @@ mod tests {
     /// The title cell is the 2nd comma-separated field of the row.
     fn title_cell(row: &str) -> String {
         row.trim_end_matches('\n')
-            .splitn(3, ',')
+            .split(',')
             .nth(1)
             .expect("row has a title cell")
             .to_string()


### PR DESCRIPTION
## Task
Reports CSV export writes user-authored vote titles unescaped — spreadsheet formula injection (bypasses the repo's own `sanitize_csv_cell`). Find the reports CSV export handler in `backend/servers/api-server` (reports/export path), identify every user-authored string field written into a CSV cell (e.g. vote titles and any other user text), and route them through the existing `sanitize_csv_cell` helper the repo already ships. Do not reimplement sanitation — reuse the existing helper. Add a regression test that a vote title beginning with a formula trigger (=, +, -, @, tab, CR) is neutralized in the exported CSV.

## Owner
pm-backend

## What changed
- **`backend/servers/api-server/src/routes/admin/audit.rs`** — promoted the existing `sanitize_csv_cell` helper from private to `pub(crate)` so the reports exporter can reuse the single implementation (no reimplementation). No behavior change to the audit export.
- **`backend/servers/api-server/src/routes/reports/helpers.rs`** — this is where the synchronous CSV generation now lives after the recent `mod.rs → helpers.rs` refactor on `dev`. The `"voting"` branch previously wrote the user-authored vote title with only comma→semicolon escaping (`v.title.replace(',', ";")`), leaving the formula-injection vector open. Extracted `voting_csv_row(&VoteParticipationDetail)` which routes the title through `sanitize_csv_cell(&v.title).replace(',', ";")`, added the `use crate::routes::admin::audit::sanitize_csv_cell;` import, and added a `#[cfg(test)] mod tests` with the regression test.

### Field analysis (every CSV cell in the sync export)
The vote **title** is the only user-authored, free-form string written into any sync-CSV cell. All other columns are non-attacker-controlled: `vote_id` (UUID), `status` (system enum string), dates, and numeric counts; the faults/occupancy/consumption reports write only fixed labels, system enum breakdowns (`status`/`category`/`priority`), and numbers. Only the vote title needed routing through the guard.

## Regression test
`voting_csv_row_neutralizes_formula_trigger_titles` asserts a title beginning with `=`, `+`, `-`, or `@` is prefixed with `'` in the exported cell. Plus `voting_csv_row_leaves_plain_titles_untouched` and `voting_csv_row_escapes_commas_in_title`.

Note on trigger list: the task mentioned `tab`/`CR` in addition to `=,+,-,@`. Per the "do not reimplement sanitation — reuse the existing helper" instruction, the title is routed through the repo's existing `sanitize_csv_cell` **as-is**, which guards `=,+,-,@` (its documented scope, shared with the audit export). Extending the shared helper to also cover leading tab/CR is a separate, cross-cutting change to the guard itself and is intentionally out of scope here; flagging for a possible follow-up.

## Verification
Backend full verify (`just verify` → `cargo clippy`/`cargo test`) could NOT complete locally: the `utoipa-swagger-ui` build script downloads swagger-ui from github.com, which is blocked by this sandbox's egress policy (HTTP 403), so the crate fails to build before any of our code compiles. This is the documented environment limitation for this repo's auto-impl PRs.

What did run locally and pass:
- `cargo fmt --all -- --check` → exit 0
- `rustfmt --edition 2021 --check` on both changed files → exit 0
- scope-drift check (`scope-check.sh --owner pm-backend`) → exit 0 (no drift)
- code-reuse pre-flight (`reuse-grep.sh --specialist rust-backend`) → empty (existing `sanitize_csv_cell` reused, no duplicate helper added)

Byte-fidelity of the MCP push was verified: pushed blob SHAs equal local `git hash-object` for both files (helpers.rs `037cc2ea…`, audit.rs `3ac2f696…`); `reports/mod.rs` and all sibling files are byte-identical to `dev`.

**CI `backend.yml` (`fmt` + `clippy` + `cargo test`) is the authoritative gate** — this PR is a DRAFT pending green CI.

## CI parity (Band C — hot-path only)
Skipped locally due to the swagger-ui egress block described above; CI backend.yml covers it. (This is a security-relevant change, so CI clippy+test is the gate before un-drafting.)

## Remote-tested
skipped (no ppt-bridge MCP in this session)

## Notes
- Branch was created from current `dev` via the GitHub MCP; the fix is correctly layered on the post-refactor tree (the vulnerable code moved from `mod.rs` to `helpers.rs`).
- `sanitize_csv_cell` reused, not reimplemented (task requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FuQqfUY7N4wVzhM9vqiKh6)_