### PR TITLE
code-review-api-handlers-voice-oauth-refresh-unauthenticated: require device-owner auth on voice OAuth refresh

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -6,6 +6,7 @@
 //! - Request signature verification
 //! - User authentication via OAuth token
 
+use crate::routes::rate_limit::{rate_limit_allowed, InProcessRateLimiter};
 use crate::services::VoiceCommandProcessor;
 use crate::state::AppState;
 use api_core::extractors::RlsConnection;
@@ -49,6 +50,35 @@ fn voice_encryption_required(e: CryptoError) -> (StatusCode, Json<ErrorResponse>
             "ENCRYPTION_REQUIRED",
             "Integration token encryption is not configured",
         )),
+    )
+}
+
+// ============================================================================
+// Rate limiting (#2769)
+// ============================================================================
+//
+// `oauth_token_refresh` rotates the linked user's upstream OAuth token and
+// makes a live call to Amazon/Google. Even for an authenticated owner, an
+// unbounded loop is an amplification vector, so throttle per PM user with the
+// shared in-process sliding-window limiter (same primitive as `routes::mfa`).
+// `std::time::Duration` is fully qualified here to avoid clashing with the
+// `chrono::Duration` already imported in this module.
+const VOICE_REFRESH_MAX_ATTEMPTS: u32 = 10;
+const VOICE_REFRESH_WINDOW: std::time::Duration = std::time::Duration::from_secs(900);
+const VOICE_REFRESH_SWEEP_THRESHOLD: usize = 1024;
+
+static VOICE_REFRESH_RATE_LIMITER: std::sync::LazyLock<InProcessRateLimiter<Uuid>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Record a refresh attempt for `user_id`; `false` once more than
+/// `VOICE_REFRESH_MAX_ATTEMPTS` occur in a rolling `VOICE_REFRESH_WINDOW`.
+fn voice_refresh_attempt_allowed(user_id: Uuid) -> bool {
+    rate_limit_allowed(
+        &VOICE_REFRESH_RATE_LIMITER,
+        user_id,
+        VOICE_REFRESH_MAX_ATTEMPTS,
+        VOICE_REFRESH_WINDOW,
+        VOICE_REFRESH_SWEEP_THRESHOLD,
     )
 }
 
@@ -521,28 +551,61 @@ async fn oauth_token_exchange(
 }
 
 /// Refresh OAuth tokens for a voice device.
+///
+/// SECURITY (#2769): this endpoint rotates the linked user's upstream
+/// Amazon/Google OAuth token, so it is invoked by the **authenticated
+/// Property Management user** (from the voice account-management flow), not
+/// anonymously by the voice platform. It requires a valid PM access token
+/// (`AuthUser`) and only refreshes a device the caller **owns**
+/// (`auth.user_id == device.user_id`) or that a platform admin manages.
+///
+/// Before this fix the handler took only `State` + `Json<{device_id}>` with no
+/// auth extractor, so any caller who learned a `device_id` could rotate that
+/// user's token and amplify unauthenticated traffic against the upstream OAuth
+/// endpoints. Authenticated callers are additionally throttled per-user.
 #[utoipa::path(
     post,
     path = "/api/v1/webhooks/voice/oauth/refresh",
     request_body = VoiceTokenRefreshRequest,
     responses(
         (status = 200, description = "Token refresh successful", body = VoiceTokenRefreshResult),
+        (status = 401, description = "Unauthorized - missing or invalid PM access token"),
+        (status = 403, description = "Forbidden - caller does not own the device"),
         (status = 404, description = "Device not found"),
+        (status = 429, description = "Too many refresh attempts"),
         (status = 500, description = "Token refresh failed"),
     ),
+    security(("bearer_auth" = [])),
     tag = "Voice OAuth"
 )]
 async fn oauth_token_refresh(
     State(state): State<AppState>,
+    auth: api_core::AuthUser,
     Json(request): Json<VoiceTokenRefreshRequest>,
 ) -> Result<Json<VoiceTokenRefreshResult>, (StatusCode, Json<ErrorResponse>)> {
     use integrations::{decrypt_if_available, VoiceOAuthManager, VoicePlatform};
 
+    // Throttle authenticated abuse: a valid principal must not be able to loop
+    // this endpoint and amplify against the upstream OAuth provider (#2769).
+    if !voice_refresh_attempt_allowed(auth.user_id) {
+        tracing::warn!(
+            user_id = %auth.user_id,
+            device_id = %request.device_id,
+            "Voice OAuth refresh rate limit exceeded"
+        );
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(ErrorResponse::new(
+                "RATE_LIMITED",
+                "Too many token refresh attempts; try again later",
+            )),
+        ));
+    }
+
     // Find the device.
-    // PAP-170 (PAP-150 P5): this endpoint is called by the voice platform (no PM
-    // principal). Bootstrap the device on a context-cleared connection — it is
-    // addressed by an opaque, server-issued device_id and carries its owning
-    // org/user, which we bind below for the token write.
+    // `voice_assistant_devices` is not RLS-bound (see migration 00226), so the
+    // lookup runs on a context-cleared connection; the ownership check below is
+    // what authorizes the rotation.
     let rls_pool = RlsPool::new(state.db.clone());
     let mut lookup = rls_pool.acquire_public().await.map_err(|e| {
         tracing::error!("Database error: {}", e);
@@ -572,6 +635,25 @@ async fn oauth_token_refresh(
             )
         })?;
     drop(lookup);
+
+    // Authorize: only the device's owner (or a platform admin) may rotate its
+    // upstream OAuth token (#2769). Reject anyone else before touching the
+    // provider or the stored token.
+    if auth.user_id != device.user_id && !auth.is_platform_admin() {
+        tracing::warn!(
+            caller_user_id = %auth.user_id,
+            device_id = %device.id,
+            device_owner = %device.user_id,
+            "Voice OAuth refresh rejected: caller does not own the device"
+        );
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "FORBIDDEN",
+                "You do not have permission to refresh this device's tokens",
+            )),
+        ));
+    }
 
     // Check if device has refresh token
     let refresh_token_encrypted = match &device.refresh_token_encrypted {

--- a/backend/servers/api-server/tests/suite_8.rs
+++ b/backend/servers/api-server/tests/suite_8.rs
@@ -45,6 +45,8 @@ mod violations_cross_org_idor_tests;
 mod violations_happy_path_tests;
 #[path = "suites/voice_oauth_exchange_auth_tests.rs"]
 mod voice_oauth_exchange_auth_tests;
+#[path = "suites/voice_oauth_refresh_auth_tests.rs"]
+mod voice_oauth_refresh_auth_tests;
 #[path = "suites/voting_behaviour_tests.rs"]
 mod voting_behaviour_tests;
 #[path = "suites/voting_happy_path_tests.rs"]

--- a/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
+++ b/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
@@ -1,0 +1,271 @@
+//! Regression tests for the unauthenticated voice OAuth *refresh* fix (#2769).
+//!
+//! Audit history: `POST /api/v1/webhooks/voice/oauth/refresh`
+//! (`oauth_token_refresh`) accepted only `State` + `Json<{device_id}>` with **no
+//! authentication extractor**. Any caller that learned a `device_id` could POST
+//! it and force a rotation of that device owner's upstream Amazon/Google OAuth
+//! token — an integration-DoS + amplification vector against the provider's
+//! token endpoint, executed entirely anonymously.
+//!
+//! The fix adds the `AuthUser` extractor (PM access-token bearer auth), a
+//! per-user rate limit, and an ownership check that only lets the device's
+//! owner (or a platform admin) rotate its tokens. This suite pins the contract:
+//!   - no / invalid bearer token                    -> 401 (before any DB work)
+//!   - authenticated caller who does NOT own device -> 403
+//!   - authenticated owner                          -> 200 + `access_token_hash`
+//!                                                     rotates on the row
+//!
+//! TestApp wiring caveat (mirrors `voice_oauth_exchange_auth_tests`): `AuthUser`
+//! reads its claims straight from the JWT, so we mint tokens directly. The
+//! `voice_assistant_devices` table exists as of migration 00226, so unlike the
+//! exchange suite this one can seed a real device row and assert the full
+//! owner-rotation path end to end.
+
+#![allow(dead_code)]
+
+use axum::{
+    body::Body,
+    http::{header, Method, Request, StatusCode},
+};
+use chrono::{Duration, Utc};
+use jsonwebtoken::{encode, EncodingKey, Header};
+use serde::Serialize;
+use serde_json::json;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::common::{TestApp, TestConfig};
+
+const REFRESH_URI: &str = "/api/v1/webhooks/voice/oauth/refresh";
+
+/// A valid 32-byte (64 hex char) AES-256 key for the test process, so the
+/// simulated-refresh branch's mandatory `encrypt_required` succeeds.
+const TEST_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+/// Mirror of `api_core::extractors::auth::Claims`.
+#[derive(Serialize)]
+struct AuthClaims {
+    sub: Uuid,
+    exp: i64,
+    iat: i64,
+    token_type: String,
+    tenant_id: Option<Uuid>,
+    role: Option<String>,
+    email: String,
+    name: String,
+}
+
+fn mint_access_token(secret: &str, user_id: Uuid, tenant_id: Option<Uuid>) -> String {
+    let now = Utc::now();
+    let claims = AuthClaims {
+        sub: user_id,
+        iat: now.timestamp(),
+        exp: (now + Duration::hours(1)).timestamp(),
+        token_type: "access".to_string(),
+        tenant_id,
+        role: Some("manager".to_string()),
+        email: "voice-refresh@example.test".to_string(),
+        name: "Voice Refresher".to_string(),
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .expect("mint access token")
+}
+
+/// Insert a linked voice device owned by `owner` with a refresh token present
+/// (so the handler proceeds past the "no refresh token" guard) and a known
+/// initial `access_token_hash`. Returns the device id.
+async fn seed_device(pool: &PgPool, owner: Uuid, initial_hash: &[u8]) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO voice_assistant_devices (
+            organization_id, user_id, platform, device_id,
+            access_token_encrypted, refresh_token_encrypted,
+            token_expires_at, capabilities, access_token_hash, is_active, linked_at
+        )
+        VALUES ($1, $2, 'alexa', $3, $4, $5,
+                NOW() + interval '1 hour', '["check_balance"]'::jsonb, $6, TRUE, NOW())
+        RETURNING id
+        "#,
+    )
+    .bind(Uuid::new_v4()) // organization_id (logical FK, unconstrained per migration 00226)
+    .bind(owner)
+    .bind(format!("device-{}", Uuid::new_v4()))
+    .bind("enc-access-placeholder")
+    .bind("enc-refresh-placeholder")
+    .bind(initial_hash)
+    .fetch_one(pool)
+    .await
+    .expect("seed voice device")
+}
+
+async fn read_token_hash(pool: &PgPool, device_id: Uuid) -> Option<Vec<u8>> {
+    sqlx::query_scalar::<_, Option<Vec<u8>>>(
+        "SELECT access_token_hash FROM voice_assistant_devices WHERE id = $1",
+    )
+    .bind(device_id)
+    .fetch_one(pool)
+    .await
+    .expect("read device token hash")
+}
+
+fn refresh_body(device_id: Uuid) -> serde_json::Value {
+    json!({ "device_id": device_id })
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: no Authorization header -> 401, before any device lookup or rotation.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_refresh_without_auth_is_rejected(pool: PgPool) {
+    let owner = Uuid::new_v4();
+    let device_id = seed_device(&pool, owner, b"initial-hash").await;
+    let app = TestApp::new(pool.clone()).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(REFRESH_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(refresh_body(device_id).to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "unauthenticated refresh must be 401, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    // The device's token hash must be untouched by the rejected request.
+    assert_eq!(
+        read_token_hash(&pool, device_id).await.as_deref(),
+        Some(&b"initial-hash"[..]),
+        "rejected request must not rotate the token"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: garbage bearer token -> 401.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_refresh_invalid_token_is_rejected(pool: PgPool) {
+    let device_id = seed_device(&pool, Uuid::new_v4(), b"initial-hash").await;
+    let app = TestApp::new(pool.clone()).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(REFRESH_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, "Bearer not-a-real-jwt")
+        .body(Body::from(refresh_body(device_id).to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::UNAUTHORIZED,
+        "invalid bearer token must be 401, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: authenticated caller who does NOT own the device -> 403, no rotation.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_refresh_non_owner_is_forbidden(pool: PgPool) {
+    let owner = Uuid::new_v4();
+    let device_id = seed_device(&pool, owner, b"initial-hash").await;
+
+    let config = TestConfig::default();
+    let secret = config.jwt_secret.clone();
+    let app = TestApp::with_config(pool.clone(), config).await;
+
+    // Token for a DIFFERENT, non-admin user.
+    let attacker = Uuid::new_v4();
+    let token = mint_access_token(&secret, attacker, Some(Uuid::new_v4()));
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(REFRESH_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(refresh_body(device_id).to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::FORBIDDEN,
+        "non-owner refresh must be 403, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    assert_eq!(
+        read_token_hash(&pool, device_id).await.as_deref(),
+        Some(&b"initial-hash"[..]),
+        "forbidden request must not rotate the token"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: the device owner -> 200 and the stored access_token_hash rotates.
+//
+// No upstream OAuth is configured in tests, so the handler takes its
+// simulated-refresh branch: it mints a fresh access token, encrypts it (needs
+// INTEGRATION_ENCRYPTION_KEY, set below) and writes a new keyed HMAC into
+// `access_token_hash`. We assert the row's hash changed from the seeded value.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_refresh_owner_rotates_token(pool: PgPool) {
+    std::env::set_var("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+
+    let owner = Uuid::new_v4();
+    let initial_hash = b"initial-hash-value";
+    let device_id = seed_device(&pool, owner, initial_hash).await;
+
+    let config = TestConfig::default();
+    let secret = config.jwt_secret.clone();
+    let app = TestApp::with_config(pool.clone(), config).await;
+
+    let token = mint_access_token(&secret, owner, Some(Uuid::new_v4()));
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(REFRESH_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(refresh_body(device_id).to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "owner refresh must be 200, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let new_hash = read_token_hash(&pool, device_id).await;
+    assert!(
+        new_hash.is_some(),
+        "owner refresh must persist a new access_token_hash"
+    );
+    assert_ne!(
+        new_hash.as_deref(),
+        Some(&initial_hash[..]),
+        "owner refresh must rotate access_token_hash away from the seeded value"
+    );
+}

--- a/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
+++ b/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
@@ -10,10 +10,9 @@
 //! The fix adds the `AuthUser` extractor (PM access-token bearer auth), a
 //! per-user rate limit, and an ownership check that only lets the device's
 //! owner (or a platform admin) rotate its tokens. This suite pins the contract:
-//! - no / invalid bearer token                    -> 401 (before any DB work)
+//! - no / invalid bearer token -> 401 (before any DB work)
 //! - authenticated caller who does NOT own device -> 403
-//! - authenticated owner                          -> 200 + `access_token_hash`
-//!                                                   rotates on the row
+//! - authenticated owner -> 200 + `access_token_hash` rotates on the row
 //!
 //! TestApp wiring caveat (mirrors `voice_oauth_exchange_auth_tests`): `AuthUser`
 //! reads its claims straight from the JWT, so we mint tokens directly. The

--- a/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
+++ b/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
@@ -10,10 +10,10 @@
 //! The fix adds the `AuthUser` extractor (PM access-token bearer auth), a
 //! per-user rate limit, and an ownership check that only lets the device's
 //! owner (or a platform admin) rotate its tokens. This suite pins the contract:
-//!   - no / invalid bearer token                    -> 401 (before any DB work)
-//!   - authenticated caller who does NOT own device -> 403
-//!   - authenticated owner                          -> 200 + `access_token_hash`
-//!                                                     rotates on the row
+//! - no / invalid bearer token                    -> 401 (before any DB work)
+//! - authenticated caller who does NOT own device -> 403
+//! - authenticated owner                          -> 200 + `access_token_hash`
+//!                                                   rotates on the row
 //!
 //! TestApp wiring caveat (mirrors `voice_oauth_exchange_auth_tests`): `AuthUser`
 //! reads its claims straight from the JWT, so we mint tokens directly. The


### PR DESCRIPTION
## Task

SECURITY: voice `/oauth/refresh` accepts unauthenticated `{device_id}` and rotates the linked user's OAuth token — anyone with a `device_id` can DoS & amplify against Amazon/Google. Fix: require authentication/authorization proving the caller owns the device before rotating tokens (or otherwise close the unauth token-rotation vector), and rate-limit. File: `backend/servers/api-server/src/routes/voice_webhooks.rs` (the `/oauth/refresh` handler, around lines 535 and 69). Plan: `.research/plans/code-review-api-handlers-voice-oauth-refresh-unauthenticated.md`.

## Owner

pm-security

## What changed

`oauth_token_refresh` (`POST /api/v1/webhooks/voice/oauth/refresh`) previously took only `State` + `Json<VoiceTokenRefreshRequest{device_id}>` — **no auth extractor**. Any caller that learned a `device_id` could force a rotation of that device owner's upstream Amazon/Google OAuth token (integration DoS + amplification against the provider's token endpoint, executed anonymously).

- **AuthUser extractor added** — same shape as the sibling `oauth_token_exchange`. Unauthenticated / invalid-bearer callers now get **401** at the extractor, before any DB work.
- **Ownership authorization** — after loading the device, the handler requires `auth.user_id == device.user_id` OR `auth.is_platform_admin()`; anyone else gets **403** with the principal mismatch logged.
- **Per-user rate limit** — throttled with the shared in-process sliding-window limiter (`routes::rate_limit::rate_limit_allowed`, the same primitive `routes::mfa` uses), keyed on `auth.user_id`, 10 attempts / 900s → **429**. No new dependency introduced (respects the plan's Out-of-scope note). `std::time::Duration` is fully qualified to avoid clashing with the module's `chrono::Duration`.
- **OpenAPI** — utoipa annotation updated with `security(("bearer_auth" = []))` and documented 401/403/429 responses.

## Suggested-approach cross-reference (plan has 6 steps)

1. Add `AuthUser` extractor — **done** (`voice_webhooks.rs`).
2. Require `auth.user_id == device.user_id` OR platform admin, else `Forbidden`, log mismatch — **done** (used `is_platform_admin()`; logs caller + owner).
3. Per-user rate limit using in-tree limiter (no new dep) — **done** (`routes::rate_limit`, mfa pattern; no `tower_governor` added).
4. Integration tests in a suite file (unauth→401, non-owner→403, owner→200+hash rotates) — **done** (`tests/suites/voice_oauth_refresh_auth_tests.rs`, registered in `suite_8.rs`). The table exists as of migration 00226, so the owner path seeds a real device and asserts `access_token_hash` rotation end-to-end.
5. `cargo test -p api-server voice_webhooks`, unauth case red-on-dev — **CI-gated** (see Verification; the 401/403 cases fail on `dev` because the handler returns 200 for anyone with a `device_id`).
6. Update OpenAPI utoipa annotation — **done**.

## Test plan

- `voice_oauth_refresh_auth_tests::oauth_refresh_without_auth_is_rejected` — 401, token hash untouched.
- `voice_oauth_refresh_auth_tests::oauth_refresh_invalid_token_is_rejected` — 401.
- `voice_oauth_refresh_auth_tests::oauth_refresh_non_owner_is_forbidden` — 403, token hash untouched.
- `voice_oauth_refresh_auth_tests::oauth_refresh_owner_rotates_token` — 200 + `access_token_hash` rotates on the row.
- Command → exit code: see Verification.

## Verification

```
VERIFY-PLAN base=7e2e04b9893114d89979794db4586e6f1ca2ea33 files=3
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cd backend && cargo fmt --all -- --check` → **exit 0 (PASS)**
- `cd backend && cargo clippy -p api-server --all-targets -- -D warnings` → **exit 101 (BUILD FAIL — environment egress limit, NOT this code)**
- `cd backend && cargo test -p api-server` → not reached (same build dependency)

### Why clippy/test cannot pass on this runner (documented, verbatim)

`api-server` transitively builds `utoipa-swagger-ui v9.0.2`, whose build script downloads Swagger UI from `github.com`. This cloud runner's egress policy returns **HTTP 403** for that host, so the download yields a 378-byte JSON error body instead of the zip and the build script panics:

```
error: failed to run custom build command for `utoipa-swagger-ui v9.0.2`
  SWAGGER_UI_DOWNLOAD_URL: https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip
  trying to download using `curl` system package
  thread 'main' panicked at utoipa-swagger-ui-9.0.2/build.rs:219:51:
  failed to open downloaded Swagger UI: InvalidArchive("Could not find EOCD")
```

Confirmed the block is upstream policy, not a TLS/CA misconfig:
```
curl -L "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip" → HTTP 403, size=378 (JSON error body)
```
The proxy README classifies 403 as an org egress denial that must not be routed around. The failure occurs entirely in a third-party build dependency; the compiler never reaches `voice_webhooks.rs` or the new tests. `cargo fmt` (which does not need that dep) passes clean.

**This is the same limitation as PR #2684.** Opened as **DRAFT** relying on CI `backend.yml` (which has github.com egress) as the authoritative gate for `clippy` + `cargo test -p api-server`.

## CI parity (Band C — hot-path)

This is a security/auth change (hot-path). `backend.yml` runs `cargo fmt`, `clippy`, and `cargo test` with full egress and is the authoritative gate here — local `act`/`gh workflow` replication is blocked by the same swagger-ui egress limit, so it is deferred to CI on this PR.

## Remote-tested

skipped (no ppt-bridge MCP in session).

## Scope drift

`scope-check.sh --owner pm-security` reports drift (exit 2): the changed paths
```
backend/servers/api-server/src/routes/voice_webhooks.rs
backend/servers/api-server/tests/suite_8.rs
backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
```
fall outside the pm-security owner globs (which list `handlers/auth/**` / `handlers/mfa/**`, but this endpoint lives under `routes/`). The drift is the task's own target file — the action explicitly names `routes/voice_webhooks.rs`. Reviewer to adjudicate.

## Code-reuse review

`reuse-grep.sh --specialist rust-backend` → empty (no warnings). The rate limiter reuses the existing shared `routes::rate_limit::rate_limit_allowed` primitive rather than re-implementing a throttle.

## Notes

- No new dependency added; no migration touched; Amazon/Google OAuth refresh flow and the HMAC-based `alexa_webhook` / `google_webhook` handlers left untouched (Out-of-scope respected — goal-check IG6 green).
- goal-check: IG1/IG3/IG5/IG6 pass. IG2 flags the branch name `auto-impl/...` vs its expected `impl/...` — the branch was chosen by the dispatcher. IG7 is the swagger-ui egress limit above.


---
_Generated by [Claude Code](https://claude.ai/code/session_0127Exznz1NnXy9TM9TiJ4AL)_