### PR TITLE
churn-hotspot useOfflineSupport: remap carried-forward actions before persisting offline queue

### DIFF
--- a/frontend/apps/mobile/src/hooks/useOfflineSupport.test.ts
+++ b/frontend/apps/mobile/src/hooks/useOfflineSupport.test.ts
@@ -419,4 +419,79 @@ describe('useOfflineSupport.processQueue — issue #1767', () => {
     });
     expect(readQueue()).toHaveLength(0);
   });
+
+  it('(g) preserves temp→server id linkage for a dependent edit carried past a mid-cycle halt', async () => {
+    // Regression: the temp→server id mapping is in-memory for one cycle only.
+    // If a CREATE resolves its temp id but an UNRELATED action between it and
+    // its dependent UPDATE fails transiently (halting the cycle), the dependent
+    // UPDATE sits *after* the halt point and was never remapped in-loop. Unless
+    // it is remapped before persisting, next cycle the CREATE is gone, the
+    // mapping is lost, and the edit orphans onto a temp id the server never
+    // knew — a silent loss of an offline edit.
+    const TEMP = 'temp-fault-g';
+    seedQueue([
+      makeAction({
+        id: 'create',
+        type: 'CREATE',
+        endpoint: '/api/v1/faults',
+        body: { title: 'leak', localRef: TEMP },
+        localId: TEMP,
+      }),
+      // Unrelated action that fails transiently and halts the cycle — it sits
+      // BETWEEN the create and the dependent update.
+      makeAction({
+        id: 'blocker',
+        type: 'UPDATE',
+        method: 'PUT',
+        endpoint: '/api/v1/announcements/known-id',
+        body: { seen: true },
+      }),
+      // Dependent update targeting the temp id — never reached this cycle.
+      makeAction({
+        id: 'dependent',
+        type: 'UPDATE',
+        method: 'PUT',
+        endpoint: `/api/v1/faults/${TEMP}`,
+        body: { id: TEMP, priority: 'high' },
+        localId: TEMP,
+      }),
+    ]);
+    const fetchMock = globalThis.fetch as jest.Mock;
+    fetchMock.mockImplementation(async (url: string) => {
+      if (url.endsWith('/api/v1/faults')) return ok({ id: 'srv-g' }); // CREATE resolves
+      if (url.includes('/api/v1/announcements/')) return serverError(503); // blocker halts
+      return ok({});
+    });
+
+    await mountHook();
+
+    // Cycle 1: CREATE succeeds and resolves TEMP→srv-g; the blocker 503s and
+    // halts the cycle before the dependent update is reached.
+    await act(async () => {
+      await api.processQueue();
+    });
+
+    // The dependent's persisted endpoint/body must already point at the server
+    // id — the mapping was applied before persisting, not lost with the cycle.
+    const afterHalt = readQueue();
+    const dependent = afterHalt.find((a) => a.id === 'dependent');
+    expect(dependent).toBeDefined();
+    expect(dependent?.endpoint).toBe('/api/v1/faults/srv-g');
+    expect(dependent?.endpoint).not.toContain(TEMP);
+    expect(JSON.stringify(dependent?.body)).toContain('srv-g');
+    expect(JSON.stringify(dependent?.body)).not.toContain(TEMP);
+    // The CREATE is gone (succeeded); blocker + dependent remain, in FIFO order.
+    expect(afterHalt.map((a) => a.id)).toEqual(['blocker', 'dependent']);
+
+    // Cycle 2: the server has recovered — the dependent now hits the real
+    // resource and drains cleanly (rather than orphaning onto the temp id).
+    fetchMock.mockImplementation(async () => ok({}));
+    await act(async () => {
+      await api.processQueue();
+    });
+    const calls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(calls).toContain('https://api.test/api/v1/faults/srv-g');
+    expect(calls.every((u) => !u.includes(TEMP))).toBe(true);
+    expect(readQueue()).toHaveLength(0);
+  });
 });

--- a/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
+++ b/frontend/apps/mobile/src/hooks/useOfflineSupport.ts
@@ -458,8 +458,25 @@ export function useOfflineSupport(): UseOfflineSupportReturn {
             return a;
           });
         // Prefer the original (post-retry-increment) objects for carried items
-        // so their bumped `retries` count is what gets persisted.
-        const merged = [...carriedForward.map((a) => byId.get(a.id) ?? a), ...newlyEnqueued];
+        // so their bumped `retries` count is what gets persisted. Also apply the
+        // temp→server id remap before persisting: a cycle that halts on a
+        // head-of-line failure breaks the loop before reaching dependent
+        // UPDATE/DELETEs queued *after* the halt point, so those never got
+        // remapped in-loop. `tempIdToServerId` is in-memory only and is gone
+        // next cycle, so if a CREATE already resolved its temp id this cycle we
+        // must rewrite its dependents now or the mapping is lost and the edit
+        // orphans onto a temp id that no longer exists server-side (same reason
+        // `newlyEnqueued` is remapped above). remapActionIds is a no-op for
+        // actions that carry no still-live temp id, so re-applying it to items
+        // that were already remapped in-loop is safe.
+        const merged = [
+          ...carriedForward.map((a) => {
+            const carried = byId.get(a.id) ?? a;
+            remapActionIds(carried, tempIdToServerId);
+            return carried;
+          }),
+          ...newlyEnqueued,
+        ];
 
         await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(merged));
         setQueuedActionsCount(merged.length);


### PR DESCRIPTION
## Task
Churn hotspot: 2 commits touching frontend/apps/mobile/src/hooks/useOfflineSupport.ts (window 2026-08-03T17:00Z → 2026-08-04T03:00Z) [retry 1/2 of failed original]. Review this hot file for latent bugs / missing test coverage / clarity issues and make a small, well-scoped improvement (bugfix or added regression tests). Keep the change minimal and within frontend/apps/mobile.

## Owner
pm-tech-lead

## What / why
Latent data-loss bug in the offline-sync queue (`processQueue`).

The temp→server id mapping (`tempIdToServerId`) built while replaying the queue is **in-memory for one cycle only**. Newly-enqueued arrivals get `remapActionIds` applied before persisting, but **carried-forward** actions sitting *after* a head-of-line halt point never did: a cycle that halts on a transient (5xx/network) failure `break`s the loop before reaching them.

Repro: a CREATE resolves its temp id → an *unrelated* action between it and its dependent UPDATE fails transiently, halting the cycle → the dependent UPDATE (after the halt) is persisted still referencing the temp id. Next cycle the resolving CREATE is gone and the mapping is lost, so the edit orphans onto a temp id the server never knew — the offline edit is silently lost.

Fix (minimal): apply `remapActionIds` to carried-forward actions before persisting, mirroring the existing remap of `newlyEnqueued`. `remapActionIds` is a no-op for actions with no live temp id, so re-applying to already-remapped items is safe.

Regression test `(g)` added; it fails on the pre-fix code (persisted endpoint stays `.../temp-fault-g`) and passes with the fix.

## Verification
```
VERIFY-PLAN base=cb0d4d18839c40c0cf2a54ebe76e7a6188c90dfa files=2
  cd frontend && pnpm exec biome check apps/mobile/src/hooks/useOfflineSupport.test.ts apps/mobile/src/hooks/useOfflineSupport.ts
  cd frontend && pnpm --filter "...[cb0d4d18839c40c0cf2a54ebe76e7a6188c90dfa]" typecheck
  cd frontend && pnpm --filter "...[cb0d4d18839c40c0cf2a54ebe76e7a6188c90dfa]" test
```
VERIFY OK 93546de92b710be8f4990fd6514f116eedcfe160

- typecheck: exit 0
- test: exit 0 (49 suites, 626 tests; useOfflineSupport.test.ts 8/8 incl. new `(g)`)
- biome check: exit 0
- IG3 proof: `git stash` the source fix → `(g)` fails with `Expected "/api/v1/faults/srv-g" / Received "/api/v1/faults/temp-fault-g"`; restore → passes.

## Scope drift
`scope-check.sh --owner pm-tech-lead` → exit 2 (scope_drift=true). `pm-tech-lead` maps only to `docs/** .research/** _bmad-output/**`, so any code change tags as drift. This is an owner_role-hint mismatch, not real drift: the diff is entirely within `frontend/apps/mobile/src/hooks/` — exactly the churn-hotspot file the task targets (pm-mobile's area). Reviewer to adjudicate.

Files:
- frontend/apps/mobile/src/hooks/useOfflineSupport.ts
- frontend/apps/mobile/src/hooks/useOfflineSupport.test.ts

## Code-reuse review
`reuse-grep.sh --specialist react-native` → clean (no new helpers; the fix reuses the existing `remapActionIds`).

## Goal-check (IG1–IG8)
IG3 (test:+fix: TDD pair) ok · IG7 (verify gate) ok. IG1/IG2 FAIL are inapplicable to a churn-hotspot task: no `.research/plans/*.md` exists (plan-less dispatcher task) and the branch name `auto-impl/...` was mandated by the dispatcher/isolation preamble, not the `impl/...` convention goal-check expects.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change) — offline-queue client sync only.

## Remote-tested
skipped

## Notes
Specialist: react-native. Two commits: `test(react-native): …` then `fix(react-native): …`. Change confined to `frontend/apps/mobile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184iRErxFmk9CtaBUWr4L9m

---
_Generated by [Claude Code](https://claude.ai/code/session_0184iRErxFmk9CtaBUWr4L9m)_