### PR TITLE
code-review-mobile-rn-meterdetail-i18n: i18n hardcoded strings in MeterDetailScreen

### DIFF
--- a/frontend/apps/mobile/src/locales/cs.json
+++ b/frontend/apps/mobile/src/locales/cs.json
@@ -440,7 +440,13 @@
     "noUnitText": "Měřiče se zobrazí po přiřazení vašeho účtu k jednotce.",
     "detailLoadError": "Nepodařilo se načíst měřič",
     "noReadingsTitle": "Zatím žádné odečty",
-    "noReadingsText": "Odešlete svůj první odečet pro tento měřič."
+    "noReadingsText": "Odešlete svůj první odečet pro tento měřič.",
+    "meterFallback": "Měřič",
+    "backToMeters": "Měřiče",
+    "latestReading": "Poslední odečet",
+    "usedSincePrevious": "Spotřeba od předchozího odečtu: {{amount}} {{unit}}",
+    "readingHistory": "Historie odečtů",
+    "submitNewReading": "Odeslat nový odečet"
   },
   "esignature": {
     "title": "Zadost o podpis",

--- a/frontend/apps/mobile/src/locales/de.json
+++ b/frontend/apps/mobile/src/locales/de.json
@@ -400,7 +400,13 @@
     "noUnitText": "Zähler werden angezeigt, sobald Ihr Konto mit einer Einheit verknüpft ist.",
     "detailLoadError": "Zähler konnte nicht geladen werden",
     "noReadingsTitle": "Noch keine Ablesungen",
-    "noReadingsText": "Reichen Sie Ihre erste Ablesung für diesen Zähler ein."
+    "noReadingsText": "Reichen Sie Ihre erste Ablesung für diesen Zähler ein.",
+    "meterFallback": "Zähler",
+    "backToMeters": "Zähler",
+    "latestReading": "Letzter Stand",
+    "usedSincePrevious": "Verbrauch seit letztem Stand: {{amount}} {{unit}}",
+    "readingHistory": "Ableseverlauf",
+    "submitNewReading": "Neuen Stand absenden"
   },
   "esignature": {
     "title": "Unterschriftsanfrage",

--- a/frontend/apps/mobile/src/locales/en.json
+++ b/frontend/apps/mobile/src/locales/en.json
@@ -440,7 +440,13 @@
     "noUnitText": "Meters appear once your account is linked to a unit.",
     "detailLoadError": "Couldn't load meter",
     "noReadingsTitle": "No readings yet",
-    "noReadingsText": "Submit your first reading for this meter."
+    "noReadingsText": "Submit your first reading for this meter.",
+    "meterFallback": "Meter",
+    "backToMeters": "Meters",
+    "latestReading": "Latest reading",
+    "usedSincePrevious": "Used since previous reading: {{amount}} {{unit}}",
+    "readingHistory": "Reading history",
+    "submitNewReading": "Submit new reading"
   },
   "esignature": {
     "title": "Signature Request",

--- a/frontend/apps/mobile/src/locales/hu.json
+++ b/frontend/apps/mobile/src/locales/hu.json
@@ -400,7 +400,13 @@
     "noUnitText": "A mérőórák akkor jelennek meg, ha fiókját egy egységhez társítják.",
     "detailLoadError": "A mérőóra nem tölthető be",
     "noReadingsTitle": "Még nincsenek leolvasások",
-    "noReadingsText": "Küldje be első leolvasását ehhez a mérőórához."
+    "noReadingsText": "Küldje be első leolvasását ehhez a mérőórához.",
+    "meterFallback": "Mérőóra",
+    "backToMeters": "Mérőórák",
+    "latestReading": "Legutóbbi leolvasás",
+    "usedSincePrevious": "Fogyasztás az előző leolvasás óta: {{amount}} {{unit}}",
+    "readingHistory": "Leolvasási előzmények",
+    "submitNewReading": "Új leolvasás beküldése"
   },
   "esignature": {
     "title": "Alairasi keres",

--- a/frontend/apps/mobile/src/locales/pl.json
+++ b/frontend/apps/mobile/src/locales/pl.json
@@ -400,7 +400,13 @@
     "noUnitText": "Liczniki pojawią się po powiązaniu Twojego konta z lokalem.",
     "detailLoadError": "Nie można załadować licznika",
     "noReadingsTitle": "Brak odczytów",
-    "noReadingsText": "Prześlij swój pierwszy odczyt dla tego licznika."
+    "noReadingsText": "Prześlij swój pierwszy odczyt dla tego licznika.",
+    "meterFallback": "Licznik",
+    "backToMeters": "Liczniki",
+    "latestReading": "Ostatni odczyt",
+    "usedSincePrevious": "Zużycie od poprzedniego odczytu: {{amount}} {{unit}}",
+    "readingHistory": "Historia odczytów",
+    "submitNewReading": "Prześlij nowy odczyt"
   },
   "esignature": {
     "title": "Prosba o podpis",

--- a/frontend/apps/mobile/src/locales/sk.json
+++ b/frontend/apps/mobile/src/locales/sk.json
@@ -440,7 +440,13 @@
     "noUnitText": "Merače sa zobrazia po priradení vášho účtu k jednotke.",
     "detailLoadError": "Nepodarilo sa načítať merač",
     "noReadingsTitle": "Zatiaľ žiadne odpočty",
-    "noReadingsText": "Odošlite svoj prvý odpočet pre tento merač."
+    "noReadingsText": "Odošlite svoj prvý odpočet pre tento merač.",
+    "meterFallback": "Merač",
+    "backToMeters": "Merače",
+    "latestReading": "Posledný odpočet",
+    "usedSincePrevious": "Spotreba od predchádzajúceho odpočtu: {{amount}} {{unit}}",
+    "readingHistory": "História odpočtov",
+    "submitNewReading": "Odoslať nový odpočet"
   },
   "esignature": {
     "title": "Ziadost o podpis",

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * MeterDetailScreen — hardcoded-string i18n regression test
+ * (code-review-mobile-rn-meterdetail-i18n).
+ *
+ * MeterDetailScreen rendered several UI strings as hardcoded English literals
+ * ("← Meters", "Latest reading", "Reading history", "Submit new reading", the
+ * "Used since previous reading" summary, and the "Meter" fallback label) even
+ * though react-i18next was already wired for its loading/error/empty states.
+ * This suite locks the contract: every one of those strings now flows through
+ * an i18n key via `t()`, and the keys resolve to real, locale-distinct copy.
+ *
+ * Two layers, mirroring FaultsListScreen.i18n.test.tsx:
+ *  1. Render layer — `src/test/setup.ts` mocks react-i18next so `t(key) => key`.
+ *     We assert the screen renders the i18n KEYS and that the OLD hardcoded
+ *     English literals are gone.
+ *  2. Resource layer — the locale JSON files carry translated, locale-distinct
+ *     values for those keys.
+ */
+
+import { render, screen } from '@testing-library/react-native';
+import cs from '../../locales/cs.json';
+import de from '../../locales/de.json';
+import en from '../../locales/en.json';
+import hu from '../../locales/hu.json';
+import pl from '../../locales/pl.json';
+import sk from '../../locales/sk.json';
+import { MeterDetailScreen } from './MeterDetailScreen';
+
+jest.mock('../../hooks/useApi', () => ({
+  useApiQuery: jest.fn(),
+}));
+
+const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
+
+function mockQuery(overrides: Record<string, unknown>) {
+  mockUseApiQuery.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: null,
+    refetch: jest.fn(),
+    isFetching: false,
+    ...overrides,
+  });
+}
+
+const responseWithReadings = {
+  meter: { id: 'm-1', meter_number: 'CW-001', unit_of_measure: 'm³' },
+  recent_readings: [
+    { id: 'r2', reading: '142.4', reading_date: '2026-03-31' },
+    { id: 'r1', reading: '141.2', reading_date: '2026-02-28' },
+  ],
+};
+
+// The old hardcoded literals that must no longer be rendered.
+const HARDCODED = ['← Meters', 'Latest reading', 'Reading history', 'Submit new reading'];
+
+describe('MeterDetailScreen hardcoded-string i18n', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the meters.* keys, not the hardcoded English literals', () => {
+    mockQuery({ data: responseWithReadings });
+    render(<MeterDetailScreen meterId="m-1" onBack={() => {}} onNavigate={() => {}} />);
+
+    expect(screen.getByText('meters.backToMeters', { exact: false })).toBeTruthy();
+    expect(screen.getByText('meters.latestReading')).toBeTruthy();
+    expect(screen.getByText('meters.usedSincePrevious')).toBeTruthy();
+    expect(screen.getByText('meters.readingHistory')).toBeTruthy();
+    expect(screen.getByText('meters.submitNewReading')).toBeTruthy();
+
+    for (const literal of HARDCODED) {
+      expect(screen.queryByText(literal)).toBeNull();
+    }
+  });
+
+  it('falls back to the meters.meterFallback key when no label or meter number is present', () => {
+    mockQuery({ data: { meter: { id: 'm-1' }, recent_readings: [] } });
+    render(<MeterDetailScreen meterId="m-1" />);
+    expect(screen.getByText('meters.meterFallback')).toBeTruthy();
+    expect(screen.queryByText('Meter')).toBeNull();
+  });
+});
+
+describe('meter detail keys resolve to real, locale-distinct translations', () => {
+  it('en carries the expected English copy', () => {
+    expect(en.meters.meterFallback).toBe('Meter');
+    expect(en.meters.backToMeters).toBe('Meters');
+    expect(en.meters.latestReading).toBe('Latest reading');
+    expect(en.meters.readingHistory).toBe('Reading history');
+    expect(en.meters.submitNewReading).toBe('Submit new reading');
+    expect(en.meters.usedSincePrevious).toContain('{{amount}}');
+    expect(en.meters.usedSincePrevious).toContain('{{unit}}');
+  });
+
+  it('every locale defines the keys and preserves the interpolation placeholders', () => {
+    for (const locale of [sk, cs, de, hu, pl]) {
+      for (const key of [
+        'backToMeters',
+        'latestReading',
+        'readingHistory',
+        'submitNewReading',
+        'meterFallback',
+        'usedSincePrevious',
+      ] as const) {
+        expect(typeof locale.meters[key]).toBe('string');
+        expect(locale.meters[key].length).toBeGreaterThan(0);
+      }
+      // Real translations, not English copies left behind.
+      expect(locale.meters.latestReading).not.toBe(en.meters.latestReading);
+      expect(locale.meters.submitNewReading).not.toBe(en.meters.submitNewReading);
+      // Interpolation placeholders survive translation.
+      expect(locale.meters.usedSincePrevious).toContain('{{amount}}');
+      expect(locale.meters.usedSincePrevious).toContain('{{unit}}');
+    }
+  });
+});

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
@@ -114,7 +114,7 @@ interface MeterDetailScreenProps {
 
 export function MeterDetailScreen({
   meterId,
-  meterLabel = 'Meter',
+  meterLabel,
   onBack,
   onNavigate,
 }: MeterDetailScreenProps) {
@@ -127,7 +127,7 @@ export function MeterDetailScreen({
 
   const response = parseMeterResponse(data);
   const readings = response ? toUiReadings(response) : [];
-  const label = response?.meter.meter_number?.trim() || meterLabel;
+  const label = response?.meter.meter_number?.trim() || meterLabel || t('meters.meterFallback');
 
   const lastTwo = readings.slice(0, 2);
   const monthDelta = lastTwo.length === 2 ? Math.max(0, lastTwo[0].value - lastTwo[1].value) : null;
@@ -141,7 +141,7 @@ export function MeterDetailScreen({
       <View style={s.header}>
         {onBack && (
           <Pressable onPress={onBack} style={styles.backLink}>
-            <Text style={styles.backLinkText}>← Meters</Text>
+            <Text style={styles.backLinkText}>← {t('meters.backToMeters')}</Text>
           </Pressable>
         )}
         <Text style={s.headerTitle}>{label}</Text>
@@ -165,20 +165,23 @@ export function MeterDetailScreen({
           <>
             {readings.length > 0 && (
               <View style={s.card}>
-                <Text style={styles.metricLabel}>Latest reading</Text>
+                <Text style={styles.metricLabel}>{t('meters.latestReading')}</Text>
                 <Text style={styles.metricValue}>
                   {readings[0].value} {readings[0].unit}
                 </Text>
                 <Text style={s.cardMeta}>{new Date(readings[0].takenAt).toLocaleDateString()}</Text>
                 {monthDelta != null && (
                   <Text style={[s.cardBody, { marginTop: 8 }]}>
-                    Used since previous reading: {monthDelta.toFixed(2)} {readings[0].unit}
+                    {t('meters.usedSincePrevious', {
+                      amount: monthDelta.toFixed(2),
+                      unit: readings[0].unit,
+                    })}
                   </Text>
                 )}
               </View>
             )}
 
-            <Text style={styles.sectionTitle}>Reading history</Text>
+            <Text style={styles.sectionTitle}>{t('meters.readingHistory')}</Text>
             {readings.length === 0 ? (
               <View style={s.emptyState}>
                 <Text style={s.emptyIcon}>📏</Text>
@@ -202,7 +205,7 @@ export function MeterDetailScreen({
               style={s.primaryButton}
               onPress={() => onNavigate?.('MeterReading', { meterId })}
             >
-              <Text style={s.primaryButtonText}>Submit new reading</Text>
+              <Text style={s.primaryButtonText}>{t('meters.submitNewReading')}</Text>
             </Pressable>
           </>
         )}


### PR DESCRIPTION
## Task
mobile-rn: `MeterDetailScreen` (under `frontend/mobile/src/`, actual path `frontend/apps/mobile/src/`) renders several hardcoded English UI strings not wrapped in `t()`, while sibling screens use react-i18next. Fix: wrap the hardcoded strings in `t()` with appropriate keys and add those keys to ALL locale bundles (en + sk/cs/de, matching how sibling screens do it). Follow the existing i18n key naming/structure used by neighboring meter screens. Add/adjust a jest test if the screen has a test harness.

## Owner
pm-frontend (specialist: react-native)

## Changes
- `MeterDetailScreen.tsx`: wrapped 6 hardcoded strings in `t()` — back link (`meters.backToMeters`), latest-reading label (`meters.latestReading`), consumption summary with interpolation (`meters.usedSincePrevious` `{{amount}}`/`{{unit}}`), reading-history heading (`meters.readingHistory`), submit CTA (`meters.submitNewReading`), and the `'Meter'` header fallback (`meters.meterFallback`).
- Added the 6 new `meters.*` keys to ALL six locale bundles: `en, sk, cs, de, hu, pl` (repo carries 6 locales, not just en/sk/cs/de — matched full set to stay consistent with sibling meter keys).
- Added `MeterDetailScreen.i18n.test.tsx` — render-layer assertions (keys rendered, old literals gone) + resource-layer assertions (keys present, locale-distinct, interpolation placeholders preserved), mirroring `FaultsListScreen.i18n.test.tsx`.

## Verification
```
VERIFY-PLAN base=6c3f73f69eaace36ad880d3f0a57cc91d53c6387 files=8
  cd frontend && pnpm exec biome check apps/mobile/src/locales/cs.json apps/mobile/src/locales/de.json apps/mobile/src/locales/en.json apps/mobile/src/locales/hu.json apps/mobile/src/locales/pl.json apps/mobile/src/locales/sk.json apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx apps/mobile/src/screens/meters/MeterDetailScreen.tsx
  cd frontend && pnpm --filter "...[6c3f73f69eaace36ad880d3f0a57cc91d53c6387]" typecheck
  cd frontend && pnpm --filter "...[6c3f73f69eaace36ad880d3f0a57cc91d53c6387]" test
```
`VERIFY OK a8e1c1246888f090ba7314ed0f4251893341e5a7`

(biome + typecheck clean; 50 suites / 619 tests pass, including the 2 MeterDetailScreen suites.)

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0 (all paths under `frontend/apps/mobile/`).

## Code-reuse review
None — `reuse-grep.sh --specialist react-native` emitted no warnings (no auth/crypto/http helpers added).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (cloud run, no ppt-bridge).

## Notes
- The dispatcher `goal-check.sh` reports IG1/IG2/IG3 FAIL — those are structural to the research-plan implementer flow (they expect a `.research/plans/<slug>.md`, an `impl/*` branch, and split `test:`/`fix:` commits). This is a dispatcher auto-impl code-review task (`auto-impl/*` branch, no research plan), so those checks don't apply; IG7 (the mandatory verify gate) passed.
- The mock `t(key) => key` (`src/test/setup.ts`) ignores interpolation args, so `usedSincePrevious` renders as its bare key in the render test — locale-layer assertions cover the `{{amount}}`/`{{unit}}` placeholders separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uj6oF9p9ZEngWRET7QT1J

---
_Generated by [Claude Code](https://claude.ai/code/session_016uj6oF9p9ZEngWRET7QT1J)_