### PR TITLE
code-review-ppt-web-ui-moderation-fabricated-context: stop fabricating moderation case context

### DIFF
--- a/frontend/apps/ppt-web/src/features/compliance/components/ModerationCaseCard.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/components/ModerationCaseCard.tsx
@@ -52,7 +52,8 @@ export type ModerationActionType =
 export interface ContentOwnerInfo {
   user_id: string;
   name: string;
-  previous_violations: number;
+  // `previous_violations` is intentionally omitted: the moderation API does not
+  // return a prior-violation count, so it must not be surfaced (or defaulted) here.
 }
 
 export interface ModerationCase {
@@ -61,7 +62,6 @@ export interface ModerationCase {
   content_id: string;
   content_preview?: string;
   content_owner: ContentOwnerInfo;
-  report_source: string;
   violation_type?: ViolationType;
   report_reason?: string;
   status: ModerationStatus;
@@ -204,8 +204,10 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
       <div className="moderation-case-content">
         <div className="moderation-content-info">
           <span className="moderation-content-type">{getContentTypeLabel(case_.content_type)}</span>
-          {case_.content_preview && (
+          {case_.content_preview ? (
             <p className="moderation-content-preview">{case_.content_preview}</p>
+          ) : (
+            <p className="moderation-content-preview unavailable">No content preview available</p>
           )}
         </div>
 
@@ -221,22 +223,6 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
         <div className="moderation-owner-info">
           <h5>Content Owner</h5>
           <span className="moderation-owner-name">{case_.content_owner.name}</span>
-          {case_.content_owner.previous_violations > 0 && (
-            <span className="moderation-previous-violations">
-              {case_.content_owner.previous_violations} previous violations
-            </span>
-          )}
-        </div>
-
-        <div className="moderation-report-info">
-          <h5>Reported By</h5>
-          <span className="moderation-report-source">
-            {case_.report_source === 'user'
-              ? 'User Report'
-              : case_.report_source === 'automated'
-                ? 'Automated Detection'
-                : case_.report_source}
-          </span>
         </div>
 
         {case_.assigned_to_name && (

--- a/frontend/apps/ppt-web/src/features/compliance/pages/ContentModerationPage.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/pages/ContentModerationPage.tsx
@@ -70,22 +70,18 @@ export const ContentModerationPage: React.FC = () => {
     content_owner: {
       user_id: c.owner_id,
       name: c.owner_name,
-      // TODO(Phase-2): Extend API to include previous_violations count
-      // Phase 1: Default value
-      previous_violations: 0,
     },
-    // TODO(Phase-2): Extend API to include report_source
-    // Phase 1: Default value
-    report_source: 'user',
     violation_type: c.violation_type as ModerationCase['violation_type'],
     status: c.status as ModerationCase['status'],
     priority: c.priority,
     assigned_to_name: c.assigned_to_name,
     appeal_filed: c.is_appeal ?? false,
     created_at: c.reported_at,
-    age_hours: c.sla_deadline
-      ? Math.max(0, (new Date().getTime() - new Date(c.reported_at).getTime()) / (1000 * 60 * 60))
-      : 0,
+    // Derived from the real `reported_at` timestamp the API returns — not fabricated.
+    age_hours: Math.max(
+      0,
+      (new Date().getTime() - new Date(c.reported_at).getTime()) / (1000 * 60 * 60)
+    ),
   }));
 
   const stats: ModerationQueueStatsData | null = statsData?.stats


### PR DESCRIPTION
## Task
ppt-web moderation page fabricates context that the moderation API never returns — misleading data. Remove the fabricated/hardcoded context and render only fields the moderation API actually provides; show an explicit empty/unavailable state where data is missing instead of inventing it.

## Owner
pm-frontend (ppt-web / React SPA)

## What was fabricated
The content-moderation dashboard (`ContentModerationPage.tsx`) mapped API `ModerationCase` records (see `packages/api-client/src/compliance/types.ts` — the API returns only `id, content_id, content_type, content_preview, violation_type, status, priority, reported_at, assigned_to_*, owner_id, owner_name, is_appeal, sla_deadline, is_overdue`) onto a richer component type by inventing values:

- `report_source: 'user'` — hardcoded, so `ModerationCaseCard` always rendered "Reported By: User Report". The API has no report-source concept.
- `content_owner.previous_violations: 0` — hardcoded default for a field the API never returns.
- `age_hours` — fell back to `0` when `sla_deadline` was absent, making old cases render as "0m ago".

## Fix (ppt-web only)
- `ModerationCase` / `ContentOwnerInfo` component types: dropped `report_source` and `previous_violations` (fields the API does not model).
- `ModerationCaseCard`: removed the fabricated "Reported By" block and the previous-violations render; added an explicit "No content preview available" state when `content_preview` is empty (a field the API does model but may be blank) instead of silently rendering nothing.
- `ContentModerationPage` transform: removed the two hardcoded defaults; `age_hours` now always derives from the real `reported_at` timestamp.

No API-client or backend changes — the API already returns everything now rendered.

## Verification
```
VERIFY-PLAN base=54d7dce5fe37c8207aeaa6b026fb4b74e1872058 files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/compliance/components/ModerationCaseCard.tsx apps/ppt-web/src/features/compliance/pages/ContentModerationPage.tsx
  cd frontend && pnpm --filter "...[54d7dce5...]" typecheck
  cd frontend && pnpm --filter "...[54d7dce5...]" test
```
```
VERIFY OK 300010d92e0921ecd710fda7adc782e49dd2ce5c
```
Biome + typecheck clean; ppt-web vitest 2252 tests passed (118 files).

## Scope drift
None — `scope-check.sh --owner pm-frontend` exit 0. Diff limited to two files under `frontend/apps/ppt-web/src/features/compliance/`.

## Code-reuse review
None — `reuse-grep.sh --specialist react-web` empty. No new helpers added (removal-only fix).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
Optional `report_reason`, `decision`, `decision_rationale`, `appeal_reason` fields remain on the component type; they are conditionally rendered only when truthy and are never populated with invented values, so they are honest (unused, not misleading). Left untouched to keep the diff minimal.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VayJTXd9zMj1C7cgmpMdrT)_