### PR TITLE
code-review-mobile-rn-nfc-accesslog-parse-unguarded: guard NFC access-log JSON.parse

### DIFF
--- a/frontend/apps/mobile/src/nfc/NFCCredentialManager.test.ts
+++ b/frontend/apps/mobile/src/nfc/NFCCredentialManager.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for NFCCredentialManager access-log parsing.
+ *
+ * Regression guard: getAccessLog() runs an unguarded JSON.parse on the stored
+ * blob. Because logAccessAttempt() reads the log AFTER access has already been
+ * granted at the door, a corrupted blob would throw a SyntaxError and reject
+ * the tap flow post-grant. The parse must be guarded: a corrupted blob is
+ * treated as an empty/unavailable log rather than throwing.
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { NFCCredentialManager } from './NFCCredentialManager';
+
+const getItem = AsyncStorage.getItem as jest.Mock;
+const setItem = AsyncStorage.setItem as jest.Mock;
+
+const ACCESS_LOG_KEY = '@ppt/access_log';
+
+describe('NFCCredentialManager.getAccessLog', () => {
+  let manager: NFCCredentialManager;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    manager = new NFCCredentialManager('http://localhost:8080');
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns an empty array when nothing is stored', async () => {
+    getItem.mockResolvedValueOnce(null);
+    await expect(manager.getAccessLog()).resolves.toEqual([]);
+  });
+
+  it('parses a valid stored log', async () => {
+    const entries = [{ id: 'log-1', credentialId: 'c1', accessPointId: 'ap1', result: 'granted' }];
+    getItem.mockResolvedValueOnce(JSON.stringify(entries));
+    await expect(manager.getAccessLog()).resolves.toEqual(entries);
+  });
+
+  it('treats a corrupted blob as an empty log instead of throwing', async () => {
+    getItem.mockResolvedValueOnce('{not valid json');
+    // Must resolve (not reject) so a corrupted blob cannot break callers.
+    await expect(manager.getAccessLog()).resolves.toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('access log corrupted'),
+      expect.anything()
+    );
+  });
+
+  it('does not reject logAccessAttempt when the stored log is corrupted (post-grant safety)', async () => {
+    // A corrupted blob is present when we go to record a just-granted access.
+    getItem.mockResolvedValue('}}garbage[[');
+
+    await expect(
+      manager.logAccessAttempt('cred-1', 'ap-1', 'Front Door', 'granted')
+    ).resolves.toBeUndefined();
+
+    // The attempt is still persisted — the corrupted prior log is discarded and
+    // replaced by a fresh single-entry array.
+    expect(setItem).toHaveBeenCalledWith(ACCESS_LOG_KEY, expect.any(String));
+    const [, written] = setItem.mock.calls[setItem.mock.calls.length - 1];
+    const parsed = JSON.parse(written as string);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      accessPointId: 'ap-1',
+      accessPointName: 'Front Door',
+      result: 'granted',
+    });
+  });
+});

--- a/frontend/apps/mobile/src/nfc/NFCCredentialManager.ts
+++ b/frontend/apps/mobile/src/nfc/NFCCredentialManager.ts
@@ -158,8 +158,21 @@ export class NFCCredentialManager {
    * Get access log.
    */
   async getAccessLog(): Promise<AccessLogEntry[]> {
+    // The stored blob may be corrupted (partial writes, manual app-data
+    // restore, OS-level storage wipe). Never let a parse failure throw:
+    // logAccessAttempt() calls this AFTER access has already been granted at
+    // the door, so a corrupted blob must not reject the tap flow. Fall back to
+    // an empty log rather than propagating the SyntaxError.
     const stored = await AsyncStorage.getItem(ACCESS_LOG_KEY);
-    return stored ? JSON.parse(stored) : [];
+    if (!stored) {
+      return [];
+    }
+    try {
+      return JSON.parse(stored);
+    } catch (err) {
+      console.warn('[nfc] Stored access log corrupted; treating as empty.', err);
+      return [];
+    }
   }
 
   /**


### PR DESCRIPTION
## Task
React Native mobile app: NFC getAccessLog JSON.parse is unguarded, so a corrupted log blob throws and rejects handleTap AFTER access was already granted. Wrap the JSON.parse in a try/catch (or a safe-parse helper): on parse failure, log and treat the access log as empty/unavailable rather than throwing, so a corrupted stored blob cannot break the tap flow after access is granted. Add a unit test covering the corrupted-blob path (jest-expo).

## Owner
pm-frontend/mobile (React Native app — `frontend/apps/mobile`)

## What changed
- `frontend/apps/mobile/src/nfc/NFCCredentialManager.ts` — `getAccessLog()` now wraps the stored-blob `JSON.parse` in try/catch, matching the existing corrupted-credential parse pattern (`loadStoredCredentials`). On failure it `console.warn`s and returns `[]` instead of throwing. Since `logAccessAttempt()` reads the log *after* access is granted at the door, this ensures a corrupted stored blob can no longer reject the tap flow post-grant.
- `frontend/apps/mobile/src/nfc/NFCCredentialManager.test.ts` — new jest-expo suite covering: empty/absent log, valid parse, corrupted-blob → empty (no throw), and the post-grant safety path where `logAccessAttempt` still resolves and persists a fresh single-entry log despite a corrupted prior blob.

## Verification
```
VERIFY-PLAN base=54d7dce5fe37c8207aeaa6b026fb4b74e1872058 files=2
  cd frontend && pnpm exec biome check apps/mobile/src/nfc/NFCCredentialManager.test.ts apps/mobile/src/nfc/NFCCredentialManager.ts
  cd frontend && pnpm --filter "...[54d7dce5fe37c8207aeaa6b026fb4b74e1872058]" typecheck
  cd frontend && pnpm --filter "...[54d7dce5fe37c8207aeaa6b026fb4b74e1872058]" test
```
VERIFY OK 0a35744a10b44feb4a34e3b2a99b3fd43a63b0a3

(biome check + full frontend typecheck + jest-expo: 53 suites / 652 tests pass, including the new `NFCCredentialManager.test.ts`.)

## Scope drift
None. Diff is exactly the two `frontend/apps/mobile/**` files — inside `pm-mobile` owner area (`scope-check.sh --owner pm-mobile --base origin/dev` → exit 0).

## Code-reuse review
None. `reuse-grep.sh` clean; the fix reuses the file's existing `try/catch` + `console.warn('[nfc] … corrupted …')` pattern rather than adding a new helper.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (defensive parse guard on local log storage; no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
- Behaviour deliberately mirrors `loadStoredCredentials`: on parse failure, log-and-continue with an empty fallback. For the access log the corrupted blob is not eagerly deleted — the very next `logAccessAttempt` overwrites the key with a fresh, valid array, so the bad blob self-heals on the next write.
- Goal-check (IG1–IG8) was skipped as non-applicable: it targets the plan-driven `ppt-research-flow` (expects `.research/plans/<slug>.md`, an `impl/<slug>` branch, split test:/fix: commits). This is a dispatcher `auto-impl/` code-review task with no plan file. The authoritative Step-3 verify gate is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VayJTXd9zMj1C7cgmpMdrT)_