### PR TITLE
code-review-ppt-web-ui-createfault-mock-ai: stop shipping fabricated AI triage on CreateFault

### DIFF
--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -378,7 +378,8 @@
       },
       "acceptSuggestion": "Accept Suggestion",
       "modifySuggestion": "Modify",
-      "lowConfidenceNote": "The AI is less certain about this suggestion. Please review and adjust if needed."
+      "lowConfidenceNote": "The AI is less certain about this suggestion. Please review and adjust if needed.",
+      "unavailable": "AI triage suggestions are currently unavailable. Please categorize the issue manually."
     },
     "category": {
       "plumbing": "Plumbing",

--- a/frontend/apps/ppt-web/src/features/faults/components/FaultForm.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/components/FaultForm.tsx
@@ -56,6 +56,8 @@ interface FaultFormProps {
   aiSuggestion?: AiSuggestion | null;
   /** Whether AI suggestion is loading */
   aiSuggestionLoading?: boolean;
+  /** Whether AI triage is unavailable (no production endpoint) — shows an honest notice instead of a fabricated suggestion */
+  aiSuggestionUnavailable?: boolean;
   /** Callback when photos change (for triggering AI analysis) */
   onPhotosChange?: (photos: UploadedPhoto[]) => void;
 }
@@ -70,6 +72,7 @@ export function FaultForm({
   enablePhotoFirst = false,
   aiSuggestion,
   aiSuggestionLoading = false,
+  aiSuggestionUnavailable = false,
   onPhotosChange,
 }: FaultFormProps) {
   const { t } = useTranslation();
@@ -223,6 +226,17 @@ export function FaultForm({
               isAccepted={aiSuggestionAccepted}
             />
           )}
+
+          {/* Honest "unavailable" notice — shown instead of a fabricated
+              suggestion when no AI triage endpoint is wired up. */}
+          {aiSuggestionUnavailable &&
+            !aiSuggestion &&
+            !aiSuggestionLoading &&
+            photos.length > 0 && (
+              <p className="mt-3 text-sm text-gray-500" role="status">
+                {t('faults.ai.unavailable')}
+              </p>
+            )}
         </div>
       )}
 

--- a/frontend/apps/ppt-web/src/features/faults/pages/CreateFaultPage.tsx
+++ b/frontend/apps/ppt-web/src/features/faults/pages/CreateFaultPage.tsx
@@ -19,6 +19,17 @@ interface CreateFaultPageProps {
   enablePhotoFirst?: boolean;
 }
 
+/**
+ * Photo-first AI triage has no production endpoint yet: the only backend
+ * suggestion route (`POST /api/v1/faults/{id}/suggest`) analyses an
+ * already-created fault's title/description text, not the pre-creation photos
+ * this page uploads. Rather than fabricate a hardcoded suggestion for real
+ * users, the mock is gated behind an explicit dev-only opt-in flag and the UI
+ * shows a clear "unavailable" state otherwise. Never ship fake AI output.
+ */
+const MOCK_AI_TRIAGE_ENABLED =
+  import.meta.env.DEV && import.meta.env.VITE_ENABLE_MOCK_AI_TRIAGE === 'true';
+
 export function CreateFaultPage({
   buildings,
   units,
@@ -30,28 +41,40 @@ export function CreateFaultPage({
   const { t } = useTranslation();
   const [aiSuggestion, setAiSuggestion] = useState<AiSuggestion | null>(null);
   const [aiSuggestionLoading, setAiSuggestionLoading] = useState(false);
+  const [aiSuggestionUnavailable, setAiSuggestionUnavailable] = useState(false);
 
-  // Simulate AI suggestion when photos are uploaded
-  // In production, this would call the backend API
   const handlePhotosChange = useCallback((photos: UploadedPhoto[]) => {
-    if (
-      photos.length > 0 &&
-      photos.some((p) => p.status === 'pending' || p.status === 'uploaded')
-    ) {
-      setAiSuggestionLoading(true);
-      // Simulate API call delay
-      setTimeout(() => {
-        // Mock AI suggestion - in production, call useRequestAiSuggestion
-        setAiSuggestion({
-          category: 'plumbing',
-          confidence: 0.85,
-          priority: 'medium',
-        });
-        setAiSuggestionLoading(false);
-      }, 1500);
-    } else {
+    const hasPendingPhotos =
+      photos.length > 0 && photos.some((p) => p.status === 'pending' || p.status === 'uploaded');
+
+    if (!hasPendingPhotos) {
       setAiSuggestion(null);
+      setAiSuggestionLoading(false);
+      setAiSuggestionUnavailable(false);
+      return;
     }
+
+    // No production endpoint exists for pre-creation photo-based AI triage
+    // (see MOCK_AI_TRIAGE_ENABLED above). Surface an honest "unavailable"
+    // state instead of fabricating a suggestion.
+    if (!MOCK_AI_TRIAGE_ENABLED) {
+      setAiSuggestion(null);
+      setAiSuggestionLoading(false);
+      setAiSuggestionUnavailable(true);
+      return;
+    }
+
+    // Dev-only mock (explicitly opted in via VITE_ENABLE_MOCK_AI_TRIAGE).
+    setAiSuggestionUnavailable(false);
+    setAiSuggestionLoading(true);
+    setTimeout(() => {
+      setAiSuggestion({
+        category: 'plumbing',
+        confidence: 0.85,
+        priority: 'medium',
+      });
+      setAiSuggestionLoading(false);
+    }, 1500);
   }, []);
 
   return (
@@ -82,6 +105,7 @@ export function CreateFaultPage({
           enablePhotoFirst={enablePhotoFirst}
           aiSuggestion={aiSuggestion}
           aiSuggestionLoading={aiSuggestionLoading}
+          aiSuggestionUnavailable={aiSuggestionUnavailable}
           onPhotosChange={handlePhotosChange}
         />
       </div>


### PR DESCRIPTION
## Task
ppt-web CreateFault page uses hardcoded mock AI triage response instead of real API — ships fake data. Wire the CreateFault page to the real AI triage API endpoint (or, if no endpoint exists, gate the mock behind an explicit dev-only flag and surface a clear "unavailable" state instead of fabricated data). Do not ship fabricated AI output to users.

## Owner
pm-frontend (ppt-web / React SPA)

## What changed & why
The photo-first flow in `CreateFaultPage` unconditionally fabricated a hardcoded AI suggestion (`{category:'plumbing', confidence:0.85, priority:'medium'}`) via a `setTimeout`, regardless of the uploaded photos — shipping fake AI output to real users.

**No production endpoint exists for this flow.** The only backend AI suggestion route is `POST /api/v1/faults/{id}/suggest` (`backend/servers/api-server/src/routes/faults.rs`), which:
- requires an **already-created** fault ID (this page runs *before* the fault exists),
- analyzes the fault's **title/description text**, not the pre-creation photos this page uploads,
- is manager-tier gated.

So there is genuinely no pre-creation photo-based triage endpoint to wire to. Per the task's fallback path, the mock is now:
1. Gated behind an explicit dev-only opt-in: `import.meta.env.DEV && import.meta.env.VITE_ENABLE_MOCK_AI_TRIAGE === 'true'`. Production (and default dev) never fabricates.
2. Replaced with an honest **"unavailable"** notice (new `aiSuggestionUnavailable` prop on `FaultForm` + `faults.ai.unavailable` i18n key) when photos are uploaded and no real suggestion is available.

Files (all within ppt-web scope):
- `frontend/apps/ppt-web/src/features/faults/pages/CreateFaultPage.tsx`
- `frontend/apps/ppt-web/src/features/faults/components/FaultForm.tsx`
- `frontend/apps/ppt-web/messages/en.json` (fallback locale; the whole `faults.ai.*` block lives only in `en` and resolves to other locales via `fallbackLng: en`)

## Verification
```
VERIFY-PLAN base=54d7dce5fe37c8207aeaa6b026fb4b74e1872058 files=3
  cd frontend && pnpm exec biome check apps/ppt-web/messages/en.json apps/ppt-web/src/features/faults/components/FaultForm.tsx apps/ppt-web/src/features/faults/pages/CreateFaultPage.tsx
  cd frontend && pnpm --filter "...[54d7dce5...]" typecheck
  cd frontend && pnpm --filter "...[54d7dce5...]" test
```
`VERIFY OK f82ec622ae01d35ca622630cbef8cfbdd21a2fb5` — biome clean, typecheck clean, 2252 tests passed (118 files).

Scope-drift check (`scope-check.sh --owner pm-frontend --base origin/dev`): exit 0 — no drift.
Code-reuse pre-flight (`reuse-grep.sh --specialist react-web`): no warnings.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- To exercise the mock locally: set `VITE_ENABLE_MOCK_AI_TRIAGE=true` in a dev `.env` (DEV builds only). No production behavior change beyond removing the fabricated output.
- A future real endpoint for pre-creation photo triage would slot into `handlePhotosChange` in place of the dev mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VayJTXd9zMj1C7cgmpMdrT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VayJTXd9zMj1C7cgmpMdrT)_