### PR TITLE
gh-issue-2752: route MeterDetailScreen reading dates through the app i18n locale

### DIFF
--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx
@@ -30,6 +30,15 @@ jest.mock('../../hooks/useApi', () => ({
   useApiQuery: jest.fn(),
 }));
 
+// Force the app locale away from the runtime default so the regression test
+// below can prove the rendered dates are formatted with `resolveLocale()`
+// rather than a bare, device-locale `toLocaleDateString()` (issue #2752).
+jest.mock('../../i18n/format', () => ({
+  resolveLocale: jest.fn(() => 'de'),
+}));
+
+const mockResolveLocale = jest.requireMock('../../i18n/format').resolveLocale as jest.Mock;
+
 const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
 
 function mockQuery(overrides: Record<string, unknown>) {
@@ -113,5 +122,33 @@ describe('meter detail keys resolve to real, locale-distinct translations', () =
       expect(locale.meters.usedSincePrevious).toContain('{{amount}}');
       expect(locale.meters.usedSincePrevious).toContain('{{unit}}');
     }
+  });
+});
+
+describe('reading dates follow the in-app locale, not the device locale (#2752)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('formats the latest-reading and history dates via resolveLocale()', () => {
+    mockQuery({ data: responseWithReadings });
+    render(<MeterDetailScreen meterId="m-1" onBack={() => {}} onNavigate={() => {}} />);
+
+    // The screen must route every reading date through the app locale helper.
+    expect(mockResolveLocale).toHaveBeenCalled();
+
+    // With resolveLocale mocked to 'de', the newest reading (2026-03-31) and
+    // the older one (2026-02-28) render in German day.month.year order — the
+    // format a bare, device-locale `toLocaleDateString()` would NOT produce.
+    const de1 = new Date('2026-03-31').toLocaleDateString('de'); // "31.3.2026"
+    const de2 = new Date('2026-02-28').toLocaleDateString('de'); // "28.2.2026"
+    // Latest-reading card + history card both show the newest date.
+    expect(screen.getAllByText(de1).length).toBeGreaterThanOrEqual(1);
+    // History card shows the older date.
+    expect(screen.getByText(de2)).toBeTruthy();
+
+    // Guard the regression: the pre-fix bare-`en-US` rendering must be gone.
+    const enUs1 = new Date('2026-03-31').toLocaleDateString('en-US'); // "3/31/2026"
+    expect(screen.queryByText(enUs1)).toBeNull();
   });
 });

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
@@ -18,6 +18,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { resolveLocale } from '../../i18n/format';
 import { warnIfListDegraded, warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
@@ -169,7 +170,9 @@ export function MeterDetailScreen({
                 <Text style={styles.metricValue}>
                   {readings[0].value} {readings[0].unit}
                 </Text>
-                <Text style={s.cardMeta}>{new Date(readings[0].takenAt).toLocaleDateString()}</Text>
+                <Text style={s.cardMeta}>
+                  {new Date(readings[0].takenAt).toLocaleDateString(resolveLocale())}
+                </Text>
                 {monthDelta != null && (
                   <Text style={[s.cardBody, { marginTop: 8 }]}>
                     {t('meters.usedSincePrevious', {
@@ -195,7 +198,9 @@ export function MeterDetailScreen({
                     <Text style={s.cardTitle}>
                       {r.value} {r.unit}
                     </Text>
-                    <Text style={s.cardMeta}>{new Date(r.takenAt).toLocaleDateString()}</Text>
+                    <Text style={s.cardMeta}>
+                      {new Date(r.takenAt).toLocaleDateString(resolveLocale())}
+                    </Text>
                   </View>
                 </View>
               ))


### PR DESCRIPTION
## Task
Follow-up: MeterDetailScreen "Latest reading" date bypasses the i18n locale (Closes #2752). The MeterDetailScreen "Latest reading" date uses a bare `toLocaleDateString()` — missed by PR #2740's `resolveLocale()` sweep, so it follows the device locale instead of the in-app language. Fix: route that date through the app's locale (`resolveLocale()`) like the sibling screens, and add a regression test if the surrounding code has test coverage patterns. This is React Native code under `frontend/apps/mobile/`.

Closes #2752

## Owner
pm-frontend (mobile-rn specialist)

## What changed
- `frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx` — the "Latest reading" date **and** the identical reading-history date (both bare `toLocaleDateString()` calls, same bug class from the missed sweep) now pass `resolveLocale()`, matching the sibling screens (`LeaseDetailScreen`, `PersonMonthsScreen`, `AnnouncementsScreen`).
- `frontend/apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx` — added a regression block that mocks `resolveLocale` to a distinctive locale and asserts both dates render via it (and that the pre-fix bare `en-US` rendering is gone). Committed as a separate `test:` commit that fails on the unfixed source (TDD evidence).

Scope note: the reading-history date shares the exact same bug and file; fixing only the "Latest reading" date would leave an identical locale leak one line away, so both bare calls in this screen are routed through `resolveLocale()`. No other files touched.

## Verification
```
VERIFY-PLAN base=398ae2b6edc9e21565c691099e7492aff4888f61 files=2
  cd frontend && pnpm exec biome check apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx apps/mobile/src/screens/meters/MeterDetailScreen.tsx
  cd frontend && pnpm --filter "...[398ae2b6edc9e21565c691099e7492aff4888f61]" typecheck
  cd frontend && pnpm --filter "...[398ae2b6edc9e21565c691099e7492aff4888f61]" test
```
```
VERIFY OK 5eb3eb626b6d1d3fefd00883691038fbd086a6b5
```
(647 mobile tests pass, typecheck clean, Biome clean.)

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. Diff stays entirely within `frontend/apps/mobile/`.

## Code-reuse review
None — `reuse-grep.sh` clean. The fix reuses the existing `resolveLocale()` helper from `src/i18n/format.ts` (no new helper introduced).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- IG goal-check: IG3 (TDD test:+fix: pair) and IG7 (verify) pass. IG1/IG2 report FAIL only because this is a direct GitHub-issue dispatch (no `.research/plans/` file; dispatcher-mandated branch name `auto-impl/...`), not the research-plan flow those checks assume — structurally N/A here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ngcj7kYr6FEirWZbUEaR1)_