### PR TITLE
code-review-api-handlers-voice-alexa-cert-fetch-no-timeout: bound Alexa cert fetch with timeouts + shared client

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -864,12 +864,47 @@ static ALEXA_CERT_CACHE: std::sync::OnceLock<
     >,
 > = std::sync::OnceLock::new();
 
+/// Time budget for establishing the TCP+TLS connection to S3 when fetching the
+/// Alexa signing certificate.
+const ALEXA_CERT_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Overall time budget for a single certificate fetch (connect + response
+/// body). Bounds how long a slow S3 can stall the webhook handler.
+const ALEXA_CERT_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Shared HTTP client for Alexa certificate fetches.
+///
+/// Built once (process-wide) with explicit connect and request timeouts and
+/// reused for every fetch. Reusing a single client keeps the connection pool
+/// and TLS session cache warm and, crucially, prevents a burst of cold-cache
+/// requests from spawning an unbounded number of independent TLS clients.
+static ALEXA_CERT_HTTP_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+
+/// Return the shared, timeout-bounded HTTP client used to fetch Alexa signing
+/// certificates, initialising it on first use.
+fn alexa_cert_http_client() -> &'static reqwest::Client {
+    ALEXA_CERT_HTTP_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(ALEXA_CERT_CONNECT_TIMEOUT)
+            .timeout(ALEXA_CERT_REQUEST_TIMEOUT)
+            .build()
+            // A builder failure means the TLS backend could not initialise; a
+            // default client would fail the same way, so fall back to it rather
+            // than panicking inside a request handler.
+            .unwrap_or_else(|_| reqwest::Client::new())
+    })
+}
+
 /// Fetch the PEM certificate chain from a (previously validated) Alexa cert
 /// URL, memoising the result for [`ALEXA_CERT_CACHE_TTL`].
 ///
 /// The URL is only ever reached after [`validate_alexa_cert_url`], so it always
 /// points at `https://s3.amazonaws.com/echo.api/…`; TLS authenticates the S3
 /// origin. Returns the raw PEM bytes (one or more concatenated certificates).
+///
+/// The fetch goes through a shared client ([`alexa_cert_http_client`]) with
+/// explicit connect/request timeouts so a slow or unresponsive S3 cannot stall
+/// the handler indefinitely.
 async fn fetch_alexa_cert_chain(url: &str) -> Result<std::sync::Arc<Vec<u8>>, String> {
     let cache =
         ALEXA_CERT_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
@@ -883,7 +918,7 @@ async fn fetch_alexa_cert_chain(url: &str) -> Result<std::sync::Arc<Vec<u8>>, St
         }
     }
 
-    let response = reqwest::Client::new()
+    let response = alexa_cert_http_client()
         .get(url)
         .send()
         .await
@@ -1685,6 +1720,28 @@ mod tests {
         headers.insert("signature", HeaderValue::from_static("sig"));
         let body = alexa_body_with_timestamp(&Utc::now().to_rfc3339());
         assert!(verify_alexa_signature(&headers, &body).await.is_err());
+    }
+
+    // The Alexa cert fetch must go through a single shared, timeout-bounded
+    // client rather than building a fresh `reqwest::Client` per call — a burst
+    // of cold-cache requests would otherwise spawn unbounded TLS clients.
+    // Guards against a regression back to `reqwest::Client::new()` per fetch.
+    #[test]
+    fn alexa_cert_http_client_is_shared() {
+        let first = alexa_cert_http_client();
+        let second = alexa_cert_http_client();
+        assert!(
+            std::ptr::eq(first, second),
+            "expected a single process-wide Alexa cert HTTP client"
+        );
+    }
+
+    // Sanity-check the fetch timeouts are ordered sensibly (connect budget is a
+    // subset of the overall request budget) and are actually bounded.
+    #[test]
+    fn alexa_cert_timeouts_are_bounded() {
+        assert!(ALEXA_CERT_CONNECT_TIMEOUT <= ALEXA_CERT_REQUEST_TIMEOUT);
+        assert!(!ALEXA_CERT_REQUEST_TIMEOUT.is_zero());
     }
 
     // Regression for issue #2668: a valid cert URL + fresh timestamp is NO


### PR DESCRIPTION
## Task
voice `fetch_alexa_cert_chain` builds a fresh `reqwest::Client` per call with no connect/request timeout — a slow S3 stalls the handler, and a burst of cold-cache calls spawns unbounded TLS clients. Fix: give the client explicit connect + request timeouts (and, if straightforward and in-scope, reuse a shared/cached client instead of building a fresh one per call). File: `backend/servers/api-server/src/routes/voice_webhooks.rs` (`fetch_alexa_cert_chain`). Keep it tightly scoped; add a test if practical.

## Owner
pm-backend

## What changed
- Added a process-wide shared HTTP client (`ALEXA_CERT_HTTP_CLIENT`, `std::sync::OnceLock<reqwest::Client>`) built **once** via `alexa_cert_http_client()` with explicit `connect_timeout` (5s) and overall `timeout` (10s). `fetch_alexa_cert_chain` now routes its `GET` through this shared client instead of `reqwest::Client::new()` per call.
  - Timeouts bound how long a slow/unresponsive S3 can stall the webhook handler.
  - A single reused client prevents a cold-cache burst from spawning an unbounded number of independent TLS clients, and keeps the connection/TLS-session pool warm.
  - Builder failure (TLS backend init) falls back to a default client rather than panicking inside a request handler.
- Added two fast, deterministic unit tests: `alexa_cert_http_client_is_shared` (guards against reverting to per-call clients) and `alexa_cert_timeouts_are_bounded` (connect ≤ request, request non-zero).

Change is confined to `fetch_alexa_cert_chain` and two new immediate helpers/constants — it does not touch the sibling functions (`verify_google_request`, `/oauth/refresh`) that overlapping PRs modify.

## Verification
VERIFY-PLAN base=7e2e04b9893114d89979794db4586e6f1ca2ea33 files=1
```
cd backend && cargo fmt --all -- --check
cd backend && cargo clippy -p api-server --all-targets -- -D warnings
cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` → **exit 0** (clean).
- `cargo clippy -p api-server --all-targets -- -D warnings` → **could not complete: BUILD failure in a dependency, unrelated to this change.** The egress-limited cloud runner cannot download the Swagger UI archive that `utoipa-swagger-ui`'s build script fetches, so `api-server`'s own sources never reach the compiler. Verbatim:

```
error: failed to run custom build command for `utoipa-swagger-ui v9.0.2`
Caused by:
  process didn't exit successfully: `.../build-script-build` (exit status: 101)
  --- stdout
  SWAGGER_UI_DOWNLOAD_URL: https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
  start download to : ".../out/v5.17.14.zip"
  reqwest feature: Err(NotPresent)
  trying to download using `curl` system package
  --- stderr
  thread 'main' (30799) panicked at .../utoipa-swagger-ui-9.0.2/build.rs:219:51:
  failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
```

- `cargo test -p api-server` → not run; would fail at the same dependency build step.

This is the documented cloud-runner limitation (same as PR #2684). fmt is green; `clippy`/`test` for the changed crate are delegated to CI `backend.yml`, which has network access to fetch the Swagger UI archive. Opened as **draft** pending green CI.

## CI parity (Band C — hot-path only)
skipped: this is a resilience/timeout hardening change to an existing fetch path; no auth/billing/data-integrity semantics changed. (Alexa signature verification logic itself is untouched.)

## Remote-tested
skipped

## Notes
- `connect_timeout`/`timeout` are core `reqwest::ClientBuilder` methods (not feature-gated) — no `Cargo.toml` change needed.
- Scope-drift check: clean (exit 0, pm-backend area). Code-reuse pre-flight: clean (no duplicate-helper warnings).


---
_Generated by [Claude Code](https://claude.ai/code/session_0127Exznz1NnXy9TM9TiJ4AL)_