### PR TITLE
code-review-api-core-payment-matcher-vs-only-threshold: payment matcher honours counterparty-IBAN tie-breaker

### DIFF
--- a/backend/servers/api-server/src/services/accounting.rs
+++ b/backend/servers/api-server/src/services/accounting.rs
@@ -9,9 +9,21 @@ use db::repositories::AccountingRepository;
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use sqlx::PgConnection;
+use std::collections::HashMap;
 use std::io::Cursor;
 use std::str::FromStr;
 use uuid::Uuid;
+
+/// Normalise an IBAN for comparison: drop all whitespace and upper-case it, so
+/// `"sk11 1000"` and `"SK111000"` compare equal. Bank exports vary in casing
+/// and grouping; the counterparty IBAN on a statement line and the IBAN stored
+/// on a contact must be compared on their canonical form, not byte-for-byte.
+fn normalize_iban(raw: &str) -> String {
+    raw.chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_uppercase()
+}
 
 #[derive(Debug, Deserialize)]
 struct CsvLine {
@@ -121,6 +133,25 @@ impl AccountingService {
             })
             .collect();
 
+        // Contact IBANs, keyed by contact id, for the counterparty-IBAN
+        // corroboration below. An invoice carries no IBAN of its own — the
+        // payer's account lives on its `Contact` — so we resolve it once here
+        // instead of per (line, invoice) pair. Only non-empty IBANs are kept,
+        // in canonical form.
+        let contact_iban: HashMap<Uuid, String> = self
+            .repo
+            .list_contacts_rls(&mut *executor)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?
+            .into_iter()
+            .filter_map(|c| {
+                c.iban
+                    .map(|i| normalize_iban(&i))
+                    .filter(|i| !i.is_empty())
+                    .map(|i| (c.id, i))
+            })
+            .collect();
+
         let threshold = Decimal::from_str("0.5").unwrap();
 
         for line in lines {
@@ -140,10 +171,22 @@ impl AccountingService {
             // disambiguation.
             let mut scored: Vec<(&Invoice, Decimal)> = Vec::new();
 
+            // The line's counterparty IBAN in canonical form, resolved once per
+            // line for the IBAN corroboration below.
+            let line_iban = line
+                .counterparty_iban
+                .as_deref()
+                .map(normalize_iban)
+                .filter(|i| !i.is_empty());
+
             for invoice in &open_invoices {
                 let mut confidence = Decimal::ZERO;
 
-                // 1. Variable Symbol match (highest weight)
+                // 1. Variable Symbol match (highest weight) — the primary
+                //    "auto-match by reference" signal (FR-16.8 / BR-16.8.1). It
+                //    is the only signal strong enough on its own to clear the
+                //    auto-suggest threshold; amount and IBAN below are
+                //    corroboration that breaks ties between VS-sharing invoices.
                 if let (Some(l_vs), Some(i_vs)) = (&line.variable_symbol, &invoice.variable_symbol)
                 {
                     if l_vs == i_vs && !l_vs.is_empty() {
@@ -151,7 +194,7 @@ impl AccountingService {
                     }
                 }
 
-                // 2. Amount match (corroboration)
+                // 2. Amount match (corroboration / tie-breaker)
                 let remaining_amount = invoice.total_amount - invoice.paid_amount;
                 if line.amount == remaining_amount {
                     confidence += Decimal::from_str("0.15").unwrap();
@@ -159,7 +202,23 @@ impl AccountingService {
                     confidence += Decimal::from_str("0.05").unwrap();
                 }
 
-                // TODO: Date proximity, IBAN match
+                // 3. Counterparty IBAN match (corroboration / tie-breaker).
+                //    When several invoices share a variable symbol (e.g. a
+                //    tenant's recurring monthly invoices), a matching payer
+                //    account promotes the invoice whose contact actually owns
+                //    the originating IBAN above its VS-only peers.
+                if let Some(l_iban) = &line_iban {
+                    if contact_iban.get(&invoice.contact_id) == Some(l_iban) {
+                        confidence += Decimal::from_str("0.05").unwrap();
+                    }
+                }
+
+                // TODO: Date proximity
+
+                // Confidence is a 0..1 score; the weights above sum to at most
+                // 1.0, but clamp defensively so future signals can't overflow
+                // the documented range.
+                let confidence = confidence.min(Decimal::ONE);
 
                 if confidence >= threshold {
                     scored.push((invoice, confidence));

--- a/backend/servers/api-server/tests/suites/accounting_payment_matcher_suggest_tests.rs
+++ b/backend/servers/api-server/tests/suites/accounting_payment_matcher_suggest_tests.rs
@@ -40,6 +40,50 @@ async fn seed_contact(pool: &PgPool, org: Uuid) -> Uuid {
     .unwrap()
 }
 
+/// Seed a contact carrying an IBAN (used for the counterparty-IBAN tie-breaker).
+async fn seed_contact_iban(pool: &PgPool, org: Uuid, iban: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO contact (tenant_id, name, iban) VALUES ($1, 'C', $2) RETURNING id",
+    )
+    .bind(org)
+    .bind(iban)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+/// Seed a bank statement plus a single unmatched line carrying a counterparty
+/// IBAN. Returns (statement_id, line_id).
+async fn seed_statement_line_iban(
+    pool: &PgPool,
+    org: Uuid,
+    amount: i64,
+    vs: &str,
+    counterparty_iban: &str,
+) -> (Uuid, Uuid) {
+    let stmt = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO bank_statement (tenant_id, source_filename, account_iban) \
+         VALUES ($1, 'S', 'IBAN') RETURNING id",
+    )
+    .bind(org)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    let line = sqlx::query_scalar::<_, Uuid>(
+        "INSERT INTO bank_statement_line (statement_id, tenant_id, booking_date, amount, currency, variable_symbol, counterparty_iban, match_state) \
+         VALUES ($1, $2, NOW(), $3, 'CZK', $4, $5, 'unmatched') RETURNING id",
+    )
+    .bind(stmt)
+    .bind(org)
+    .bind(amount)
+    .bind(vs)
+    .bind(counterparty_iban)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    (stmt, line)
+}
+
 /// Seed an open (issued) invoice with the given number, total, and variable
 /// symbol. `paid_amount` stays 0, so `remaining = total`.
 async fn seed_invoice(
@@ -158,5 +202,41 @@ async fn genuinely_tied_candidates_are_all_surfaced(pool: PgPool) {
     assert_eq!(
         suggested, expected,
         "both genuinely-tied top candidates must be surfaced for disambiguation"
+    );
+}
+
+/// Two invoices that would otherwise tie (same VS, both exact-amount -> 0.95)
+/// must be disambiguated by the counterparty IBAN: only the invoice whose
+/// contact owns the originating account is suggested. Regression for the
+/// matcher previously ignoring the documented IBAN tie-breaker (the old
+/// `// TODO: ... IBAN match`), so a VS+amount tie surfaced BOTH invoices.
+///
+/// The line's IBAN is supplied lower-cased and space-grouped to also exercise
+/// canonical-form normalisation against the stored contact IBAN.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn counterparty_iban_breaks_a_vs_amount_tie(pool: PgPool) {
+    let org = seed_org(&pool, "matcher-iban-tiebreak").await;
+    let contact_a = seed_contact_iban(&pool, org, "SK11 1000").await;
+    let contact_b = seed_contact_iban(&pool, org, "SK22 2000").await;
+
+    // Both share VS "VSIBAN" and owe exactly 100 (== line amount) -> both 0.95
+    // on VS+exact-amount alone. Only A's contact IBAN matches the line, so A
+    // gets the extra +0.05 (=> 1.0) and wins outright.
+    let a = seed_invoice(&pool, org, contact_a, "INV-A", 100, "VSIBAN").await;
+    let _b = seed_invoice(&pool, org, contact_b, "INV-B", 100, "VSIBAN").await;
+    let (stmt, line) = seed_statement_line_iban(&pool, org, 100, "VSIBAN", "sk111000").await;
+
+    let svc = AccountingService::new(AccountingRepository::new(pool.clone()));
+    let mut conn = pool.acquire().await.unwrap();
+    set_ctx(&mut conn, org).await;
+    svc.run_payment_matcher(&mut conn, org, stmt)
+        .await
+        .expect("run matcher");
+
+    let suggested = suggested_invoices(&pool, line).await;
+    assert_eq!(
+        suggested,
+        vec![a],
+        "the counterparty-IBAN match must break the VS+amount tie in favour of the owning contact"
     );
 }


### PR DESCRIPTION
## Task
payment matcher uses a single VS-only threshold — ignores IBAN / amount tie-breakers documented in spec

## Owner
pm-backend

## What changed
`AccountingService::run_payment_matcher` scored only the variable symbol (VS,
+0.8) and amount (exact +0.15 / partial +0.05); the counterparty IBAN was left
unimplemented behind a `// TODO: Date proximity, IBAN match`. Because VS is the
only signal strong enough to clear the 0.5 auto-suggest threshold, two invoices
sharing a VS (e.g. a tenant's recurring monthly invoices) that also matched on
amount tied at 0.95 and were **both** surfaced — even when only one invoice's
contact owned the account the payment actually came from. The IBAN tie-breaker
documented for reconciliation (FR-16.8 "auto-match by reference"; migration
`00183` records `matched_by` values including `'iban+amount'`) was ignored.

- Resolve each invoice's contact IBAN once per statement (an `Invoice` carries
  no IBAN of its own — the payer account lives on its `Contact`).
- Add a `+0.05` counterparty-IBAN corroboration, compared in canonical form
  (whitespace-stripped, upper-cased) via a new `normalize_iban` helper.
- VS remains the only signal that clears the auto-suggest threshold on its own
  (spec: auto-match by reference); amount and IBAN stay corroboration that
  breaks ties between VS-sharing invoices. Confidence is clamped to the
  documented `0..1` range.
- Regression test `counterparty_iban_breaks_a_vs_amount_tie`: two invoices that
  otherwise tie on VS+exact-amount (0.95) are disambiguated so only the invoice
  whose contact owns the counterparty IBAN is suggested. The line IBAN is
  supplied lower-cased/space-grouped to also exercise normalisation.

## Verification
VERIFY-PLAN base=9f3da46325147d0e3cbd946b8ba22e1092423fd1 files=2
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server

- `cargo fmt --all -- --check` — **exit 0 (passed)**.
- `cargo clippy -p api-server --all-targets -- -D warnings` — **could not run in
  the implementer sandbox**: compiling api-server triggers the
  `utoipa-swagger-ui` build script, which downloads the Swagger UI zip from
  `github.com/swagger-api/...` at build time. The org egress policy blocks that
  host (HTTP 403 "GitHub access to this repository is not enabled for this
  session"), so the build aborts in a transitive build-dependency before
  reaching any first-party code. This is an environment limitation, not a
  compile error in this change.
- `cargo test -p api-server` — **could not run in the sandbox**: the suite uses
  `#[sqlx::test]`, needing a live Postgres at runtime, and no DB / `ppt-bridge`
  MCP was available (and it hits the same swagger build wall first).

Both changed files use only runtime sqlx (`sqlx::query*::<_, T>(...)`), so they
need no compile-time DB. CI `backend.yml` (network + provisioned Postgres) is
the authoritative gate and will run clippy + the new `#[sqlx::test]` before this
draft is marked ready. **Draft is intentional** pending that CI signal.

## CI parity (Band C — hot-path only)
This touches payment reconciliation (money-adjacent). CI `backend.yml` runs the
DB-backed `cargo test -p api-server` against a provisioned Postgres — the one
gate step that cannot run on this DB-less runner. Draft PR left for that to
confirm the new `#[sqlx::test]` before marking ready.

## Remote-tested
skipped (ppt-bridge MCP not connected)

## Notes
- Scope: 2 files, both `backend/servers/api-server/` (owner pm-backend).
  scope_drift=false.
- Weight choice keeps confidence ≤ 1.0 (0.8 + 0.15 + 0.05); IBAN weighted equal
  to a partial-amount match, below an exact-amount match, so exact amount still
  dominates and IBAN breaks the residual ties.
- Date-proximity remains a `// TODO` (out of scope for this finding).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YCa6SDg7rNYFR4srg9qGxM)_