### PR TITLE
code-review-api-handlers-voice-alexa-noverify-retry1: fail closed on Alexa /verify branch

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -727,16 +727,33 @@ async fn verify_webhook_signature(
 ) -> Json<WebhookVerificationResult> {
     let result = match request.platform.as_str() {
         "alexa" => {
-            // Alexa uses certificate-based signature verification
-            // Simplified check for demo
+            // SECURITY: Alexa request signing is certificate-chain based — the
+            // caller must present a `SignatureCertChainUrl` header, a base64
+            // `Signature` header, and the *raw* request body, which are then
+            // verified as a PKCS#1 v1.5 RSA-SHA1 signature under an Amazon-issued
+            // leaf certificate (see `verify_alexa_signature` /
+            // `verify_alexa_cert_and_signature`, wired into the mounted
+            // `POST /api/v1/webhooks/voice/alexa` receiver).
+            //
+            // This JSON introspection endpoint receives none of that material
+            // (no cert-chain URL, and `body` is a lossy string rather than the
+            // raw signed bytes), so it CANNOT cryptographically verify an Alexa
+            // signature and MUST NOT claim it did. The previous implementation
+            // returned `valid: !signature.is_empty()`, accepting any non-empty
+            // string as a valid Alexa signature — a forgery vector that let an
+            // attacker have an arbitrary payload reported as "valid". Fail
+            // CLOSED: never report `valid: true` from this endpoint for Alexa.
             WebhookVerificationResult {
-                valid: !request.signature.is_empty(),
+                valid: false,
                 platform: "alexa".to_string(),
-                error: if request.signature.is_empty() {
-                    Some("Missing signature".to_string())
+                error: Some(if request.signature.is_empty() {
+                    "Missing signature".to_string()
                 } else {
-                    None
-                },
+                    "Alexa signature verification is certificate-chain based and \
+                     is performed by POST /api/v1/webhooks/voice/alexa; this \
+                     endpoint cannot verify Alexa signatures"
+                        .to_string()
+                }),
             }
         }
         "google" => {
@@ -2093,19 +2110,48 @@ dQPD++LeIpOChiX4Ru2uMQ==\n\
     }
 
     #[tokio::test]
-    async fn verify_endpoint_alexa_branch() {
-        // Non-empty signature -> valid.
+    async fn verify_endpoint_alexa_branch_fails_closed() {
+        // SECURITY regression: the JSON /verify endpoint must NEVER report an
+        // Alexa signature as valid. It has no certificate-chain URL and no raw
+        // signed body, so it cannot perform Amazon's cert-based verification;
+        // the old code returned `valid: !signature.is_empty()`, accepting any
+        // non-empty string as a valid Alexa signature (a forgery vector).
+
+        // A forged, attacker-controlled non-empty "signature" is rejected — this
+        // is exactly the input the old code accepted as valid.
         let resp = verify_webhook_signature(Json(VerifyWebhookRequest {
             platform: "alexa".to_string(),
-            signature: "present".to_string(),
+            signature: "any-forged-non-empty-string".to_string(),
+            body: r#"{"request":{"type":"IntentRequest","intent":{"name":"evil"}}}"#.to_string(),
+            timestamp: None,
+        }))
+        .await;
+        assert!(
+            !resp.0.valid,
+            "a non-empty (forged) Alexa signature must NOT be accepted"
+        );
+        assert_eq!(resp.0.platform, "alexa");
+        assert!(
+            resp.0
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("cannot verify Alexa signatures")),
+            "unexpected error: {:?}",
+            resp.0.error
+        );
+
+        // Even a plausibly base64-shaped signature is rejected — there is no
+        // input to this endpoint that yields `valid: true` for Alexa.
+        let resp = verify_webhook_signature(Json(VerifyWebhookRequest {
+            platform: "alexa".to_string(),
+            signature: BASE64.encode([0u8; 256]),
             body: "b".to_string(),
             timestamp: None,
         }))
         .await;
-        assert!(resp.0.valid);
-        assert_eq!(resp.0.platform, "alexa");
+        assert!(!resp.0.valid, "no Alexa input may be reported as valid");
 
-        // Empty signature -> invalid with "Missing signature".
+        // Empty signature -> still invalid, with the "Missing signature" hint.
         let resp = verify_webhook_signature(Json(VerifyWebhookRequest {
             platform: "alexa".to_string(),
             signature: String::new(),


### PR DESCRIPTION
## Task
backend/servers/api-server/src/routes/voice_webhooks.rs — the `alexa` branch of webhook verification set `valid: !request.signature.is_empty()` with NO cryptographic check whatsoever: any non-empty string was accepted as a valid Alexa signature. Fix: implement real Alexa request signature verification, or if full cert-chain validation is out of scope, fail CLOSED and gate behind a configured secret/cert rather than accepting any non-empty string. Add a regression test proving an invalid/forged signature is rejected.

## Owner
pm-backend (specialist: rust-backend)

## What changed
The vulnerable branch is the JSON introspection endpoint `POST /api/v1/webhooks/voice/verify` (`verify_webhook_signature`). Its `VerifyWebhookRequest` shape carries only `signature` + `body` strings — it receives **no** `SignatureCertChainUrl` header and **no** raw signed body — so Amazon's certificate-chain verification is structurally impossible on this endpoint.

Real Alexa verification already exists and correctly guards the actual receiver `POST /api/v1/webhooks/voice/alexa` via `verify_alexa_signature` / `verify_alexa_cert_and_signature` (issue #2668: cert-URL validation + timestamp + leaf cert validity/SAN + PKCS#1 v1.5 RSA-SHA1 over the raw body).

Per the task's explicit fallback, this `/verify` branch now **fails CLOSED**: it never returns `valid: true` for Alexa, and points callers at the signed `/alexa` receiver that performs real verification. Empty signatures still report `Missing signature`.

## Regression test
`verify_endpoint_alexa_branch_fails_closed` (rewritten from the prior `verify_endpoint_alexa_branch`, which had asserted the vulnerable "non-empty -> valid" behavior). It proves:
- an attacker-controlled non-empty forged signature is rejected (`valid == false`) — the exact input the old code accepted;
- a base64-shaped 256-byte signature is also rejected (no input yields `valid: true`);
- an empty signature still fails with `Missing signature`.

## Verification
```
VERIFY-PLAN base=e7b4f53b3e55553027b8286e6a3121f67d79db2a files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```
- `cd backend && cargo fmt --all -- --check` — **exit 0** (clean).
- `cargo clippy -p api-server` / `cargo test -p api-server` — **environmentally blocked**: the build fails inside the `utoipa-swagger-ui v9.0.2` build script, which downloads `https://github.com/swagger-api/swagger-ui/.../v5.17.14.zip` at build time. GitHub release downloads route through the agent proxy (not in its noProxy allowlist) and return a JSON error body instead of the zip → `InvalidArchive("Could not find EOCD")`. This is the known `utoipa-swagger-ui` egress limitation, unrelated to this diff (a non-optional dep used in `main.rs`, no feature flag to disable). Relying on CI `backend.yml` as the gate.

```
VERIFY FAIL: cd backend && cargo clippy -p api-server --all-targets -- -D warnings   (cause: utoipa-swagger-ui build-script zip download blocked by proxy — environmental)
```

## Scope drift
None — `scope-check.sh --owner pm-backend` exit 0 (single file under `backend/servers/api-server/`).

## Code-reuse review
None — `reuse-grep.sh --specialist rust-backend` exit 0. The fix reuses the existing security surface conceptually (references `verify_alexa_signature`) and adds no new helper.

## CI parity (Band C — hot-path)
Security hot-path change. Local Band-C replication is blocked by the same `utoipa-swagger-ui` egress limitation; `backend.yml` (fmt + clippy + test) is the authoritative gate and has network access to fetch the Swagger UI zip.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- This closes the `/verify` introspection gap; the actual Alexa receiver `/alexa` was already hardened under #2668.
- Retry 1/2: the prior attempt died before opening a PR — no prior branch existed; this is a fresh branch off `origin/dev`.
- `security` label applied to satisfy the "Security label — test-file required" CI gate (regression test included).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fsi1HEZMqByqvvUxsoWQ2n)_