### PR TITLE
churn-hotspot-voice-oauth-refresh-auth-tests: pin platform-admin bypass arm of /oauth/refresh authz

### DIFF
--- a/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
+++ b/backend/servers/api-server/tests/suites/voice_oauth_refresh_auth_tests.rs
@@ -13,6 +13,10 @@
 //! - no / invalid bearer token -> 401 (before any DB work)
 //! - authenticated caller who does NOT own device -> 403
 //! - authenticated owner -> 200 + `access_token_hash` rotates on the row
+//! - authenticated **platform admin** who does NOT own the device -> 200 +
+//!   rotation (the `is_platform_admin()` arm of `auth.user_id ==
+//!   device.user_id || auth.is_platform_admin()` — the only authorization path
+//!   that lets a non-owner through, so it is pinned here alongside the 403 arm)
 //!
 //! TestApp wiring caveat (mirrors `voice_oauth_exchange_auth_tests`): `AuthUser`
 //! reads its claims straight from the JWT, so we mint tokens directly. The
@@ -54,7 +58,17 @@ struct AuthClaims {
     name: String,
 }
 
-fn mint_access_token(secret: &str, user_id: Uuid, tenant_id: Option<Uuid>) -> String {
+/// Mint an access token carrying an explicit `role` claim. `AuthUser` reads the
+/// role straight from the JWT (no DB membership lookup), and
+/// `is_platform_admin()` is driven purely by that claim, so a `"platform_admin"`
+/// / `"super_admin"` token is sufficient to exercise the admin-bypass arm.
+/// The wire values are the `snake_case` serde renames of `TenantRole`.
+fn mint_access_token_with_role(
+    secret: &str,
+    user_id: Uuid,
+    tenant_id: Option<Uuid>,
+    role: &str,
+) -> String {
     let now = Utc::now();
     let claims = AuthClaims {
         sub: user_id,
@@ -62,7 +76,7 @@ fn mint_access_token(secret: &str, user_id: Uuid, tenant_id: Option<Uuid>) -> St
         exp: (now + Duration::hours(1)).timestamp(),
         token_type: "access".to_string(),
         tenant_id,
-        role: Some("manager".to_string()),
+        role: Some(role.to_string()),
         email: "voice-refresh@example.test".to_string(),
         name: "Voice Refresher".to_string(),
     };
@@ -72,6 +86,12 @@ fn mint_access_token(secret: &str, user_id: Uuid, tenant_id: Option<Uuid>) -> St
         &EncodingKey::from_secret(secret.as_bytes()),
     )
     .expect("mint access token")
+}
+
+/// A non-admin (`manager`) access token — the common case for owner /
+/// non-owner callers.
+fn mint_access_token(secret: &str, user_id: Uuid, tenant_id: Option<Uuid>) -> String {
+    mint_access_token_with_role(secret, user_id, tenant_id, "manager")
 }
 
 /// Insert a linked voice device owned by `owner` with a refresh token present
@@ -266,5 +286,65 @@ async fn oauth_refresh_owner_rotates_token(pool: PgPool) {
         new_hash.as_deref(),
         Some(&initial_hash[..]),
         "owner refresh must rotate access_token_hash away from the seeded value"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: a platform admin who does NOT own the device -> 200 and rotation.
+//
+// The authorization gate is `auth.user_id == device.user_id ||
+// auth.is_platform_admin()`. Test 3 pins the 403 arm (non-owner, non-admin);
+// this pins the *other* way a caller who is not the owner is allowed through —
+// the `is_platform_admin()` bypass. Without this test a regression that dropped
+// the admin arm (locking admins out) or, worse, widened it to the wrong roles
+// would slip past the suite. The caller here is a different user than the
+// owner and carries a `platform_admin` role claim; the seeded device is owned
+// by someone else. Same simulated-refresh branch as Test 4, so
+// `INTEGRATION_ENCRYPTION_KEY` is set and we assert the hash rotates.
+// ---------------------------------------------------------------------------
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_refresh_platform_admin_non_owner_rotates_token(pool: PgPool) {
+    std::env::set_var("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+
+    let owner = Uuid::new_v4();
+    let initial_hash = b"initial-hash-admin";
+    let device_id = seed_device(&pool, owner, initial_hash).await;
+
+    let config = TestConfig::default();
+    let secret = config.jwt_secret.clone();
+    let app = TestApp::with_config(pool.clone(), config).await;
+
+    // A DIFFERENT user who is a platform admin (not the device owner).
+    let admin = Uuid::new_v4();
+    assert_ne!(admin, owner, "admin must not coincidentally be the owner");
+    let token = mint_access_token_with_role(&secret, admin, Some(Uuid::new_v4()), "platform_admin");
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(REFRESH_URI)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(refresh_body(device_id).to_string()))
+        .unwrap();
+
+    let resp = app.execute(req).await;
+
+    assert_eq!(
+        resp.status,
+        StatusCode::OK,
+        "platform-admin non-owner refresh must be 200, got {}: {}",
+        resp.status,
+        resp.text()
+    );
+
+    let new_hash = read_token_hash(&pool, device_id).await;
+    assert!(
+        new_hash.is_some(),
+        "platform-admin refresh must persist a new access_token_hash"
+    );
+    assert_ne!(
+        new_hash.as_deref(),
+        Some(&initial_hash[..]),
+        "platform-admin refresh must rotate access_token_hash away from the seeded value"
     );
 }


### PR DESCRIPTION
## Task
voice_oauth_refresh_auth_tests.rs — new 270-line suite pins /oauth/refresh device-owner authz contract (monitor). This is a churn-hotspot monitor item: inspect backend/ for the voice /oauth/refresh device-owner authorization tests and the code path they cover. If there is a concrete, in-scope hardening or test-coverage gap on that authz contract, implement it with a focused test; if the contract is already fully covered and nothing concrete remains to do, return status=blocked note=nothing-actionable rather than inventing speculative changes or an empty PR.

## Owner
pm-qa

## What the monitor found (concrete, in-scope gap)
The authorization gate in `oauth_token_refresh` (`backend/servers/api-server/src/routes/voice_webhooks.rs:651`) is:

```rust
if auth.user_id != device.user_id && !auth.is_platform_admin() {
    return Err(403);
}
```

The existing suite pinned three arms — unauthenticated → 401, invalid bearer → 401, non-owner-non-admin → 403, owner → 200+rotation — but left the **platform-admin bypass** completely untested. That `is_platform_admin()` arm is the *only other* way a caller who is not the device owner is allowed through. A regression that dropped it (locking admins out) or, worse, widened it to the wrong roles would slip past the suite entirely. This is a genuine coverage gap on the device-owner authz contract, so it is in scope.

## Change
Adds **Test 5** `oauth_refresh_platform_admin_non_owner_rotates_token`: a caller who is a `platform_admin` but does **not** own the seeded device gets `200` and the stored `access_token_hash` rotates. Factors a small role-parameterized token minter (`mint_access_token_with_role`) so the existing manager-role helper is reused rather than duplicated. Test-only; no production code touched.

The test is a meaningful regression guard: if the `&& !auth.is_platform_admin()` sub-condition were dropped (so any non-owner is rejected), this admin caller would receive 403 and the test would fail.

## Verification
```
VERIFY-PLAN base=6ec2dcb263c0b2b0171f3aae45157ebb300e15f5 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

Results in this environment:
- `cargo fmt --all -- --check` — **PASS**
- `cargo clippy -p api-server --all-targets -- -D warnings` — **PASS** (all test targets compile clean)
- Targeted suite `cargo test -p api-server --test suite_8 voice_oauth_refresh_auth_tests` — **PASS, 5/5** (incl. the new Test 5)
- Full `cargo test -p api-server` — **599 passed, 1 failed**

The single failure is `services::actions::api_call::tests::execute_rejects_dns_rebinding_to_private_ip_at_connect`, a `--lib` unit test in an **unrelated, unchanged module** (`src/services/actions/api_call.rs`). It is a DNS-rebinding / SSRF guard test that is sensitive to the sandbox's DNS-resolver re-resolution behavior. This diff adds only an integration test file under `tests/`; the `--lib` binary is compiled purely from `src/` and is byte-identical to base `dev`, so this failure is pre-existing and not attributable to this change. Expected to pass on CI's runner. Kept as a **draft** for that reason — please confirm the CI `backend.yml` run is green (aside from any pre-existing DNS-rebinding flake) before marking ready.

Environment note: the backend build-dep `utoipa-swagger-ui` downloads the Swagger UI zip from GitHub, which this session's egress policy 403-blocks; verification used a local `file://` `SWAGGER_UI_DOWNLOAD_URL` stub (static assets only — no effect on any compiled Rust). CI is unaffected.

## CI parity (Band C — hot-path only)
skipped: test-only change (no production security/auth/billing/data-integrity code modified). The endpoint under test is auth-sensitive, but this PR adds coverage rather than changing behavior.

## Remote-tested
skipped

## Notes
- `scope-check.sh --owner pm-qa` → exit 0 (no scope drift).
- `reuse-grep.sh --specialist rust-backend` → no warnings.
- IG3 (failing-on-main regression test) intentionally not applicable: this is a pure test-coverage addition for already-correct code (no `fix:` paired), which is on IG3's excluded list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsxSqnFoBpm4aQpzAFHFLB)_