### PR TITLE
gh-issue-2754: guard ProtectedRoute common.loading + errors.unauthorized i18n keys + regression test

### DIFF
--- a/frontend/apps/ppt-web/src/components/ProtectedRoute.tsx
+++ b/frontend/apps/ppt-web/src/components/ProtectedRoute.tsx
@@ -110,7 +110,9 @@ export function ProtectedRoute({
             defaultValue: 'Checking authentication',
           })}
         />
-        <span className="protected-route-loading-text">{t('common.loading')}</span>
+        <span className="protected-route-loading-text">
+          {t('common.loading', { defaultValue: 'Loading...' })}
+        </span>
       </div>
     );
   }
@@ -130,7 +132,11 @@ export function ProtectedRoute({
       return (
         <div className="protected-route-unauthorized">
           <h1>{t('errors.accessDenied', { defaultValue: 'Access Denied' })}</h1>
-          <p>{t('errors.unauthorized')}</p>
+          <p>
+            {t('errors.unauthorized', {
+              defaultValue: 'You are not authorized to view this page.',
+            })}
+          </p>
         </div>
       );
     }

--- a/frontend/apps/ppt-web/src/i18n/protectedRouteI18n.test.ts
+++ b/frontend/apps/ppt-web/src/i18n/protectedRouteI18n.test.ts
@@ -1,0 +1,111 @@
+/// <reference types="vitest/globals" />
+/**
+ * `ProtectedRoute` i18n regression — defaultValue-guard parity + locale lockstep.
+ *
+ * PR #2737 (code-review-ppt-web-ui-protectedroute-i18n) migrated the
+ * `ProtectedRoute` component (`src/components/ProtectedRoute.tsx`) to
+ * react-i18next but shipped with NO regression test — unlike its sibling
+ * ppt-web/mobile i18n PRs (#2736 OfflineIndicator, #2739 MeterDetail), which
+ * each locked their strings in with a lockstep bundle test. It also left two of
+ * its four `t(...)` calls (`common.loading`, `errors.unauthorized`) WITHOUT the
+ * `defaultValue` guard that the other two keys (`accessibility.checkingAuthentication`,
+ * `errors.accessDenied`) carry. An unguarded `t('missing.key')` renders the raw
+ * key string to the user if the key is ever dropped from the bundle — invisible
+ * to typecheck + lint. This follow-up (Closes #2754) adds the guards and this test.
+ *
+ * Two things are locked in here:
+ *   1. Guard parity — every `t('...')` call in ProtectedRoute.tsx passes a
+ *      `defaultValue`, so a dropped key degrades to readable English rather
+ *      than a raw dotted key. Fails on `dev` (two calls unguarded), passes
+ *      once the guards are added.
+ *   2. Locale lockstep — the keys ProtectedRoute actually resolves from the
+ *      bundles (`common.loading`, `errors.unauthorized`) exist and are
+ *      non-empty in all six shipped locales, matching the sibling PRs' test.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import cs from '../../messages/cs.json';
+import de from '../../messages/de.json';
+import en from '../../messages/en.json';
+import hu from '../../messages/hu.json';
+import pl from '../../messages/pl.json';
+import sk from '../../messages/sk.json';
+
+type Json = Record<string, unknown>;
+
+const BUNDLES: Record<string, Json> = { en, sk, cs, de, pl, hu };
+
+/** Keys ProtectedRoute resolves from the shipped locale bundles (not defaultValue-only). */
+const BUNDLE_KEYS = ['common.loading', 'errors.unauthorized'] as const;
+
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, part) => {
+    if (acc === null || typeof acc !== 'object') return undefined;
+    return (acc as Json)[part];
+  }, obj);
+}
+
+const PROTECTED_ROUTE_SRC = readFileSync(
+  join(process.cwd(), 'src', 'components', 'ProtectedRoute.tsx'),
+  'utf8'
+);
+
+/** Extract the first string-literal argument of every `t('...')` call. */
+function translationKeys(src: string): string[] {
+  return [...src.matchAll(/\bt\(\s*['"]([^'"]+)['"]/g)].map((m) => m[1]);
+}
+
+/** For a given key, does its `t('key'` call carry a `defaultValue` before the call closes? */
+function isGuarded(src: string, key: string): boolean {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const call = new RegExp(`\\bt\\(\\s*['"]${escaped}['"][\\s\\S]*?\\)`, 'm').exec(src);
+  return call != null && /defaultValue\s*:/.test(call[0]);
+}
+
+describe('ProtectedRoute i18n', () => {
+  it('covers exactly the six shipped locale bundles', () => {
+    expect(Object.keys(BUNDLES).sort()).toEqual(['cs', 'de', 'en', 'hu', 'pl', 'sk']);
+  });
+
+  it('finds the ProtectedRoute translation calls', () => {
+    const keys = translationKeys(PROTECTED_ROUTE_SRC);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        'accessibility.checkingAuthentication',
+        'common.loading',
+        'errors.accessDenied',
+        'errors.unauthorized',
+      ])
+    );
+  });
+
+  it('guards every t() call with a defaultValue (parity — no raw-key leaks)', () => {
+    const keys = translationKeys(PROTECTED_ROUTE_SRC);
+    const unguarded = keys.filter((k) => !isGuarded(PROTECTED_ROUTE_SRC, k));
+    expect(unguarded, `t() calls missing a defaultValue guard: ${unguarded.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  for (const [locale, bundle] of Object.entries(BUNDLES)) {
+    describe(`locale: ${locale}`, () => {
+      for (const path of BUNDLE_KEYS) {
+        it(`defines a non-empty ${path}`, () => {
+          const value = getPath(bundle, path);
+          expect(value, `${path} missing in ${locale}.json`).toBeTypeOf('string');
+          expect((value as string).trim().length).toBeGreaterThan(0);
+        });
+      }
+    });
+  }
+
+  it('keeps every locale in lockstep for the bundle-resolved keys', () => {
+    for (const [locale, bundle] of Object.entries(BUNDLES)) {
+      const present = BUNDLE_KEYS.filter((p) => typeof getPath(bundle, p) === 'string');
+      expect(present, `${locale}.json ProtectedRoute-key set drifted from the reference`).toEqual([
+        ...BUNDLE_KEYS,
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
## Task
Follow-up: ProtectedRoute i18n shipped without a regression test + two unguarded keys (Closes #2754). PR #2737 shipped ProtectedRoute i18n with NO regression test (unlike sibling PRs #2736/#2739) and two unguarded translation keys (`common.loading`, `errors.unauthorized`) that lack the `defaultValue` guard the new keys use. Fix: add the missing `defaultValue` guards to those two keys for parity, and add the lockstep regression test that the sibling screens have. This is ppt-web frontend code (`frontend/apps/ppt-web/`), specifically the ProtectedRoute component and its i18n keys.

Closes #2754

## Owner
pm-frontend (ppt-web specialist) — specialist: `react-web`

## What changed
- `frontend/apps/ppt-web/src/components/ProtectedRoute.tsx` — added `defaultValue` guards to the two previously-unguarded `t()` calls (`common.loading` → `'Loading...'`, `errors.unauthorized` → `'You are not authorized to view this page.'`), bringing them to parity with the two keys PR #2737 already guarded (`accessibility.checkingAuthentication`, `errors.accessDenied`). A dropped bundle key now degrades to readable English instead of leaking the raw dotted key.
- `frontend/apps/ppt-web/src/i18n/protectedRouteI18n.test.ts` — new lockstep regression test (mirrors sibling PR #2736's `offlineIndicatorI18n.test.ts` / `ariaI18n.test.ts`). Asserts (1) every `t()` call in ProtectedRoute carries a `defaultValue` guard — parity, fails on `dev`, passes with the fix — and (2) the bundle-resolved keys (`common.loading`, `errors.unauthorized`) are present and non-empty across all six shipped locales (en, sk, cs, de, pl, hu).

Delivered as a `test:` → `fix:` commit pair (TDD evidence): the guard-parity assertion fails on `dev` (two unguarded `t()` calls) and passes once the guards land — confirmed locally.

## Verification
```
VERIFY-PLAN base=398ae2b6edc9e21565c691099e7492aff4888f61 files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/components/ProtectedRoute.tsx apps/ppt-web/src/i18n/protectedRouteI18n.test.ts
  cd frontend && pnpm --filter "...[398ae2b6edc9e21565c691099e7492aff4888f61]" typecheck
  cd frontend && pnpm --filter "...[398ae2b6edc9e21565c691099e7492aff4888f61]" test
```
```
VERIFY OK c2c432c4e38deae66a5c982d519fb28201e19052
```
(118 test files / 2205 tests passed; biome + typecheck clean.)

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. Both files are under `frontend/apps/ppt-web/src/`.

## Code-reuse review
None — `reuse-grep.sh --specialist react-web` produced no warnings (no new auth/crypto/http helpers).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — i18n string guards + test only).

## Remote-tested
skipped.

## Notes
- Goal-check IG1 (`.research/plans/*.md` absent) and IG2 (branch name) are inapplicable to this GitHub-issue dispatcher task: it is issue-driven rather than plan-driven (and the task explicitly forbids touching `.research/**`), and the branch name `auto-impl/gh-issue-2754-d6feccf1` is dispatcher-fixed. The substantive goal checks pass: IG3 (test:+fix: TDD pair) ok, IG7 (verify gate) ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Ngcj7kYr6FEirWZbUEaR1)_