### PR TITLE
gh-issue-2753: consolidate inline toLocale* onto format.ts date helpers

### DIFF
--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx
@@ -10,7 +10,7 @@ import {
   View,
 } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 
 export interface AnnouncementAttachment {
@@ -151,7 +151,7 @@ export function formatRelativeDate(dateString: string, now: Date = new Date()): 
   if (diffDays < 7) {
     return `${diffDays}d ago`;
   }
-  return date.toLocaleDateString(resolveLocale(), { month: 'short', day: 'numeric' });
+  return formatDate(date, { month: 'short', day: 'numeric' });
 }
 
 interface AnnouncementsScreenProps {

--- a/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentsScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
 import { useFolderTree } from '../../hooks/useFolderTree';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate as formatLocaleDate } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 import type { AccessScope } from './DocumentPermissionsScreen';
 import {
@@ -181,14 +181,12 @@ export function DocumentsScreen({ onNavigate: _onNavigate }: DocumentsScreenProp
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
   };
 
-  const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString(resolveLocale(), {
+  const formatDate = (dateString: string): string =>
+    formatLocaleDate(dateString, {
       month: 'short',
       day: 'numeric',
       year: 'numeric',
     });
-  };
 
   const navigateToFolder = (folder: Document) => {
     setCurrentPath((prev) => [...prev, { id: folder.id, name: folder.name }]);

--- a/frontend/apps/mobile/src/screens/faults/FaultsListScreen.tsx
+++ b/frontend/apps/mobile/src/screens/faults/FaultsListScreen.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate as formatLocaleDate } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 
 export type FaultStatus = 'open' | 'in_progress' | 'resolved' | 'closed';
@@ -121,15 +121,13 @@ const categoryIcon: Record<FaultCategory, string> = {
   other: '🔧',
 };
 
-const formatDate = (dateString: string): string => {
-  const date = new Date(dateString);
-  return date.toLocaleDateString(resolveLocale(), {
+const formatDate = (dateString: string): string =>
+  formatLocaleDate(dateString, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
   });
-};
 
 export function FaultsListScreen({ onNavigate }: FaultsListScreenProps) {
   const { t } = useTranslation();

--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
@@ -16,7 +16,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate } from '../../i18n/format';
 import { warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 import { type Lease, toUiLeaseStatus } from './LeasesScreen';
@@ -100,7 +100,7 @@ export function toUiLease(detail: ApiLeaseDetail): Lease {
 function periodLabel(dueDate: string): string {
   const d = new Date(dueDate);
   if (Number.isNaN(d.getTime())) return dueDate;
-  return d.toLocaleDateString(resolveLocale(), { month: 'long', year: 'numeric' });
+  return formatDate(d, { month: 'long', year: 'numeric' });
 }
 
 /** Map api-server payments onto the UI payment rows, soonest `due_date` first.

--- a/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/MessagesScreen.tsx
@@ -9,7 +9,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, Text, TextInput, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 /** Shape returned by `GET /api/v1/messages/threads`. The api-server serializes
@@ -59,7 +59,7 @@ function formatRelative(iso: string): string {
   if (hours < 24) return `${hours}h`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d`;
-  return new Date(iso).toLocaleDateString(resolveLocale(), { month: 'short', day: 'numeric' });
+  return formatDate(iso, { month: 'short', day: 'numeric' });
 }
 
 function participantName(p: ParticipantInfo): string {

--- a/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/messages/ThreadDetailScreen.tsx
@@ -29,7 +29,7 @@ import {
 import { QueryErrorBanner } from '../../components/QueryErrorBanner';
 import { useAuth } from '../../contexts/AuthContext';
 import { useApiMutation, useApiQuery } from '../../hooks/useApi';
-import { resolveLocale } from '../../i18n/format';
+import { formatTime } from '../../i18n/format';
 import { warnIfListDegraded, warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
@@ -122,7 +122,7 @@ function sentAtSortKey(sentAt: string): number {
 export function formatMessageTime(sentAt: string): string {
   const d = new Date(sentAt);
   if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleTimeString(resolveLocale(), { hour: '2-digit', minute: '2-digit' });
+  return formatTime(d, { hour: '2-digit', minute: '2-digit' });
 }
 
 /** Map api-server messages onto UI bubbles, oldest first. `currentUserId`

--- a/frontend/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
@@ -14,7 +14,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { EmptyState } from '../../components/states';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export type NotificationCategory =
@@ -103,7 +103,7 @@ function formatRelative(iso: string): string {
   if (hours < 24) return `${hours}h ago`;
   const days = Math.floor(hours / 24);
   if (days < 7) return `${days}d ago`;
-  return new Date(iso).toLocaleDateString(resolveLocale(), { month: 'short', day: 'numeric' });
+  return formatDate(iso, { month: 'short', day: 'numeric' });
 }
 
 interface NotificationsScreenProps {

--- a/frontend/apps/mobile/src/screens/outages/OutagesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/outages/OutagesScreen.tsx
@@ -8,7 +8,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate, formatTime } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export type OutageCommodity = 'water' | 'electricity' | 'gas' | 'heat' | 'internet';
@@ -101,19 +101,15 @@ function formatRange(startsAt: string, endsAt: string): string {
   const start = new Date(startsAt);
   const end = new Date(endsAt);
   const sameDay = start.toDateString() === end.toDateString();
-  const locale = resolveLocale();
   const dateOpts: Intl.DateTimeFormatOptions = { month: 'short', day: 'numeric' };
   const timeOpts: Intl.DateTimeFormatOptions = { hour: '2-digit', minute: '2-digit' };
   if (sameDay) {
-    return `${start.toLocaleDateString(locale, dateOpts)} · ${start.toLocaleTimeString(
-      locale,
+    return `${formatDate(start, dateOpts)} · ${formatTime(start, timeOpts)} – ${formatTime(
+      end,
       timeOpts
-    )} – ${end.toLocaleTimeString(locale, timeOpts)}`;
+    )}`;
   }
-  return `${start.toLocaleDateString(locale, dateOpts)} – ${end.toLocaleDateString(
-    locale,
-    dateOpts
-  )}`;
+  return `${formatDate(start, dateOpts)} – ${formatDate(end, dateOpts)}`;
 }
 
 interface OutagesScreenProps {

--- a/frontend/apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
@@ -25,7 +25,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 interface PersonMonthEntry {
@@ -44,7 +44,7 @@ const MOCK_ENTRIES: PersonMonthEntry[] = [
 
 function formatMonth(month: string): string {
   const [year, m] = month.split('-').map(Number);
-  return new Date(year, (m ?? 1) - 1, 1).toLocaleDateString(resolveLocale(), {
+  return formatDate(new Date(year, (m ?? 1) - 1, 1), {
     month: 'long',
     year: 'numeric',
   });


### PR DESCRIPTION
## Task
Follow-up: adopt (or drop) the unused format.ts date helpers; ~10 screens duplicate the resolveLocale() call (Closes #2753). The `format.ts` `formatDate`/`formatTime`/`formatDateTime` wrappers are tested but currently unused; ~10 screens duplicate `toLocaleDateString(resolveLocale(), ...)` inline. Consolidate the duplicated inline calls onto the existing helpers (preferred) OR drop the dead exports and add a lint/parity guard against bare `toLocale*` — pick the smaller, safer change that the codebase supports. This is frontend code (likely `frontend/apps/mobile/` and/or `frontend/apps/ppt-web/`). Keep scope tight and behavior-preserving.

Closes #2753

## Owner
pm-frontend

## Approach chosen
Took the **preferred consolidation** variant, scoped to `frontend/apps/mobile/`. The `formatDate`/`formatTime` wrappers in `src/i18n/format.ts` were tested-but-unused while 9 screens duplicated `X.toLocale*(resolveLocale(), opts)` inline. Routed every inline call site through the helpers, so the dead-but-tested exports become live and the `resolveLocale()` plumbing lives in one place.

This is behavior-preserving: each helper is an exact wrapper of the same `new Date(value).toLocale*(resolveLocale(language), options)` the screens were calling by hand. The `resolveLocale` export stays (used internally by the helpers and still covered by `format.test.ts`).

The alternative — "drop dead exports + add a lint guard against bare `toLocale*`" — is **not** supported cheaply here: dozens of other call sites across the mobile app and admin-web legitimately use `toLocale*` with `undefined` / `i18n.language` / the default locale (LeasesScreen, meters, news, voting, dashboard, admin-web, …). A repo-wide bare-`toLocale*` guard would fail on all of those and fan the change out well beyond this issue. So the consolidation variant is the smaller, safer change.

### Screens migrated (9)
- `person-months/PersonMonthsScreen.tsx` → `formatDate`
- `faults/FaultsListScreen.tsx` → `formatDate` (aliased `formatLocaleDate` — local `formatDate` wrapper delegates)
- `notifications/NotificationsScreen.tsx` → `formatDate`
- `messages/MessagesScreen.tsx` → `formatDate`
- `messages/ThreadDetailScreen.tsx` → `formatTime` (NaN guard preserved)
- `announcements/AnnouncementsScreen.tsx` → `formatDate`
- `leases/LeaseDetailScreen.tsx` → `formatDate` (NaN guard preserved)
- `outages/OutagesScreen.tsx` → `formatDate` + `formatTime` (dropped hoisted `locale` var)
- `documents/DocumentsScreen.tsx` → `formatDate` (aliased — local `formatDate` wrapper delegates)

## Verification
```
VERIFY-PLAN base=53b53d289bc2f338bffb5a4e530afea7d9a04585 files=9
  cd frontend && pnpm exec biome check apps/mobile/src/screens/announcements/AnnouncementsScreen.tsx apps/mobile/src/screens/documents/DocumentsScreen.tsx apps/mobile/src/screens/faults/FaultsListScreen.tsx apps/mobile/src/screens/leases/LeaseDetailScreen.tsx apps/mobile/src/screens/messages/MessagesScreen.tsx apps/mobile/src/screens/messages/ThreadDetailScreen.tsx apps/mobile/src/screens/notifications/NotificationsScreen.tsx apps/mobile/src/screens/outages/OutagesScreen.tsx apps/mobile/src/screens/person-months/PersonMonthsScreen.tsx
  cd frontend && pnpm --filter "...[53b53d289bc2f338bffb5a4e530afea7d9a04585]" typecheck
  cd frontend && pnpm --filter "...[53b53d289bc2f338bffb5a4e530afea7d9a04585]" test
```
`VERIFY OK ee1f9056378a03ca572771a10a04814a4f5e5720`

Biome clean, typecheck clean, 646/646 mobile tests pass (incl. existing `format.test.ts` and the screen tests). Goal-check PASS (IG7 green; IG1/IG2/IG8 skipped as plan-flow-only, IG3 skipped — pure behavior-preserving refactor, no new regression test required).

## Scope drift
None — all 9 files are under `frontend/apps/mobile/**`, inside the `pm-frontend` owner area. `scope-check.sh` exit 0.

## Code-reuse review
None — `reuse-grep.sh` exit 0. (This change *is* a reuse consolidation onto existing helpers.)

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- `formatDateTime` (the `toLocaleString` date+time wrapper) has **no** matching `X.toLocaleString(resolveLocale(), …)` call site in the mobile app, so it remains exported + tested but not yet consumed. Left in place (behavior-preserving, minimal-scope); a follow-up could adopt or drop it, but no screen currently exercises that exact pattern.
- Two screens (`FaultsListScreen`, `DocumentsScreen`) define a local `formatDate`; the helper is imported aliased as `formatLocaleDate` there and the thin local wrapper delegates to it, keeping call sites unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ngcj7kYr6FEirWZbUEaR1)_