### PR TITLE
churn-hotspot-protected-route-i18n-test: cover ProtectedRoute i18n fallback + guard behavior

### DIFF
--- a/frontend/apps/ppt-web/src/i18n/protectedRouteI18n.test.ts
+++ b/frontend/apps/ppt-web/src/i18n/protectedRouteI18n.test.ts
@@ -25,6 +25,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import i18next, { type i18n as I18nInstance } from 'i18next';
 import cs from '../../messages/cs.json';
 import de from '../../messages/de.json';
 import en from '../../messages/en.json';
@@ -38,6 +39,18 @@ const BUNDLES: Record<string, Json> = { en, sk, cs, de, pl, hu };
 
 /** Keys ProtectedRoute resolves from the shipped locale bundles (not defaultValue-only). */
 const BUNDLE_KEYS = ['common.loading', 'errors.unauthorized'] as const;
+
+/**
+ * Keys ProtectedRoute renders which are intentionally NOT in any bundle — they
+ * ride entirely on the `defaultValue` guard. If one of these ever leaks into a
+ * bundle it must land in ALL six (see `deadNamespaceI18n.test.ts` for the
+ * inverse-parity bug that a partial add causes), so the classification test
+ * below asserts they stay absent everywhere.
+ */
+const DEFAULTVALUE_ONLY_KEYS = [
+  'accessibility.checkingAuthentication',
+  'errors.accessDenied',
+] as const;
 
 function getPath(obj: unknown, path: string): unknown {
   return path.split('.').reduce<unknown>((acc, part) => {
@@ -61,6 +74,40 @@ function isGuarded(src: string, key: string): boolean {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const call = new RegExp(`\\bt\\(\\s*['"]${escaped}['"][\\s\\S]*?\\)`, 'm').exec(src);
   return call != null && /defaultValue\s*:/.test(call[0]);
+}
+
+/** Extract the `defaultValue` string literal from a key's `t('key', { defaultValue: '...' })` call. */
+function defaultValueOf(src: string, key: string): string | undefined {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const call = new RegExp(`\\bt\\(\\s*['"]${escaped}['"][\\s\\S]*?\\)`, 'm').exec(src);
+  if (call == null) return undefined;
+  const dv = /defaultValue\s*:\s*(['"])([\s\S]*?)\1/.exec(call[0]);
+  return dv?.[2];
+}
+
+/**
+ * A standalone i18next instance mirroring `src/i18n/index.ts` (six bundles,
+ * `fallbackLng: 'en'`), so the tests exercise the SAME resolution + fallback
+ * path the component sees at runtime rather than only reading the raw JSON.
+ * `createInstance` keeps it isolated from the app-global i18n singleton.
+ */
+function makeI18n(): I18nInstance {
+  const instance = i18next.createInstance();
+  instance.init({
+    resources: {
+      en: { translation: en },
+      sk: { translation: sk },
+      cs: { translation: cs },
+      de: { translation: de },
+      pl: { translation: pl },
+      hu: { translation: hu },
+    },
+    lng: 'en',
+    fallbackLng: 'en',
+    supportedLngs: ['en', 'sk', 'cs', 'de', 'pl', 'hu'],
+    interpolation: { escapeValue: false },
+  });
+  return instance;
 }
 
 describe('ProtectedRoute i18n', () => {
@@ -106,6 +153,129 @@ describe('ProtectedRoute i18n', () => {
       expect(present, `${locale}.json ProtectedRoute-key set drifted from the reference`).toEqual([
         ...BUNDLE_KEYS,
       ]);
+    }
+  });
+});
+
+/**
+ * Key classification integrity.
+ *
+ * The two lists above (`BUNDLE_KEYS`, `DEFAULTVALUE_ONLY_KEYS`) encode an
+ * assumption about which of ProtectedRoute's four `t()` calls are bundle-backed
+ * vs guard-only. The static suite above trusts that split; these tests make it
+ * self-verifying against the source and the bundles, so a fifth `t()` call — or
+ * a stray add of a guard-only key into one locale — can't slip through
+ * unnoticed.
+ */
+describe('ProtectedRoute i18n — key classification', () => {
+  it('classifies every t() call as bundle-backed or defaultValue-only (no unclassified key)', () => {
+    const keys = new Set(translationKeys(PROTECTED_ROUTE_SRC));
+    const classified = new Set<string>([...BUNDLE_KEYS, ...DEFAULTVALUE_ONLY_KEYS]);
+    const unclassified = [...keys].filter((k) => !classified.has(k));
+    expect(
+      unclassified,
+      `ProtectedRoute t() keys not covered by BUNDLE_KEYS/DEFAULTVALUE_ONLY_KEYS: ${unclassified.join(', ')}`
+    ).toEqual([]);
+    // ...and every classified key is actually used by the component (lists don't rot).
+    const unused = [...classified].filter((k) => !keys.has(k));
+    expect(
+      unused,
+      `classified keys no longer referenced in ProtectedRoute.tsx: ${unused.join(', ')}`
+    ).toEqual([]);
+  });
+
+  for (const [locale, bundle] of Object.entries(BUNDLES)) {
+    for (const key of DEFAULTVALUE_ONLY_KEYS) {
+      it(`${locale}.json does not carry the defaultValue-only key ${key}`, () => {
+        expect(
+          getPath(bundle, key),
+          `${key} unexpectedly present in ${locale}.json — add it to ALL six locales (and BUNDLE_KEYS) or drop it, never partially`
+        ).toBeUndefined();
+      });
+    }
+  }
+});
+
+/**
+ * defaultValue ↔ English-bundle parity.
+ *
+ * For a bundle-backed key the component renders the localized bundle string on
+ * the happy path and the `defaultValue` only if the key is ever dropped. If the
+ * two diverge, an English user sees different copy depending on whether the key
+ * still resolves — a silent inconsistency. Locking the guard's English text to
+ * `en.json` keeps the degraded path indistinguishable from the resolved path
+ * for English readers.
+ */
+describe('ProtectedRoute i18n — defaultValue guards are meaningful English', () => {
+  for (const key of translationKeys(PROTECTED_ROUTE_SRC)) {
+    it(`${key} guard is a non-empty readable string, not a dotted key`, () => {
+      const dv = defaultValueOf(PROTECTED_ROUTE_SRC, key);
+      expect(dv, `${key} has no extractable defaultValue literal`).toBeTypeOf('string');
+      expect((dv as string).trim().length).toBeGreaterThan(0);
+      // A defaultValue equal to the key itself would defeat the guard.
+      expect(dv).not.toBe(key);
+    });
+  }
+
+  for (const key of BUNDLE_KEYS) {
+    it(`${key} guard matches en.json (degraded English == resolved English)`, () => {
+      expect(defaultValueOf(PROTECTED_ROUTE_SRC, key)).toBe(getPath(en, key));
+    });
+  }
+});
+
+/**
+ * Runtime resolution + fallback behavior.
+ *
+ * The static tests prove keys EXIST in JSON; these prove the component's actual
+ * `t()` calls RESOLVE the way the UI depends on — through a real i18next
+ * instance with `fallbackLng: 'en'`. This is the behavior the `defaultValue`
+ * guard exists to protect, and it was previously untested.
+ */
+describe('ProtectedRoute i18n — runtime resolution & fallback', () => {
+  let i18n: I18nInstance;
+
+  beforeAll(async () => {
+    i18n = makeI18n();
+  });
+
+  for (const locale of Object.keys(BUNDLES)) {
+    describe(`locale: ${locale}`, () => {
+      for (const key of BUNDLE_KEYS) {
+        it(`resolves ${key} to the ${locale} bundle string (not the raw key)`, async () => {
+          await i18n.changeLanguage(locale);
+          const resolved = i18n.t(key);
+          expect(resolved).toBe(getPath(BUNDLES[locale], key));
+          expect(resolved, `${key} leaked the raw key in ${locale}`).not.toBe(key);
+        });
+      }
+
+      for (const key of DEFAULTVALUE_ONLY_KEYS) {
+        it(`renders the readable guard for ${key} (never the raw key) in ${locale}`, async () => {
+          await i18n.changeLanguage(locale);
+          const dv = defaultValueOf(PROTECTED_ROUTE_SRC, key) as string;
+          // The component passes the guard, so the user sees readable English…
+          expect(i18n.t(key, { defaultValue: dv })).toBe(dv);
+          // …whereas WITHOUT the guard the same missing key leaks its dotted path.
+          // This is exactly the raw-key-leak the guard-parity test prevents.
+          expect(i18n.t(key)).toBe(key);
+        });
+      }
+    });
+  }
+
+  it('non-English locales resolve bundle keys to translated (non-English) copy', async () => {
+    // Guards against a locale silently mirroring en — the "announces English to
+    // non-English users" failure the sibling aria/offline tests were written for.
+    await i18n.changeLanguage('sk');
+    expect(i18n.t('common.loading')).not.toBe(getPath(en, 'common.loading'));
+    expect(i18n.t('errors.unauthorized')).not.toBe(getPath(en, 'errors.unauthorized'));
+  });
+
+  it('falls back to English for an unsupported language (fallbackLng)', () => {
+    // An unknown lng must not leak the raw key — it must degrade to en copy.
+    for (const key of BUNDLE_KEYS) {
+      expect(i18n.t(key, { lng: 'fr' })).toBe(getPath(en, key));
     }
   });
 });


### PR DESCRIPTION
## Task

`frontend/apps/ppt-web/src/i18n/protectedRouteI18n.test.ts` is a churn hotspot (+111 lines, a new test suite from PR #2757). Review this frontend test suite for coverage gaps around protected-route i18n (missing locale/namespace cases, untested fallback behavior, missing assertions on redirect/guard messaging per locale) and add the missing tests.

## Owner

pm-qa

## Coverage-gap analysis

The existing 16-test suite was **purely static** — it read the locale JSON bundles and regex-scanned `ProtectedRoute.tsx` source, but never ran i18next. Concrete gaps found (the component has four `t()` calls: `common.loading` + `errors.unauthorized` are bundle-backed in all six locales; `accessibility.checkingAuthentication` + `errors.accessDenied` are intentionally defaultValue-only, absent from every bundle):

1. **Untested fallback behavior** — nothing exercised the actual `t()` resolution path with `fallbackLng: 'en'`. The whole point of the `defaultValue` guards (degrade to readable English instead of leaking a raw dotted key) was never verified at runtime.
2. **Per-locale guard messaging** — only 2 of the 4 keys had per-locale assertions; the access-denied path's `errors.accessDenied` / `accessibility.checkingAuthentication` had no behavioral coverage.
3. **No English-consistency check** — nothing tied the component's `defaultValue` literals to `en.json`, so the degraded-English text could silently diverge from the resolved-English text.
4. **Non-self-verifying key lists** — the `BUNDLE_KEYS` split was a hardcoded assumption a fifth `t()` call could silently escape.

## What was added (16 → 61 tests, +45)

- **Runtime resolution & fallback** — a real isolated `i18next` instance (mirroring `src/i18n/index.ts`): bundle keys resolve to per-locale copy; defaultValue-only keys degrade to readable English and *never* the raw key (and the same key WITHOUT the guard is shown to leak its dotted path — the exact hazard the guard-parity test prevents); non-English locales don't mirror `en`; an unsupported `lng` falls back to `en`.
- **defaultValue ↔ `en.json` parity** — the guard's English text must equal the bundle value, so the degraded path is indistinguishable from the resolved path for English readers. (Verified fail-on-regression: diverging the guard makes this test red.)
- **Key-classification integrity** — every `t()` key is bundle-backed or guard-only (no unclassified/unused key), and defaultValue-only keys stay absent from all six bundles (inverse-parity guard, cf. `deadNamespaceI18n.test.ts`).

## Verification

```
VERIFY-PLAN base=7e2e04b9893114d89979794db4586e6f1ca2ea33 files=1
  cd frontend && pnpm exec biome check apps/ppt-web/src/i18n/protectedRouteI18n.test.ts
  cd frontend && pnpm --filter "...[7e2e04b9893114d89979794db4586e6f1ca2ea33]" typecheck
  cd frontend && pnpm --filter "...[7e2e04b9893114d89979794db4586e6f1ca2ea33]" test
```

```
VERIFY OK 4333ed750508c634f39b6f05aa5a83bdc9211d57
```

Full frontend gate green on re-run: **118 files / 2252 tests passed**. (An earlier run had one flaky *unrelated* timeout in `src/routes/groups/reports.create-schedule.route.test.tsx` [gap-81-1] under heavy parallel load — it passes 5/5 in isolation, is unchanged on `dev`, and is not in this diff.)

## Scope drift

`scope-check.sh --owner pm-qa` exits 2 — the only changed file is `frontend/apps/ppt-web/src/i18n/protectedRouteI18n.test.ts`, which falls outside pm-qa's mapped owner areas. This is expected: a QA-authored frontend test suite. Single test-only file, no production code touched. Reviewer to adjudicate.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (test-only change; no security/auth/billing/data-integrity production code).

## Remote-tested

skipped

## Notes

- Test-only change (one file). No production/component code modified.
- goal-check IG1/IG2/IG8 are N/A for this dispatcher churn-hotspot task (no `.research/plans/` file, branch name pre-chosen by dispatcher, and `.research/` is intentionally untouched); IG7 (`just verify`) passed.


---
_Generated by [Claude Code](https://claude.ai/code/session_0127Exznz1NnXy9TM9TiJ4AL)_