### PR TITLE
gh-issue-2768: fail closed on unparseable workflow condition

### DIFF
--- a/backend/servers/api-server/src/services/workflow_executor.rs
+++ b/backend/servers/api-server/src/services/workflow_executor.rs
@@ -87,7 +87,14 @@ pub enum ComparisonOperator {
 }
 
 /// A single condition to evaluate.
+///
+/// `deny_unknown_fields` is deliberate: a stored condition JSON that carries
+/// keys outside this shape is treated as *unparseable* rather than being
+/// silently coerced, so [`evaluate_conditions_list`] can fail closed on it
+/// (issue #2768). Without it, serde would ignore the stray keys and accept a
+/// malformed rule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Condition {
     /// Field path to evaluate (e.g., "trigger.amount", "action_1.status")
     pub field: String,
@@ -108,7 +115,15 @@ pub enum LogicalOperator {
 }
 
 /// A group of conditions with a logical operator.
+///
+/// `deny_unknown_fields` is deliberate (issue #2768). Every field here is
+/// `#[serde(default)]`, so without this attribute serde would happily
+/// deserialize *any* JSON object into an empty `And` group — which then
+/// evaluates as vacuously satisfied, letting a corrupt or unknown stored rule
+/// wave the workflow's actions through unguarded. Denying unknown fields makes
+/// a malformed object fail to parse so it reaches the fail-closed branch.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ConditionGroup {
     /// Logical operator to combine conditions
     #[serde(default)]
@@ -461,33 +476,57 @@ impl WorkflowExecutor {
         conditions: &[serde_json::Value],
         context: &ActionContext,
     ) -> Result<bool, WorkflowError> {
-        if conditions.is_empty() {
-            return Ok(true);
-        }
-
-        for condition_json in conditions {
-            // Try to parse as a condition group
-            if let Ok(group) = serde_json::from_value::<ConditionGroup>(condition_json.clone()) {
-                if !evaluate_condition_group(&group, context)? {
-                    return Ok(false);
-                }
-            } else if let Ok(condition) =
-                serde_json::from_value::<Condition>(condition_json.clone())
-            {
-                // Try to parse as a single condition
-                if !evaluate_single_condition(&condition, context)? {
-                    return Ok(false);
-                }
-            } else {
-                tracing::warn!(
-                    condition = ?condition_json,
-                    "Could not parse condition, skipping"
-                );
-            }
-        }
-
-        Ok(true)
+        evaluate_conditions_list(conditions, context)
     }
+}
+
+/// Evaluate a workflow's stored condition list against an [`ActionContext`].
+///
+/// Semantics:
+/// - **Empty list ⇒ satisfied.** A workflow with no conditions always runs;
+///   `Ok(true)` is returned immediately.
+/// - **All conditions must hold.** The list is an implicit AND — the first
+///   condition that evaluates to `false` short-circuits to `Ok(false)`.
+/// - **Unparseable condition ⇒ FAIL CLOSED.** If a stored condition JSON
+///   deserializes as neither a [`ConditionGroup`] nor a [`Condition`], we
+///   return `Err(WorkflowError::ConditionError(..))` instead of silently
+///   skipping it. A corrupt or unknown rule must halt execution visibly:
+///   skipping it would let the workflow's actions run *unguarded*, which is
+///   exactly the guard the condition was meant to enforce (issue #2768).
+fn evaluate_conditions_list(
+    conditions: &[serde_json::Value],
+    context: &ActionContext,
+) -> Result<bool, WorkflowError> {
+    if conditions.is_empty() {
+        return Ok(true);
+    }
+
+    for condition_json in conditions {
+        // Try to parse as a condition group
+        if let Ok(group) = serde_json::from_value::<ConditionGroup>(condition_json.clone()) {
+            if !evaluate_condition_group(&group, context)? {
+                return Ok(false);
+            }
+        } else if let Ok(condition) = serde_json::from_value::<Condition>(condition_json.clone()) {
+            // Try to parse as a single condition
+            if !evaluate_single_condition(&condition, context)? {
+                return Ok(false);
+            }
+        } else {
+            // Fail closed: an unparseable stored condition must NOT be treated
+            // as satisfied. Halt execution so the corrupt rule is surfaced
+            // rather than letting the workflow's actions run unguarded.
+            tracing::error!(
+                condition = ?condition_json,
+                "Unparseable workflow condition; failing closed"
+            );
+            return Err(WorkflowError::ConditionError(format!(
+                "unparseable condition (matches neither ConditionGroup nor Condition): {condition_json}"
+            )));
+        }
+    }
+
+    Ok(true)
 }
 
 /// Evaluate a condition group.
@@ -1144,6 +1183,75 @@ mod tests {
         .unwrap();
 
         assert!(evaluate_condition_group(&group, &ctx).unwrap());
+    }
+
+    // ------------------------------------------------------------------
+    // evaluate_conditions_list: fail-closed on unparseable stored condition
+    // (issue #2768). An unknown/corrupt condition must halt execution with
+    // a ConditionError instead of being silently skipped (which would let
+    // the workflow's actions run unguarded). Empty / valid condition lists
+    // must keep their existing "satisfied" behavior.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_unparseable_condition_fails_closed() {
+        let ctx = eval_ctx(serde_json::json!({ "amount": 50, "status": "open" }));
+        // Matches neither ConditionGroup (no `operator`) nor Condition
+        // (no `field`/`operator`) — a corrupt/unknown stored rule.
+        let garbage = serde_json::json!({ "totally": "unknown", "shape": [1, 2, 3] });
+
+        let result = evaluate_conditions_list(&[garbage], &ctx);
+        assert!(
+            matches!(result, Err(WorkflowError::ConditionError(_))),
+            "unparseable condition must fail closed, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_unparseable_condition_after_valid_one_still_fails_closed() {
+        // A valid, satisfied condition followed by a garbage one must still
+        // fail closed — the corrupt rule cannot be skipped just because an
+        // earlier condition passed.
+        let ctx = eval_ctx(serde_json::json!({ "amount": 50, "status": "open" }));
+        let valid = serde_json::json!({
+            "field": "trigger.amount", "operator": "gt", "value": 10
+        });
+        let garbage = serde_json::json!(["not", "an", "object"]);
+
+        let result = evaluate_conditions_list(&[valid, garbage], &ctx);
+        assert!(
+            matches!(result, Err(WorkflowError::ConditionError(_))),
+            "unparseable condition must fail closed even after a valid one, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_empty_conditions_still_satisfied() {
+        // No conditions ⇒ the workflow always runs. Fail-closed applies only
+        // to *unparseable* conditions, never to an empty list.
+        let ctx = eval_ctx(serde_json::json!({ "amount": 50 }));
+        assert!(
+            evaluate_conditions_list(&[], &ctx).unwrap(),
+            "empty condition list must be satisfied"
+        );
+    }
+
+    #[test]
+    fn test_valid_conditions_still_evaluate() {
+        // Sanity: well-formed conditions keep evaluating normally after the
+        // fail-closed change — a satisfied single condition ⇒ true, an
+        // unsatisfied one ⇒ false.
+        let ctx = eval_ctx(serde_json::json!({ "amount": 50, "status": "open" }));
+
+        let satisfied = serde_json::json!({
+            "field": "trigger.amount", "operator": "gt", "value": 10
+        });
+        assert!(evaluate_conditions_list(&[satisfied], &ctx).unwrap());
+
+        let unsatisfied = serde_json::json!({
+            "field": "trigger.amount", "operator": "lt", "value": 10
+        });
+        assert!(!evaluate_conditions_list(&[unsatisfied], &ctx).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Task

`backend/servers/api-server/src/services/workflow_executor.rs` — `evaluate_conditions()` currently **FAILS OPEN** on an unparseable stored condition: when a stored condition JSON deserializes as neither `ConditionGroup` nor `Condition`, the `else` branch treats it as satisfied, so workflow actions run **unguarded**. Change it to **FAIL CLOSED**: an unparseable condition must return `WorkflowError::ConditionError(...)` so a corrupt/unknown rule halts execution visibly instead of being silently skipped. Add regression tests.

Closes #2768

## Root cause (deeper than the report)

The literal `else` branch was almost **never reached**. `ConditionGroup` has every field `#[serde(default)]` and — by serde default — silently ignores unknown keys, so **any** JSON object deserialized into an empty `And` group, which `evaluate_conjunction` treats as *vacuously true*. A corrupt/unknown rule therefore waved the workflow's actions through as "satisfied" without ever hitting the warn-and-skip `else`.

## Fix

- Add `#[serde(deny_unknown_fields)]` to `Condition` **and** `ConditionGroup`, so a malformed/unknown object no longer coerces into an empty group and instead fails to deserialize.
- The parse-failure branch now returns `Err(WorkflowError::ConditionError(..))` (was: `tracing::warn!` + skip) — fail closed.
- **Empty condition lists still return `Ok(true)`** (unchanged). Only *unparseable* conditions fail closed.
- Extracted the loop into a free fn `evaluate_conditions_list()` so the behavior is unit-testable without a DB-backed `WorkflowExecutor`. The public `evaluate_conditions(&self, ...)` method delegates to it (signature unchanged).

### Caller audit (why the prior 3 attempts broke `test-shard`)

- The **only** production caller is `handle_event()`, which already propagates via `?` — the new `Err` surfaces correctly, and empty/valid conditions are unaffected.
- Audited every workflow fixture/seed/integration test: **no** test or seed stores a non-empty workflow condition — all use `'[]'::jsonb` (empty) or `conditions: Some(vec[])`. So `deny_unknown_fields` + fail-closed cannot flip any existing DB-backed test from `Ok(true)` to `Err`.

## Owner

pm-tech-lead (implemented by the rust-backend specialist)

## Verification

```
VERIFY-PLAN base=c9dcb0bc45a155d3027fb2dc4c72536b0296e00a files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` — **OK** (exit 0)
- `cargo clippy -p api-server --all-targets -- -D warnings` — **OK** (exit 0)
- `cargo test -p api-server --lib workflow_executor` — **OK**, 20/20 pass, including the 4 new regressions:
  - `test_unparseable_condition_fails_closed`
  - `test_unparseable_condition_after_valid_one_still_fails_closed`
  - `test_empty_conditions_still_satisfied`
  - `test_valid_conditions_still_evaluate`
- `cargo test -p api-server` (full crate) — 580 pass; the only 12 failures are **environmental in this sandbox, not from this change**: 11× `DATABASE_URL must be set` (`#[sqlx::test]` needing live Postgres, none in `workflow_executor`) and 1× DNS-rebinding network test. These are unreproducible in CI where Postgres is present — which is why this PR is a **draft**: CI's `backend.yml` `test-shard` (with a DB) is the authoritative full-suite gate.

> Sandbox note: the `utoipa-swagger-ui` build script's GitHub download is egress-blocked here, so the build was pointed at a `file:` URL repackaged from the `swagger-ui-dist@5.17.14` npm package (npm registry is allowed). No source change; affects local build only.

## CI parity (Band C — hot-path)

This is a data-integrity/guard fix, so Band C applies. `act`/`gh workflow` replication isn't runnable in this cloud sandbox; the draft PR triggers the real `backend.yml` (`fmt` + `clippy` + `test-shard` with Postgres) as the authoritative parity run.

## Scope drift

`scope-check.sh --owner pm-tech-lead` exited 2 because `pm-tech-lead` maps only to `docs/**`, `.research/**`, `_bmad-output/**` in `owner-areas.json` — a backend code change is outside that. The drift is expected and justified: this task is a backend code fix routed to the rust-backend specialist under a tech-lead owner. Only one file changed, squarely the target of the task:
- `backend/servers/api-server/src/services/workflow_executor.rs`

## Code-reuse review

`reuse-grep.sh --specialist rust-backend` — clean (no warnings). Reuses the existing `WorkflowError::ConditionError` variant; no new helpers introduced.

## Remote-tested

skipped (ppt-bridge MCP not connected this session)

## Notes

- Supersedes the quarantined PR #2684 (branch `auto-impl/code-review-api-core-workflow-cond-parse-dd416f1f`), which reached fmt/clippy/check green but failed `test-shard`. This PR's caller/fixture audit above is the specific mitigation for that failure mode.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DBbzPFkRS9K2e8fSCj9UJB)_