### PR TITLE
code-review-mobile-rn-date-locale-en-us: localize mobile dates via active i18n locale

### DIFF
--- a/frontend/apps/mobile/src/i18n/format.test.ts
+++ b/frontend/apps/mobile/src/i18n/format.test.ts
@@ -1,0 +1,62 @@
+import { formatDate, formatDateTime, formatTime, resolveLocale } from './format';
+
+describe('resolveLocale', () => {
+  it.each([
+    ['en', 'en'],
+    ['sk', 'sk'],
+    ['cs', 'cs'],
+    ['de', 'de'],
+    ['pl', 'pl'],
+    ['hu', 'hu'],
+  ])('passes through the supported language %s', (input, expected) => {
+    expect(resolveLocale(input)).toBe(expected);
+  });
+
+  it('strips the region subtag (de-DE -> de)', () => {
+    expect(resolveLocale('de-DE')).toBe('de');
+    expect(resolveLocale('en-US')).toBe('en');
+  });
+
+  it('falls back to the default locale for unsupported languages', () => {
+    expect(resolveLocale('fr')).toBe('en');
+    expect(resolveLocale('')).toBe('en');
+  });
+
+  it('falls back to the default locale when nothing is active', () => {
+    // No explicit language and (in the unit-test env) no initialised i18next
+    // language → must not throw and must not emit a foreign locale.
+    expect(resolveLocale()).toBe('en');
+  });
+});
+
+describe('formatDate', () => {
+  const iso = '2026-07-01T00:00:00Z';
+
+  // Regression for #2282: the hardcoded 'en-US' meant dates never localised.
+  // A non-en locale must format the same instant differently from en.
+  it('formats a non-en locale differently from en', () => {
+    const en = formatDate(iso, { month: 'long', year: 'numeric' }, 'en');
+    const de = formatDate(iso, { month: 'long', year: 'numeric' }, 'de');
+    const sk = formatDate(iso, { month: 'long', year: 'numeric' }, 'sk');
+
+    expect(en).toBeTruthy();
+    // German "Juli" / Slovak "júl" differ from English "July".
+    expect(de).not.toBe(en);
+    expect(sk).not.toBe(en);
+  });
+
+  it('honours the locale it is handed for each supported language', () => {
+    for (const lang of ['en', 'sk', 'cs', 'de', 'pl', 'hu']) {
+      expect(formatDate(iso, { year: 'numeric' }, lang)).toMatch(/2026/);
+    }
+  });
+});
+
+describe('formatTime / formatDateTime', () => {
+  const iso = '2026-07-01T13:37:00Z';
+
+  it('produce non-empty localized strings', () => {
+    expect(formatTime(iso, { hour: '2-digit', minute: '2-digit' }, 'de')).toBeTruthy();
+    expect(formatDateTime(iso, { dateStyle: 'short', timeStyle: 'short' }, 'sk')).toBeTruthy();
+  });
+});

--- a/frontend/apps/mobile/src/i18n/format.ts
+++ b/frontend/apps/mobile/src/i18n/format.ts
@@ -1,0 +1,56 @@
+/**
+ * Locale-aware date/time formatting helpers.
+ *
+ * Historically many screens formatted dates with a hardcoded `'en-US'` locale
+ * (an incomplete fix of #2282), so dates never localised for sk/cs/de/pl/hu
+ * users regardless of the language they picked in-app. These helpers derive
+ * the formatting locale from the app's *active* i18next language instead, so a
+ * rendered date matches the rest of the UI.
+ *
+ * The active language is read from the shared i18next singleton (the same
+ * instance configured in `./index`), so module-level formatters localise
+ * without having to thread the language through every call site. An explicit
+ * `language` override is accepted, mainly so the behaviour can be unit-tested
+ * without mutating global i18next state.
+ */
+import i18n from 'i18next';
+import { defaultLocale, locales } from './config';
+
+/**
+ * Map an i18next language (e.g. `'sk'`, `'de-DE'`) onto a BCP-47 locale to hand
+ * to `Intl` / `toLocale*` APIs. Falls back to the default locale (`'en'`) for
+ * unset or unsupported languages so formatting never throws or silently emits
+ * a fixed `en-US`.
+ */
+export function resolveLocale(language?: string): string {
+  const raw = language ?? i18n.language ?? defaultLocale;
+  const base = raw.split('-')[0].toLowerCase();
+  return (locales as readonly string[]).includes(base) ? base : defaultLocale;
+}
+
+/** `Date#toLocaleDateString` using the app's active i18n locale. */
+export function formatDate(
+  value: string | number | Date,
+  options?: Intl.DateTimeFormatOptions,
+  language?: string
+): string {
+  return new Date(value).toLocaleDateString(resolveLocale(language), options);
+}
+
+/** `Date#toLocaleTimeString` using the app's active i18n locale. */
+export function formatTime(
+  value: string | number | Date,
+  options?: Intl.DateTimeFormatOptions,
+  language?: string
+): string {
+  return new Date(value).toLocaleTimeString(resolveLocale(language), options);
+}
+
+/** `Date#toLocaleString` (date + time) using the app's active i18n locale. */
+export function formatDateTime(
+  value: string | number | Date,
+  options?: Intl.DateTimeFormatOptions,
+  language?: string
+): string {
+  return new Date(value).toLocaleString(resolveLocale(language), options);
+}

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { resolveLocale } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 
 export interface AnnouncementAttachment {
@@ -150,7 +151,7 @@ export function formatRelativeDate(dateString: string, now: Date = new Date()): 
   if (diffDays < 7) {
     return `${diffDays}d ago`;
   }
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return date.toLocaleDateString(resolveLocale(), { month: 'short', day: 'numeric' });
 }
 
 interface AnnouncementsScreenProps {

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
 import { useFolderTree } from '../../hooks/useFolderTree';
+import { resolveLocale } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 import type { AccessScope } from './DocumentPermissionsScreen';
 import {
@@ -182,7 +183,11 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
 
   const formatDate = (dateString: string): string => {
     const date = new Date(dateString);
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    return date.toLocaleDateString(resolveLocale(), {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
   };
 
   const navigateToFolder = (folder: Document) => {

--- a/frontend/apps/mobile/src/screens/faults/FaultsListScreen.tsx
+++ b/frontend/apps/mobile/src/screens/faults/FaultsListScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { resolveLocale } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 
 export type FaultStatus = 'open' | 'in_progress' | 'resolved' | 'closed';
@@ -122,7 +123,7 @@ const categoryIcon: Record<FaultCategory, string> = {
 
 const formatDate = (dateString: string): string => {
   const date = new Date(dateString);
-  return date.toLocaleDateString('en-US', {
+  return date.toLocaleDateString(resolveLocale(), {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
@@ -16,6 +16,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { resolveLocale } from '../../i18n/format';
 import { warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 import { type Lease, toUiLeaseStatus } from './LeasesScreen';
@@ -99,7 +100,7 @@ export function toUiLease(detail: ApiLeaseDetail): Lease {
 function periodLabel(dueDate: string): string {
   const d = new Date(dueDate);
   if (Number.isNaN(d.getTime())) return dueDate;
-  return d.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  return d.toLocaleDateString(resolveLocale(), { month: 'long', year: 'numeric' });
 }
 
 /** Map api-server payments onto the UI payment rows, soonest `due_date` first.

--- a/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
@@ -9,6 +9,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, Text, TextInput, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { resolveLocale } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 /** Shape returned by `GET /api/v1/messages/threads`. The api-server serializes
@@ -58,7 +59,7 @@ function formatRelative(iso: string): string {
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d`;
-  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return new Date(iso).toLocaleDateString(resolveLocale(), { month: 'short', day: 'numeric' });
 }
 
 function participantName(p: ParticipantInfo): string {

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -29,6 +29,7 @@ import {
 import { QueryErrorBanner } from '../../components/QueryErrorBanner';
 import { useAuth } from '../../contexts/AuthContext';
 import { useApiMutation, useApiQuery } from '../../hooks/useApi';
+import { resolveLocale } from '../../i18n/format';
 import { warnIfListDegraded, warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
@@ -121,7 +122,7 @@ function sentAtSortKey(sentAt: string): number {
 export function formatMessageTime(sentAt: string): string {
   const d = new Date(sentAt);
   if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+  return d.toLocaleTimeString(resolveLocale(), { hour: '2-digit', minute: '2-digit' });
 }
 
 /** Map api-server messages onto UI bubbles, oldest first. `currentUserId`

--- a/frontend/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { EmptyState } from '../../components/states';
+import { resolveLocale } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export type NotificationCategory =
@@ -102,7 +103,7 @@ function formatRelative(iso: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return new Date(iso).toLocaleDateString(resolveLocale(), { month: 'short', day: 'numeric' });
 }
 
 interface NotificationsScreenProps {

--- a/frontend/apps/mobile/src/screens/outages/OutagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/outages/OutagesScreen.tsx
@@ -8,6 +8,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { resolveLocale } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export type OutageCommodity = 'water' | 'electricity' | 'gas' | 'heat' | 'internet';
@@ -100,16 +101,17 @@ function formatRange(startsAt: string, endsAt: string): string {
   const start = new Date(startsAt);
   const end = new Date(endsAt);
   const sameDay = start.toDateString() === end.toDateString();
+  const locale = resolveLocale();
   const dateOpts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
   const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
   if (sameDay) {
-    return `${start.toLocaleDateString('en-US', dateOpts)} · ${start.toLocaleTimeString(
-      'en-US',
+    return `${start.toLocaleDateString(locale, dateOpts)} · ${start.toLocaleTimeString(
+      locale,
       timeOpts
-    )} – ${end.toLocaleTimeString('en-US', timeOpts)}`;
+    )} – ${end.toLocaleTimeString(locale, timeOpts)}`;
   }
-  return `${start.toLocaleDateString('en-US', dateOpts)} – ${end.toLocaleDateString(
-    'en-US',
+  return `${start.toLocaleDateString(locale, dateOpts)} – ${end.toLocaleDateString(
+    locale,
     dateOpts
   )}`;
 }

--- a/frontend/apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
@@ -25,6 +25,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { resolveLocale } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 interface PersonMonthEntry {
@@ -43,7 +44,7 @@ const MOCK_ENTRIES: PersonMonthEntry[] = [
 
 function formatMonth(month: string): string {
   const [year, m] = month.split('-').map(Number);
-  return new Date(year, (m ?? 1) - 1, 1).toLocaleDateString('en-US', {
+  return new Date(year, (m ?? 1) - 1, 1).toLocaleDateString(resolveLocale(), {
     month: 'long',
     year: 'numeric',
   });


### PR DESCRIPTION
## Task
mobile-rn: date formatters hardcode the 'en-US' locale across many screens under `frontend/mobile/src/` (an incomplete fix of #2282), so dates never localize for sk/cs/de users. Fix: replace the hardcoded 'en-US' locale in date/number `Intl`/`toLocaleDateString`/`toLocaleString`/`date-fns` calls with the app's active i18n locale (derive from the i18next/react-i18next current language, mapping to sk/cs/de/en). Prefer a shared helper (reuse an existing locale/formatting util if one exists — check first) over per-screen fixes. Add/adjust jest tests asserting a non-en locale formats a date differently.

## Owner
pm-frontend (specialist: react-native)

## What changed
- New shared helper `frontend/apps/mobile/src/i18n/format.ts`: `resolveLocale()` maps the active i18next language (read from the i18next singleton, with an optional override for tests) to a BCP-47 locale (en/sk/cs/de/pl/hu), falling back to the default `en` for unset/unsupported languages. Plus `formatDate` / `formatTime` / `formatDateTime` convenience wrappers.
- Replaced the hardcoded `'en-US'` at every **display** date/time formatter site with `resolveLocale()`:
  - `screens/person-months/PersonMonthsScreen.tsx`
  - `screens/faults/FaultsListScreen.tsx`
  - `screens/notifications/NotificationsScreen.tsx`
  - `screens/messages/MessagesScreen.tsx`, `screens/messages/ThreadDetailScreen.tsx`
  - `screens/announcements/AnnouncementsScreen.tsx`
  - `screens/leases/LeaseDetailScreen.tsx`
  - `screens/outages/OutagesScreen.tsx` (5 occurrences)
  - `screens/documents/DocumentsScreen.tsx`
- New tests `frontend/apps/mobile/src/i18n/format.test.ts` assert non-en locales (de, sk) format the same instant differently from en, that region subtags are stripped (`de-DE`→`de`), and that unsupported languages fall back to `en`.

Note: the already-fixed reference screens (`DashboardScreen`, `VotingScreen`, `AnnouncementDetailScreen`, `features/layout/registry.tsx`) already thread `i18n.language` and were left as-is. Sites intentionally **not** touched (out of scope — not display date/number formatting): `voice/VoiceAssistant.ts` (`language: 'en-US'` is the speech-recognition language) and `onboarding/FeedbackManager.ts` (`… ?? 'en-US'` is a telemetry fallback capturing the resolved *device* locale, not a rendered date).

## Verification
```
VERIFY-PLAN base=6c3f73f69eaace36ad880d3f0a57cc91d53c6387 files=11
  cd frontend && pnpm exec biome check apps/mobile/src/i18n/format.test.ts apps/mobile/src/i18n/format.ts apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx apps/mobile/src/screens/documents/DocumentsScreen.tsx apps/mobile/src/screens/faults/FaultsListScreen.tsx apps/mobile/src/screens/leases/LeaseDetailScreen.tsx apps/mobile/src/screens/messages/MessagesScreen.tsx apps/mobile/src/screens/messages/ThreadDetailScreen.tsx apps/mobile/src/screens/notifications/NotificationsScreen.tsx apps/mobile/src/screens/outages/OutagesScreen.tsx apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
  cd frontend && pnpm --filter "...[6c3f73f69eaace36ad880d3f0a57cc91d53c6387]" typecheck
  cd frontend && pnpm --filter "...[6c3f73f69eaace36ad880d3f0a57cc91d53c6387]" test
```
VERIFY OK 42b8d385495fd09fdfaad45400cbd3ddd32029e4

(biome clean; mobile typecheck clean; jest 627 passed / 50 suites incl. new `format.test.ts`.)

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. Diff is confined to `frontend/apps/mobile/`.

## Code-reuse review
`reuse-grep.sh --specialist react-native` returned no warnings. No existing mobile locale/date util existed (each screen rolled its own `formatDate`); this PR introduces the shared helper the task asked for.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- IG goal-check (`goal-check.sh`) reports IG1/IG2/IG3 failures because it is calibrated for the `.research/plans/<slug>.md` flow: (IG1) this is a dispatcher code-review action with no plan file; (IG2) the branch name `auto-impl/…` is dispatcher-assigned rather than `impl/…`; (IG3) the added regression test covers a brand-new helper module, so a "failing-on-main" split `test:` commit doesn't apply. The hard gate IG7 (`just verify`) passed.
- The helper reads the live i18next language, so module-level formatters localise on mount for a persisted language. Two screens (`PersonMonthsScreen`, `NotificationsScreen`) don't subscribe via `useTranslation`, so a *live* in-session language switch won't re-render them until remount — correct on mount either way; left untouched to keep scope tight.

---
_Generated by [Claude Code](https://claude.ai/code/session_016uj6oF9p9ZEngWRET7QT1J)_