### PR TITLE
gh-issue-2759: complete mobile date-formatting consolidation + bare-toLocale* guard

### DIFF
--- a/frontend/apps/mobile/src/features/faults/components/FaultCard.tsx
+++ b/frontend/apps/mobile/src/features/faults/components/FaultCard.tsx
@@ -5,6 +5,7 @@
 
 import { useTranslation } from 'react-i18next';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { formatDate } from '../../../i18n/format';
 import { colors } from '../../../screens/shared/screenStyles';
 
 export type FaultStatus =
@@ -91,7 +92,7 @@ export function FaultCard({ fault, onPress }: FaultCardProps) {
       </View>
 
       <Text style={styles.date}>
-        {t('faults.reported')}: {new Date(fault.createdAt).toLocaleDateString()}
+        {t('faults.reported')}: {formatDate(fault.createdAt)}
       </Text>
     </TouchableOpacity>
   );

--- a/frontend/apps/mobile/src/features/layout/registry.tsx
+++ b/frontend/apps/mobile/src/features/layout/registry.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { formatDate as formatLocaleDate } from '../../i18n/format';
 import { colors } from '../../screens/shared/screenStyles';
 import type { ResolvedScreen } from './types';
 
@@ -120,7 +121,7 @@ export function DashboardStatsSection({ mode: _mode, props: _props }: SectionCom
 
 // --- ActionQueueSection ---
 export function ActionQueueSection({ mode: _mode, props: _props }: SectionComponentProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
 
   const votesQuery = useApiQuery<ApiVoteListResponse>(['dashboard', 'votes'], '/api/v1/voting', {
     staleTime: 60_000,
@@ -136,10 +137,8 @@ export function ActionQueueSection({ mode: _mode, props: _props }: SectionCompon
       dueDate: v.end_at,
     }));
 
-  const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' });
-  };
+  const formatDate = (dateString: string): string =>
+    formatLocaleDate(dateString, { month: 'short', day: 'numeric' });
 
   const getActionIcon = (type: PendingAction['type']): string => {
     switch (type) {

--- a/frontend/apps/mobile/src/i18n/no-bare-tolocale.test.ts
+++ b/frontend/apps/mobile/src/i18n/no-bare-tolocale.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Guard against bare `toLocale*` date rendering (GitHub #2759, follow-up to
+ * #2755 / #2752 / #2282).
+ *
+ * Screens must format dates/times through the shared locale-aware helpers in
+ * `src/i18n/format.ts` (`formatDate` / `formatTime` / `formatDateTime`), which
+ * derive the formatting locale from the app's *active* i18next language. A bare
+ * `new Date(x).toLocaleDateString()` (or `toLocaleTimeString` / `toLocaleString`)
+ * renders in the **device** locale instead — so a Slovak/Czech/German/Polish/
+ * Hungarian user who picked their language in-app still sees dates formatted for
+ * whatever locale the phone happens to be set to. This drift has been fixed
+ * screen-by-screen more than once; this test locks the contract tree-wide so it
+ * cannot silently come back.
+ *
+ * The only sanctioned home for `toLocale*` is `src/i18n/format.ts` itself (the
+ * helper implementation). Test files are exempt — they legitimately compute
+ * expected values with an explicit locale.
+ *
+ * Reads the source tree directly (no build step) so the guard tracks the actual
+ * code, not a snapshot.
+ */
+
+// This suite runs under Node (jest), but the React Native `tsconfig` doesn't
+// pull in `@types/node`, so declare the tiny slice of the Node API we use here
+// rather than adding a project-wide dependency just for one test. `require`
+// resolves at runtime because babel-jest compiles this module to CommonJS.
+declare const __dirname: string;
+declare function require(id: 'node:fs'): {
+  readFileSync(path: string, encoding: 'utf8'): string;
+  readdirSync(
+    path: string,
+    opts: { withFileTypes: true }
+  ): Array<{
+    name: string;
+    isDirectory(): boolean;
+    isFile(): boolean;
+  }>;
+};
+declare function require(id: 'node:path'): {
+  join(...parts: string[]): string;
+  relative(from: string, to: string): string;
+};
+
+const { readFileSync, readdirSync } = require('node:fs');
+const { join, relative } = require('node:path');
+
+// i18n/ → src
+const SRC_ROOT = join(__dirname, '..');
+
+// The one sanctioned home for `toLocale*`: the helper implementation.
+const ALLOWLIST = new Set<string>(['i18n/format.ts']);
+
+// `.toLocaleDateString(` / `.toLocaleTimeString(` / `.toLocaleString(`.
+const BARE_TOLOCALE = /\.toLocale(?:Date|Time)?String\s*\(/;
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__snapshots__') continue;
+      collectSourceFiles(full, acc);
+    } else if (entry.isFile()) {
+      if (!/\.(ts|tsx)$/.test(entry.name)) continue;
+      // Exempt every test / spec file — those may build expected values with an
+      // explicit locale.
+      if (/\.(test|spec)\.(ts|tsx)$/.test(entry.name)) continue;
+      const rel = relative(SRC_ROOT, full).split('\\').join('/');
+      if (ALLOWLIST.has(rel)) continue;
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+describe('no bare toLocale* date formatting', () => {
+  it('every screen formats dates through src/i18n/format.ts helpers', () => {
+    const offenders: string[] = [];
+
+    for (const file of collectSourceFiles(SRC_ROOT)) {
+      const lines = readFileSync(file, 'utf8').split('\n');
+      lines.forEach((line, i) => {
+        if (BARE_TOLOCALE.test(line)) {
+          const rel = relative(SRC_ROOT, file).split('\\').join('/');
+          offenders.push(`${rel}:${i + 1}  ${line.trim()}`);
+        }
+      });
+    }
+
+    if (offenders.length > 0) {
+      throw new Error(
+        [
+          'Bare `toLocale*` date formatting found. Use the locale-aware helpers',
+          "from 'src/i18n/format.ts' (formatDate / formatTime / formatDateTime)",
+          'so dates match the active in-app language instead of the device locale:',
+          '',
+          ...offenders,
+        ].join('\n')
+      );
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/announcements/AnnouncementDetailScreen.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ActivityIndicator, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { apiRequest, useApiMutation, useApiQuery } from '../../hooks/useApi';
+import { formatDate as formatLocaleDate } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 
 // ─── API shapes ──────────────────────────────────────────────────────────────
@@ -71,7 +72,7 @@ export function AnnouncementDetailScreen({
   onBack,
 }: AnnouncementDetailScreenProps) {
   const queryClient = useQueryClient();
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const markReadFired = useRef(false);
 
   // Fetch announcement detail
@@ -116,7 +117,7 @@ export function AnnouncementDetailScreen({
 
   const formatDate = (dateString?: string | null): string => {
     if (!dateString) return '';
-    return new Date(dateString).toLocaleDateString(i18n.language, {
+    return formatLocaleDate(dateString, {
       year: 'numeric',
       month: 'long',
       day: 'numeric',

--- a/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
+++ b/frontend/apps/mobile/src/screens/dashboard/DashboardScreen.tsx
@@ -7,6 +7,7 @@ import { LayoutSections } from '../../features/layout/LayoutSections';
 import { dashboardRegistry, NavigateContext } from '../../features/layout/registry';
 import { useDashboardLayout } from '../../features/layout/useDashboardLayout';
 import { useApiQuery } from '../../hooks/useApi';
+import { formatDate as formatLocaleDate } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 
 interface Announcement {
@@ -51,7 +52,7 @@ interface DashboardScreenProps {
 }
 
 export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { user, logout } = useAuth();
   const { layout } = useDashboardLayout('ppt/dashboard');
 
@@ -117,10 +118,8 @@ export function DashboardScreen({ onNavigate }: DashboardScreenProps) {
 
   // Localize dates to the active UI language (mirrors VotingScreen). Previously
   // hardcoded `'en-US'`, so dates never localized for sk/cs/de/hu/pl users (#2282).
-  const formatDate = (dateString: string): string => {
-    const date = new Date(dateString);
-    return date.toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' });
-  };
+  const formatDate = (dateString: string): string =>
+    formatLocaleDate(dateString, { month: 'short', day: 'numeric' });
 
   const getCategoryColor = (category: Announcement['category']): string => {
     switch (category) {

--- a/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentDetailScreen.tsx
@@ -15,6 +15,7 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Alert, Linking, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { apiRequest, useApiQuery } from '../../hooks/useApi';
+import { formatDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 import { isPreviewUnsupportedError } from './DocumentPreviewScreen';
 import { DocumentShareSheet } from './DocumentShareSheet';
@@ -174,9 +175,7 @@ export function DocumentDetailScreen({ documentId, onBack }: DocumentDetailScree
                 {typeof document.size_bytes === 'number' && document.size_bytes > 0 && (
                   <Text style={s.cardMeta}>{formatBytes(document.size_bytes)}</Text>
                 )}
-                <Text style={s.cardMeta}>
-                  Updated {new Date(document.updated_at).toLocaleDateString()}
-                </Text>
+                <Text style={s.cardMeta}>Updated {formatDate(document.updated_at)}</Text>
               </View>
             </View>
 
@@ -186,9 +185,7 @@ export function DocumentDetailScreen({ documentId, onBack }: DocumentDetailScree
               <Text style={[styles.sectionLabel, { marginTop: 12 }]}>File</Text>
               <Text style={styles.sectionValue}>{document.file_name}</Text>
               <Text style={[styles.sectionLabel, { marginTop: 12 }]}>Created</Text>
-              <Text style={styles.sectionValue}>
-                {new Date(document.created_at).toLocaleDateString()}
-              </Text>
+              <Text style={styles.sectionValue}>{formatDate(document.created_at)}</Text>
             </View>
 
             <Pressable

--- a/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPermissionsScreen.tsx
@@ -13,6 +13,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { formatDate as formatLocaleDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 // ─── types ───────────────────────────────────────────────────────────────────
@@ -121,7 +122,7 @@ function getStatusMeta(status: DocumentStatus | undefined): StatusMeta {
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
+  return formatLocaleDate(iso, {
     day: '2-digit',
     month: 'short',
     year: 'numeric',

--- a/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentPreviewScreen.tsx
@@ -30,6 +30,7 @@ import {
   View,
 } from 'react-native';
 import { apiRequest } from '../../hooks/useApi';
+import { formatDate, formatTime } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 import type { Document } from './DocumentsScreen';
 
@@ -244,7 +245,7 @@ export function DocumentPreviewScreen({ document, onBack }: DocumentPreviewScree
               <Text style={s.cardMeta}>{formatBytes(document.size)}</Text>
             )}
             <Text style={s.cardMeta}>
-              {t('documents.preview.updated')} {new Date(document.updatedAt).toLocaleDateString()}
+              {t('documents.preview.updated')} {formatDate(document.updatedAt)}
             </Text>
           </View>
         </View>
@@ -281,7 +282,7 @@ export function DocumentPreviewScreen({ document, onBack }: DocumentPreviewScree
               <Text style={styles.urlLabel}>{t('documents.preview.urlReady')}</Text>
               <Text style={styles.urlExpiry}>
                 {t('documents.preview.expiresAt')}{' '}
-                {state.expiresAt.toLocaleTimeString([], {
+                {formatTime(state.expiresAt, {
                   hour: '2-digit',
                   minute: '2-digit',
                 })}

--- a/frontend/apps/mobile/src/screens/documents/DocumentShareSheet.tsx
+++ b/frontend/apps/mobile/src/screens/documents/DocumentShareSheet.tsx
@@ -28,6 +28,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { formatDate } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 import {
   type CreateShareRequest,
@@ -62,7 +63,7 @@ function isActive(share: ShareWithDocument): boolean {
 }
 
 function formatExpiry(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString(undefined, {
+  return formatDate(dateStr, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',

--- a/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/forms/FormsScreen.tsx
@@ -22,6 +22,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { formatDate } from '../../i18n/format';
 import { warnIfListDegraded } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
@@ -162,7 +163,7 @@ export function FormsScreen({ onNavigate }: FormsScreenProps) {
                 )}
                 {form.dueAt && (
                   <Text style={[s.cardMeta, { marginLeft: 'auto' }]}>
-                    Due {new Date(form.dueAt).toLocaleDateString()}
+                    Due {formatDate(form.dueAt)}
                   </Text>
                 )}
               </View>

--- a/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseDetailScreen.tsx
@@ -157,8 +157,7 @@ export function LeaseDetailScreen({ leaseId, onBack, onNavigate }: LeaseDetailSc
               {lease.buildingName ? ` · ${lease.buildingName}` : ''}
             </Text>
             <Text style={s.headerSubtitle}>
-              {new Date(lease.startsAt).toLocaleDateString()} –{' '}
-              {new Date(lease.endsAt).toLocaleDateString()}
+              {formatDate(lease.startsAt)} – {formatDate(lease.endsAt)}
             </Text>
           </>
         ) : (
@@ -207,9 +206,7 @@ export function LeaseDetailScreen({ leaseId, onBack, onNavigate }: LeaseDetailSc
                       {payment.amount} {lease.currency}
                     </Text>
                   </View>
-                  <Text style={s.cardBody}>
-                    Due {new Date(payment.dueDate).toLocaleDateString()}
-                  </Text>
+                  <Text style={s.cardBody}>Due {formatDate(payment.dueDate)}</Text>
                 </View>
               ))
             )}

--- a/frontend/apps/mobile/src/screens/leases/LeaseSignatureScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeaseSignatureScreen.tsx
@@ -30,6 +30,7 @@ import {
   View,
 } from 'react-native';
 import { useApiMutation, useApiQuery } from '../../hooks/useApi';
+import { formatDateTime } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 // ─── API Types ─────────────────────────────────────────────────────────────────
@@ -219,12 +220,12 @@ export function LeaseSignatureScreen({ esignatureId, onBack }: LeaseSignatureScr
               <MetaRow label={t('esignature.requestedBy')} value={request.requester_name} />
               <MetaRow
                 label={t('esignature.requestedAt')}
-                value={new Date(request.requested_at).toLocaleString()}
+                value={formatDateTime(request.requested_at)}
               />
               {request.expires_at ? (
                 <MetaRow
                   label={t('esignature.expiresAt')}
-                  value={new Date(request.expires_at).toLocaleString()}
+                  value={formatDateTime(request.expires_at)}
                 />
               ) : null}
               {request.signed_at ? (
@@ -234,7 +235,7 @@ export function LeaseSignatureScreen({ esignatureId, onBack }: LeaseSignatureScr
                       ? t('esignature.signedAt')
                       : t('esignature.declinedAt')
                   }
-                  value={new Date(request.signed_at).toLocaleString()}
+                  value={formatDateTime(request.signed_at)}
                 />
               ) : null}
               {request.webhook_delivered && (

--- a/frontend/apps/mobile/src/screens/leases/LeasesScreen.tsx
+++ b/frontend/apps/mobile/src/screens/leases/LeasesScreen.tsx
@@ -14,6 +14,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery, useTenantId } from '../../hooks/useApi';
+import { formatDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export type LeaseStatus = 'active' | 'pending' | 'expired' | 'terminated';
@@ -204,8 +205,7 @@ export function LeasesScreen({ onNavigate }: LeasesScreenProps) {
                   {lease.rentAmount} {lease.currency} / month
                 </Text>
                 <Text style={[s.cardMeta, { marginTop: 8 }]}>
-                  {new Date(lease.startsAt).toLocaleDateString()} –{' '}
-                  {new Date(lease.endsAt).toLocaleDateString()}
+                  {formatDate(lease.startsAt)} – {formatDate(lease.endsAt)}
                 </Text>
               </Pressable>
             );

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.i18n.test.tsx
@@ -31,13 +31,14 @@ jest.mock('../../hooks/useApi', () => ({
 }));
 
 // Force the app locale away from the runtime default so the regression test
-// below can prove the rendered dates are formatted with `resolveLocale()`
-// rather than a bare, device-locale `toLocaleDateString()` (issue #2752).
+// below can prove the rendered dates are formatted with the shared locale-aware
+// `formatDate()` helper rather than a bare, device-locale `toLocaleDateString()`
+// (issues #2752 / #2759). The mock pins the formatting locale to 'de'.
 jest.mock('../../i18n/format', () => ({
-  resolveLocale: jest.fn(() => 'de'),
+  formatDate: jest.fn((value: string | number | Date) => new Date(value).toLocaleDateString('de')),
 }));
 
-const mockResolveLocale = jest.requireMock('../../i18n/format').resolveLocale as jest.Mock;
+const mockFormatDate = jest.requireMock('../../i18n/format').formatDate as jest.Mock;
 
 const mockUseApiQuery = jest.requireMock('../../hooks/useApi').useApiQuery as jest.Mock;
 
@@ -130,12 +131,12 @@ describe('reading dates follow the in-app locale, not the device locale (#2752)'
     jest.clearAllMocks();
   });
 
-  it('formats the latest-reading and history dates via resolveLocale()', () => {
+  it('formats the latest-reading and history dates via the shared formatDate helper', () => {
     mockQuery({ data: responseWithReadings });
     render(<MeterDetailScreen meterId="m-1" onBack={() => {}} onNavigate={() => {}} />);
 
     // The screen must route every reading date through the app locale helper.
-    expect(mockResolveLocale).toHaveBeenCalled();
+    expect(mockFormatDate).toHaveBeenCalled();
 
     // With resolveLocale mocked to 'de', the newest reading (2026-03-31) and
     // the older one (2026-02-28) render in German day.month.year order — the

--- a/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MeterDetailScreen.tsx
@@ -18,7 +18,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
-import { resolveLocale } from '../../i18n/format';
+import { formatDate } from '../../i18n/format';
 import { warnIfListDegraded, warnIfParseFailed } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
@@ -170,9 +170,7 @@ export function MeterDetailScreen({
                 <Text style={styles.metricValue}>
                   {readings[0].value} {readings[0].unit}
                 </Text>
-                <Text style={s.cardMeta}>
-                  {new Date(readings[0].takenAt).toLocaleDateString(resolveLocale())}
-                </Text>
+                <Text style={s.cardMeta}>{formatDate(readings[0].takenAt)}</Text>
                 {monthDelta != null && (
                   <Text style={[s.cardBody, { marginTop: 8 }]}>
                     {t('meters.usedSincePrevious', {
@@ -198,9 +196,7 @@ export function MeterDetailScreen({
                     <Text style={s.cardTitle}>
                       {r.value} {r.unit}
                     </Text>
-                    <Text style={s.cardMeta}>
-                      {new Date(r.takenAt).toLocaleDateString(resolveLocale())}
-                    </Text>
+                    <Text style={s.cardMeta}>{formatDate(r.takenAt)}</Text>
                   </View>
                 </View>
               ))

--- a/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
+++ b/frontend/apps/mobile/src/screens/meters/MetersScreen.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useAuth } from '../../contexts/AuthContext';
 import { useApiQuery } from '../../hooks/useApi';
+import { formatDate } from '../../i18n/format';
 import { warnIfListDegraded } from '../shared/parserWarnings';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
@@ -190,9 +191,7 @@ export function MetersScreen({ onNavigate }: MetersScreenProps) {
                 {meter.lastReading != null
                   ? `${meter.lastReading} ${meter.unit}`
                   : '— no reading yet'}
-                {meter.lastReadingAt
-                  ? ` (${new Date(meter.lastReadingAt).toLocaleDateString()})`
-                  : ''}
+                {meter.lastReadingAt ? ` (${formatDate(meter.lastReadingAt)})` : ''}
               </Text>
 
               <View style={s.cardFooter}>

--- a/frontend/apps/mobile/src/screens/news/NewsScreen.tsx
+++ b/frontend/apps/mobile/src/screens/news/NewsScreen.tsx
@@ -9,6 +9,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Image, Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { formatDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 export interface NewsArticle {
@@ -149,9 +150,7 @@ export function NewsScreen({ onNavigate }: NewsScreenProps) {
               <Text style={s.cardBody} numberOfLines={3}>
                 {article.excerpt}
               </Text>
-              <Text style={[s.cardMeta, { marginTop: 8 }]}>
-                {new Date(article.publishedAt).toLocaleDateString()}
-              </Text>
+              <Text style={[s.cardMeta, { marginTop: 8 }]}>{formatDate(article.publishedAt)}</Text>
             </Pressable>
           ))
         )}

--- a/frontend/apps/mobile/src/screens/voting/VoteDetailScreen.tsx
+++ b/frontend/apps/mobile/src/screens/voting/VoteDetailScreen.tsx
@@ -35,6 +35,7 @@ import {
   View,
 } from 'react-native';
 import { useApiMutation, useApiQuery } from '../../hooks/useApi';
+import { formatDate } from '../../i18n/format';
 import { colors, screenStyles as s } from '../shared/screenStyles';
 
 interface ApiQuestionOption {
@@ -270,7 +271,7 @@ export function VoteDetailScreen({ voteId, onBack }: VoteDetailScreenProps) {
         {detail && (
           <Text style={s.headerSubtitle}>
             {detail.building_name} ·{' '}
-            {new Date(detail.end_at).toLocaleDateString(undefined, {
+            {formatDate(detail.end_at, {
               year: 'numeric',
               month: 'short',
               day: 'numeric',

--- a/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
+++ b/frontend/apps/mobile/src/screens/voting/VotingScreen.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useApiQuery } from '../../hooks/useApi';
+import { formatDate as formatLocaleDate } from '../../i18n/format';
 import { colors } from '../shared/screenStyles';
 
 export type VoteStatus = 'active' | 'closed' | 'pending';
@@ -87,11 +88,7 @@ export function parseVoteSummaries(data: unknown): ApiVoteSummary[] {
  *  the rest of the UI. Exported so the formatting can be unit-tested without
  *  rendering the screen. */
 export function formatVoteDate(dateString: string, locale: string): string {
-  return new Date(dateString).toLocaleDateString(locale, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
+  return formatLocaleDate(dateString, { month: 'short', day: 'numeric', year: 'numeric' }, locale);
 }
 
 /** Map the api-server's status string onto the UI's narrowed enum.


### PR DESCRIPTION
## Task
Follow-up: mobile date consolidation is incomplete — a dozen+ screens still render device-locale dates + no bare-toLocale* guard (PR #2755). Closes #2759. Complete the mobile (frontend/apps/mobile, React Native) date-formatting consolidation: route remaining screens through the shared date-format helper instead of raw toLocale*/device-locale rendering, and add a lint/guard against bare toLocale* usage. Scope to frontend/ (React Native + shared) — this is NOT a mobile-native/KMP task.

## Owner
pm-frontend

## What changed
PR #2755 introduced the shared locale-aware helpers in `frontend/apps/mobile/src/i18n/format.ts` (`formatDate` / `formatTime` / `formatDateTime`, backed by `resolveLocale`) but left a dozen-plus screens still rendering dates with bare `toLocale*` — the **device** locale — so dates never matched the in-app language for sk/cs/de/pl/hu users (the same class of bug as #2752 / #2282).

**Screens routed through the shared helper (19 files):**
- `features/faults/components/FaultCard.tsx`, `features/layout/registry.tsx`
- `screens/dashboard/DashboardScreen.tsx`, `screens/announcements/AnnouncementDetailScreen.tsx`
- `screens/meters/{MetersScreen,MeterDetailScreen}.tsx`, `screens/news/NewsScreen.tsx`, `screens/forms/FormsScreen.tsx`
- `screens/leases/{LeasesScreen,LeaseDetailScreen,LeaseSignatureScreen}.tsx`
- `screens/voting/{VotingScreen,VoteDetailScreen}.tsx`
- `screens/documents/{DocumentDetailScreen,DocumentPreviewScreen,DocumentPermissionsScreen,DocumentShareSheet}.tsx`

`formatDateTime` replaces the `toLocaleString()` date+time calls (lease signature); `formatTime` replaces the preview link expiry `toLocaleTimeString`. Screens that were partially converted in #2755 (their remaining bare calls) are finished here. Unused `i18n` destructures left over from the old `toLocaleDateString(i18n.language, …)` calls were dropped.

**Guard:** `frontend/apps/mobile/src/i18n/no-bare-tolocale.test.ts` — a tree-wide jest guard that walks `src/`, exempts test files and the helper (`i18n/format.ts`) itself, and fails on any bare `.toLocale(Date|Time|)String(` call. It runs in `pnpm -F mobile test` (enforced by `frontend.yml` CI). Committed test-first: it **fails on the current tree** (proof below) and is made green by the fix commit.

`MeterDetailScreen.i18n.test.tsx` was updated to mock the new `formatDate` surface (it previously mocked `resolveLocale`), preserving the #2752 intent.

## Verification
```
VERIFY-PLAN base=50170d2d98245f2b6425e04c4ed8a6c4a0cf0281 files=19
  cd frontend && pnpm exec biome check apps/mobile/src/... (19 files)
  cd frontend && pnpm --filter "...[<base>]" typecheck
  cd frontend && pnpm --filter "...[<base>]" test
```
```
VERIFY OK fe67d2b7baf95de008eb5c1879048db1243daad4
```
Frontend suite: 52 suites / 648 tests passed. Standalone TDD proof — the guard at the test-only commit `b6b9ca5`: `Tests: 1 failed, 1 total`; green at HEAD.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Scope drift
None. Diff is confined to `frontend/apps/mobile/**` (pm-frontend). `scope-check.sh --base origin/dev` → exit 0. (Against local `dev`, which trailed `origin/dev`, the script mis-reported unrelated `.research/**` commits — verified false positive against `origin/dev`.)

## Code-reuse review
None — no new helpers added; the change consumes the existing `src/i18n/format.ts` helpers.

## Notes
- Goal-check IG1 (`.research/plans/<slug>.md`) and IG2 (`impl/<slug>` branch name) don't apply to this dispatcher gh-issue task (no plan file; dispatcher-assigned `auto-impl/…` branch). IG3 (TDD test:+fix: pair) and IG7 (verify) pass.
- The guard forbids all three `toLocale*` date methods; there are currently no number-`toLocaleString` uses in mobile, so no false positives. A future number-formatting need should get its own helper rather than a bare call.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKPsrSvubWfjEqMV6uttXy)_