### PR TITLE
gh-issue-2643-retry1: move OAuth token-usage recording off the hot token path

### DIFF
--- a/backend/servers/api-server/src/services/oauth.rs
+++ b/backend/servers/api-server/src/services/oauth.rs
@@ -194,19 +194,35 @@ impl OAuthService {
 
     /// Best-effort record of an OAuth token lifecycle event (Epic 10A, #2628).
     ///
-    /// Deliberately swallows every error: token issuance / refresh / revocation
-    /// must never fail because analytics could not be persisted. A failure is
-    /// logged at `warn!` and otherwise ignored, matching the repository's
-    /// documented "log-and-ignore" contract.
-    async fn record_token_event(&self, event: CreateOAuthTokenEvent) {
-        if let Some(repo) = &self.token_event_repo {
+    /// The analytics `INSERT` is dispatched to a **detached background task**
+    /// ([`tokio::spawn`]) rather than awaited inline, so the DB round-trip never
+    /// sits on the hot token path (#2643): token issuance / refresh / revocation
+    /// return their `TokenResponse` without waiting on this write. `record`
+    /// itself is called only from inside the spawned task.
+    ///
+    /// Errors are still swallowed: a recording failure is logged at `warn!` and
+    /// otherwise ignored, matching the repository's documented "log-and-ignore"
+    /// contract — it must never alter or fail the token flow.
+    ///
+    /// Returns the spawned task's [`JoinHandle`] when a recorder is wired
+    /// (`None` when analytics is disabled). Production callers drop it —
+    /// fire-and-forget; tests can `.await` it to deterministically observe the
+    /// persisted row without racing the runtime.
+    ///
+    /// [`JoinHandle`]: tokio::task::JoinHandle
+    fn record_token_event(
+        &self,
+        event: CreateOAuthTokenEvent,
+    ) -> Option<tokio::task::JoinHandle<()>> {
+        let repo = self.token_event_repo.clone()?;
+        Some(tokio::spawn(async move {
             if let Err(e) = repo.record(event).await {
                 tracing::warn!(
                     error = %e,
                     "Failed to record OAuth token-usage event (analytics only, ignored)"
                 );
             }
-        }
+        }))
     }
 
     // ==================== Client Management ====================
@@ -511,13 +527,14 @@ impl OAuthService {
             .await?;
 
         // Best-effort token-usage analytics (Epic 10A, #2628): record the
-        // issuance from the already-resolved grant. Never fails the exchange.
-        self.record_token_event(CreateOAuthTokenEvent::issued(
+        // issuance from the already-resolved grant off the hot path (#2643).
+        // The write runs in a detached task; dropping the handle is
+        // fire-and-forget and never fails the exchange.
+        drop(self.record_token_event(CreateOAuthTokenEvent::issued(
             auth_code.client_id.clone(),
             Some(auth_code.user_id),
             auth_code.scopes.0.clone(),
-        ))
-        .await;
+        )));
 
         Ok(TokenResponse {
             access_token,
@@ -600,13 +617,14 @@ impl OAuthService {
             .await?;
 
         // Best-effort token-usage analytics (Epic 10A, #2628): record the
-        // refresh from the already-resolved grant. Never fails the refresh.
-        self.record_token_event(CreateOAuthTokenEvent::refreshed(
+        // refresh from the already-resolved grant off the hot path (#2643).
+        // Detached write; dropping the handle is fire-and-forget and never
+        // fails the refresh.
+        drop(self.record_token_event(CreateOAuthTokenEvent::refreshed(
             client_id,
             Some(refresh_token.user_id),
             refresh_token.scopes.0.clone(),
-        ))
-        .await;
+        )));
 
         Ok(TokenResponse {
             access_token,
@@ -698,14 +716,15 @@ impl OAuthService {
             if access_token.client_id == authenticated_client_id {
                 self.repo.revoke_access_token_by_hash(&token_hash).await?;
                 // Best-effort token-usage analytics (Epic 10A, #2628): record
-                // the revocation from the resolved token row. Never fails the
-                // revoke (RFC 7009 must still return 200).
-                self.record_token_event(CreateOAuthTokenEvent::revoked(
+                // the revocation from the resolved token row off the hot path
+                // (#2643). Detached write; dropping the handle is
+                // fire-and-forget and never fails the revoke (RFC 7009 must
+                // still return 200).
+                drop(self.record_token_event(CreateOAuthTokenEvent::revoked(
                     access_token.client_id.clone(),
                     Some(access_token.user_id),
                     OAuthTokenKind::Access,
-                ))
-                .await;
+                )));
             }
             return Ok(());
         }
@@ -714,13 +733,13 @@ impl OAuthService {
         if let Some(refresh_token) = self.repo.find_refresh_token_by_hash(&token_hash).await? {
             if refresh_token.client_id == authenticated_client_id {
                 self.repo.revoke_refresh_token_by_hash(&token_hash).await?;
-                // Best-effort token-usage analytics (Epic 10A, #2628).
-                self.record_token_event(CreateOAuthTokenEvent::revoked(
+                // Best-effort token-usage analytics (Epic 10A, #2628): detached
+                // write off the hot path (#2643); fire-and-forget.
+                drop(self.record_token_event(CreateOAuthTokenEvent::revoked(
                     refresh_token.client_id.clone(),
                     Some(refresh_token.user_id),
                     OAuthTokenKind::Refresh,
-                ))
-                .await;
+                )));
             }
             return Ok(());
         }
@@ -983,5 +1002,114 @@ mod tests {
         // Should be 22 chars (16 bytes base64url encoded without padding)
         assert_eq!(id1.len(), 22);
         assert_ne!(id1, id2);
+    }
+
+    // ─── #2643: token-usage recording is off the hot token path ──────────────
+
+    /// With no analytics recorder wired, `record_token_event` short-circuits to
+    /// `None` — it neither spawns a task nor touches the DB, so the token path
+    /// is completely untouched. Runs without a database or a Tokio runtime
+    /// (the lazy pool is never connected because the `None` branch returns
+    /// before any query), pinning the "analytics stays optional" contract.
+    #[test]
+    fn record_token_event_without_recorder_returns_none() {
+        // `connect_lazy` never opens a connection until first use; the `None`
+        // branch below returns before any query, so no DB is required.
+        let pool = sqlx::PgPool::connect_lazy("postgres://ppt:ppt@127.0.0.1/ppt")
+            .expect("build lazy pool");
+        let service = OAuthService::new(
+            OAuthRepository::new(pool.clone()),
+            UserRepository::new(pool.clone()),
+            AuthService::new(),
+        );
+        assert!(
+            service
+                .record_token_event(CreateOAuthTokenEvent::issued(
+                    "some-client",
+                    None,
+                    vec!["profile".to_string()],
+                ))
+                .is_none(),
+            "no recorder wired ⇒ no task spawned, nothing recorded"
+        );
+    }
+
+    /// #2643 — the token-usage recording is no longer awaited inline on the hot
+    /// token path. `record_token_event` dispatches the analytics `INSERT` to a
+    /// detached [`tokio::spawn`] task and returns its `JoinHandle`
+    /// *synchronously*, so the token-granting caller regains control (and can
+    /// return its `TokenResponse`) before the write has run.
+    ///
+    /// The test pins both halves of the contract:
+    ///   1. **Off the hot path** — immediately after the (non-`async`) call the
+    ///      spawned task has not completed (`!is_finished()`), proving the write
+    ///      was not awaited inline. On the current-thread test runtime the
+    ///      spawned task cannot have been polled yet (no `.await` happened since
+    ///      the spawn), so the observation is deterministic.
+    ///   2. **No dropped write** — driving the returned handle to completion
+    ///      persists exactly one `oauth_token_events` row, so the recording is
+    ///      preserved on the happy path.
+    ///
+    /// Against the pre-#2643 inline `.await` the caller blocked on the DB
+    /// round-trip and there was no handle to observe (1) with at all.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn record_token_event_runs_off_the_hot_path(pool: sqlx::PgPool) {
+        // oauth_token_events.client_id FKs to oauth_clients — seed the client.
+        let client_id = format!("hotpath-{}", &Uuid::new_v4().to_string()[..8]);
+        sqlx::query(
+            r#"
+            INSERT INTO oauth_clients
+                (client_id, client_secret_hash, name, redirect_uris, scopes,
+                 is_confidential, rotate_refresh_tokens)
+            VALUES ($1, 'unused-hash', 'Hot Path Test',
+                    '["https://app.example.com/cb"]'::jsonb,
+                    '["profile"]'::jsonb, false, false)
+            "#,
+        )
+        .bind(&client_id)
+        .execute(&pool)
+        .await
+        .expect("seed oauth client");
+
+        let service = OAuthService::new(
+            OAuthRepository::new(pool.clone()),
+            UserRepository::new(pool.clone()),
+            AuthService::new(),
+        )
+        .with_token_event_repo(OAuthTokenEventRepository::new(pool.clone()));
+
+        // Synchronous call (no `.await`): spawns the write and hands back the
+        // task handle without touching the DB on the caller's thread.
+        let handle = service
+            .record_token_event(CreateOAuthTokenEvent::issued(
+                client_id.clone(),
+                None,
+                vec!["profile".to_string()],
+            ))
+            .expect("recorder is wired ⇒ Some(handle)");
+
+        // (1) Off the hot path: the analytics INSERT has NOT completed at the
+        // point the caller regains control.
+        assert!(
+            !handle.is_finished(),
+            "token-usage write must not be awaited inline on the hot path (#2643)"
+        );
+
+        // (2) No dropped write: driving the detached task to completion persists
+        // the event exactly once.
+        handle.await.expect("recording task must not panic");
+
+        let count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oauth_token_events \
+             WHERE client_id = $1 AND event_type = 'issued'",
+        )
+        .bind(&client_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count token events");
+        assert_eq!(
+            count, 1,
+            "the detached task must persist exactly one issued event"
+        );
     }
 }

--- a/backend/servers/api-server/src/services/oauth.rs
+++ b/backend/servers/api-server/src/services/oauth.rs
@@ -1008,11 +1008,13 @@ mod tests {
 
     /// With no analytics recorder wired, `record_token_event` short-circuits to
     /// `None` — it neither spawns a task nor touches the DB, so the token path
-    /// is completely untouched. Runs without a database or a Tokio runtime
-    /// (the lazy pool is never connected because the `None` branch returns
-    /// before any query), pinning the "analytics stays optional" contract.
-    #[test]
-    fn record_token_event_without_recorder_returns_none() {
+    /// is completely untouched. Runs without a database (the lazy pool is never
+    /// connected because the `None` branch returns before any query), pinning
+    /// the "analytics stays optional" contract. It still runs under a Tokio
+    /// runtime because `PgPool::connect_lazy` needs a reactor to build the pool,
+    /// mirroring the sibling `record_token_event_runs_off_the_hot_path` test.
+    #[tokio::test]
+    async fn record_token_event_without_recorder_returns_none() {
         // `connect_lazy` never opens a connection until first use; the `None`
         // branch below returns before any query, so no DB is required.
         let pool = sqlx::PgPool::connect_lazy("postgres://ppt:ppt@127.0.0.1/ppt")

--- a/backend/servers/api-server/tests/suites/oauth_integration_tests.rs
+++ b/backend/servers/api-server/tests/suites/oauth_integration_tests.rs
@@ -171,6 +171,30 @@ async fn count_token_events(pool: &PgPool, client_id: &str, event_type: &str) ->
     .unwrap_or(0)
 }
 
+/// Wait until at least `expected` `oauth_token_events` rows exist for
+/// `client_id` + `event_type`, or panic after a short timeout.
+///
+/// Since #2643 the token-usage recording is written by a **detached background
+/// task** off the hot token path, so the row may not be visible the instant the
+/// HTTP token response returns. Polling here removes that race while still
+/// proving the recording is preserved on the happy path (no dropped writes) —
+/// a genuinely dropped write makes this time out and fail.
+async fn await_token_event_count(pool: &PgPool, client_id: &str, event_type: &str, expected: i64) {
+    // ~2s budget (100 × 20ms) — comfortably covers a local INSERT round-trip
+    // while still failing fast if the event is never recorded.
+    for _ in 0..100 {
+        if count_token_events(pool, client_id, event_type).await >= expected {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!(
+        "timed out waiting for {expected} `{event_type}` token-usage event(s) for client \
+         {client_id}; observed {} — the detached recorder dropped the write",
+        count_token_events(pool, client_id, event_type).await,
+    );
+}
+
 /// Run the full PKCE S256 authorization-code flow for a **confidential** client
 /// and return `(access_token, refresh_token)`.
 ///
@@ -2952,14 +2976,12 @@ mod token_usage_analytics {
         let (user_at, _) = create_authenticated_user(&app, &user).await;
         let (client_id, client_secret, redirect_uri) = seed_confidential_client(&pool).await;
 
-        // 1) authorization_code exchange → one `issued` event.
+        // 1) authorization_code exchange → one `issued` event. Recording is
+        // detached off the hot path (#2643), so poll for it rather than reading
+        // once; a genuinely dropped write makes this time out.
         let (access_token, refresh_token) =
             confidential_auth_flow(&app, &user_at, &client_id, &client_secret, &redirect_uri).await;
-        assert_eq!(
-            count_token_events(&pool, &client_id, "issued").await,
-            1,
-            "authorization_code exchange must record an `issued` token-usage event"
-        );
+        await_token_event_count(&pool, &client_id, "issued", 1).await;
 
         // 2) refresh_token grant → one `refreshed` event.
         let refresh_body = form_body(&[
@@ -2977,11 +2999,7 @@ mod token_usage_analytics {
             "refresh must succeed. body={}",
             refresh_resp.text()
         );
-        assert_eq!(
-            count_token_events(&pool, &client_id, "refreshed").await,
-            1,
-            "refresh_token grant must record a `refreshed` token-usage event"
-        );
+        await_token_event_count(&pool, &client_id, "refreshed", 1).await;
 
         // 3) RFC 7009 revocation of the access token → one `revoked` event.
         let revoke_status = revoke_rfc7009(
@@ -2997,13 +3015,10 @@ mod token_usage_analytics {
             StatusCode::OK,
             "revoke must succeed per RFC 7009"
         );
-        assert_eq!(
-            count_token_events(&pool, &client_id, "revoked").await,
-            1,
-            "revocation must record a `revoked` token-usage event"
-        );
+        await_token_event_count(&pool, &client_id, "revoked", 1).await;
 
-        // The per-client rollup the dashboard reads must now be non-empty and
+        // All three detached writes have landed (we polled for each above), so
+        // the per-client rollup the dashboard reads must now be non-empty and
         // consistent with the three lifecycle transitions above.
         let repo = db::repositories::OAuthTokenEventRepository::new(pool.clone());
         let since = chrono::Utc::now() - chrono::Duration::hours(1);
@@ -3063,11 +3078,9 @@ mod token_usage_analytics {
             "public client token exchange must succeed. body={}",
             resp.text()
         );
-        assert_eq!(
-            count_token_events(&pool, &client_id, "issued").await,
-            1,
-            "public client authorization_code exchange must record an `issued` event"
-        );
+        // Detached recording off the hot path (#2643): poll for the `issued`
+        // event rather than reading once.
+        await_token_event_count(&pool, &client_id, "issued", 1).await;
     }
 }
 
@@ -3199,11 +3212,9 @@ mod token_usage_read_route {
         let (user_at, _) = create_authenticated_user(app, &user).await;
         let (client_id, client_secret, redirect_uri) = seed_confidential_client(pool).await;
         confidential_auth_flow(app, &user_at, &client_id, &client_secret, &redirect_uri).await;
-        assert_eq!(
-            count_token_events(pool, &client_id, "issued").await,
-            1,
-            "precondition: one issuance must be seeded through the router"
-        );
+        // Recording is detached off the hot path (#2643): wait for the seeded
+        // issuance to land before the read-route assertions depend on it.
+        await_token_event_count(pool, &client_id, "issued", 1).await;
         client_id
     }
 


### PR DESCRIPTION
## Task
Follow-up: OAuth token-usage recording is awaited inline on the token hot path (PR #2629) (Closes #2643). The token-issuance / token-refresh hot path awaits the token-usage recording (DB write) inline before returning the token to the caller, adding DB latency to every auth call. Make the usage recording non-blocking (fire-and-forget / spawned task / background write) so it does not block the response, while preserving the recording (no dropped writes on the happy path) and handling errors via logging rather than failing the auth request. Add/adjust a test proving the token response no longer awaits the usage-recording write.

## What changed
`OAuthService::record_token_event` (in `backend/servers/api-server/src/services/oauth.rs`) was `.await`ed **inline** on every token issuance, refresh, and revocation, so each auth call paid the analytics `INSERT` round-trip latency before returning its `TokenResponse` — even though the error was already swallowed.

- The method is now **synchronous**: it dispatches the write to a detached `tokio::spawn` task and returns the task's `JoinHandle`. The four hot-path call sites `drop()` the handle → fire-and-forget; the DB write is fully off the critical path.
- **Log-and-ignore contract preserved**: a failed recording only `warn!`s and never alters or fails the token flow (RFC 7009 revoke still returns 200, issuance/refresh still return their tokens).
- **No dropped writes on the happy path**: the write still runs; it is simply carried by the spawned task instead of the caller.

Scoped narrowly to the medium-severity hot-path finding in #2643. The two low-severity findings in the same issue (unbounded `usage_per_client`, sequential `totals`/`usage_per_client` awaits on the admin read route) are intentionally **not** included here to keep this PR focused on the token hot path; they can be a separate follow-up.

## Owner
owner_role hint: `pm-tech-lead`. Specialist: `rust-backend` (backend / api-server — Rust).

## Tests
- **New service unit tests** (`services/oauth.rs`):
  - `record_token_event_runs_off_the_hot_path` — proves the response no longer awaits the write: after the (now non-`async`) call the returned `JoinHandle` is **not finished** (`!is_finished()` — deterministic on the current-thread test runtime, no `.await` between spawn and check), yet driving the handle to completion persists **exactly one** `oauth_token_events` row (no dropped write).
  - `record_token_event_without_recorder_returns_none` — DB-free guard pinning the disabled-analytics path (returns `None`, spawns nothing).
- **Existing integration analytics tests** (`tests/suites/oauth_integration_tests.rs`) now poll via a new `await_token_event_count` helper instead of reading once, removing the race the fire-and-forget write would otherwise introduce while still failing if a write is genuinely dropped.

## Verification
```
VERIFY-PLAN base=f2c27597bf2bc8e76b3d4a7c8fa019a694ad5fae files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```
- `cargo fmt --all -- --check` → **PASS** (validates the edits parse and are formatted).
- `cargo clippy -p api-server` / `cargo test -p api-server` → **blocked locally** by the known **swagger-ui egress-403 limitation**: the `utoipa-swagger-ui` build script downloads `github.com/swagger-api/swagger-ui/archive/.../v5.17.14.zip`, which this session's egress policy returns **403** for (confirmed: the "download" is a JSON policy-denial body, so the build script fails with `InvalidArchive("Could not find EOCD")`). Per proxy rules, policy denials must not be routed around. **CI `backend.yml` is the authoritative gate** — this is a draft pending green CI, same posture as prior PR #2731.

## CI parity (Band C — hot-path only)
This touches the OAuth token path (auth). Local CI-parity replication (`cargo clippy`/`cargo test`) is blocked by the same swagger-ui egress-403 limitation above; deferring to CI `backend.yml`, which runs the full backend gate with network access to the swagger-ui artifact.

## Remote-tested
skipped (no ppt-bridge MCP in this session)

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports drift because the dispatcher's `owner_role` hint `pm-tech-lead` maps (in `owner-areas.json`) to `docs/**` / `.research/**` / `_bmad-output/**`, whereas this is a Rust change. The diff is confined to **two files under `backend/servers/api-server/`** — squarely the `pm-backend` area (`backend/**`) and the correct home for this `rust-backend` task. The "drift" is purely the owner-label mismatch, not an out-of-area edit. No `.research/**` files were touched.

## Notes
- `OAuthTokenEventRepository` is already `Clone`, so the spawned task owns its own repo handle (as suggested in #2643).
- goal-check IG1/IG4/IG5/IG6 (plan file), IG2 (`impl/*` branch name), and IG8 (archive move) are N/A for this dispatcher issue-driven task (no `.research/plans/*` plan; branch name is dispatcher-mandated `auto-impl/*`; `.research/**` is off-limits). IG3's separate `test:` commit is not applicable here because the new tests depend on the changed `record_token_event` signature and so cannot compile against pre-fix `main`; fix + regression tests ship together in one commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FDySgASXXrzbUnrdcB13cD)_