### PR TITLE
code-review-api-handlers-marketplace-award-quote-idor-retry1: verify awarded quote belongs to RFQ (IDOR)

### DIFF
--- a/backend/crates/db/src/repositories/marketplace.rs
+++ b/backend/crates/db/src/repositories/marketplace.rs
@@ -783,9 +783,15 @@ impl MarketplaceRepository {
         id: Uuid,
         quote_id: Uuid,
     ) -> Result<Option<RequestForQuote>, SqlxError> {
-        // Get quote info
-        let quote = self.find_quote_by_id(quote_id).await?;
-        let provider_id = quote.map(|q| q.provider_id);
+        // Get quote info. Defense-in-depth against IDOR: the awarded quote must
+        // belong to THIS rfq. A quote from a different RFQ (possibly another
+        // org) must never be awardable, even if a caller reaches this method
+        // without the route-level ownership check. Return `Ok(None)` (surfaced
+        // as 404) rather than awarding a foreign quote.
+        let provider_id = match self.find_quote_by_id(quote_id).await? {
+            Some(q) if q.rfq_id == id => Some(q.provider_id),
+            _ => return Ok(None),
+        };
 
         // Update RFQ
         let rfq = sqlx::query_as::<_, RequestForQuote>(

--- a/backend/servers/api-server/src/routes/marketplace.rs
+++ b/backend/servers/api-server/src/routes/marketplace.rs
@@ -927,9 +927,37 @@ async fn award_quote(
 ) -> Result<Json<RequestForQuote>, (StatusCode, Json<ErrorResponse>)> {
     load_rfq_for_org(&state, user.user_id, id).await?;
 
+    // IDOR guard: `quote_id` comes from the request body, while the org check
+    // above only proves the caller owns the RFQ path param `{id}`. Verify the
+    // awarded quote actually belongs to THIS rfq before awarding — otherwise a
+    // caller could award a quote from a foreign RFQ (and, transitively, another
+    // org) by guessing its id. Surface a mismatch as 404 (same shape as a
+    // missing quote) so quote existence is not leaked across tenants.
+    let quote = state
+        .marketplace_repo
+        .find_quote_by_id(data.quote_id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "Failed to load quote for award");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("DB_ERROR", "Database error")),
+            )
+        })?
+        .filter(|q| q.rfq_id == id)
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse::new(
+                    "NOT_FOUND",
+                    format!("Quote {} not found for RFQ {}", data.quote_id, id),
+                )),
+            )
+        })?;
+
     let rfq = state
         .marketplace_repo
-        .award_rfq(id, data.quote_id)
+        .award_rfq(id, quote.id)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to award RFQ");

--- a/backend/servers/api-server/tests/suite_5.rs
+++ b/backend/servers/api-server/tests/suite_5.rs
@@ -41,6 +41,8 @@ mod listings_core_backfill_batch3_tests;
 mod listings_global_publish_authz_tests;
 #[path = "suites/market_pricing_happy_path_tests.rs"]
 mod market_pricing_happy_path_tests;
+#[path = "suites/marketplace_award_quote_idor_tests.rs"]
+mod marketplace_award_quote_idor_tests;
 #[path = "suites/marketplace_ecosystem_backfill_batch3_tests.rs"]
 mod marketplace_ecosystem_backfill_batch3_tests;
 #[path = "suites/marketplace_lifecycle_backfill_batch2_tests.rs"]

--- a/backend/servers/api-server/tests/suites/marketplace_award_quote_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/marketplace_award_quote_idor_tests.rs
@@ -1,0 +1,298 @@
+//! Regression tests for the cross-RFQ / cross-tenant IDOR on the marketplace
+//! "award quote" endpoint (`POST /api/v1/marketplace/rfqs/{id}/award`).
+//!
+//! Audit history: `award_quote` authorised ONLY the parent RFQ path param
+//! `{id}` via `load_rfq_for_org(...)`, but the quote being awarded is taken
+//! from the request body (`AwardQuoteRequest.quote_id`) and was passed straight
+//! to `award_rfq(id, quote_id)` WITHOUT verifying the quote actually belongs to
+//! that RFQ. A caller who legitimately owns RFQ A could therefore award RFQ A
+//! to a quote submitted against RFQ B — including an RFQ owned by a different
+//! organization — by guessing/knowing the foreign quote id. That leaks the
+//! foreign provider onto the award and mutates the foreign quote's lifecycle.
+//!
+//! The fix threads a quote-ownership check into the handler (reject with 404
+//! when `quote.rfq_id != {id}`) and hardens the `award_rfq` repo method as
+//! defense-in-depth (returns `None` — surfaced as 404 — for a non-matching
+//! quote). These tests pin the contract at the HTTP layer using the same
+//! token-minting harness as the sibling marketplace success-path suite.
+
+use axum::http::StatusCode;
+use chrono::Utc;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::common::{seed_membership, TestApp, TestConfig};
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+async fn seed_org(pool: &PgPool, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO organizations (name, slug, contact_email, status)
+        VALUES ($1, $2, $3, 'active') RETURNING id
+        "#,
+    )
+    .bind(format!("Award IDOR Org {slug}"))
+    .bind(format!("award-idor-{slug}-{}", Uuid::new_v4()))
+    .bind(format!("{slug}-{}@award-idor.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed org")
+}
+
+async fn seed_user(pool: &PgPool, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO users (email, password_hash, name, status, email_verified_at)
+        VALUES ($1, 'test_hash', 'Award IDOR User', 'active', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .expect("seed user")
+}
+
+async fn seed_provider(pool: &PgPool, user_id: Uuid, slug: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO service_provider_profiles
+            (user_id, company_name, contact_name, contact_email, status)
+        VALUES ($1, $2, 'Contact', $3, 'active')
+        RETURNING id
+        "#,
+    )
+    .bind(user_id)
+    .bind(format!("Provider {slug}"))
+    .bind(format!("{slug}-{}@award-provider.test", Uuid::new_v4()))
+    .fetch_one(pool)
+    .await
+    .expect("seed provider")
+}
+
+async fn seed_rfq(pool: &PgPool, org_id: Uuid, created_by: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO rfqs (organization_id, created_by, title, description, service_category, status)
+        VALUES ($1, $2, 'Roof repair', 'Fix the roof', 'roofing', 'sent')
+        RETURNING id
+        "#,
+    )
+    .bind(org_id)
+    .bind(created_by)
+    .fetch_one(pool)
+    .await
+    .expect("seed rfq")
+}
+
+/// Seed a submitted quote for `rfq_id` from `provider_id`; return its id.
+async fn seed_quote(pool: &PgPool, rfq_id: Uuid, provider_id: Uuid) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO provider_quotes (rfq_id, provider_id, price, currency, status, submitted_at)
+        VALUES ($1, $2, 999.00, 'EUR', 'submitted', NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(rfq_id)
+    .bind(provider_id)
+    .fetch_one(pool)
+    .await
+    .expect("seed quote")
+}
+
+/// Claims shape matching `api_core::extractors::auth::Claims`.
+#[derive(Serialize)]
+struct TestClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+fn mint_token(user_id: Uuid, email: &str, org_id: Option<Uuid>) -> String {
+    let now = Utc::now().timestamp();
+    let claims = TestClaims {
+        sub: user_id,
+        exp: now + 3600,
+        iat: now,
+        token_type: "access".to_string(),
+        tenant_id: org_id,
+        role: Some("manager".to_string()),
+        email: email.to_string(),
+        name: "Award IDOR User".to_string(),
+    };
+    let secret = TestConfig::default().jwt_secret;
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("encode test JWT")
+}
+
+async fn rfq_awarded_quote_id(pool: &PgPool, rfq_id: Uuid) -> Option<Uuid> {
+    sqlx::query_scalar::<_, Option<Uuid>>(r#"SELECT awarded_quote_id FROM rfqs WHERE id = $1"#)
+        .bind(rfq_id)
+        .fetch_one(pool)
+        .await
+        .expect("read rfq awarded_quote_id")
+}
+
+// ---------------------------------------------------------------------------
+// T1 — a quote from a DIFFERENT org's RFQ cannot be awarded (the IDOR)
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn award_rejects_quote_from_another_orgs_rfq(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Org A owns RFQ A; the caller is an org_admin of org A.
+    let org_a = seed_org(&pool, "a").await;
+    let buyer_a = seed_user(&pool, "buyer-a@award-idor.test").await;
+    seed_membership(&pool, org_a, buyer_a, "org_admin").await;
+    let rfq_a = seed_rfq(&pool, org_a, buyer_a).await;
+
+    // Org B owns RFQ B with a submitted quote — foreign to the caller.
+    let org_b = seed_org(&pool, "b").await;
+    let buyer_b = seed_user(&pool, "buyer-b@award-idor.test").await;
+    seed_membership(&pool, org_b, buyer_b, "org_admin").await;
+    let rfq_b = seed_rfq(&pool, org_b, buyer_b).await;
+    let prov_b_user = seed_user(&pool, "prov-b@award-idor.test").await;
+    let prov_b = seed_provider(&pool, prov_b_user, "b").await;
+    let foreign_quote = seed_quote(&pool, rfq_b, prov_b).await;
+
+    let token = mint_token(buyer_a, "buyer-a@award-idor.test", Some(org_a));
+
+    // Caller owns RFQ A (path param passes load_rfq_for_org) but tries to award
+    // it to a quote that belongs to org B's RFQ B.
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/marketplace/rfqs/{rfq_a}/award"))
+                .bearer(&token)
+                .json(json!({ "quote_id": foreign_quote }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "awarding a quote from another org's RFQ must be rejected (404), got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    // RFQ A must remain un-awarded, and the foreign quote must be untouched.
+    assert_eq!(
+        rfq_awarded_quote_id(&pool, rfq_a).await,
+        None,
+        "RFQ A must not have been awarded to the foreign quote"
+    );
+    let foreign_status: String =
+        sqlx::query_scalar(r#"SELECT status FROM provider_quotes WHERE id = $1"#)
+            .bind(foreign_quote)
+            .fetch_one(&pool)
+            .await
+            .expect("read foreign quote status");
+    assert_eq!(
+        foreign_status, "submitted",
+        "the foreign quote's lifecycle must not have been mutated"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T2 — a quote belonging to another RFQ in the SAME org still cannot be awarded
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn award_rejects_quote_from_another_rfq_same_org(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "same").await;
+    let buyer = seed_user(&pool, "buyer-same@award-idor.test").await;
+    seed_membership(&pool, org, buyer, "org_admin").await;
+
+    let rfq_target = seed_rfq(&pool, org, buyer).await;
+    let rfq_other = seed_rfq(&pool, org, buyer).await;
+
+    let prov_user = seed_user(&pool, "prov-same@award-idor.test").await;
+    let prov = seed_provider(&pool, prov_user, "same").await;
+    let other_quote = seed_quote(&pool, rfq_other, prov).await;
+
+    let token = mint_token(buyer, "buyer-same@award-idor.test", Some(org));
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/marketplace/rfqs/{rfq_target}/award"))
+                .bearer(&token)
+                .json(json!({ "quote_id": other_quote }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "awarding a quote that belongs to a different RFQ must be rejected (404), got {}: {}",
+        resp.status,
+        resp.text()
+    );
+    assert_eq!(
+        rfq_awarded_quote_id(&pool, rfq_target).await,
+        None,
+        "the target RFQ must not have been awarded to a quote from another RFQ"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T3 — positive path: a quote that DOES belong to the RFQ is awarded
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn award_succeeds_for_own_quote(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "ok").await;
+    let buyer = seed_user(&pool, "buyer-ok@award-idor.test").await;
+    seed_membership(&pool, org, buyer, "org_admin").await;
+    let rfq = seed_rfq(&pool, org, buyer).await;
+
+    let prov_user = seed_user(&pool, "prov-ok@award-idor.test").await;
+    let prov = seed_provider(&pool, prov_user, "ok").await;
+    let quote = seed_quote(&pool, rfq, prov).await;
+
+    let token = mint_token(buyer, "buyer-ok@award-idor.test", Some(org));
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/marketplace/rfqs/{rfq}/award"))
+                .bearer(&token)
+                .json(json!({ "quote_id": quote }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "awarding a quote that belongs to the RFQ must succeed (200), got {}: {}",
+        resp.status,
+        resp.text()
+    );
+    assert_eq!(
+        rfq_awarded_quote_id(&pool, rfq).await,
+        Some(quote),
+        "the RFQ must be awarded to its own quote"
+    );
+}


### PR DESCRIPTION
## Task
backend/servers/api-server/src/routes/marketplace.rs:922-951 — award_quote (wired POST /api/v1/marketplace/rfqs/{id}/award at marketplace.rs:246) authorizes ONLY the parent RFQ: `load_rfq_for_org(&state, user.user_id, id)` verifies the caller owns the RFQ path param `{id}`, but the quote being awarded is taken from the request body WITHOUT verifying that quote belongs to that RFQ (IDOR). Fix: verify the awarded quote_id actually belongs to the RFQ `{id}` (and to the caller's org) before awarding — reject with 403/404 otherwise. Add a regression test proving a quote from a different RFQ/org cannot be awarded.

## Owner
pm-security

## Fix
- **Handler** (`routes/marketplace.rs::award_quote`): after `load_rfq_for_org` proves the caller owns RFQ `{id}`, load the body's `quote_id` via `find_quote_by_id` and reject with **404** when the quote is missing or `quote.rfq_id != id`. The RFQ is then awarded to the validated `quote.id`. 404 (not 403) matches the rest of the file's cross-tenant shape so quote existence is not leaked.
- **Repo** (`repositories/marketplace.rs::award_rfq`): defense-in-depth — the method now returns `Ok(None)` (surfaced as 404) unless the quote's `rfq_id` matches the RFQ being awarded, so a foreign quote is never awardable even if a future caller bypasses the handler check.

## Verification
```
VERIFY-PLAN base=e7b4f53b3e55553027b8286e6a3121f67d79db2a files=4
  cd backend && cargo fmt --all -- --check                        # PASS (exit 0)
  cd backend && cargo clippy -p db --all-targets -- -D warnings    # PASS (exit 0)
  cd backend && cargo clippy -p api-server --all-targets ...       # BLOCKED: utoipa-swagger-ui build script
  cd backend && cargo test  -p api-server                          # BLOCKED: same (test target won't link)
```
The `api-server` clippy/test targets cannot build locally: the `utoipa-swagger-ui v9.0.2` build script downloads the Swagger UI zip from github.com, which the agent proxy blocks (`InvalidArchive("Could not find EOCD")`). This is the known environmental egress limitation, not a code fault — the full dependency graph compiled and failed only in that transitive build script. `db` (the crate carrying the repo change, no swagger-ui dep) clippy-passes cleanly, and `cargo fmt` passes. **CI `backend.yml` is the gate for the api-server test target.**

## Tests
`backend/servers/api-server/tests/suites/marketplace_award_quote_idor_tests.rs` (registered in `suite_5.rs`), HTTP-level via the `TestApp` harness with `tenant_id`-bearing tokens:
- **T1** `award_rejects_quote_from_another_orgs_rfq` — caller owns RFQ A, tries to award org B's quote → 404; RFQ A stays un-awarded and the foreign quote stays `submitted`.
- **T2** `award_rejects_quote_from_another_rfq_same_org` — quote from a different RFQ in the same org → 404.
- **T3** `award_succeeds_for_own_quote` — quote belonging to the RFQ → 200, `awarded_quote_id` set.

## CI parity (Band C — hot-path)
Security/IDOR fix. Local `act`/workflow replay is blocked by the same utoipa-swagger-ui egress limitation; relying on CI `backend.yml` (`cargo fmt` + `clippy` + `cargo test`) as the gate.

## Remote-tested
skipped

## Notes
- No SQL `query!`/`query_as!` macro changes (both edits use runtime `query_as::<_, T>` / existing repo methods), so no `.sqlx` offline regen needed.
- Scope-drift check: clean (all paths inside pm-security area). Code-reuse pre-flight: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fsi1HEZMqByqvvUxsoWQ2n

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fsi1HEZMqByqvvUxsoWQ2n)_