### PR TITLE
fix(dispatcher): un-wedge oversize-archive push (#1162) + close retry-remint cross-id ghost (#2460)

### DIFF
--- a/.research/dispatcher-prompt.md
+++ b/.research/dispatcher-prompt.md
@@ -2263,10 +2263,30 @@ bash .claude/skills/ppt-implement/scripts/commit-scope-guard.sh \
 # code). It is now placed here, right after the final `git add`, so the check
 # actually fires. The guard self-skips when PUSH_METHOD != mcp (direct `git push`
 # has no inline-content limit), so it is safe to run unconditionally.
-if ! PUSH_METHOD="${PUSH_METHOD:-mcp}" bash .research/mcp-push-size-guard.sh --staged; then
-  echo "PHASE 6 ABORT: mcp-push-size-guard tripped — a staged file exceeds the MCP inline-push ceiling; refusing to commit/MCP-push (would truncate/corrupt it on dev, #1014). Remediation: re-run the reconcilers to shrink state, or land this run via 'PUSH_METHOD=git' where the proxy allows. Not marking this run successful." >&2
-  exit 0
-fi
+#
+# ARCHIVE-ROUTING (issue #1162 / #2743): the two append-only ledgers
+# (assignments-archive.json, action-list-archive.json) legitimately grow past the
+# ceiling and cannot be shrunk without losing history. When they are the ONLY
+# oversize staged files the guard exits 4 ("route via git push") rather than 3
+# ("abort") — a legit archive append must NEVER fail-close-wedge the whole Phase 6
+# push (that regression is exactly what #2743 hit). We honour the routing here by
+# forcing PUSH_METHOD=git for THIS commit; git push has no inline-content limit so
+# the archive lands intact. An oversize ACTIVE state file (the #1014 corruption
+# class) still exits 3 and aborts — those must be shrunk by the reconcilers, never
+# pushed oversize. PUSH_METHOD_EFF carries the (possibly-overridden) method into
+# the push branch below.
+PUSH_METHOD_EFF="${PUSH_METHOD:-mcp}"
+SIZE_GUARD_RC=0
+PUSH_METHOD="$PUSH_METHOD_EFF" bash .research/mcp-push-size-guard.sh --staged || SIZE_GUARD_RC=$?
+case "$SIZE_GUARD_RC" in
+  0) : ;;  # all staged files inline-safe (or guard skipped under PUSH_METHOD=git)
+  4) echo "PHASE 6: oversize append-only archive staged — routing THIS push via PUSH_METHOD=git (MCP inline-push would truncate it, #1014; git push has no inline limit, #1162/#2743)." >&2
+     PUSH_METHOD_EFF=git ;;
+  3) echo "PHASE 6 ABORT: mcp-push-size-guard tripped — an ACTIVE-state staged file exceeds the MCP inline-push ceiling; refusing to commit/MCP-push (would truncate/corrupt it on dev, #1014). Remediation: re-run the reconcilers to shrink state, or land this run via 'PUSH_METHOD=git' where the proxy allows. Not marking this run successful." >&2
+     exit 0 ;;
+  *) echo "PHASE 6 ABORT: mcp-push-size-guard returned unexpected rc=$SIZE_GUARD_RC — refusing to commit/push. Not marking this run successful." >&2
+     exit 0 ;;
+esac
 
 # Pre-commit self-test gate. Phase 8 finding `self-test-fail-recurs-each-run`:
 # T11 / T4 / T18 / T19 were enforced only by the post-hoc self-test, so every
@@ -2303,7 +2323,12 @@ INTENDED_TREE=$(git rev-parse HEAD^{tree})   # the state tree we MUST land (reba
 # full retry/backoff loop before failing EVERY run (recurred R8). Default to MCP;
 # fall back to git push only when the MCP tool is unavailable. `PUSH_METHOD=git`
 # forces the legacy path for environments where direct push works.
-if [ "${PUSH_METHOD:-mcp}" = "mcp" ]; then
+#
+# PUSH_METHOD_EFF (not the raw PUSH_METHOD) is the effective method for THIS run:
+# the size guard above sets it to `git` when only oversize append-only archives
+# are staged (#1162/#2743 archive-routing), so an oversize archive is pushed via
+# git (no inline limit) instead of wedging the MCP path.
+if [ "${PUSH_METHOD_EFF:-${PUSH_METHOD:-mcp}}" = "mcp" ]; then
   # NOTE (issue #2126): the MCP inline-push size guard already ran BEFORE
   # `git commit` above (right after the final `git add`), where
   # `git diff --cached` still reflected the staged payload. Do NOT re-run it

--- a/.research/mcp-push-size-guard.sh
+++ b/.research/mcp-push-size-guard.sh
@@ -21,21 +21,53 @@
 #   # or read the staged set from git:
 #   PUSH_METHOD=mcp ./.research/mcp-push-size-guard.sh --staged
 #
+# Append-only-archive routing (issue #1162 / #2743): two files legitimately
+# grow without bound and CANNOT be shrunk without losing history — the
+# dispatcher's own append-only ledgers `assignments-archive.json` and
+# `action-list-archive.json`. #1162 originally kept the pipeline moving when
+# those crossed the ceiling by NOT treating them as a fail-closed #1014 hazard:
+# they are append-only and the dispatcher is their sole writer, so a direct
+# `git push` (which has NO inline-content limit) lands them intact. That routing
+# regressed — the guard began fail-closing on ALL oversize files — and a single
+# archive append could wedge every Phase 6 push (#2743). This restores it: when
+# the ONLY oversize staged files are these known append-only archives, the guard
+# exits 4 ("route via git push") instead of 3 ("abort"). An oversize ACTIVE
+# state file (action-list.json / assignments.json — the #1014 corruption class)
+# still fail-closes hard (exit 3): those must be shrunk by the reconcilers, never
+# inline-pushed.
+#
 # Tunables (env):
 #   PUSH_METHOD            mcp (default) | git. Guard only enforces under mcp.
 #   MCP_INLINE_MAX_BYTES   per-file hard ceiling, default 65536 (64 KiB).
 #                          Files above this are NOT safe to inline-push.
+#   MCP_ARCHIVE_BASENAMES  space-separated basenames of append-only archives
+#                          that are safe to route via git push when oversize.
+#                          Default: "assignments-archive.json action-list-archive.json".
 #
 # Exit codes:
 #   0  all files safe to inline-push (or PUSH_METHOD != mcp → skipped).
-#   3  at least one file exceeds the inline ceiling — DO NOT MCP-push.
-#      Remediation printed on stderr (run the reconcilers / use git push).
+#   3  at least one NON-archive (active-state) file exceeds the ceiling — DO NOT
+#      push at all this run; the reconcilers must shrink it first (#1014).
+#   4  the ONLY oversize files are known append-only archives — NOT safe to
+#      MCP-inline-push, but SAFE to route this commit via direct `git push`
+#      (no inline-content limit). Caller should set PUSH_METHOD=git (#1162/#2743).
 #  64  usage error.
 
 set -euo pipefail
 
 PUSH_METHOD="${PUSH_METHOD:-mcp}"
 MCP_INLINE_MAX_BYTES="${MCP_INLINE_MAX_BYTES:-65536}"
+MCP_ARCHIVE_BASENAMES="${MCP_ARCHIVE_BASENAMES:-assignments-archive.json action-list-archive.json}"
+
+# Is $1 one of the known append-only archives (matched by basename)?
+is_archive() {
+  local b; b="$(basename "$1")"
+  local a
+  for a in $MCP_ARCHIVE_BASENAMES; do
+    [ "$b" = "$a" ] && return 0
+  done
+  return 1
+}
 
 if [ "$#" -eq 0 ]; then
   echo "usage: $0 <file> [<file>...] | --staged" >&2
@@ -64,22 +96,30 @@ fi
 
 file_size() { wc -c < "$1" | tr -d '[:space:]'; }
 
-OVERSIZE=0
+ACTIVE_OVERSIZE=0     # non-archive state files over the ceiling — #1014 hazard
+ARCHIVE_OVERSIZE=0    # known append-only archives over the ceiling — git-routable
 for f in "${FILES[@]}"; do
   [ -f "$f" ] || continue
   sz=$(file_size "$f")
   if [ "$sz" -gt "$MCP_INLINE_MAX_BYTES" ]; then
-    echo "mcp-push-size-guard: OVERSIZE $f = ${sz}B > ${MCP_INLINE_MAX_BYTES}B ceiling" >&2
-    OVERSIZE=$((OVERSIZE + 1))
+    if is_archive "$f"; then
+      echo "mcp-push-size-guard: OVERSIZE(archive) $f = ${sz}B > ${MCP_INLINE_MAX_BYTES}B — route via git push" >&2
+      ARCHIVE_OVERSIZE=$((ARCHIVE_OVERSIZE + 1))
+    else
+      echo "mcp-push-size-guard: OVERSIZE $f = ${sz}B > ${MCP_INLINE_MAX_BYTES}B ceiling" >&2
+      ACTIVE_OVERSIZE=$((ACTIVE_OVERSIZE + 1))
+    fi
   else
     echo "mcp-push-size-guard: ok       $f = ${sz}B"
   fi
 done
 
-if [ "$OVERSIZE" -gt 0 ]; then
+# An oversize ACTIVE state file is the #1014 corruption class — fail closed,
+# regardless of any archive that is also oversize. It must be shrunk first.
+if [ "$ACTIVE_OVERSIZE" -gt 0 ]; then
   cat >&2 <<EOF
 
-mcp-push-size-guard: ABORT — $OVERSIZE file(s) exceed the MCP inline-push ceiling.
+mcp-push-size-guard: ABORT — $ACTIVE_OVERSIZE active-state file(s) exceed the MCP inline-push ceiling.
   Inline MCP push_files would TRUNCATE these and corrupt them on dev (issue #1014).
   Remediation (in order):
     1. Run the archive reconcilers to shrink active state, then re-stage:
@@ -91,6 +131,20 @@ mcp-push-size-guard: ABORT — $OVERSIZE file(s) exceed the MCP inline-push ceil
        recoverable; a truncated one is not.
 EOF
   exit 3
+fi
+
+# Only append-only archives are oversize — they cannot be shrunk without losing
+# history and are safe to git-push (no inline limit). Route, do NOT wedge (#1162/#2743).
+if [ "$ARCHIVE_OVERSIZE" -gt 0 ]; then
+  cat >&2 <<EOF
+
+mcp-push-size-guard: ROUTE=git — $ARCHIVE_OVERSIZE append-only archive(s) exceed the ${MCP_INLINE_MAX_BYTES}B inline ceiling.
+  These are append-only ledgers (dispatcher is the sole writer); they cannot be
+  shrunk without losing history and MUST NOT be inline-MCP-pushed (would truncate,
+  #1014). Land this commit via direct 'git push' (PUSH_METHOD=git) — it has no
+  inline-content limit (#1162/#2743). Caller: set PUSH_METHOD=git for this push.
+EOF
+  exit 4
 fi
 
 echo "mcp-push-size-guard: all ${#FILES[@]} file(s) within ${MCP_INLINE_MAX_BYTES}B inline ceiling — safe to MCP-push"

--- a/.research/retry-remint.sh
+++ b/.research/retry-remint.sh
@@ -46,6 +46,16 @@
 #       landed under a different id, was already satisfied, or is non-completable
 #       — the signal the coverage/dev-log guards (which key on the task's OWN id)
 #       structurally miss. Degrades gracefully when the archive is absent.
+#     - already-landed summary guard (issue #2743 — cross-issue-id ghost, a
+#       recurrence-hardening of #2460): NONE of the stem's failed rows carry an
+#       `implementer_summary` matching an "already-landed" signal — `already
+#       fixed`/`already landed`/`already satisfied`, `empty diff`, or `no PR
+#       needed`. That summary is the escape hatch the ORIGINAL implementer
+#       emits when it finds the work already merged on dev under a DIFFERENT
+#       issue/PR id (e.g. gh-issue-2658/#2660 satisfying a `voice-webhook`
+#       stem). The coverage/dev-log/subject-prefix guards all join on an id and
+#       structurally cannot see a cross-id landing; this intrinsic-row signal
+#       can. Degrades gracefully when the field is absent (no exclusion).
 #
 #   Minted rows carry `retry_of` (the original failed task_id) and
 #   `retry_round`. `retry_of` is the field Phase 3 and backlog-refill.sh use
@@ -201,6 +211,15 @@ CANDIDATES=$(jq -n \
              rounds_used: (length - 1),          # attempts beyond the original
              newest_failure: $newest,
              retryable: (all(.[]; .pr_number == null)),
+             # Already-landed guard (issue #2743): a failed row whose own
+             # implementer_summary reports the work already merged on dev under a
+             # DIFFERENT issue/PR id. An intrinsic-row signal (no id join), so it
+             # catches the cross-issue-id ghost the coverage/dev-log/subject
+             # guards structurally miss.
+             already_landed: (any(.[];
+               ((.implementer_summary // "")
+                | test("already[ ._-]?(fixed|landed|satisfied)|empty[ ._-]?diff|no[ ._-]?pr[ ._-]?needed"; "i"))
+             )),
              original_id: (map(.task_id) | sort | .[0])
            }
        )
@@ -213,6 +232,7 @@ CANDIDATES=$(jq -n \
          and ((.stem | IN($cov_done_stems[])) | not)
          and ((.stem | IN($dev_landed_stems[])) | not)
          and ((.stem | IN($ghost_marked_stems[])) | not)
+         and ((.already_landed) | not)
          and (($now_e - (.newest_failure | epoch)) >= $cooldown_s)
        ))
      | map(. + { mint_id: (.stem + "-retry" + ((.rounds_used + 1) | tostring)) })

--- a/.research/test-mcp-push-size-guard.sh
+++ b/.research/test-mcp-push-size-guard.sh
@@ -14,6 +14,12 @@
 #       any commit) — catches an oversize staged file. This is the regression
 #       the #2126 reorder fixes: run the guard while the index still differs
 #       from HEAD.
+#   (d) archive-routing (#1162/#2743): when the ONLY oversize staged file is a
+#       known append-only archive (assignments-archive.json / action-list-
+#       archive.json), the guard exits 4 ("route via git push") — NOT 3 — so a
+#       legit archive append can never fail-close-wedge a Phase 6 push.
+#   (e) an oversize ACTIVE state file alongside an oversize archive STILL trips
+#       exit 3 — the #1014 corruption class fail-closes hard regardless.
 #
 # Plus a few guardrails: a small staged file passes; explicit-file mode still
 # trips on an oversize arg; and (the dead-guard regression itself) running the
@@ -82,6 +88,32 @@ mk_file "$REPO/assignments.json" $((CEIL + 20000))   # a 2nd oversize state file
 # BEFORE `git commit`.
 git -C "$REPO" add assignments.json small.json
 expect_rc 3 "(c) Phase-6 add->guard (pre-commit) catches oversize staged file" \
+  bash -c "cd '$REPO' && PUSH_METHOD=mcp bash '$GUARD' --staged"
+
+# =============================================================================
+# (d) archive-routing (#1162/#2743): an oversize APPEND-ONLY ARCHIVE is the ONLY
+#     oversize staged file -> exit 4 ("route via git push"), NOT the fail-closed
+#     exit 3. This is the regression that wedged the pipeline: a legit archive
+#     append must never abort the whole push.
+# =============================================================================
+git -C "$REPO" reset -q
+BIGARCH="$REPO/assignments-archive.json" ; mk_file "$BIGARCH" $((CEIL + 200000))  # ~256 KiB archive
+git -C "$REPO" add assignments-archive.json small.json
+expect_rc 4 "(d) oversize archive-only staged set routes to git (exit 4)" \
+  bash -c "cd '$REPO' && PUSH_METHOD=mcp bash '$GUARD' --staged"
+
+# The 2nd known archive basename routes too (explicit-file mode, exit 4).
+BIGARCH2="$REPO/action-list-archive.json" ; mk_file "$BIGARCH2" $((CEIL + 100000))
+expect_rc 4 "(d) oversize action-list-archive arg routes to git (exit 4)" \
+  bash -c "PUSH_METHOD=mcp bash '$GUARD' '$BIGARCH2'"
+
+# =============================================================================
+# (e) an oversize ACTIVE state file ALONGSIDE an oversize archive STILL trips
+#     exit 3 — the #1014 corruption class fail-closes hard and dominates routing.
+# =============================================================================
+git -C "$REPO" reset -q
+git -C "$REPO" add assignments-archive.json action-list.json    # archive(4) + active(3)
+expect_rc 3 "(e) oversize active file dominates: archive+active staged trips exit 3" \
   bash -c "cd '$REPO' && PUSH_METHOD=mcp bash '$GUARD' --staged"
 
 # =============================================================================

--- a/.research/test-retry-remint.sh
+++ b/.research/test-retry-remint.sh
@@ -8,7 +8,11 @@
 # subject exclusion, both degrading gracefully when their input is missing),
 # and the issue #2460 archive-marker guard (skip a stem whose LATEST
 # action-list-archive row carries a done/ghost marker — latest-row semantics
-# and graceful degradation when the archive is absent).
+# and graceful degradation when the archive is absent), and the issue #2743
+# already-landed summary guard (skip a stem whose failed row's own
+# implementer_summary reports the work already merged on dev under a DIFFERENT
+# issue/PR id — an intrinsic-row signal that catches the cross-issue-id ghost
+# the id-join guards structurally miss; a benign summary must NOT exclude).
 set -uo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -50,7 +54,8 @@ EOF
   cat > "$ASGA" <<'EOF'
 { "assignments": [
   { "task_id": "bug-retryable",       "status": "failed", "pr_number": null,
-    "last_updated": "2026-06-20T00:00:00Z" },
+    "last_updated": "2026-06-20T00:00:00Z",
+    "implementer_summary": "implementer died before opening a PR: sandbox timeout; retry safe" },
   { "task_id": "bug-had-pr",          "status": "failed", "pr_number": 42,
     "last_updated": "2026-06-20T00:00:00Z" },
   { "task_id": "bug-too-fresh",       "status": "failed", "pr_number": null,
@@ -78,7 +83,10 @@ EOF
   { "task_id": "bug-on-dev",          "status": "failed", "pr_number": null,
     "last_updated": "2026-06-20T00:00:00Z" },
   { "task_id": "bug-ghost-marked",    "status": "failed", "pr_number": null,
-    "last_updated": "2026-06-20T00:00:00Z" }
+    "last_updated": "2026-06-20T00:00:00Z" },
+  { "task_id": "bug-already-landed",  "status": "failed", "pr_number": null,
+    "last_updated": "2026-06-20T00:00:00Z",
+    "implementer_summary": "already-fixed on dev by fdeca2a (gh-issue-2658/#2660) under a different id — empty diff, no PR needed" }
 ] }
 EOF
   # Dev-truth fixtures (issue #2153): a coverage story flipped "done" out of
@@ -116,6 +124,8 @@ grep -q "live-stem-task"   <<<"$OUT" && bad "live action-list stem must block (T
 grep -q "bug-cov-done"     <<<"$OUT" && bad "coverage-done story must not re-mint (#2153)" || ok "coverage-done stem excluded"
 grep -q "bug-on-dev"       <<<"$OUT" && bad "anchored dev-log subject must block (#2153)" || ok "dev-log subject-prefix excluded"
 grep -q "bug-ghost-marked" <<<"$OUT" && bad "archive-marker stem must not re-mint (#2460)" || ok "archive-marker stem excluded"
+grep -q "bug-already-landed" <<<"$OUT" && bad "already-landed implementer_summary must not re-mint (#2743)" || ok "already-landed summary stem excluded"
+grep -q "bug-retryable-retry1" <<<"$OUT" && ok "benign (non-landed) implementer_summary does NOT exclude (#2743)" || bad "benign summary wrongly excluded bug-retryable"
 grep -q "bug-second-round-retry2" <<<"$OUT" && ok "loose (non-anchored) dev-log mention does NOT exclude" || bad "non-anchored mention wrongly excluded bug-second-round"
 grep -q "bug-retryable-retry1"    <<<"$OUT" && ok "coverage status=partial does NOT exclude" || bad "coverage partial wrongly excluded bug-retryable"
 [ "$(jq '.items | length' "$AL")" = "2" ] && ok "dry-run leaves file untouched" || bad "dry-run mutated action-list"
@@ -198,6 +208,38 @@ OUT=$(ACTION_LIST="$AL" ACTION_ARCHIVE="$TMP/no-ala.json" ASSIGN="$ASG" ASSIGN_A
       COVERAGE_FILE="$COV" DEV_LOG_FILE="$DEVLOG" RETRY_NOW="$NOW" bash "$SCRIPT"); RC=$?
 [ "$RC" -eq 0 ] && ok "missing archive exits 0" || bad "missing archive errored (rc=$RC): $OUT"
 grep -q "bug-ghost-marked-retry1" <<<"$OUT" && ok "archive-marker guard inert when archive missing" || bad "marker guard fired without archive file: $OUT"
+
+echo "T9 already-landed summary guard: signal variants + graceful degradation (#2743)"
+# Each "already-landed" summary variant must exclude its stem; a benign summary
+# and a MISSING field must NOT exclude. Intrinsic-row signal — no external file,
+# so it fires regardless of coverage/dev-log presence.
+A9="$TMP/al9.json"; ALA9="$TMP/ala9.json"; ASG9="$TMP/asg9.json"; ASGA9="$TMP/asga9.json"
+cat > "$A9"   <<'EOF'
+{ "version": 1, "items": [] }
+EOF
+cat > "$ALA9" <<'EOF'
+{ "version": 1, "items": [] }
+EOF
+cat > "$ASG9" <<'EOF'
+{ "assignments": [] }
+EOF
+cat > "$ASGA9" <<'EOF'
+{ "assignments": [
+  { "task_id": "sig-already-fixed",  "status": "failed", "pr_number": null, "last_updated": "2026-06-20T00:00:00Z", "implementer_summary": "already fixed on dev under #999" },
+  { "task_id": "sig-empty-diff",     "status": "failed", "pr_number": null, "last_updated": "2026-06-20T00:00:00Z", "implementer_summary": "landed out-of-band; empty diff, closing" },
+  { "task_id": "sig-no-pr-needed",   "status": "failed", "pr_number": null, "last_updated": "2026-06-20T00:00:00Z", "implementer_summary": "No PR needed — satisfied elsewhere" },
+  { "task_id": "sig-benign",         "status": "failed", "pr_number": null, "last_updated": "2026-06-20T00:00:00Z", "implementer_summary": "verify-env failure: disk pressure, will retry" },
+  { "task_id": "sig-no-field",       "status": "failed", "pr_number": null, "last_updated": "2026-06-20T00:00:00Z" }
+] }
+EOF
+OUT=$(ACTION_LIST="$A9" ACTION_ARCHIVE="$ALA9" ASSIGN="$ASG9" ASSIGN_ARCHIVE="$ASGA9" \
+      RETRY_NOW="$NOW" bash "$SCRIPT"); RC=$?
+[ "$RC" -eq 0 ] && ok "guard run exits 0" || bad "guard run errored (rc=$RC): $OUT"
+grep -q "sig-already-fixed" <<<"$OUT" && bad "'already fixed' must exclude" || ok "'already fixed' excluded"
+grep -q "sig-empty-diff"    <<<"$OUT" && bad "'empty diff' must exclude"    || ok "'empty diff' excluded"
+grep -q "sig-no-pr-needed"  <<<"$OUT" && bad "'no PR needed' must exclude"  || ok "'no PR needed' excluded"
+grep -q "sig-benign-retry1"   <<<"$OUT" && ok "benign summary still mints"       || bad "benign summary wrongly excluded: $OUT"
+grep -q "sig-no-field-retry1" <<<"$OUT" && ok "missing field degrades to no-exclusion (mints)" || bad "missing field wrongly excluded: $OUT"
 
 echo
 [ "$FAIL" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }


### PR DESCRIPTION
Closes #2743.

Two previously-fixed dispatcher defects recurred and were compounding. Both fixes are scoped strictly to `.research/` scripts + prompt logic + their tests — no runtime state files touched.

## 1. Archive-push wedge — recurrence of #1162 (CRITICAL, was actively blocking the pipeline)

The append-only ledgers `assignments-archive.json` (~660 KB) and `action-list-archive.json` (~637 KB) again exceed the 64 KiB `mcp__github__push_files` inline ceiling. `mcp-push-size-guard.sh` had regressed to **fail-closing (exit 3) on _every_ oversize staged file**, so any terminal transition that appended a single archive row wedged the whole Phase 6 push. The dispatcher was one merge/fail away from being unable to commit its state.

**Fix — restore #1162's routing mechanism.** The guard now *classifies* oversize staged files instead of blanket-aborting:
- an oversize **active-state** file (`action-list.json` / `assignments.json` — the #1014 truncation-corruption class) still **fail-closes hard, exit 3**;
- when the **only** oversize files are the known append-only archives, the guard exits **4** = *"NOT safe to MCP-inline-push, but SAFE via direct `git push`"* (git push has no inline-content limit; these are append-only and the dispatcher is their sole writer).

Phase 6 in `dispatcher-prompt.md` now honours exit 4 by forcing `PUSH_METHOD=git` for that commit (via `PUSH_METHOD_EFF`), so a legit archive append can never fail-close-wedge the push again. Archive basenames are configurable via `MCP_ARCHIVE_BASENAMES`.

> Note on the cloud runner: direct `git push` is the routing target. In the operator's MCP-only cloud runner, `git push` still needs to be reachable for `.research/management/**` (issue #2743 option 3 — scoped deploy key/token). This change makes routing correct and un-wedges the guard; a fully MCP-only durable path (shard/rotate archives so no single file ever exceeds the ceiling) is a larger, higher-blast-radius change (touches both reconcilers + self-test T4/T17/T18) left as a follow-up.

## 2. retry-remint ghost retry — recurrence of #2460

`retry-remint.sh` re-minted a `-retry1` for work that **already landed on dev under a different id** (gh-issue-2658 / PR #2660 satisfying the `voice-webhook-default-secret` stem). The existing dev-truth guards all **join on the failed task's own id** (coverage `done` stems, anchored `<id>:` commit-subject prefix), so a cross-issue-id landing structurally slips through.

**Fix — add an intrinsic-row guard.** A failed stem is now excluded when any of its failed rows carries an `implementer_summary` matching an "already-landed" signal (`already fixed/landed/satisfied`, `empty diff`, `no PR needed`) — the exact escape hatch the original implementer emits when it finds the work already merged elsewhere. This needs no id join, so it catches the blind spot the subject-prefix guard cannot. Degrades gracefully when the field is absent (no exclusion).

## Tests

- `test-mcp-push-size-guard.sh`: oversize archive-only staged set routes to git (**exit 4**); oversize archive **+** oversize active file still fails closed (**exit 3**); explicit-file archive routing.
- `test-retry-remint.sh`: already-landed summary variants exclude; benign summary and missing field still mint; graceful degradation.

**Verify gate (all green):** `dispatcher-self-test.sh` PASS, `test-retry-remint.sh` ALL PASS, `test-mcp-push-size-guard.sh` PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVEftXgsemV55pxxjpiPNY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVEftXgsemV55pxxjpiPNY)_