### PR TITLE
churn-hotspot-marketplace-award-quote-idor-tests: close IDOR coverage gaps on the marketplace award endpoint

### DIFF
--- a/backend/servers/api-server/tests/suites/marketplace_award_quote_idor_tests.rs
+++ b/backend/servers/api-server/tests/suites/marketplace_award_quote_idor_tests.rs
@@ -296,3 +296,120 @@ async fn award_succeeds_for_own_quote(pool: PgPool) {
         "the RFQ must be awarded to its own quote"
     );
 }
+
+// ---------------------------------------------------------------------------
+// T4 — the RFQ path param itself must be org-scoped: a caller cannot award a
+// FOREIGN org's RFQ, even when the body quote legitimately belongs to it.
+//
+// T1/T2 pin the body `quote_id` IDOR (the fix threaded into the handler), but
+// every one of them targets an RFQ the caller already owns — so the *first*
+// authz layer, `load_rfq_for_org` (path param `{id}` -> `verify_org_access`),
+// is never exercised as a negative. Here org A's admin points the award at org
+// B's RFQ using B's OWN valid, matching quote. The quote-ownership `filter`
+// would pass; the only thing standing between the caller and mutating a foreign
+// org's award is the path-param org check. It must reject with 404 (not leak
+// existence) BEFORE any quote lookup, and must not touch RFQ B's state.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn award_rejects_foreign_rfq_via_path_param(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    // Caller is an org_admin of org A.
+    let org_a = seed_org(&pool, "path-a").await;
+    let buyer_a = seed_user(&pool, "buyer-path-a@award-idor.test").await;
+    seed_membership(&pool, org_a, buyer_a, "org_admin").await;
+
+    // Org B owns RFQ B and a valid, matching quote submitted against it.
+    let org_b = seed_org(&pool, "path-b").await;
+    let buyer_b = seed_user(&pool, "buyer-path-b@award-idor.test").await;
+    seed_membership(&pool, org_b, buyer_b, "org_admin").await;
+    let rfq_b = seed_rfq(&pool, org_b, buyer_b).await;
+    let prov_b_user = seed_user(&pool, "prov-path-b@award-idor.test").await;
+    let prov_b = seed_provider(&pool, prov_b_user, "path-b").await;
+    let own_quote_b = seed_quote(&pool, rfq_b, prov_b).await;
+
+    // Caller from org A aims the award at org B's RFQ path param.
+    let token = mint_token(buyer_a, "buyer-path-a@award-idor.test", Some(org_a));
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/marketplace/rfqs/{rfq_b}/award"))
+                .bearer(&token)
+                .json(json!({ "quote_id": own_quote_b }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "awarding a foreign org's RFQ (path param) must be rejected (404), got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    // RFQ B must remain un-awarded and its quote lifecycle untouched.
+    assert_eq!(
+        rfq_awarded_quote_id(&pool, rfq_b).await,
+        None,
+        "the foreign RFQ must not have been awarded by a non-member"
+    );
+    let quote_status: String =
+        sqlx::query_scalar(r#"SELECT status FROM provider_quotes WHERE id = $1"#)
+            .bind(own_quote_b)
+            .fetch_one(&pool)
+            .await
+            .expect("read foreign quote status");
+    assert_eq!(
+        quote_status, "submitted",
+        "the foreign RFQ's own quote must not have been mutated by a non-member"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T5 — a non-existent `quote_id` on an RFQ the caller DOES own is a 404.
+//
+// T1/T2 both hit the `filter(|q| q.rfq_id == id)` mismatch branch (the quote
+// exists but points at another RFQ). The distinct branch where `find_quote_by_id`
+// returns `None` outright — a guessed/garbage id — is unexercised. It must
+// surface the same 404 shape and leave the RFQ un-awarded, so a caller cannot
+// probe quote-id existence through the award endpoint.
+// ---------------------------------------------------------------------------
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn award_rejects_nonexistent_quote(pool: PgPool) {
+    let app = TestApp::new(pool.clone()).await;
+
+    let org = seed_org(&pool, "ghost").await;
+    let buyer = seed_user(&pool, "buyer-ghost@award-idor.test").await;
+    seed_membership(&pool, org, buyer, "org_admin").await;
+    let rfq = seed_rfq(&pool, org, buyer).await;
+
+    let token = mint_token(buyer, "buyer-ghost@award-idor.test", Some(org));
+
+    // A quote id that does not exist anywhere.
+    let phantom_quote = Uuid::new_v4();
+
+    let resp = app
+        .execute(
+            app.post(&format!("/api/v1/marketplace/rfqs/{rfq}/award"))
+                .bearer(&token)
+                .json(json!({ "quote_id": phantom_quote }))
+                .build(),
+        )
+        .await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::NOT_FOUND,
+        "awarding a non-existent quote must be rejected (404), got {}: {}",
+        resp.status,
+        resp.text()
+    );
+    assert_eq!(
+        rfq_awarded_quote_id(&pool, rfq).await,
+        None,
+        "the RFQ must not have been awarded to a phantom quote"
+    );
+}


### PR DESCRIPTION
## Task
`backend/servers/api-server/tests/suites/marketplace_award_quote_idor_tests.rs` is a churn hotspot (+298 lines, a new IDOR test suite from PR #2747). Review the test suite for GAPS in IDOR (Insecure Direct Object Reference) coverage on the marketplace award/quote endpoints — missing negative cases (cross-tenant/cross-org access should be 403/404), missing authz assertions, or cases that assert weakly. Add the missing regression tests.

## Owner
pm-qa

## Gap analysis
`POST /api/v1/marketplace/rfqs/{id}/award` (`award_quote`) has **two** distinct authz layers:
1. `load_rfq_for_org(&state, user, id)` → `verify_org_access` — the RFQ **path param** must belong to the caller's org (404 on non-member).
2. the body `quote_id` must belong to *that* RFQ — `find_quote_by_id(...).filter(|q| q.rfq_id == id)` (404 on mismatch/missing).

The existing suite (T1/T2/T3) exercised **only layer 2**, and every test targeted an RFQ the caller already owns:
- T1 — cross-org body quote (mismatch branch) → 404 ✓
- T2 — same-org other-RFQ body quote (mismatch branch) → 404 ✓
- T3 — positive path → 200 ✓

Two branches were left completely unexercised — both genuine IDOR/authz gaps, not padding:

- **Layer 1 (RFQ path-param org check) had zero negative coverage.** A non-member awarding a *foreign org's* RFQ directly via `{id}`, using that RFQ's own valid, matching quote, would sail past the layer-2 quote filter — only `verify_org_access` stands between the caller and mutating another tenant's award. Untested.
- **The `find_quote_by_id` → `None` branch** (a guessed/phantom `quote_id`) is distinct from the `filter` mismatch branch both T1/T2 hit; a caller could otherwise probe quote-id existence through the award endpoint. Untested.

## Added tests
- `award_rejects_foreign_rfq_via_path_param` — org A admin awards org B's RFQ (path param) with B's own valid quote → asserts 404, RFQ B still un-awarded, and B's quote lifecycle untouched (`status = submitted`).
- `award_rejects_nonexistent_quote` — phantom `quote_id` on an owned RFQ → asserts 404 and RFQ un-awarded.

Both reuse the suite's existing token-minting harness and seed fixtures; no production code touched.

## Verification
```
VERIFY-PLAN base=7e2e04b9893114d89979794db4586e6f1ca2ea33 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` → **PASS** (exit 0).
- `cargo clippy -p api-server` / `cargo test -p api-server` → could **not build** on the cloud runner: the `utoipa-swagger-ui v9.0.2` build script fails because github.com egress is blocked (same limitation as PR #2684). Verbatim:

```
error: failed to run custom build command for `utoipa-swagger-ui v9.0.2`
Caused by:
  process didn't exit successfully: .../build-script-build (exit status: 101)
  SWAGGER_UI_DOWNLOAD_URL: https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
  trying to download using `curl` system package
  thread 'main' panicked at .../utoipa-swagger-ui-9.0.2/build.rs:219:51:
  failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
VERIFY FAIL: cd backend && cargo clippy -p api-server --all-targets -- -D warnings
```

This failure is at dependency **build** time and is unrelated to the change (test-only, +117 lines in one file). Opened as **draft** relying on CI `backend.yml` to run clippy + `cargo test -p api-server` in an environment with egress.

## Scope drift
None — diff touches only `backend/servers/api-server/tests/suites/marketplace_award_quote_idor_tests.rs`. scope-check.sh (owner=pm-qa) → exit 0.

## Code-reuse review
None — reuse-grep.sh → empty. Tests reuse in-suite fixtures; no new helpers.

## CI parity (Band C — hot-path)
This is a security/IDOR regression suite; CI `backend.yml` is the authoritative clippy+test run (local build blocked by the egress limitation above).

## Remote-tested
skipped (ppt-bridge MCP not used).

## Notes
Pure test addition; no production code changed. Ready for CI to green the clippy/test steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127Exznz1NnXy9TM9TiJ4AL

---
_Generated by [Claude Code](https://claude.ai/code/session_0127Exznz1NnXy9TM9TiJ4AL)_