### PR TITLE
churn-hotspot-frontend-apps-ppt-web-src-lib-websocket-ts-retry1: harden WebSocket disconnect() lifecycle + tests

### DIFF
--- a/frontend/apps/ppt-web/src/lib/websocket.reconnect.test.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.reconnect.test.ts
@@ -170,3 +170,58 @@ describe('WebSocketService — reconnect budget & resume after give-up', () => {
     expect(maxRetries).toHaveBeenCalledTimes(2);
   });
 });
+
+/**
+ * disconnect() lifecycle (regression).
+ *
+ * disconnect() must detach the current socket's handlers before closing it —
+ * the same guard teardownStaleSocket() uses. In a real browser close() delivers
+ * its `close` event asynchronously; if the still-attached onclose fires after
+ * the caller has moved on (a connect() racing the close on logout->login /
+ * token rotation), it would run against the live service and — because the
+ * reconnect branch fires regardless of `wasClean` — schedule a spurious
+ * reconnect the caller never asked for. Detaching the handlers makes any late
+ * close/error on the old socket inert.
+ */
+describe('WebSocketService — disconnect() lifecycle', () => {
+  function openService(): { service: WebSocketService; socket: FakeWebSocket } {
+    const service = makeService(5);
+    service.connect();
+    const socket = FakeWebSocket.lastInstance;
+    if (!socket) throw new Error('expected a socket to be constructed');
+    socket.readyState = FakeWebSocket.OPEN;
+    socket.onopen?.({});
+    expect(service.getConnectionState()).toBe('connected');
+    return { service, socket };
+  }
+
+  it('detaches the socket handlers on disconnect', () => {
+    const { service, socket } = openService();
+
+    service.disconnect();
+
+    expect(service.getConnectionState()).toBe('disconnected');
+    // Every handler the service attached must be gone so the imminent async
+    // close/error event on this socket cannot fire back into the service.
+    expect(socket.onopen).toBeNull();
+    expect(socket.onclose).toBeNull();
+    expect(socket.onerror).toBeNull();
+    expect(socket.onmessage).toBeNull();
+  });
+
+  it('makes a late unclean close on a disconnected socket inert (no reconnect)', () => {
+    const { service, socket } = openService();
+    const constructedBefore = FakeWebSocket.constructed;
+
+    service.disconnect();
+
+    // The browser delivers the socket's close event *after* disconnect() has
+    // returned. With handlers detached this is a no-op; without the detach it
+    // would drive scheduleReconnect() and spin up a new socket.
+    socket.simulateUncleanClose();
+    vi.advanceTimersByTime(10_000);
+
+    expect(FakeWebSocket.constructed).toBe(constructedBefore);
+    expect(service.getConnectionState()).toBe('disconnected');
+  });
+});

--- a/frontend/apps/ppt-web/src/lib/websocket.ts
+++ b/frontend/apps/ppt-web/src/lib/websocket.ts
@@ -377,16 +377,20 @@ export class WebSocketService {
 
   /**
    * Disconnect from the WebSocket server.
+   *
+   * The current socket's handlers are detached before it is closed (via
+   * {@link detachAndCloseSocket}) so that the browser's asynchronous `close`
+   * event on this socket cannot fire back into the service. Without that
+   * detach, a `connect()` that races the pending close (logout->login, token
+   * rotation) would let the stale socket's `onclose` run against the live
+   * service and drive a spurious `scheduleReconnect()` — the reconnect branch
+   * runs regardless of `wasClean`, so even the clean 1000 close below would
+   * re-arm reconnection against a service the caller asked to disconnect.
    */
   disconnect(): void {
     this.shouldReconnect = false;
     this.clearReconnectTimeout();
-
-    if (this.socket) {
-      this.socket.close(1000, 'Client disconnecting');
-      this.socket = null;
-    }
-
+    this.detachAndCloseSocket('Client disconnecting');
     this.currentToken = null;
     this.setConnectionState('disconnected');
   }
@@ -397,12 +401,25 @@ export class WebSocketService {
    * Unlike {@link disconnect}, this does NOT flip `shouldReconnect` or emit a
    * `disconnected` state — it is an internal replace step used by
    * {@link connect} when re-establishing the connection (e.g. after a token
-   * rotation) or when the previous socket is already closed. The stale socket's
-   * handlers are detached first so its imminent `close` event cannot drive a
-   * spurious reconnect or state transition on the service that is about to own
-   * a fresh socket.
+   * rotation) or when the previous socket is already closed. Handler detach and
+   * close are delegated to {@link detachAndCloseSocket}.
    */
   private teardownStaleSocket(): void {
+    this.detachAndCloseSocket('Reconnecting with a new token');
+  }
+
+  /**
+   * Detach the current socket's event handlers, close it, and drop the
+   * reference. Shared by {@link disconnect} and {@link teardownStaleSocket}.
+   *
+   * Detaching the handlers first is the load-bearing step: it guarantees the
+   * socket's imminent (and, in real browsers, asynchronous) `close`/`error`
+   * events cannot drive a state transition or reconnect on a service that has
+   * already moved on to a fresh socket or been shut down. Closing an
+   * already-closed/closing socket can throw in some engines, so the `close()`
+   * call is guarded — the socket is being discarded regardless.
+   */
+  private detachAndCloseSocket(reason: string): void {
     if (!this.socket) return;
 
     const stale = this.socket;
@@ -412,7 +429,7 @@ export class WebSocketService {
     stale.onmessage = null;
 
     try {
-      stale.close(1000, 'Reconnecting with a new token');
+      stale.close(1000, reason);
     } catch {
       // Closing an already-closed/closing socket can throw in some engines;
       // the socket is being discarded regardless, so the error is irrelevant.


### PR DESCRIPTION
## Task
Churn hotspot: `frontend/apps/ppt-web/src/lib/websocket.ts` (+11/-94 heartbeat removal in PR #2689). This file churns repeatedly. Investigate the recent instability, add/strengthen tests around the websocket reconnect/heartbeat lifecycle so future changes are safe, and make a small targeted hardening/refactor if a concrete defect or fragility is found. Retry 1/2 of a failed prior attempt (the prior implementer died before opening a PR). Scope strictly to `frontend/apps/ppt-web/src/lib/websocket.ts` and its tests.

## Owner
pm-frontend

## Investigation
The heartbeat removal (PR #2689) is sound and already well-covered — liveness lives at the protocol layer (server `Ping` + browser auto-`Pong`); there is no app-level heartbeat left to churn on. Existing tests already pin: the URL/parse contract helpers, the reconnect-budget give-up/resume, message delivery + fan-out, token-rotation re-auth, and a regression that a healthy socket is not force-closed after 60s with no app-level pong.

One concrete fragility remained in the lifecycle: **`disconnect()` closed the socket without detaching its event handlers**, unlike `teardownStaleSocket()` which detaches precisely to avoid this. In a real browser `close()` delivers its `close` event asynchronously; if a `connect()` races that pending close (logout→login, token rotation), the stale socket's still-attached `onclose` fires against the live service and calls `scheduleReconnect()` — the reconnect branch runs regardless of `wasClean` — producing a spurious reconnect / second socket. This is exactly the class of subtle lifecycle bug that keeps this file churning.

## Change
- Extract the shared detach-and-close logic into a private `detachAndCloseSocket(reason)` and call it from both `disconnect()` and `teardownStaleSocket()` (dedupes the two paths and closes the leak).
- Add two regression tests under `WebSocketService — disconnect() lifecycle` in `websocket.reconnect.test.ts`: handlers are detached on disconnect, and a late unclean close on a disconnected socket is inert (no new socket, state stays `disconnected`). Both tests **fail on the pre-fix source** (verified: the late close drives state to `error` and schedules a reconnect) and pass with the fix.

Scope stayed strictly within `websocket.ts` and its test file.

## Verification
```
VERIFY-PLAN base=50170d2d98245f2b6425e04c4ed8a6c4a0cf0281 files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/lib/websocket.reconnect.test.ts apps/ppt-web/src/lib/websocket.ts
  cd frontend && pnpm --filter "...[50170d2d98245f2b6425e04c4ed8a6c4a0cf0281]" typecheck
  cd frontend && pnpm --filter "...[50170d2d98245f2b6425e04c4ed8a6c4a0cf0281]" test
```
`VERIFY OK ef63b3e9c3dda0b8a90406d6acbcffffbc393b1f` — Biome clean, typecheck clean, 2207 frontend tests pass (118 files).

IG3 TDD evidence: separate `test:` (red-on-main) and `fix:` commits on the branch. IG7 green. IG1/IG2 are N/A for a dispatcher churn-hotspot task (no `.research/plans/` file; dispatcher-assigned `auto-impl/*` branch).

## Scope drift
None — diff vs `origin/dev` is exactly `websocket.ts` + `websocket.reconnect.test.ts`. (`scope-check.sh` printed unrelated `.research/**` paths only because the local `dev` ref lags `origin/dev`; exit 0.)

## Code-reuse review
`reuse-grep.sh` — no warnings. The change removes duplication rather than adding a helper.

## CI parity (Band C — hot-path only)
Skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
Skipped.

## Notes
Draft PR opened by the ppt-implement dispatcher flow (retry 1/2 of a prior aborted attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKPsrSvubWfjEqMV6uttXy)_