### PR TITLE
code-review-reality-server-sso-backslash-redirect-retry1: fail closed on backslash-obfuscated open-redirect in SSO

### DIFF
--- a/backend/servers/reality-server/src/routes/sso.rs
+++ b/backend/servers/reality-server/src/routes/sso.rs
@@ -137,8 +137,9 @@ fn ensure_redirect_uri_allowed(state: &AppState, raw: &str) -> Result<(), String
 ///
 /// - Same-origin **relative** paths (`/dashboard`) are allowed unconditionally;
 ///   the browser resolves them against the trusted reality-web origin. Note
-///   that protocol-relative URLs (`//evil.com`) are NOT relative paths and fall
-///   through to allowlist matching.
+///   that protocol-relative URLs (`//evil.com`) — including the backslash-
+///   obfuscated form (`/\evil.com`), which browsers normalise to `//evil.com`
+///   — are NOT relative paths and fall through to allowlist matching.
 /// - Absolute URLs must use `http`/`https` (blocks `javascript:`, `data:`,
 ///   `file:`, …) and their origin (`scheme://host[:port]`) must appear in
 ///   `allowed_origins`.
@@ -146,7 +147,11 @@ fn check_redirect_uri_allowed(raw: &str, allowed_origins: &[String]) -> Result<(
     // Allow same-origin relative paths (e.g. "/dashboard") unconditionally —
     // the browser will resolve them against the reality-web origin that
     // initiated the flow, which by definition the user already trusts.
-    if raw.starts_with('/') && !raw.starts_with("//") {
+    //
+    // A leading "/" is a same-origin relative path ONLY when the next char is
+    // neither "/" nor "\" — browsers normalise "\" to "/", so "/\evil.com" and
+    // "//evil.com" both resolve to a foreign authority (open-redirect bypass).
+    if raw.starts_with('/') && !raw.starts_with("//") && !raw.starts_with("/\\") {
         return Ok(());
     }
 
@@ -1770,6 +1775,28 @@ mod sso_consumer_security_tests {
             res.is_err(),
             "protocol-relative URL must not bypass the allowlist: {res:?}"
         );
+    }
+
+    /// Regression (open-redirect): a backslash-obfuscated authority
+    /// (`/\evil.com`, `/\\evil.com`, `/\/evil.com`) must NOT be treated as a
+    /// same-origin relative path. Browsers normalise `\` to `/`, so these
+    /// resolve to the foreign authority `//evil.com`. They must fall through to
+    /// allowlist matching (and be rejected here, with an empty allowlist),
+    /// while a legitimate relative path like `/dashboard` still passes.
+    #[test]
+    fn redirect_backslash_authority_is_not_treated_as_relative() {
+        let empty: Vec<String> = Vec::new();
+        for raw in ["/\\evil.com", "/\\\\evil.com", "/\\/evil.com"] {
+            let res = check_redirect_uri_allowed(raw, &empty);
+            assert!(
+                res.is_err(),
+                "backslash-obfuscated authority must not bypass the allowlist: {raw} -> {res:?}"
+            );
+        }
+        // Guard against over-tightening: a legitimate relative path still works.
+        assert!(check_redirect_uri_allowed("/dashboard", &empty).is_ok());
+        // Existing behaviour preserved: protocol-relative form also rejected.
+        assert!(check_redirect_uri_allowed("//evil.com", &empty).is_err());
     }
 
     /// Regression (issue #820): dangerous non-http(s) schemes (`javascript:`,


### PR DESCRIPTION
## Vulnerability

`check_redirect_uri_allowed` in `backend/servers/reality-server/src/routes/sso.rs` has a relative-path fast-path that returns `Ok(())` for any URI starting with `/` (except `//`):

```rust
if raw.starts_with('/') && !raw.starts_with("//") {
    return Ok(());   // treated "/\evil.com" as a trusted relative path
}
```

Browsers normalise a backslash `\` to a forward slash `/` inside URLs, so `/\evil.com` (and `/\\evil.com`, `/\/evil.com`) resolve to a **protocol-relative absolute authority** `//evil.com` — i.e. a redirect to an attacker-controlled origin. The `!starts_with("//")` guard only caught the plain protocol-relative form and let the backslash-obfuscated variants through, making this an **open-redirect bypass** in the SSO login/callback redirect flow.

## Fix

Tighten the fast-path so a leading `/` is treated as a same-origin relative path **only** when the next character is neither `/` nor `\`:

```rust
if raw.starts_with('/')
    && !raw.starts_with("//")
    && !raw.starts_with("/\\")
{
    return Ok(());
}
```

Anything not caught by the fast-path already falls through to `url::Url::parse` + the origin allowlist, which correctly rejects the foreign authority (and, with an empty allowlist, fails closed). Legitimate relative paths like `/dashboard` and `/` are unaffected. The function-level doc comment was updated to note the backslash form.

## Tests

Added `redirect_backslash_authority_is_not_treated_as_relative` in the existing `sso_consumer_security_tests` module, asserting:

- `/\evil.com`, `/\\evil.com`, `/\/evil.com` → `Err` (would have been `Ok` before the fix)
- `/dashboard` → `Ok` (guard against over-tightening)
- `//evil.com` → `Err` (existing behaviour preserved)

## Verification

Run from the branch worktree against `backend/`:

| Command | Result |
|---------|--------|
| `cargo fmt --all -- --check` | exit 0 — clean |
| `cargo test -p reality-server check_redirect` | exit 101 — **environment-blocked** (does not compile in sandbox) |
| `cargo clippy -p reality-server --all-targets -- -D warnings` | not runnable — same environment block |

The clippy/test failure is **not** a code error: the `utoipa-swagger-ui` build script downloads swagger-ui from `github.com`, which is egress-blocked in this sandbox, so the crate fails to build before any test runs:

```
error: failed to run custom build command for `utoipa-swagger-ui v9.0.2`
  thread 'main' panicked at build.rs:219:51:
  failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
```

`cargo fmt` is clean, and CI `backend.yml` (fmt + clippy + `cargo test`) is the authoritative gate — hence this PR is opened as a **draft**.

## Scope

Clean — single file changed (`backend/servers/reality-server/src/routes/sso.rs`), no scope drift.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LA4rXd13zYBL8yHPD6ZQ6m)_