### PR TITLE
code-review-ppt-web-core-logout-purge-notif-triggers: purge notification-triggers query root on logout

### DIFF
--- a/frontend/apps/ppt-web/src/contexts/AuthContext.test.tsx
+++ b/frontend/apps/ppt-web/src/contexts/AuthContext.test.tsx
@@ -197,6 +197,11 @@ describe('AuthContext.logout — Issue #712', () => {
       'predictive-maintenance',
       'sentiment',
       'notification-analytics',
+      // Per-user granular notification-trigger preferences — regression guard
+      // for the PR #2650 follow-up where this root was still missed and the
+      // previous user's notification-preference cache leaked into the next
+      // session on a shared workstation.
+      'notification-triggers',
       // Tenant-scoped financial + operational caches — the most sensitive
       // data in the app (invoices, contacts, bank statements, payment
       // matching, AR aging, report schedules) plus rentals/meters and the
@@ -227,6 +232,9 @@ describe('AuthContext.logout — Issue #712', () => {
     queryClient.setQueryData(['predictive-maintenance', 'needing-maintenance'], [{ id: 'e-1' }]);
     queryClient.setQueryData(['sentiment', 'dashboard'], { score: 0.42 });
     queryClient.setQueryData(['notification-analytics', {}], { delivered: 10 });
+    // Per-user notification-trigger preferences — real key from
+    // notificationTriggerKeys.events() (@ppt/api-client granular-notifications).
+    queryClient.setQueryData(['notification-triggers', 'events'], [{ id: 'nt-1' }]);
     // Tenant-scoped financial + operational caches — real keys from
     // queryKeys.accounting (invoices/contacts/statements/matching),
     // financial.tsx (['financial','ar-aging',orgId]), reportKeys
@@ -252,6 +260,7 @@ describe('AuthContext.logout — Issue #712', () => {
     ).toBeDefined();
     expect(queryClient.getQueryData(['sentiment', 'dashboard'])).toBeDefined();
     expect(queryClient.getQueryData(['notification-analytics', {}])).toBeDefined();
+    expect(queryClient.getQueryData(['notification-triggers', 'events'])).toBeDefined();
     expect(queryClient.getQueryData(['accounting', 'invoices'])).toBeDefined();
     expect(queryClient.getQueryData(['financial', 'ar-aging', 'org-1'])).toBeDefined();
     expect(queryClient.getQueryData(['reports', 'schedules', 'list', 'org-1'])).toBeDefined();
@@ -284,6 +293,8 @@ describe('AuthContext.logout — Issue #712', () => {
     ).toBeUndefined();
     expect(queryClient.getQueryData(['sentiment', 'dashboard'])).toBeUndefined();
     expect(queryClient.getQueryData(['notification-analytics', {}])).toBeUndefined();
+    // Per-user notification-trigger preferences must not survive logout.
+    expect(queryClient.getQueryData(['notification-triggers', 'events'])).toBeUndefined();
     // Tenant-scoped financial + operational caches must not survive logout.
     expect(queryClient.getQueryData(['accounting', 'invoices'])).toBeUndefined();
     expect(queryClient.getQueryData(['financial', 'ar-aging', 'org-1'])).toBeUndefined();

--- a/frontend/apps/ppt-web/src/lib/queryKeys.ts
+++ b/frontend/apps/ppt-web/src/lib/queryKeys.ts
@@ -340,8 +340,8 @@ export const queryKeys = {
  * ppt-web (`messages`, `meters`, `reports`), and the ad-hoc roots used
  * directly in feature hooks (`developer`, `ocr`, `actionQueue`,
  * `executionLogs`, `executionStats`, `ai-chat`, `predictive-maintenance`,
- * `sentiment`, `notification-analytics`, `financial`, `rentals`, and the
- * `auth`-rooted active-sessions cache).
+ * `sentiment`, `notification-analytics`, `notification-triggers`,
+ * `financial`, `rentals`, and the `auth`-rooted active-sessions cache).
  *
  * When you add a new auth-scoped query root, add it here too — otherwise the
  * cached data will leak into the next user's session. This must cover ALL
@@ -384,6 +384,11 @@ export const AUTHED_QUERY_KEY_ROOTS = [
   'predictive-maintenance',
   'sentiment',
   'notification-analytics',
+  // Granular notification-trigger preferences (@ppt/api-client
+  // granular-notifications — `notificationTriggerKeys`, Story 84.4). These are
+  // per-user preference caches; without this root they leaked into the next
+  // session (PR #2650 fix was incomplete — this root was missed).
+  'notification-triggers',
 ] as const;
 
 // ============================================================================


### PR DESCRIPTION
## Task
ppt-web logout cache purge still misses the 'notification-triggers' query root (PR #2650 fix incomplete) — user notification-preference cache leaks into the next session.

## Owner
pm-backend (hint) — actual code is ppt-web frontend; implemented by the `react-web` specialist.

## Root cause
`AUTHED_QUERY_KEY_ROOTS` (`frontend/apps/ppt-web/src/lib/queryKeys.ts`) is the allowlist `AuthContext.logout()` iterates to `queryClient.removeQueries({ queryKey: [root] })`. It was missing the `notification-triggers` root used by the `@ppt/api-client` granular-notifications hooks (`notificationTriggerKeys`, Story 84.4). PR #2650 closed the same class of leak for the analytics roots but missed this one, so a prior user's per-user notification-preference cache survived logout and leaked into the next session on a shared workstation.

## Fix
- Added `'notification-triggers'` to `AUTHED_QUERY_KEY_ROOTS` (+ doc comment).
- Extended the Issue #712 logout regression test (`AuthContext.test.tsx`): asserts the root is in the allowlist, seeds `['notification-triggers','events']`, and asserts it is evicted on logout.

## Verification
- `pnpm -F @ppt/web typecheck` — exit 0
- `npx biome check` on the two changed files — exit 0 (no fixes)
- `npx vitest run src/contexts/AuthContext.test.tsx` — 2 passed
- IG3: with only the source-list change reverted, the test FAILS (`expected [Array(27)] to include 'notification-triggers'`); with the fix it passes. Regression guard confirmed.

## Scope drift
None — only `frontend/apps/ppt-web/src/` touched. `scope-check.sh` exit 0.

## Code-reuse review
None — no new helpers added.

## CI parity (Band C — hot-path only)
Skipped: no security/auth-token/billing/data-integrity logic change (cache-eviction allowlist entry + test only).

## Remote-tested
Skipped (no ppt-bridge MCP).

## Notes
Single `fix(ppt-web):` commit carries both the source fix and the regression test.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JmfQX2Lijr6WNfw3mr2tyH)_