### PR TITLE
code-review-ppt-web-ui-offline-ind-i18n: i18n OfflineIndicator banner

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1307,6 +1307,10 @@
     "disconnectedDescription": "Aktualizace v reálném čase nejsou dostupné",
     "clickToReconnect": "Kliknutím se znovu připojíte"
   },
+  "offlineIndicator": {
+    "offline": "Jste offline. Některé funkce nemusí být dostupné.",
+    "reconnected": "Připojení obnoveno"
+  },
   "submissionStatus": {
     "status": {
       "draft": "Koncept",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1256,6 +1256,10 @@
     "disconnectedDescription": "Echtzeit-Updates sind nicht verfügbar",
     "clickToReconnect": "Zum erneuten Verbinden klicken"
   },
+  "offlineIndicator": {
+    "offline": "Sie sind offline. Einige Funktionen sind möglicherweise nicht verfügbar.",
+    "reconnected": "Verbindung wiederhergestellt"
+  },
   "submissionStatus": {
     "status": {
       "draft": "Entwurf",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -3494,6 +3494,10 @@
     "disconnectedDescription": "Real-time updates are not available",
     "clickToReconnect": "Click to reconnect"
   },
+  "offlineIndicator": {
+    "offline": "You are offline. Some features may be unavailable.",
+    "reconnected": "Connection restored"
+  },
   "submissionStatus": {
     "status": {
       "draft": "Draft",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1229,6 +1229,10 @@
     "disconnectedDescription": "A valós idejű frissítések nem érhetők el",
     "clickToReconnect": "Kattintson az újracsatlakozáshoz"
   },
+  "offlineIndicator": {
+    "offline": "Nincs internetkapcsolat. Egyes funkciók nem elérhetők.",
+    "reconnected": "A kapcsolat helyreállt"
+  },
   "submissionStatus": {
     "status": {
       "draft": "Vázlat",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1235,6 +1235,10 @@
     "disconnectedDescription": "Aktualizacje w czasie rzeczywistym są niedostępne",
     "clickToReconnect": "Kliknij, aby połączyć ponownie"
   },
+  "offlineIndicator": {
+    "offline": "Jesteś offline. Niektóre funkcje mogą być niedostępne.",
+    "reconnected": "Połączenie przywrócone"
+  },
   "submissionStatus": {
     "status": {
       "draft": "Wersja robocza",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1309,6 +1309,10 @@
     "disconnectedDescription": "Aktualizácie v reálnom čase nie sú dostupné",
     "clickToReconnect": "Kliknutím sa znova pripojíte"
   },
+  "offlineIndicator": {
+    "offline": "Ste offline. Niektoré funkcie nemusia byť dostupné.",
+    "reconnected": "Pripojenie obnovené"
+  },
   "submissionStatus": {
     "status": {
       "draft": "Koncept",

--- a/frontend/apps/ppt-web/src/components/OfflineIndicator.tsx
+++ b/frontend/apps/ppt-web/src/components/OfflineIndicator.tsx
@@ -5,6 +5,7 @@
  * Animates smoothly in and out.
  */
 
+import { useTranslation } from 'react-i18next';
 import { useNetworkStatus } from '../hooks/useNetworkStatus';
 import './OfflineIndicator.css';
 
@@ -27,6 +28,7 @@ import './OfflineIndicator.css';
  * ```
  */
 export function OfflineIndicator() {
+  const { t } = useTranslation();
   const { isOnline, wasOffline } = useNetworkStatus();
 
   // Show offline banner
@@ -55,9 +57,7 @@ export function OfflineIndicator() {
             <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
             <line x1="12" y1="20" x2="12.01" y2="20" />
           </svg>
-          <span className="offline-indicator__text">
-            You are offline. Some features may be unavailable.
-          </span>
+          <span className="offline-indicator__text">{t('offlineIndicator.offline')}</span>
         </div>
       </div>
     );
@@ -86,7 +86,7 @@ export function OfflineIndicator() {
             <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
             <line x1="12" y1="20" x2="12.01" y2="20" />
           </svg>
-          <span className="offline-indicator__text">Connection restored</span>
+          <span className="offline-indicator__text">{t('offlineIndicator.reconnected')}</span>
         </div>
       </div>
     );

--- a/frontend/apps/ppt-web/src/i18n/offlineIndicatorI18n.test.ts
+++ b/frontend/apps/ppt-web/src/i18n/offlineIndicatorI18n.test.ts
@@ -1,0 +1,81 @@
+/// <reference types="vitest/globals" />
+/**
+ * `offlineIndicator.*` namespace i18n key-presence regression.
+ *
+ * The `OfflineIndicator` banner (`src/components/OfflineIndicator.tsx`) shipped
+ * with two hardcoded English strings ("You are offline. Some features may be
+ * unavailable." and "Connection restored") instead of going through
+ * react-i18next like the rest of ppt-web (see
+ * code-review-ppt-web-ui-offline-ind-i18n). Non-English users saw English text
+ * in a `role="alert"` banner — invisible to typecheck + lint because the
+ * literals were valid JSX.
+ *
+ * The strings now live under the `offlineIndicator` namespace and are consumed
+ * via `t('offlineIndicator.offline')` / `t('offlineIndicator.reconnected')`.
+ * This test locks it in: every leaf key present under `offlineIndicator` in
+ * `en.json` must exist — and be a non-empty string — in all six shipped locale
+ * bundles. It fails on `main` (the namespace does not exist in any bundle) and
+ * passes once the block is added to all six.
+ */
+
+import cs from '../../messages/cs.json';
+import de from '../../messages/de.json';
+import en from '../../messages/en.json';
+import hu from '../../messages/hu.json';
+import pl from '../../messages/pl.json';
+import sk from '../../messages/sk.json';
+
+type Json = Record<string, unknown>;
+
+const BUNDLES: Record<string, Json> = { en, sk, cs, de, pl, hu };
+
+/** Dotted leaf-key paths reachable from a nested object. */
+function leafPaths(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object') return [prefix];
+  return Object.entries(obj as Json).flatMap(([k, v]) =>
+    leafPaths(v, prefix ? `${prefix}.${k}` : k)
+  );
+}
+
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, part) => {
+    if (acc === null || typeof acc !== 'object') return undefined;
+    return (acc as Json)[part];
+  }, obj);
+}
+
+/** The full set of offlineIndicator.* leaf-key paths, taken from en.json. */
+const OFFLINE_PATHS: string[] = leafPaths((en as Json).offlineIndicator, 'offlineIndicator');
+
+describe('offlineIndicator.* i18n keys', () => {
+  it('covers exactly the six shipped locale bundles', () => {
+    expect(Object.keys(BUNDLES).sort()).toEqual(['cs', 'de', 'en', 'hu', 'pl', 'sk']);
+  });
+
+  it('reference key set includes the banner strings', () => {
+    expect(OFFLINE_PATHS).toEqual(
+      expect.arrayContaining(['offlineIndicator.offline', 'offlineIndicator.reconnected'])
+    );
+  });
+
+  for (const [locale, bundle] of Object.entries(BUNDLES)) {
+    describe(`locale: ${locale}`, () => {
+      for (const path of OFFLINE_PATHS) {
+        it(`defines a non-empty ${path}`, () => {
+          const value = getPath(bundle, path);
+          expect(value, `${path} missing in ${locale}.json`).toBeTypeOf('string');
+          expect((value as string).trim().length).toBeGreaterThan(0);
+        });
+      }
+    });
+  }
+
+  it('keeps every locale in lockstep — no locale has missing offlineIndicator keys', () => {
+    for (const [locale, bundle] of Object.entries(BUNDLES)) {
+      const present = OFFLINE_PATHS.filter((p) => typeof getPath(bundle, p) === 'string');
+      expect(present, `${locale}.json offlineIndicator-key set drifted from the reference`).toEqual(
+        OFFLINE_PATHS
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Task
ppt-web-ui: `OfflineIndicator` banner text is hardcoded English, not i18n. The `OfflineIndicator` component in the ppt-web app (`frontend/apps/ppt-web`) renders a banner with hardcoded English text; it must use react-i18next like the rest of the app. Add translation keys to the ppt-web i18n locale files and consume them via the `useTranslation` hook, matching existing i18n patterns in the codebase.

Auto-implemented dispatcher task `code-review-ppt-web-ui-offline-ind-i18n`.

## Owner
pm-tech-lead (hint) — the actual work is ppt-web frontend (pm-frontend area).

## Change
- `OfflineIndicator.tsx`: replaced the two hardcoded strings ("You are offline. Some features may be unavailable." / "Connection restored") with `t('offlineIndicator.offline')` / `t('offlineIndicator.reconnected')` via `useTranslation()`, mirroring the sibling `ConnectionStatus.tsx` pattern.
- Added the `offlineIndicator` namespace (`offline`, `reconnected`) to all six ppt-web locale bundles: `en, sk, cs, de, pl, hu`.
- Added `src/i18n/offlineIndicatorI18n.test.ts` — a locale-parity regression (same shape as the existing `ariaI18n.test.ts` / `deadNamespaceI18n.test.ts`) asserting every `offlineIndicator.*` leaf key is present and non-empty across all six locales. Fails on `dev` (namespace absent), passes after this change.

## Verification
```
VERIFY-PLAN base=43b42be17e73d405be5975372deeeffd2136c241 files=8
  cd frontend && pnpm exec biome check apps/ppt-web/messages/cs.json apps/ppt-web/messages/de.json apps/ppt-web/messages/en.json apps/ppt-web/messages/hu.json apps/ppt-web/messages/pl.json apps/ppt-web/messages/sk.json apps/ppt-web/src/components/OfflineIndicator.tsx apps/ppt-web/src/i18n/offlineIndicatorI18n.test.ts
  cd frontend && pnpm --filter "...[43b42be17e73d405be5975372deeeffd2136c241]" typecheck
  cd frontend && pnpm --filter "...[43b42be17e73d405be5975372deeeffd2136c241]" test
```
```
VERIFY OK 733eeae5e1ddf85d15e7a3427d3b1a24a6dac2ca
```
biome clean, typecheck clean, 2184 tests passed (116 files) for the ppt-web slice.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
The deterministic `scope-check.sh` flags drift because `owner_role=pm-tech-lead` maps only to `docs/**`, `.research/**`, `_bmad-output/**`, whereas this task is inherently a ppt-web frontend fix. Benign owner-hint mismatch (the task text explicitly targets `frontend/apps/ppt-web`); no code was touched outside the ppt-web slice. Drifting paths are exactly the intended change set:
- `frontend/apps/ppt-web/src/components/OfflineIndicator.tsx`
- `frontend/apps/ppt-web/messages/{en,sk,cs,de,pl,hu}.json`
- `frontend/apps/ppt-web/src/i18n/offlineIndicatorI18n.test.ts`

## Code-reuse review
`reuse-grep.sh` (react-web) returned no warnings — no new auth/crypto/http helper introduced; reuses the existing `useTranslation` + `messages/*.json` bundle mechanism.

## Notes
- Namespace `offlineIndicator` inserted directly after `connectionStatus` in each bundle to keep the two connectivity banners adjacent.
- Split into a `test:` commit (fails on `dev`) then a `fix:` commit to keep the TDD/IG3 shape visible in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zRbfa54fUUr3RqUF1vFJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012zRbfa54fUUr3RqUF1vFJQ)_