### PR TITLE
screen-map-drift-pr-2646-ppt-retry1: reconcile ppt error-handling screen-map with PR #2646 route-outlet boundary

### DIFF
--- a/docs/screens/ppt/error-handling-toasts.md
+++ b/docs/screens/ppt/error-handling-toasts.md
@@ -44,8 +44,13 @@ The capability spans four shipped pieces:
 
 1. **Toast notifications** — `ToastProvider` + `useToast` (`components/Toast.tsx`),
    mounted high in the app tree (`App.tsx`).
-2. **Global error boundary** — `ErrorBoundary` (`components/ErrorBoundary.tsx`),
-   mounted at the root in `main.tsx`, with an i18n fallback UI + retry/reload.
+2. **Error boundaries (two-tier)** — `ErrorBoundary` (`components/ErrorBoundary.tsx`)
+   with an i18n fallback UI + retry/reload, mounted at two levels: a **global**
+   boundary at the root in `main.tsx` (wraps the whole `<App />`), and a
+   **route-outlet** boundary `RouteErrorBoundary` (`App.tsx`) that wraps
+   `<AppRoutes />` inside `<main>`, keyed on `pathname`, so a single route
+   render / stale-chunk `lazy()` failure is scoped to the content region and
+   cannot unmount the app shell (nav, language switcher, connection status).
 3. **Offline / reconnection indicator** — `OfflineIndicator` +
    `useNetworkStatus` (`components/OfflineIndicator.tsx`, `hooks/useNetworkStatus.ts`).
 4. **API error parsing** — `parseApiError` / `formatValidationErrors` /
@@ -66,11 +71,14 @@ The capability spans four shipped pieces:
 - [x] [w] Timeouts tracked per-toast and cleared on manual dismiss + on provider unmount (no leaked timers)
 - [x] [w] a11y: container `role="region"` + `aria-label`; each toast `role="alert"`; `aria-live="assertive"` for errors, `"polite"` otherwise
 
-### Global error boundary
+### Error boundaries (two-tier)
 - [x] [w] `ErrorBoundary` catches render / lifecycle / constructor errors anywhere in the tree
 - [x] [w] Friendly fallback UI with "try again" + "reload page", i18n strings
 - [x] [w] Optional `onError` reporting callback (Sentry-style) + optional custom `fallback`
-- [x] [w] Mounted at app root in `main.tsx`
+- [x] [w] Global tier: mounted at app root in `main.tsx` (wraps the entire `<App />`)
+- [x] [w] Route-outlet tier: `RouteErrorBoundary` (`App.tsx`) wraps `<AppRoutes />` inside `<main>`, below `<AppNavigation>` — scopes a route render / stale-chunk `lazy()` failure to the content region so the app shell survives
+- [x] [w] Route-outlet boundary is keyed on `pathname`, so navigating to another route after a failure resets it automatically (no full page reload required)
+- [x] [w] Regression coverage: `App.route-error-boundary.test.tsx` (throwing route + stale-chunk `lazy()` rejection + navigate-to-recover)
 
 ### Offline / connectivity
 - [x] [w] `OfflineIndicator` banner shows on offline, "reconnected" message on recovery; `role="alert"` + `aria-live="assertive"`
@@ -90,7 +98,8 @@ The capability spans four shipped pieces:
 - **Validation error**: feature form maps `fieldErrors` to inline messages; a summary toast may also fire.
 - **Offline**: `OfflineIndicator` banner pinned; mutations that fail surface a network-error toast/banner.
 - **Reconnected**: transient "back online" message via `wasOffline`.
-- **Render crash**: `ErrorBoundary` fallback replaces the subtree with retry/reload.
+- **Route render crash**: `RouteErrorBoundary` catches the failure at the route outlet, replaces only the content region with the retry/reload fallback, and keeps the app shell (nav) mounted; navigating away auto-recovers.
+- **Non-recoverable render crash**: an error outside the route outlet propagates to the global `ErrorBoundary` in `main.tsx`, whose fallback replaces the whole UI with retry/reload.
 
 ## Notes
 
@@ -105,6 +114,16 @@ underneath them.
 
 ### Specific (recent)
 
+- 2026-08-11 — PR #2646 added a second error-boundary tier: `RouteErrorBoundary`
+  in `App.tsx` wraps `<AppRoutes />` (inside `<main>`, below `<AppNavigation>`)
+  and is keyed on `pathname`. It reuses the same `ErrorBoundary` component/fallback
+  as the root boundary, but scopes route-render / stale-chunk `lazy()` failures to
+  the content region so the shell (nav, language switcher, connection status) is no
+  longer torn down by a single bad route — the earlier behaviour, where any route
+  failure escaped to the root `main.tsx` boundary and unmounted all of `<App />`.
+  When editing App.tsx routing, keep `RouteErrorBoundary` between `<main>` and the
+  `<Suspense>`/`<AppRoutes>` outlet, and inside `BrowserRouter` (it calls
+  `useLocation`). Covered by `App.route-error-boundary.test.tsx`.
 - 2026-06-28 — coverage-gap verify (task 79-3): implementation confirmed fully
   shipped on `dev` — `ToastProvider`/`useToast`, `ErrorBoundary`, `OfflineIndicator`/
   `useNetworkStatus`, and `lib/errorHandler.parseApiError` all present and wired
@@ -125,4 +144,5 @@ underneath them.
 
 <!-- newest entries on top -->
 
+- 2026-08-11 — agent: reconciled screen-map with PR #2646 (ppt-web route-wrapper change, App.tsx). Documented the new route-outlet-level `RouteErrorBoundary` as a second error-boundary tier alongside the root `main.tsx` boundary: updated the capability description (piece 2 → "Error boundaries (two-tier)"), the checklist, the States section (route render crash keeps the shell mounted; keyed on pathname for auto-recovery), and Notes. Also noted the `App.route-error-boundary.test.tsx` regression coverage. No frontmatter status change — still `buildStatus: shipped`, `error-boundary` already in sharedComponents; non-routed cross-cutting capability so `sitemapRefs {}` unchanged.
 - 2026-06-28 — agent: created screen-map for the orphan "Error Handling & Toast Notifications" capability; verified ppt-web implementation shipped (Toast/ErrorBoundary/OfflineIndicator/errorHandler) and wired in App.tsx + main.tsx; checklist marked shipped; sitemapRefs left `{}` (non-routed cross-cutting capability); related to server-error/session-expired/forbidden.


### PR DESCRIPTION
## Task

screen-map drift: PR #2646 touched the ppt-web route wrapper (App.tsx) without updating docs/screens/ppt/. Reconcile the screen-map: run `/screens update` to detect drift, then update the affected `docs/screens/ppt/*.md` entries (frontmatter + Agent Log) to match the current routes, and run `/screens validate`. Keep the change scoped to docs/screens/ppt/ (and screen-map tooling artifacts).

## Owner

pm-qa

## What PR #2646 changed (and why the screen-map was stale)

PR #2646 added a **route-outlet-level** error boundary `RouteErrorBoundary` in `frontend/apps/ppt-web/src/App.tsx`: it wraps `<AppRoutes />` inside `<main>` (below `<AppNavigation>`), is keyed on `pathname`, and reuses the existing `ErrorBoundary` component. It scopes a single route render / stale-chunk `lazy()` failure to the content region so it can no longer unmount the whole app shell (previously any route failure escaped to the root `ErrorBoundary` in `main.tsx`, which wraps all of `<App />`). PR #2646 also added `App.route-error-boundary.test.tsx`.

**No routes / sitemap entries were added, removed, or renamed** — so `/screens update` reports no route drift. The drift was purely *documentation* drift in the cross-cutting `ppt/error-handling-toasts` screen-map, which described the error boundary as a single root-level `main.tsx` boundary only.

## `/screens update` result

`pnpm --filter @ppt/screen-map cli update` reports 368 pre-existing baseline issues, **all** of kind `unknown-component` (332) and `unknown-epic` (36) — none route-related and none introduced by PR #2646 (no `unmapped-sitemap`, `unknown-endpoint`, or `orphan` kinds). Those are out of scope for this task (they predate #2646 and span the whole reality/ tree). The only #2646-attributable reconciliation is the `error-handling-toasts` screen-map update below.

## Change (scoped to docs/screens/ppt/)

`docs/screens/ppt/error-handling-toasts.md` (only file changed):
- Capability description: piece 2 "Global error boundary" → "Error boundaries (two-tier)" (global root in `main.tsx` + route-outlet `RouteErrorBoundary` in `App.tsx`).
- Functionality checklist: added route-outlet tier bullets (shell-survives scoping, `pathname`-keyed auto-recovery, `App.route-error-boundary.test.tsx` regression coverage).
- States: split "Render crash" into route-render-crash (shell survives) vs non-recoverable (global boundary).
- Notes > Specific (recent) + Agent Log: dated 2026-08-11 entries.
- Frontmatter: no status change needed — already `buildStatus: shipped`, `error-boundary` already in `sharedComponents`, non-routed capability so `sitemapRefs: {}` unchanged.

## `/screens validate` result

`Validated 167 screen-maps: 0 errors, 0 warnings.` (exit 0)

## Verification

```
VERIFY-PLAN base=cb0d4d18839c40c0cf2a54ebe76e7a6188c90dfa files=1
VERIFY OK 15085d3e362b56ae4fe482cb9ede9d91e7f8366e
```
Docs-only diff → empty impact plan. Key gate for a docs/screens change is `/screens validate` (clean, above).

## Scope drift

`scope-check.sh --owner pm-qa` exits 2 for `docs/screens/ppt/error-handling-toasts.md` — `pm-qa` has no mapped area covering `docs/screens/`. This is **expected and justified**: the task explicitly scopes the work to `docs/screens/ppt/`. No files outside `docs/screens/ppt/` were touched.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change; docs-only).

## Remote-tested

skipped.

## Notes

- Goal-check (`goal-check.sh`) IG1/IG2/IG3 are structurally N/A here: this is a dispatcher-driven docs reconciliation (no `.research/plans/*.md`, pre-chosen `auto-impl/` branch, no code test), not the research-plan implementer workflow those checks model. IG7 (verify) passed.
- The 368 baseline `unknown-component`/`unknown-epic` drift issues are pre-existing and out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184iRErxFmk9CtaBUWr4L9m

---
_Generated by [Claude Code](https://claude.ai/code/session_0184iRErxFmk9CtaBUWr4L9m)_