### PR TITLE
84-1-s3-presigned-urls: forward building association on direct-to-S3 document upload (#2366)

### DIFF
--- a/frontend/packages/api-client/src/documents/api.test.ts
+++ b/frontend/packages/api-client/src/documents/api.test.ts
@@ -156,13 +156,13 @@ describe('documents api client', () => {
     vi.unstubAllGlobals();
   });
 
-  it('uploadDocumentDirect forwards folder_id but NOT building_id (#2366)', async () => {
-    // Guards the deliberate omission documented in `uploadDocumentDirect`:
-    // the backend registration contract has no `building_id` (no column, no
-    // struct field, no `deny_unknown_fields`), so forwarding it would be a
-    // silent no-op — a false-green. `folder_id` DOES carry building scope and
-    // must survive. When #2366's backend support lands, this test should be
-    // updated deliberately alongside the forwarding change.
+  it('uploadDocumentDirect forwards folder_id and building scope via access_scope (#2366)', async () => {
+    // The shipped registration contract (`POST /api/v1/documents`) has no
+    // `building_id` field — building association is expressed as
+    // `access_scope='building'` + `access_target_ids=[buildingId]` (the JSONB
+    // array the RLS gate and building list/search filter read). gap-84-1
+    // originally dropped the association when it switched to the direct path;
+    // #2366 restores it the shipped way. `folder_id` must also survive.
     const listeners: Record<string, () => void> = {};
     const xhrMock = {
       upload: { addEventListener: vi.fn() },
@@ -209,7 +209,65 @@ describe('documents api client', () => {
       (vi.mocked(fetch).mock.calls[1][1] as RequestInit).body as string
     );
     expect(registerBody.folder_id).toBe('folder-3');
+    // Building association is carried by the shipped access-scope mechanism,
+    // NOT a raw `building_id` field (which the server would ignore).
     expect(registerBody).not.toHaveProperty('building_id');
+    expect(registerBody.access_scope).toBe('building');
+    expect(registerBody.access_target_ids).toEqual(['building-7']);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('uploadDocumentDirect omits access_scope when no building is supplied (#2366)', async () => {
+    // Without a building context the client must NOT set an access scope — the
+    // server then applies its default (organization) scope. Setting
+    // `access_scope='building'` unconditionally would 400 (missing
+    // access_target_ids) and would wrongly narrow org-wide uploads.
+    const listeners: Record<string, () => void> = {};
+    const xhrMock = {
+      upload: { addEventListener: vi.fn() },
+      addEventListener: (evt: string, cb: () => void) => {
+        listeners[evt] = cb;
+      },
+      open: vi.fn(),
+      setRequestHeader: vi.fn(),
+      send: vi.fn(() => {
+        queueMicrotask(() => {
+          xhrMock.status = 200;
+          listeners.load?.();
+        });
+      }),
+      status: 0,
+    };
+    vi.stubGlobal('XMLHttpRequest', function XMLHttpRequestMock() {
+      return xhrMock;
+    });
+
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        mockOkResponse({
+          url: 'https://s3.example/bucket/key?sig=abc',
+          file_key: 'org/2026/07/uuid_report.pdf',
+          content_type: 'application/pdf',
+          method: 'PUT',
+          expires_at: '2026-07-15T00:05:00Z',
+        })
+      )
+      .mockResolvedValueOnce(mockOkResponse({ id: 'doc-1', message: 'created' }));
+
+    const file = new File(['hello'], 'report.pdf', { type: 'application/pdf' });
+    await uploadDocumentDirect({
+      file,
+      title: 'Report',
+      category: 'report',
+      organizationId: 'org-1',
+    });
+
+    const registerBody = JSON.parse(
+      (vi.mocked(fetch).mock.calls[1][1] as RequestInit).body as string
+    );
+    expect(registerBody).not.toHaveProperty('access_scope');
+    expect(registerBody).not.toHaveProperty('access_target_ids');
 
     vi.unstubAllGlobals();
   });

--- a/frontend/packages/api-client/src/documents/api.ts
+++ b/frontend/packages/api-client/src/documents/api.ts
@@ -420,19 +420,20 @@ export async function uploadDocumentDirect(
     params.onProgress
   );
 
-  // NOTE (#2366): `params.buildingId` is deliberately NOT forwarded here.
-  // There is no `building_id` on the registration contract — the backend
-  // `documents` table has no such column, `CreateDocumentRequest` (Rust) has no
-  // such field, and it lacks `#[serde(deny_unknown_fields)]`, so a forwarded
-  // `building_id` would be *silently* dropped server-side (a false-green: the
-  // client would compile and pass CI while persisting nothing). The legacy
-  // multipart `uploadDocument` path drops it the same way (drained + ignored in
-  // the handler). Building association today is carried by `folder_id`
-  // (folders are building-scoped) or by `access_scope='building'` +
-  // `access_target_ids`. Adding a real `building_id` needs a backend
-  // migration + struct + repo change first — tracked in #2366. Do not add
-  // `building_id` here until that lands, or association loss just moves one
-  // layer deeper.
+  // Building association (#2366): the shipped registration contract
+  // (`POST /api/v1/documents`, Rust `CreateDocumentRequest`) has NO `building_id`
+  // column or field — building scope is expressed on the shipped API via
+  // `access_scope='building'` + `access_target_ids=[buildingId]` (the JSONB
+  // array the RLS gate and the building list/search filter both read). gap-84-1
+  // switched `DocumentUpload` from the multipart proxy to this direct path and
+  // dropped the association entirely; a raw `building_id` field never worked
+  // either (the legacy multipart handler drained + ignored it, and the JSON
+  // registration route has no such field). Forward it the shipped way so
+  // building-scoped uploads keep their association. Only set the scope when a
+  // building context was supplied — otherwise leave `access_scope` unset so the
+  // server applies its default (organization) scope. `access_target_ids` is
+  // required by the server whenever `access_scope='building'`, and we always
+  // provide it in the same branch.
   const registration: CreateDocumentRequest = {
     title: params.title,
     description: params.description,
@@ -442,6 +443,9 @@ export async function uploadDocumentDirect(
     file_name: params.file.name,
     mime_type: presigned.content_type,
     size_bytes: params.file.size,
+    ...(params.buildingId
+      ? { access_scope: 'building' as const, access_target_ids: [params.buildingId] }
+      : {}),
   };
 
   // ORPHANED-OBJECT CLEANUP (#2534, #2564): by this point step 2 has already PUT


### PR DESCRIPTION
## Task
Wire direct-to-S3 upload in ppt-web via POST /api/v1/documents/upload-url (api-client binding + UploadDocument integration). Backend SigV4 presigner landed in #2309; scope strictly to the shipped API. Include the building_id association so building-scoped documents keep it (see #2366).

## Owner
pm-frontend (specialist: react-web)

## What this changes (and what was already shipped)
The api-client binding (`createUploadUrl` / `uploadFileToPresignedUrl` / `uploadDocumentDirect` / `deleteUploadedFile` + `useUploadDocumentDirect`) and the `DocumentUpload` integration already landed on `dev` (gap-84-1, PR #2345, against the #2309 presigner). The one shipped-API gap remaining was the **building association** flagged in #2366: `uploadDocumentDirect` accepted `buildingId` but dropped it, so building-scoped uploads were registered org-scoped and disappeared from building listing/filtering.

Fix (api-client only, `uploadDocumentDirect`):
- The shipped registration contract `POST /api/v1/documents` (Rust `CreateDocumentRequest`, `core.rs:232`) has **no** `building_id` field — building scope is expressed via `access_scope='building'` + `access_target_ids=[buildingId]` (the JSONB array the RLS gate and the building list/search filter both read). Verified: the legacy multipart handler explicitly drains + ignores a raw `building_id` field (`core.rs:2019-2023`), so raw forwarding never worked.
- When a `buildingId` is supplied, forward it the shipped way (`access_scope='building'` + `access_target_ids=[buildingId]`). When absent, leave `access_scope` unset so the server applies its default (organization) scope — avoids a spurious 400 (access_target_ids required) and avoids wrongly narrowing org-wide uploads.
- The `DocumentUpload` component already forwards `buildingId` into the mutation params; no component change needed.

Strictly within the shipped API — no new endpoint, type field, migration, or backend change.

## Verification
```
VERIFY-PLAN base=456d45719a730e3dbaf083620b31344dfd9c2715 files=2
  cd frontend && pnpm exec biome check packages/api-client/src/documents/api.test.ts packages/api-client/src/documents/api.ts
  cd frontend && pnpm --filter "...[456d45719a730e3dbaf083620b31344dfd9c2715]" typecheck
  cd frontend && pnpm --filter "...[456d45719a730e3dbaf083620b31344dfd9c2715]" test
```
VERIFY OK 26db4db14e548db772bfaf5ca6a50b46939de70f

(api-client documents tests: 9 passed; ppt-web: 2252 passed; typecheck clean across dependents.)

## Scope drift
none — `scope-check.sh --owner pm-frontend` exit 0. Diff touches only `frontend/packages/api-client/src/documents/{api.ts,api.test.ts}`.

## Code-reuse review
none — `reuse-grep.sh --specialist react-web` exit 0.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no auth/billing/data-integrity/security surface change; frontend api-client contract only).

## Remote-tested
skipped (no ppt-bridge MCP in session).

## Notes
- IG3 satisfied via a `test:` + `fix:` commit pair (regression test asserts building scope is forwarded and that org-scoped uploads leave `access_scope` unset; fails on `dev`).
- goal-check IG1/IG2/IG8 are N/A for this dispatcher action-list task (no `.research/plans/<slug>.md`, `auto-impl/*` branch, no archive move).
- Closes the frontend contract gap in #2366. The issue's literal suggestion (add `building_id?` to `CreateDocumentRequest`) was intentionally NOT followed because the shipped backend has no such field — that path would be a silent no-op; the access-scope mechanism is the shipped, verified way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UogCtT8DdZDRpq1nU7TrDs

---
_Generated by [Claude Code](https://claude.ai/code/session_01UogCtT8DdZDRpq1nU7TrDs)_