### PR TITLE
code-review-ppt-web-core-errorhandler-i18n-gap: route ppt-web errorHandler catalogue through react-i18next

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -748,7 +748,82 @@
     "bookingNotFound": "Rezervace nebyla nalezena",
     "faultNotFound": "Závada nebyla nalezena",
     "meterNotFound": "Měřič nebyl nalezen",
-    "entityNotFound": "{{entity}} nebylo nalezeno"
+    "entityNotFound": "{{entity}} nebylo nalezeno",
+    "catalogue": {
+      "AUTHENTICATION_ERROR": {
+        "title": "Vyžaduje se přihlášení",
+        "message": "Pro pokračování se prosím přihlaste."
+      },
+      "INVALID_CREDENTIALS": {
+        "title": "Neplatné přihlašovací údaje",
+        "message": "Zadaný e-mail nebo heslo je nesprávné."
+      },
+      "SESSION_EXPIRED": {
+        "title": "Relace vypršela",
+        "message": "Vaše relace vypršela. Přihlaste se prosím znovu."
+      },
+      "UNAUTHORIZED": {
+        "title": "Přístup odepřen",
+        "message": "Nemáte oprávnění provést tuto akci."
+      },
+      "VALIDATION_ERROR": {
+        "title": "Chyba ověření",
+        "message": "Zkontrolujte prosím chyby ve formuláři."
+      },
+      "INVALID_INPUT": {
+        "title": "Neplatný vstup",
+        "message": "Poskytnuté údaje jsou neplatné."
+      },
+      "NOT_FOUND": {
+        "title": "Nenalezeno",
+        "message": "Požadovaný zdroj se nepodařilo najít."
+      },
+      "RESOURCE_NOT_FOUND": {
+        "title": "Zdroj nenalezen",
+        "message": "Položka, kterou hledáte, neexistuje nebo byla odstraněna."
+      },
+      "CONFLICT": {
+        "title": "Konflikt",
+        "message": "Tato operace je v konfliktu s existujícími údaji."
+      },
+      "DUPLICATE_ENTRY": {
+        "title": "Duplicitní záznam",
+        "message": "Položka se stejnou hodnotou již existuje."
+      },
+      "RATE_LIMITED": {
+        "title": "Příliš mnoho požadavků",
+        "message": "Odeslali jste příliš mnoho požadavků. Před dalším pokusem prosím počkejte."
+      },
+      "RATE_LIMIT_EXCEEDED": {
+        "title": "Překročen limit požadavků",
+        "message": "Zpomalte prosím a zkuste to znovu za okamžik."
+      },
+      "INTERNAL_ERROR": {
+        "title": "Chyba serveru",
+        "message": "Došlo k neočekávané chybě. Zkuste to prosím později."
+      },
+      "SERVICE_UNAVAILABLE": {
+        "title": "Služba nedostupná",
+        "message": "Služba je dočasně nedostupná. Zkuste to prosím později."
+      },
+      "TIMEOUT": {
+        "title": "Vypršel časový limit požadavku",
+        "message": "Požadavek trval příliš dlouho. Zkuste to prosím znovu."
+      },
+      "NETWORK_ERROR": {
+        "title": "Chyba sítě",
+        "message": "Nepodařilo se připojit k serveru. Zkontrolujte prosím své připojení k internetu."
+      },
+      "OFFLINE": {
+        "title": "Jste offline",
+        "message": "Zkontrolujte prosím své připojení k internetu a zkuste to znovu."
+      },
+      "default": {
+        "title": "Chyba",
+        "message": "Došlo k neočekávané chybě."
+      },
+      "rateLimitRetry": "Před dalším pokusem prosím počkejte {{seconds}} sekund."
+    }
   },
   "notifications": {
     "title": "Oznámení",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -701,7 +701,82 @@
     "bookingNotFound": "Buchung nicht gefunden",
     "faultNotFound": "Störung nicht gefunden",
     "meterNotFound": "Zähler nicht gefunden",
-    "entityNotFound": "{{entity}} nicht gefunden"
+    "entityNotFound": "{{entity}} nicht gefunden",
+    "catalogue": {
+      "AUTHENTICATION_ERROR": {
+        "title": "Anmeldung erforderlich",
+        "message": "Bitte melden Sie sich an, um fortzufahren."
+      },
+      "INVALID_CREDENTIALS": {
+        "title": "Ungültige Anmeldedaten",
+        "message": "Die eingegebene E-Mail-Adresse oder das Passwort ist falsch."
+      },
+      "SESSION_EXPIRED": {
+        "title": "Sitzung abgelaufen",
+        "message": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an."
+      },
+      "UNAUTHORIZED": {
+        "title": "Zugriff verweigert",
+        "message": "Sie haben keine Berechtigung, diese Aktion auszuführen."
+      },
+      "VALIDATION_ERROR": {
+        "title": "Validierungsfehler",
+        "message": "Bitte überprüfen Sie das Formular auf Fehler."
+      },
+      "INVALID_INPUT": {
+        "title": "Ungültige Eingabe",
+        "message": "Die bereitgestellten Daten sind ungültig."
+      },
+      "NOT_FOUND": {
+        "title": "Nicht gefunden",
+        "message": "Die angeforderte Ressource konnte nicht gefunden werden."
+      },
+      "RESOURCE_NOT_FOUND": {
+        "title": "Ressource nicht gefunden",
+        "message": "Das gesuchte Element existiert nicht oder wurde gelöscht."
+      },
+      "CONFLICT": {
+        "title": "Konflikt",
+        "message": "Dieser Vorgang steht im Konflikt mit vorhandenen Daten."
+      },
+      "DUPLICATE_ENTRY": {
+        "title": "Doppelter Eintrag",
+        "message": "Ein Element mit demselben Wert existiert bereits."
+      },
+      "RATE_LIMITED": {
+        "title": "Zu viele Anfragen",
+        "message": "Sie haben zu viele Anfragen gestellt. Bitte warten Sie, bevor Sie es erneut versuchen."
+      },
+      "RATE_LIMIT_EXCEEDED": {
+        "title": "Anfragelimit überschritten",
+        "message": "Bitte verlangsamen Sie und versuchen Sie es gleich noch einmal."
+      },
+      "INTERNAL_ERROR": {
+        "title": "Serverfehler",
+        "message": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es später erneut."
+      },
+      "SERVICE_UNAVAILABLE": {
+        "title": "Dienst nicht verfügbar",
+        "message": "Der Dienst ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut."
+      },
+      "TIMEOUT": {
+        "title": "Zeitüberschreitung der Anfrage",
+        "message": "Die Anfrage hat zu lange gedauert. Bitte versuchen Sie es erneut."
+      },
+      "NETWORK_ERROR": {
+        "title": "Netzwerkfehler",
+        "message": "Verbindung zum Server nicht möglich. Bitte überprüfen Sie Ihre Internetverbindung."
+      },
+      "OFFLINE": {
+        "title": "Sie sind offline",
+        "message": "Bitte überprüfen Sie Ihre Internetverbindung und versuchen Sie es erneut."
+      },
+      "default": {
+        "title": "Fehler",
+        "message": "Ein unerwarteter Fehler ist aufgetreten."
+      },
+      "rateLimitRetry": "Bitte warten Sie {{seconds}} Sekunden, bevor Sie es erneut versuchen."
+    }
   },
   "notifications": {
     "title": "Benachrichtigungen",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -885,7 +885,82 @@
     "bookingNotFound": "Booking not found",
     "faultNotFound": "Fault not found",
     "meterNotFound": "Meter not found",
-    "entityNotFound": "{{entity}} not found"
+    "entityNotFound": "{{entity}} not found",
+    "catalogue": {
+      "AUTHENTICATION_ERROR": {
+        "title": "Authentication Required",
+        "message": "Please log in to continue."
+      },
+      "INVALID_CREDENTIALS": {
+        "title": "Invalid Credentials",
+        "message": "The email or password you entered is incorrect."
+      },
+      "SESSION_EXPIRED": {
+        "title": "Session Expired",
+        "message": "Your session has expired. Please log in again."
+      },
+      "UNAUTHORIZED": {
+        "title": "Access Denied",
+        "message": "You do not have permission to perform this action."
+      },
+      "VALIDATION_ERROR": {
+        "title": "Validation Error",
+        "message": "Please check the form for errors."
+      },
+      "INVALID_INPUT": {
+        "title": "Invalid Input",
+        "message": "The provided data is invalid."
+      },
+      "NOT_FOUND": {
+        "title": "Not Found",
+        "message": "The requested resource could not be found."
+      },
+      "RESOURCE_NOT_FOUND": {
+        "title": "Resource Not Found",
+        "message": "The item you are looking for does not exist or has been deleted."
+      },
+      "CONFLICT": {
+        "title": "Conflict",
+        "message": "This operation conflicts with existing data."
+      },
+      "DUPLICATE_ENTRY": {
+        "title": "Duplicate Entry",
+        "message": "An item with the same value already exists."
+      },
+      "RATE_LIMITED": {
+        "title": "Too Many Requests",
+        "message": "You have made too many requests. Please wait before trying again."
+      },
+      "RATE_LIMIT_EXCEEDED": {
+        "title": "Rate Limit Exceeded",
+        "message": "Please slow down and try again in a moment."
+      },
+      "INTERNAL_ERROR": {
+        "title": "Server Error",
+        "message": "An unexpected error occurred. Please try again later."
+      },
+      "SERVICE_UNAVAILABLE": {
+        "title": "Service Unavailable",
+        "message": "The service is temporarily unavailable. Please try again later."
+      },
+      "TIMEOUT": {
+        "title": "Request Timeout",
+        "message": "The request took too long. Please try again."
+      },
+      "NETWORK_ERROR": {
+        "title": "Network Error",
+        "message": "Unable to connect to the server. Please check your internet connection."
+      },
+      "OFFLINE": {
+        "title": "You are Offline",
+        "message": "Please check your internet connection and try again."
+      },
+      "default": {
+        "title": "Error",
+        "message": "An unexpected error occurred."
+      },
+      "rateLimitRetry": "Please wait {{seconds}} seconds before trying again."
+    }
   },
   "notifications": {
     "title": "Notifications",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -701,7 +701,82 @@
     "bookingNotFound": "A foglalás nem található",
     "faultNotFound": "A hiba nem található",
     "meterNotFound": "A mérő nem található",
-    "entityNotFound": "{{entity}} nem található"
+    "entityNotFound": "{{entity}} nem található",
+    "catalogue": {
+      "AUTHENTICATION_ERROR": {
+        "title": "Bejelentkezés szükséges",
+        "message": "A folytatáshoz jelentkezzen be."
+      },
+      "INVALID_CREDENTIALS": {
+        "title": "Érvénytelen hitelesítő adatok",
+        "message": "A megadott e-mail-cím vagy jelszó helytelen."
+      },
+      "SESSION_EXPIRED": {
+        "title": "A munkamenet lejárt",
+        "message": "A munkamenete lejárt. Jelentkezzen be újra."
+      },
+      "UNAUTHORIZED": {
+        "title": "Hozzáférés megtagadva",
+        "message": "Nincs jogosultsága a művelet végrehajtásához."
+      },
+      "VALIDATION_ERROR": {
+        "title": "Érvényesítési hiba",
+        "message": "Ellenőrizze az űrlap hibáit."
+      },
+      "INVALID_INPUT": {
+        "title": "Érvénytelen bevitel",
+        "message": "A megadott adatok érvénytelenek."
+      },
+      "NOT_FOUND": {
+        "title": "Nem található",
+        "message": "A kért erőforrás nem található."
+      },
+      "RESOURCE_NOT_FOUND": {
+        "title": "Az erőforrás nem található",
+        "message": "A keresett elem nem létezik, vagy törölték."
+      },
+      "CONFLICT": {
+        "title": "Ütközés",
+        "message": "Ez a művelet ütközik a meglévő adatokkal."
+      },
+      "DUPLICATE_ENTRY": {
+        "title": "Ismétlődő bejegyzés",
+        "message": "Egy azonos értékű elem már létezik."
+      },
+      "RATE_LIMITED": {
+        "title": "Túl sok kérés",
+        "message": "Túl sok kérést küldött. Kérjük, várjon, mielőtt újra próbálkozik."
+      },
+      "RATE_LIMIT_EXCEEDED": {
+        "title": "Kéréskorlát túllépve",
+        "message": "Kérjük, lassítson, és próbálja újra egy pillanat múlva."
+      },
+      "INTERNAL_ERROR": {
+        "title": "Kiszolgálóhiba",
+        "message": "Váratlan hiba történt. Kérjük, próbálja újra később."
+      },
+      "SERVICE_UNAVAILABLE": {
+        "title": "A szolgáltatás nem érhető el",
+        "message": "A szolgáltatás átmenetileg nem érhető el. Kérjük, próbálja újra később."
+      },
+      "TIMEOUT": {
+        "title": "A kérés időtúllépése",
+        "message": "A kérés túl sokáig tartott. Kérjük, próbálja újra."
+      },
+      "NETWORK_ERROR": {
+        "title": "Hálózati hiba",
+        "message": "Nem sikerült csatlakozni a kiszolgálóhoz. Ellenőrizze az internetkapcsolatát."
+      },
+      "OFFLINE": {
+        "title": "Ön offline állapotban van",
+        "message": "Ellenőrizze az internetkapcsolatát, és próbálja újra."
+      },
+      "default": {
+        "title": "Hiba",
+        "message": "Váratlan hiba történt."
+      },
+      "rateLimitRetry": "Kérjük, várjon {{seconds}} másodpercet, mielőtt újra próbálkozik."
+    }
   },
   "notifications": {
     "title": "Értesítések",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -703,7 +703,82 @@
     "bookingNotFound": "Rezerwacja nie została znaleziona",
     "faultNotFound": "Usterka nie została znaleziona",
     "meterNotFound": "Licznik nie został znaleziony",
-    "entityNotFound": "Nie znaleziono: {{entity}}"
+    "entityNotFound": "Nie znaleziono: {{entity}}",
+    "catalogue": {
+      "AUTHENTICATION_ERROR": {
+        "title": "Wymagane logowanie",
+        "message": "Zaloguj się, aby kontynuować."
+      },
+      "INVALID_CREDENTIALS": {
+        "title": "Nieprawidłowe dane logowania",
+        "message": "Wprowadzony adres e-mail lub hasło jest nieprawidłowe."
+      },
+      "SESSION_EXPIRED": {
+        "title": "Sesja wygasła",
+        "message": "Twoja sesja wygasła. Zaloguj się ponownie."
+      },
+      "UNAUTHORIZED": {
+        "title": "Odmowa dostępu",
+        "message": "Nie masz uprawnień do wykonania tej akcji."
+      },
+      "VALIDATION_ERROR": {
+        "title": "Błąd walidacji",
+        "message": "Sprawdź formularz pod kątem błędów."
+      },
+      "INVALID_INPUT": {
+        "title": "Nieprawidłowe dane",
+        "message": "Podane dane są nieprawidłowe."
+      },
+      "NOT_FOUND": {
+        "title": "Nie znaleziono",
+        "message": "Nie można znaleźć żądanego zasobu."
+      },
+      "RESOURCE_NOT_FOUND": {
+        "title": "Nie znaleziono zasobu",
+        "message": "Element, którego szukasz, nie istnieje lub został usunięty."
+      },
+      "CONFLICT": {
+        "title": "Konflikt",
+        "message": "Ta operacja jest w konflikcie z istniejącymi danymi."
+      },
+      "DUPLICATE_ENTRY": {
+        "title": "Zduplikowany wpis",
+        "message": "Element o tej samej wartości już istnieje."
+      },
+      "RATE_LIMITED": {
+        "title": "Zbyt wiele żądań",
+        "message": "Wysłano zbyt wiele żądań. Poczekaj przed ponowną próbą."
+      },
+      "RATE_LIMIT_EXCEEDED": {
+        "title": "Przekroczono limit żądań",
+        "message": "Zwolnij i spróbuj ponownie za chwilę."
+      },
+      "INTERNAL_ERROR": {
+        "title": "Błąd serwera",
+        "message": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie później."
+      },
+      "SERVICE_UNAVAILABLE": {
+        "title": "Usługa niedostępna",
+        "message": "Usługa jest tymczasowo niedostępna. Spróbuj ponownie później."
+      },
+      "TIMEOUT": {
+        "title": "Przekroczono limit czasu żądania",
+        "message": "Żądanie trwało zbyt długo. Spróbuj ponownie."
+      },
+      "NETWORK_ERROR": {
+        "title": "Błąd sieci",
+        "message": "Nie można połączyć się z serwerem. Sprawdź swoje połączenie internetowe."
+      },
+      "OFFLINE": {
+        "title": "Jesteś offline",
+        "message": "Sprawdź swoje połączenie internetowe i spróbuj ponownie."
+      },
+      "default": {
+        "title": "Błąd",
+        "message": "Wystąpił nieoczekiwany błąd."
+      },
+      "rateLimitRetry": "Poczekaj {{seconds}} sekund przed ponowną próbą."
+    }
   },
   "notifications": {
     "title": "Powiadomienia",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -750,7 +750,82 @@
     "bookingNotFound": "Rezervácia nebola nájdená",
     "faultNotFound": "Porucha nebola nájdená",
     "meterNotFound": "Merač nebol nájdený",
-    "entityNotFound": "{{entity}} sa nenašlo"
+    "entityNotFound": "{{entity}} sa nenašlo",
+    "catalogue": {
+      "AUTHENTICATION_ERROR": {
+        "title": "Vyžaduje sa prihlásenie",
+        "message": "Pre pokračovanie sa prosím prihláste."
+      },
+      "INVALID_CREDENTIALS": {
+        "title": "Neplatné prihlasovacie údaje",
+        "message": "Zadaný e-mail alebo heslo je nesprávne."
+      },
+      "SESSION_EXPIRED": {
+        "title": "Relácia vypršala",
+        "message": "Vaša relácia vypršala. Prihláste sa prosím znova."
+      },
+      "UNAUTHORIZED": {
+        "title": "Prístup zamietnutý",
+        "message": "Nemáte oprávnenie vykonať túto akciu."
+      },
+      "VALIDATION_ERROR": {
+        "title": "Chyba overenia",
+        "message": "Skontrolujte prosím chyby vo formulári."
+      },
+      "INVALID_INPUT": {
+        "title": "Neplatný vstup",
+        "message": "Poskytnuté údaje sú neplatné."
+      },
+      "NOT_FOUND": {
+        "title": "Nenájdené",
+        "message": "Požadovaný zdroj sa nepodarilo nájsť."
+      },
+      "RESOURCE_NOT_FOUND": {
+        "title": "Zdroj nenájdený",
+        "message": "Položka, ktorú hľadáte, neexistuje alebo bola odstránená."
+      },
+      "CONFLICT": {
+        "title": "Konflikt",
+        "message": "Táto operácia je v konflikte s existujúcimi údajmi."
+      },
+      "DUPLICATE_ENTRY": {
+        "title": "Duplicitný záznam",
+        "message": "Položka s rovnakou hodnotou už existuje."
+      },
+      "RATE_LIMITED": {
+        "title": "Príliš veľa požiadaviek",
+        "message": "Odoslali ste príliš veľa požiadaviek. Pred ďalším pokusom prosím počkajte."
+      },
+      "RATE_LIMIT_EXCEEDED": {
+        "title": "Prekročený limit požiadaviek",
+        "message": "Spomaľte prosím a skúste to znova o chvíľu."
+      },
+      "INTERNAL_ERROR": {
+        "title": "Chyba servera",
+        "message": "Vyskytla sa neočakávaná chyba. Skúste to prosím neskôr."
+      },
+      "SERVICE_UNAVAILABLE": {
+        "title": "Služba nedostupná",
+        "message": "Služba je dočasne nedostupná. Skúste to prosím neskôr."
+      },
+      "TIMEOUT": {
+        "title": "Vypršal časový limit požiadavky",
+        "message": "Požiadavka trvala príliš dlho. Skúste to prosím znova."
+      },
+      "NETWORK_ERROR": {
+        "title": "Chyba siete",
+        "message": "Nepodarilo sa pripojiť k serveru. Skontrolujte prosím svoje internetové pripojenie."
+      },
+      "OFFLINE": {
+        "title": "Ste offline",
+        "message": "Skontrolujte prosím svoje internetové pripojenie a skúste to znova."
+      },
+      "default": {
+        "title": "Chyba",
+        "message": "Vyskytla sa neočakávaná chyba."
+      },
+      "rateLimitRetry": "Pred ďalším pokusom prosím počkajte {{seconds}} sekúnd."
+    }
   },
   "notifications": {
     "title": "Oznámenia",

--- a/frontend/apps/ppt-web/src/lib/errorHandler.test.ts
+++ b/frontend/apps/ppt-web/src/lib/errorHandler.test.ts
@@ -18,6 +18,8 @@
  * Additive-only: no production code is touched.
  */
 
+import i18n from 'i18next';
+import sk from '../../messages/sk.json';
 import {
   type ErrorResponse,
   formatValidationErrors,
@@ -302,5 +304,70 @@ describe('getFieldError', () => {
 
   it('returns undefined when the map itself is undefined', () => {
     expect(getFieldError(undefined, 'email')).toBeUndefined();
+  });
+});
+
+describe('parseApiError — i18n localisation', () => {
+  // Regression for the hardcoded-English error catalogue: user-facing titles
+  // and messages must follow the active react-i18next language rather than
+  // always emitting English. This fails on `dev` (where the catalogue was a
+  // literal English `Record`) and passes once parsing routes through
+  // `errors.catalogue.*`.
+  beforeAll(() => {
+    // Ensure the Slovak bundle is available on the shared i18next instance the
+    // error handler reads from, regardless of test import order.
+    i18n.addResourceBundle('sk', 'translation', sk, true, true);
+  });
+
+  afterEach(() => {
+    // Restore English so the other suites (and other test files sharing the
+    // singleton) are unaffected.
+    i18n.changeLanguage('en');
+  });
+
+  it('translates a known error title/message into the active locale', () => {
+    i18n.changeLanguage('sk');
+
+    const result = parseApiError({
+      requestId: 'req-sk',
+      error: 'SESSION_EXPIRED',
+      message: '',
+    });
+
+    expect(result.code).toBe('SESSION_EXPIRED');
+    expect(result.title).toBe('Relácia vypršala');
+    expect(result.message).toBe('Vaša relácia vypršala. Prihláste sa prosím znova.');
+  });
+
+  it('translates the default fallback copy for unknown codes', () => {
+    i18n.changeLanguage('sk');
+
+    const result = parseApiError({ response: { status: 418, data: undefined } });
+
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.title).toBe('Chyba');
+  });
+
+  it('localises the interpolated rate-limit retry message', () => {
+    i18n.changeLanguage('sk');
+
+    const result = parseApiError({
+      response: {
+        status: 429,
+        data: { requestId: 'r', error: 'RATE_LIMITED', message: '' },
+        headers: { 'retry-after': '30' },
+      },
+    });
+
+    expect(result.isRateLimitError).toBe(true);
+    expect(result.message).toBe('Pred ďalším pokusom prosím počkajte 30 sekúnd.');
+  });
+
+  it('still emits English copy when the active locale is English', () => {
+    i18n.changeLanguage('en');
+
+    const result = parseApiError({ requestId: 'r', error: 'SESSION_EXPIRED', message: '' });
+
+    expect(result.title).toBe('Session Expired');
   });
 });

--- a/frontend/apps/ppt-web/src/lib/errorHandler.ts
+++ b/frontend/apps/ppt-web/src/lib/errorHandler.ts
@@ -3,7 +3,14 @@
  *
  * Parses backend ErrorResponse format and maps error codes to user-friendly messages.
  * Supports validation errors with field paths for inline form feedback.
+ *
+ * User-facing copy (error titles/messages) is resolved through the shared
+ * react-i18next instance under the `errors.catalogue.*` keys, so the strings
+ * follow the user's selected language. Developer-facing values — error `code`s,
+ * `requestId`s and raw backend `message`s — are passed through untranslated.
  */
+
+import i18n from '../i18n';
 
 /**
  * Backend error response format.
@@ -48,97 +55,68 @@ export interface ParsedApiError {
 }
 
 /**
- * Error code to user-friendly message mapping.
+ * Resolved, user-facing copy for an error code.
  */
-const ERROR_MESSAGES: Record<string, { title: string; message: string }> = {
-  // Authentication errors
-  AUTHENTICATION_ERROR: {
-    title: 'Authentication Required',
-    message: 'Please log in to continue.',
-  },
-  INVALID_CREDENTIALS: {
-    title: 'Invalid Credentials',
-    message: 'The email or password you entered is incorrect.',
-  },
-  SESSION_EXPIRED: {
-    title: 'Session Expired',
-    message: 'Your session has expired. Please log in again.',
-  },
-  UNAUTHORIZED: {
-    title: 'Access Denied',
-    message: 'You do not have permission to perform this action.',
-  },
-
-  // Validation errors
-  VALIDATION_ERROR: {
-    title: 'Validation Error',
-    message: 'Please check the form for errors.',
-  },
-  INVALID_INPUT: {
-    title: 'Invalid Input',
-    message: 'The provided data is invalid.',
-  },
-
-  // Resource errors
-  NOT_FOUND: {
-    title: 'Not Found',
-    message: 'The requested resource could not be found.',
-  },
-  RESOURCE_NOT_FOUND: {
-    title: 'Resource Not Found',
-    message: 'The item you are looking for does not exist or has been deleted.',
-  },
-  CONFLICT: {
-    title: 'Conflict',
-    message: 'This operation conflicts with existing data.',
-  },
-  DUPLICATE_ENTRY: {
-    title: 'Duplicate Entry',
-    message: 'An item with the same value already exists.',
-  },
-
-  // Rate limiting
-  RATE_LIMITED: {
-    title: 'Too Many Requests',
-    message: 'You have made too many requests. Please wait before trying again.',
-  },
-  RATE_LIMIT_EXCEEDED: {
-    title: 'Rate Limit Exceeded',
-    message: 'Please slow down and try again in a moment.',
-  },
-
-  // Server errors
-  INTERNAL_ERROR: {
-    title: 'Server Error',
-    message: 'An unexpected error occurred. Please try again later.',
-  },
-  SERVICE_UNAVAILABLE: {
-    title: 'Service Unavailable',
-    message: 'The service is temporarily unavailable. Please try again later.',
-  },
-  TIMEOUT: {
-    title: 'Request Timeout',
-    message: 'The request took too long. Please try again.',
-  },
-
-  // Network errors
-  NETWORK_ERROR: {
-    title: 'Network Error',
-    message: 'Unable to connect to the server. Please check your internet connection.',
-  },
-  OFFLINE: {
-    title: 'You are Offline',
-    message: 'Please check your internet connection and try again.',
-  },
-};
+interface ErrorCopy {
+  title: string;
+  message: string;
+}
 
 /**
- * Default error message for unknown error codes.
+ * Error codes that have a dedicated translation entry under
+ * `errors.catalogue.<CODE>`. Any code outside this set falls back to the
+ * default copy (`errors.catalogue.default`).
  */
-const DEFAULT_ERROR = {
-  title: 'Error',
-  message: 'An unexpected error occurred.',
-};
+const KNOWN_ERROR_CODES = new Set<string>([
+  // Authentication errors
+  'AUTHENTICATION_ERROR',
+  'INVALID_CREDENTIALS',
+  'SESSION_EXPIRED',
+  'UNAUTHORIZED',
+  // Validation errors
+  'VALIDATION_ERROR',
+  'INVALID_INPUT',
+  // Resource errors
+  'NOT_FOUND',
+  'RESOURCE_NOT_FOUND',
+  'CONFLICT',
+  'DUPLICATE_ENTRY',
+  // Rate limiting
+  'RATE_LIMITED',
+  'RATE_LIMIT_EXCEEDED',
+  // Server errors
+  'INTERNAL_ERROR',
+  'SERVICE_UNAVAILABLE',
+  'TIMEOUT',
+  // Network errors
+  'NETWORK_ERROR',
+  'OFFLINE',
+]);
+
+/**
+ * Default, user-facing copy for unknown error codes, resolved from the active
+ * i18n bundle.
+ */
+function defaultErrorCopy(): ErrorCopy {
+  return {
+    title: i18n.t('errors.catalogue.default.title'),
+    message: i18n.t('errors.catalogue.default.message'),
+  };
+}
+
+/**
+ * Resolve the user-facing title/message for an error code from the active i18n
+ * bundle. Unknown codes fall back to {@link defaultErrorCopy}.
+ */
+function errorCopy(code: string): ErrorCopy {
+  if (!KNOWN_ERROR_CODES.has(code)) {
+    return defaultErrorCopy();
+  }
+  return {
+    title: i18n.t(`errors.catalogue.${code}.title`),
+    message: i18n.t(`errors.catalogue.${code}.message`),
+  };
+}
 
 /**
  * Parse an API error response into a user-friendly format.
@@ -149,9 +127,10 @@ const DEFAULT_ERROR = {
 export function parseApiError(error: unknown): ParsedApiError {
   // Handle network errors
   if (isNetworkError(error)) {
+    const copy = errorCopy('NETWORK_ERROR');
     return {
-      title: ERROR_MESSAGES.NETWORK_ERROR.title,
-      message: ERROR_MESSAGES.NETWORK_ERROR.message,
+      title: copy.title,
+      message: copy.message,
       code: 'NETWORK_ERROR',
       isNetworkError: true,
       isRateLimitError: false,
@@ -167,11 +146,12 @@ export function parseApiError(error: unknown): ParsedApiError {
     // Check for rate limiting
     if (statusCode === 429) {
       const retryAfter = parseRetryAfter(response?.headers?.['retry-after']);
+      const copy = errorCopy('RATE_LIMITED');
       return {
-        title: ERROR_MESSAGES.RATE_LIMITED.title,
+        title: copy.title,
         message: retryAfter
-          ? `Please wait ${retryAfter} seconds before trying again.`
-          : ERROR_MESSAGES.RATE_LIMITED.message,
+          ? i18n.t('errors.catalogue.rateLimitRetry', { seconds: retryAfter })
+          : copy.message,
         code: 'RATE_LIMITED',
         requestId: data?.requestId,
         statusCode: 429,
@@ -191,9 +171,10 @@ export function parseApiError(error: unknown): ParsedApiError {
 
   // Handle fetch-style errors
   if (isFetchError(error)) {
+    const copy = errorCopy('NETWORK_ERROR');
     return {
-      title: ERROR_MESSAGES.NETWORK_ERROR.title,
-      message: ERROR_MESSAGES.NETWORK_ERROR.message,
+      title: copy.title,
+      message: copy.message,
       code: 'NETWORK_ERROR',
       isNetworkError: true,
       isRateLimitError: false,
@@ -207,9 +188,10 @@ export function parseApiError(error: unknown): ParsedApiError {
 
   // Handle Error instances
   if (error instanceof Error) {
+    const copy = defaultErrorCopy();
     return {
-      title: DEFAULT_ERROR.title,
-      message: error.message || DEFAULT_ERROR.message,
+      title: copy.title,
+      message: error.message || copy.message,
       code: 'UNKNOWN_ERROR',
       isNetworkError: false,
       isRateLimitError: false,
@@ -217,9 +199,10 @@ export function parseApiError(error: unknown): ParsedApiError {
   }
 
   // Fallback for unknown error types
+  const copy = defaultErrorCopy();
   return {
-    title: DEFAULT_ERROR.title,
-    message: DEFAULT_ERROR.message,
+    title: copy.title,
+    message: copy.message,
     code: 'UNKNOWN_ERROR',
     isNetworkError: false,
     isRateLimitError: false,
@@ -230,7 +213,7 @@ export function parseApiError(error: unknown): ParsedApiError {
  * Parse a structured ErrorResponse into ParsedApiError.
  */
 function parseErrorResponse(data: ErrorResponse, statusCode?: number): ParsedApiError {
-  const errorInfo = ERROR_MESSAGES[data.error] ?? DEFAULT_ERROR;
+  const errorInfo = errorCopy(data.error);
   const validationErrors = parseValidationDetails(data.details);
 
   return {
@@ -271,7 +254,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
   switch (statusCode) {
     case 400:
       return {
-        ...ERROR_MESSAGES.INVALID_INPUT,
+        ...errorCopy('INVALID_INPUT'),
         code: 'INVALID_INPUT',
         statusCode,
         isNetworkError: false,
@@ -279,7 +262,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
       };
     case 401:
       return {
-        ...ERROR_MESSAGES.AUTHENTICATION_ERROR,
+        ...errorCopy('AUTHENTICATION_ERROR'),
         code: 'AUTHENTICATION_ERROR',
         statusCode,
         isNetworkError: false,
@@ -287,7 +270,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
       };
     case 403:
       return {
-        ...ERROR_MESSAGES.UNAUTHORIZED,
+        ...errorCopy('UNAUTHORIZED'),
         code: 'UNAUTHORIZED',
         statusCode,
         isNetworkError: false,
@@ -295,7 +278,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
       };
     case 404:
       return {
-        ...ERROR_MESSAGES.NOT_FOUND,
+        ...errorCopy('NOT_FOUND'),
         code: 'NOT_FOUND',
         statusCode,
         isNetworkError: false,
@@ -303,7 +286,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
       };
     case 409:
       return {
-        ...ERROR_MESSAGES.CONFLICT,
+        ...errorCopy('CONFLICT'),
         code: 'CONFLICT',
         statusCode,
         isNetworkError: false,
@@ -311,7 +294,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
       };
     case 429:
       return {
-        ...ERROR_MESSAGES.RATE_LIMITED,
+        ...errorCopy('RATE_LIMITED'),
         code: 'RATE_LIMITED',
         statusCode,
         isNetworkError: false,
@@ -321,7 +304,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
     case 502:
     case 503:
       return {
-        ...ERROR_MESSAGES.INTERNAL_ERROR,
+        ...errorCopy('INTERNAL_ERROR'),
         code: 'INTERNAL_ERROR',
         statusCode,
         isNetworkError: false,
@@ -329,7 +312,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
       };
     case 504:
       return {
-        ...ERROR_MESSAGES.TIMEOUT,
+        ...errorCopy('TIMEOUT'),
         code: 'TIMEOUT',
         statusCode,
         isNetworkError: false,
@@ -337,7 +320,7 @@ function parseHttpStatusError(statusCode?: number): ParsedApiError {
       };
     default:
       return {
-        ...DEFAULT_ERROR,
+        ...defaultErrorCopy(),
         code: 'UNKNOWN_ERROR',
         statusCode,
         isNetworkError: false,


### PR DESCRIPTION
## Task
ppt-web errorHandler.ts: the entire client error catalogue is hardcoded English (no i18n). Route the user-facing error messages through the existing react-i18next setup used elsewhere in ppt-web — add translation keys and look them up, matching the app's established i18n pattern. Keep developer-facing/log strings as-is; only user-facing messages need translation keys.

## Owner
pm-frontend (ppt-web / React SPA under frontend/apps/ppt-web)

## What changed
- `frontend/apps/ppt-web/src/lib/errorHandler.ts`: replaced the hardcoded English `ERROR_MESSAGES` / `DEFAULT_ERROR` record with i18n-backed lookups. Titles/messages now resolve via the shared react-i18next instance (`import i18n from '../i18n'`) under new `errors.catalogue.*` keys, following the current language. A `KNOWN_ERROR_CODES` set decides which codes map to a dedicated entry vs the default fallback. The interpolated rate-limit retry line is now `errors.catalogue.rateLimitRetry` with a `{{seconds}}` placeholder.
- Developer-facing values are untranslated by design: error `code`s, `requestId`s, raw backend `message`s (which still take precedence over the canned copy), field-name formatting, and the type guards.
- Added the `errors.catalogue` block (19 entries: 17 error codes + `default` + `rateLimitRetry`) to **all six** ppt-web locale bundles: `en`, `sk`, `cs`, `de`, `pl`, `hu`.
- `errorHandler.test.ts`: added a localisation regression suite (Slovak title/message, default fallback, interpolated retry, English-still-English) that fails on `dev` and passes here.

## Verification
```
VERIFY-PLAN base=54d7dce5fe37c8207aeaa6b026fb4b74e1872058 files=7
  cd frontend && pnpm exec biome check apps/ppt-web/messages/cs.json apps/ppt-web/messages/de.json apps/ppt-web/messages/en.json apps/ppt-web/messages/hu.json apps/ppt-web/messages/pl.json apps/ppt-web/messages/sk.json apps/ppt-web/src/lib/errorHandler.ts
  cd frontend && pnpm --filter "...[54d7dce5fe37c8207aeaa6b026fb4b74e1872058]" typecheck
  cd frontend && pnpm --filter "...[54d7dce5fe37c8207aeaa6b026fb4b74e1872058]" test
```
```
VERIFY OK 626e2510336a237189f9048d3fbff3c844bed69a
```
(biome clean, typecheck clean, 2252 tests pass — including the 4 new i18n cases. The `VERIFY OK` hash predates the test-commit; the errorHandler suite was re-run green afterward: 39/39.)

## Scope drift
None — diff is confined to `frontend/apps/ppt-web/` (scope-check vs `origin/dev` → exit 0).

## Code-reuse review
None — reuse-grep vs `origin/dev` produced no warnings.

## Goal-check (IG1–IG8)
- IG3 satisfied: 1 `test:` commit + 1 `fix:` commit on `origin/dev..HEAD`.
- IG7 satisfied: verify gate green (see above).
- IG1/IG2 report FAIL only because this is a dispatcher-spawned task (pre-assigned `auto-impl/…` branch, no `.research/plans/<slug>.md`), not the plan-driven `impl/<slug>` flow — structural, not a code issue.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change — pure user-facing i18n copy).

## Remote-tested
skipped

## Notes
- The i18n singleton is read directly (`i18n.t(...)`) rather than via a React hook because `errorHandler.ts` is a plain lib module invoked from event handlers/mutations, not a component. Errors are surfaced imperatively (toasts) at call time, so `i18n.t` reads the active language correctly; this matches the app's non-component translation needs while keeping the `parseApiError` signature and all existing call sites unchanged.
- Non-English translations (sk/cs/de/pl/hu) were authored for this PR and are worth a native-speaker glance, though they mirror the established tone of each existing bundle.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VayJTXd9zMj1C7cgmpMdrT)_