### PR TITLE
code-review-ppt-web-ui-moderation-no-i18n: internationalize content moderation dashboard strings

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1,4 +1,117 @@
 {
+  "moderation": {
+    "dashboard": {
+      "title": "Nástěnka moderování obsahu",
+      "subtitle": "Kontrolujte a moderujte uživatelský obsah v souladu s DSA.",
+      "loading": "Načítání fronty moderování...",
+      "loadError": "Nepodařilo se načíst případy moderování: {{message}}",
+      "retry": "Zkusit znovu"
+    },
+    "queue": {
+      "heading": "Fronta moderování",
+      "emptyTitle": "Nebyly nalezeny žádné případy moderování odpovídající kritériím.",
+      "emptySubtitle": "Fronta moderování je momentálně prázdná."
+    },
+    "filters": {
+      "status": "Stav",
+      "contentType": "Typ obsahu",
+      "violationType": "Typ porušení",
+      "priority": "Priorita",
+      "unassignedOnly": "Pouze nepřiřazené",
+      "allStatuses": "Všechny stavy",
+      "allTypes": "Všechny typy",
+      "allViolations": "Všechna porušení",
+      "allPriorities": "Všechny priority"
+    },
+    "templates": {
+      "heading": "Šablony akcí"
+    },
+    "stats": {
+      "pendingCases": "Čekající případy",
+      "underReview": "Kontrolované",
+      "totalQueue": "Celá fronta",
+      "avgResolution": "Prům. vyřešení",
+      "byPriority": "Podle priority",
+      "byViolationType": "Podle typu porušení",
+      "overdue_one": "{{count}} případ po termínu (SLA 24 h+)",
+      "overdue_other": "{{count}} případů po termínu (SLA 24 h+)"
+    },
+    "status": {
+      "pending": "Čeká",
+      "under_review": "Kontrolované",
+      "approved": "Schváleno",
+      "removed": "Odstraněno",
+      "restricted": "Omezeno",
+      "warned": "Upozorněno",
+      "appealed": "Odvoláno",
+      "appeal_approved": "Odvolání schváleno",
+      "appeal_rejected": "Odvolání zamítnuto"
+    },
+    "priorityLabel": {
+      "1": "Kritická",
+      "2": "Vysoká",
+      "3": "Střední",
+      "4": "Nízká",
+      "5": "Nejnižší",
+      "fallback": "P{{priority}}"
+    },
+    "contentType": {
+      "listing": "Inzerát",
+      "listing_photo": "Foto inzerátu",
+      "user_profile": "Profil uživatele",
+      "review": "Recenze",
+      "comment": "Komentář",
+      "message": "Zpráva",
+      "announcement": "Oznámení",
+      "document": "Dokument",
+      "community_post": "Komunitní příspěvek"
+    },
+    "violationType": {
+      "spam": "Spam",
+      "harassment": "Obtěžování",
+      "hate_speech": "Nenávistný projev",
+      "violence": "Násilí",
+      "illegal_content": "Nelegální obsah",
+      "misinformation": "Dezinformace",
+      "fraud": "Podvod",
+      "privacy": "Soukromí",
+      "intellectual_property": "Duševní vlastnictví",
+      "inappropriate_content": "Nevhodný obsah",
+      "other": "Jiné",
+      "notSpecified": "Neuvedeno"
+    },
+    "actionType": {
+      "remove": "Odstranit",
+      "restrict": "Omezit",
+      "warn": "Upozornit",
+      "approve": "Schválit",
+      "ignore": "Ignorovat",
+      "escalate": "Eskalovat"
+    },
+    "card": {
+      "contentOwner": "Vlastník obsahu",
+      "assignedTo": "Přiřazeno",
+      "decision": "Rozhodnutí",
+      "appealFiled": "Podané odvolání",
+      "appealUpheld": "Odvolání potvrzeno",
+      "appealRejected": "Odvolání zamítnuto",
+      "ageAgo": "před {{age}}",
+      "created": "Vytvořeno: {{date}}",
+      "viewContent": "Zobrazit obsah",
+      "assignToMe": "Přiřadit mně",
+      "takeAction": "Provést akci",
+      "decideAppeal": "Rozhodnout o odvolání"
+    },
+    "prompts": {
+      "actionType": "Zadejte typ akce (remove, restrict, warn, approve):",
+      "actionRationale": "Zadejte odůvodnění této akce:",
+      "decision": "Zadejte rozhodnutí (uphold, overturn):",
+      "decisionRationale": "Zadejte odůvodnění tohoto rozhodnutí:",
+      "assignError": "Nepodařilo se přiřadit případ. Zkuste to znovu.",
+      "actionError": "Nepodařilo se provést akci. Zkuste to znovu.",
+      "appealError": "Nepodařilo se rozhodnout o odvolání. Zkuste to znovu."
+    }
+  },
   "common": {
     "search": "Hledat",
     "login": "Přihlásit se",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1,4 +1,117 @@
 {
+  "moderation": {
+    "dashboard": {
+      "title": "Dashboard zur Inhaltsmoderation",
+      "subtitle": "Nutzergenerierte Inhalte gemäß DSA prüfen und moderieren.",
+      "loading": "Moderationswarteschlange wird geladen...",
+      "loadError": "Moderationsfälle konnten nicht geladen werden: {{message}}",
+      "retry": "Erneut versuchen"
+    },
+    "queue": {
+      "heading": "Moderationswarteschlange",
+      "emptyTitle": "Keine Moderationsfälle gefunden, die den Kriterien entsprechen.",
+      "emptySubtitle": "Die Moderationswarteschlange ist derzeit leer."
+    },
+    "filters": {
+      "status": "Status",
+      "contentType": "Inhaltstyp",
+      "violationType": "Verstoßart",
+      "priority": "Priorität",
+      "unassignedOnly": "Nur nicht zugewiesene",
+      "allStatuses": "Alle Status",
+      "allTypes": "Alle Typen",
+      "allViolations": "Alle Verstöße",
+      "allPriorities": "Alle Prioritäten"
+    },
+    "templates": {
+      "heading": "Aktionsvorlagen"
+    },
+    "stats": {
+      "pendingCases": "Ausstehende Fälle",
+      "underReview": "In Prüfung",
+      "totalQueue": "Gesamte Warteschlange",
+      "avgResolution": "Durchschn. Bearbeitung",
+      "byPriority": "Nach Priorität",
+      "byViolationType": "Nach Verstoßart",
+      "overdue_one": "{{count}} Fall überfällig (24 h+ SLA)",
+      "overdue_other": "{{count}} Fälle überfällig (24 h+ SLA)"
+    },
+    "status": {
+      "pending": "Ausstehend",
+      "under_review": "In Prüfung",
+      "approved": "Genehmigt",
+      "removed": "Entfernt",
+      "restricted": "Eingeschränkt",
+      "warned": "Verwarnt",
+      "appealed": "Widerspruch eingelegt",
+      "appeal_approved": "Widerspruch stattgegeben",
+      "appeal_rejected": "Widerspruch abgelehnt"
+    },
+    "priorityLabel": {
+      "1": "Kritisch",
+      "2": "Hoch",
+      "3": "Mittel",
+      "4": "Niedrig",
+      "5": "Am niedrigsten",
+      "fallback": "P{{priority}}"
+    },
+    "contentType": {
+      "listing": "Anzeige",
+      "listing_photo": "Anzeigenfoto",
+      "user_profile": "Benutzerprofil",
+      "review": "Bewertung",
+      "comment": "Kommentar",
+      "message": "Nachricht",
+      "announcement": "Ankündigung",
+      "document": "Dokument",
+      "community_post": "Community-Beitrag"
+    },
+    "violationType": {
+      "spam": "Spam",
+      "harassment": "Belästigung",
+      "hate_speech": "Hassrede",
+      "violence": "Gewalt",
+      "illegal_content": "Illegale Inhalte",
+      "misinformation": "Fehlinformation",
+      "fraud": "Betrug",
+      "privacy": "Datenschutz",
+      "intellectual_property": "Geistiges Eigentum",
+      "inappropriate_content": "Unangemessene Inhalte",
+      "other": "Sonstiges",
+      "notSpecified": "Nicht angegeben"
+    },
+    "actionType": {
+      "remove": "Entfernen",
+      "restrict": "Einschränken",
+      "warn": "Verwarnen",
+      "approve": "Genehmigen",
+      "ignore": "Ignorieren",
+      "escalate": "Eskalieren"
+    },
+    "card": {
+      "contentOwner": "Inhaltseigentümer",
+      "assignedTo": "Zugewiesen an",
+      "decision": "Entscheidung",
+      "appealFiled": "Widerspruch eingereicht",
+      "appealUpheld": "Widerspruch bestätigt",
+      "appealRejected": "Widerspruch abgelehnt",
+      "ageAgo": "vor {{age}}",
+      "created": "Erstellt: {{date}}",
+      "viewContent": "Inhalt anzeigen",
+      "assignToMe": "Mir zuweisen",
+      "takeAction": "Maßnahme ergreifen",
+      "decideAppeal": "Über Widerspruch entscheiden"
+    },
+    "prompts": {
+      "actionType": "Aktionstyp eingeben (remove, restrict, warn, approve):",
+      "actionRationale": "Begründung für diese Maßnahme eingeben:",
+      "decision": "Entscheidung eingeben (uphold, overturn):",
+      "decisionRationale": "Begründung für diese Entscheidung eingeben:",
+      "assignError": "Fall konnte nicht zugewiesen werden. Bitte erneut versuchen.",
+      "actionError": "Maßnahme konnte nicht ausgeführt werden. Bitte erneut versuchen.",
+      "appealError": "Über den Widerspruch konnte nicht entschieden werden. Bitte erneut versuchen."
+    }
+  },
   "common": {
     "search": "Suchen",
     "login": "Anmelden",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -1,4 +1,117 @@
 {
+  "moderation": {
+    "dashboard": {
+      "title": "Content Moderation Dashboard",
+      "subtitle": "Review and moderate user-generated content for DSA compliance.",
+      "loading": "Loading moderation queue...",
+      "loadError": "Failed to load moderation cases: {{message}}",
+      "retry": "Retry"
+    },
+    "queue": {
+      "heading": "Moderation Queue",
+      "emptyTitle": "No moderation cases found matching the criteria.",
+      "emptySubtitle": "The moderation queue is currently empty."
+    },
+    "filters": {
+      "status": "Status",
+      "contentType": "Content Type",
+      "violationType": "Violation Type",
+      "priority": "Priority",
+      "unassignedOnly": "Unassigned Only",
+      "allStatuses": "All Statuses",
+      "allTypes": "All Types",
+      "allViolations": "All Violations",
+      "allPriorities": "All Priorities"
+    },
+    "templates": {
+      "heading": "Action Templates"
+    },
+    "stats": {
+      "pendingCases": "Pending Cases",
+      "underReview": "Under Review",
+      "totalQueue": "Total Queue",
+      "avgResolution": "Avg Resolution",
+      "byPriority": "By Priority",
+      "byViolationType": "By Violation Type",
+      "overdue_one": "{{count}} case overdue (24h+ SLA)",
+      "overdue_other": "{{count}} cases overdue (24h+ SLA)"
+    },
+    "status": {
+      "pending": "Pending",
+      "under_review": "Under Review",
+      "approved": "Approved",
+      "removed": "Removed",
+      "restricted": "Restricted",
+      "warned": "Warned",
+      "appealed": "Appealed",
+      "appeal_approved": "Appeal Approved",
+      "appeal_rejected": "Appeal Rejected"
+    },
+    "priorityLabel": {
+      "1": "Critical",
+      "2": "High",
+      "3": "Medium",
+      "4": "Low",
+      "5": "Lowest",
+      "fallback": "P{{priority}}"
+    },
+    "contentType": {
+      "listing": "Listing",
+      "listing_photo": "Listing Photo",
+      "user_profile": "User Profile",
+      "review": "Review",
+      "comment": "Comment",
+      "message": "Message",
+      "announcement": "Announcement",
+      "document": "Document",
+      "community_post": "Community Post"
+    },
+    "violationType": {
+      "spam": "Spam",
+      "harassment": "Harassment",
+      "hate_speech": "Hate Speech",
+      "violence": "Violence",
+      "illegal_content": "Illegal Content",
+      "misinformation": "Misinformation",
+      "fraud": "Fraud",
+      "privacy": "Privacy",
+      "intellectual_property": "Intellectual Property",
+      "inappropriate_content": "Inappropriate Content",
+      "other": "Other",
+      "notSpecified": "Not specified"
+    },
+    "actionType": {
+      "remove": "Remove",
+      "restrict": "Restrict",
+      "warn": "Warn",
+      "approve": "Approve",
+      "ignore": "Ignore",
+      "escalate": "Escalate"
+    },
+    "card": {
+      "contentOwner": "Content Owner",
+      "assignedTo": "Assigned To",
+      "decision": "Decision",
+      "appealFiled": "Appeal Filed",
+      "appealUpheld": "Appeal Upheld",
+      "appealRejected": "Appeal Rejected",
+      "ageAgo": "{{age}} ago",
+      "created": "Created: {{date}}",
+      "viewContent": "View Content",
+      "assignToMe": "Assign to Me",
+      "takeAction": "Take Action",
+      "decideAppeal": "Decide Appeal"
+    },
+    "prompts": {
+      "actionType": "Enter action type (remove, restrict, warn, approve):",
+      "actionRationale": "Enter rationale for this action:",
+      "decision": "Enter decision (uphold, overturn):",
+      "decisionRationale": "Enter rationale for this decision:",
+      "assignError": "Failed to assign case. Please try again.",
+      "actionError": "Failed to take action. Please try again.",
+      "appealError": "Failed to decide appeal. Please try again."
+    }
+  },
   "common": {
     "search": "Search",
     "login": "Login",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1,4 +1,117 @@
 {
+  "moderation": {
+    "dashboard": {
+      "title": "Tartalommoderálási irányítópult",
+      "subtitle": "Felhasználói tartalom ellenőrzése és moderálása a DSA megfelelőség érdekében.",
+      "loading": "Moderálási várólista betöltése...",
+      "loadError": "Nem sikerült betölteni a moderálási eseteket: {{message}}",
+      "retry": "Újrapróbálás"
+    },
+    "queue": {
+      "heading": "Moderálási várólista",
+      "emptyTitle": "Nem található a feltételeknek megfelelő moderálási eset.",
+      "emptySubtitle": "A moderálási várólista jelenleg üres."
+    },
+    "filters": {
+      "status": "Állapot",
+      "contentType": "Tartalomtípus",
+      "violationType": "Szabálysértés típusa",
+      "priority": "Prioritás",
+      "unassignedOnly": "Csak a nem hozzárendeltek",
+      "allStatuses": "Minden állapot",
+      "allTypes": "Minden típus",
+      "allViolations": "Minden szabálysértés",
+      "allPriorities": "Minden prioritás"
+    },
+    "templates": {
+      "heading": "Műveleti sablonok"
+    },
+    "stats": {
+      "pendingCases": "Függőben lévő esetek",
+      "underReview": "Ellenőrzés alatt",
+      "totalQueue": "Teljes várólista",
+      "avgResolution": "Átl. megoldási idő",
+      "byPriority": "Prioritás szerint",
+      "byViolationType": "Szabálysértés típusa szerint",
+      "overdue_one": "{{count}} eset lejárt (24 óra+ SLA)",
+      "overdue_other": "{{count}} eset lejárt (24 óra+ SLA)"
+    },
+    "status": {
+      "pending": "Függőben",
+      "under_review": "Ellenőrzés alatt",
+      "approved": "Jóváhagyva",
+      "removed": "Eltávolítva",
+      "restricted": "Korlátozva",
+      "warned": "Figyelmeztetve",
+      "appealed": "Fellebbezve",
+      "appeal_approved": "Fellebbezés jóváhagyva",
+      "appeal_rejected": "Fellebbezés elutasítva"
+    },
+    "priorityLabel": {
+      "1": "Kritikus",
+      "2": "Magas",
+      "3": "Közepes",
+      "4": "Alacsony",
+      "5": "Legalacsonyabb",
+      "fallback": "P{{priority}}"
+    },
+    "contentType": {
+      "listing": "Hirdetés",
+      "listing_photo": "Hirdetés fotó",
+      "user_profile": "Felhasználói profil",
+      "review": "Értékelés",
+      "comment": "Hozzászólás",
+      "message": "Üzenet",
+      "announcement": "Közlemény",
+      "document": "Dokumentum",
+      "community_post": "Közösségi bejegyzés"
+    },
+    "violationType": {
+      "spam": "Spam",
+      "harassment": "Zaklatás",
+      "hate_speech": "Gyűlöletbeszéd",
+      "violence": "Erőszak",
+      "illegal_content": "Illegális tartalom",
+      "misinformation": "Félretájékoztatás",
+      "fraud": "Csalás",
+      "privacy": "Adatvédelem",
+      "intellectual_property": "Szellemi tulajdon",
+      "inappropriate_content": "Nem megfelelő tartalom",
+      "other": "Egyéb",
+      "notSpecified": "Nincs megadva"
+    },
+    "actionType": {
+      "remove": "Eltávolítás",
+      "restrict": "Korlátozás",
+      "warn": "Figyelmeztetés",
+      "approve": "Jóváhagyás",
+      "ignore": "Figyelmen kívül hagyás",
+      "escalate": "Eszkaláció"
+    },
+    "card": {
+      "contentOwner": "Tartalom tulajdonosa",
+      "assignedTo": "Hozzárendelve",
+      "decision": "Döntés",
+      "appealFiled": "Fellebbezés benyújtva",
+      "appealUpheld": "Fellebbezés helybenhagyva",
+      "appealRejected": "Fellebbezés elutasítva",
+      "ageAgo": "{{age}} ezelőtt",
+      "created": "Létrehozva: {{date}}",
+      "viewContent": "Tartalom megtekintése",
+      "assignToMe": "Hozzárendelés magamhoz",
+      "takeAction": "Művelet végrehajtása",
+      "decideAppeal": "Fellebbezésről döntés"
+    },
+    "prompts": {
+      "actionType": "Adja meg a művelet típusát (remove, restrict, warn, approve):",
+      "actionRationale": "Adja meg a művelet indoklását:",
+      "decision": "Adja meg a döntést (uphold, overturn):",
+      "decisionRationale": "Adja meg a döntés indoklását:",
+      "assignError": "Nem sikerült hozzárendelni az esetet. Kérjük, próbálja újra.",
+      "actionError": "Nem sikerült végrehajtani a műveletet. Kérjük, próbálja újra.",
+      "appealError": "Nem sikerült dönteni a fellebbezésről. Kérjük, próbálja újra."
+    }
+  },
   "common": {
     "search": "Keresés",
     "login": "Bejelentkezés",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1,4 +1,117 @@
 {
+  "moderation": {
+    "dashboard": {
+      "title": "Panel moderacji treści",
+      "subtitle": "Przeglądaj i moderuj treści użytkowników zgodnie z DSA.",
+      "loading": "Ładowanie kolejki moderacji...",
+      "loadError": "Nie udało się załadować spraw moderacji: {{message}}",
+      "retry": "Spróbuj ponownie"
+    },
+    "queue": {
+      "heading": "Kolejka moderacji",
+      "emptyTitle": "Nie znaleziono spraw moderacji spełniających kryteria.",
+      "emptySubtitle": "Kolejka moderacji jest obecnie pusta."
+    },
+    "filters": {
+      "status": "Status",
+      "contentType": "Typ treści",
+      "violationType": "Typ naruszenia",
+      "priority": "Priorytet",
+      "unassignedOnly": "Tylko nieprzypisane",
+      "allStatuses": "Wszystkie statusy",
+      "allTypes": "Wszystkie typy",
+      "allViolations": "Wszystkie naruszenia",
+      "allPriorities": "Wszystkie priorytety"
+    },
+    "templates": {
+      "heading": "Szablony działań"
+    },
+    "stats": {
+      "pendingCases": "Oczekujące sprawy",
+      "underReview": "W trakcie przeglądu",
+      "totalQueue": "Cała kolejka",
+      "avgResolution": "Śr. czas rozwiązania",
+      "byPriority": "Według priorytetu",
+      "byViolationType": "Według typu naruszenia",
+      "overdue_one": "{{count}} sprawa po terminie (SLA 24 h+)",
+      "overdue_other": "{{count}} spraw po terminie (SLA 24 h+)"
+    },
+    "status": {
+      "pending": "Oczekująca",
+      "under_review": "W trakcie przeglądu",
+      "approved": "Zatwierdzona",
+      "removed": "Usunięta",
+      "restricted": "Ograniczona",
+      "warned": "Ostrzeżenie",
+      "appealed": "Odwołanie",
+      "appeal_approved": "Odwołanie zatwierdzone",
+      "appeal_rejected": "Odwołanie odrzucone"
+    },
+    "priorityLabel": {
+      "1": "Krytyczny",
+      "2": "Wysoki",
+      "3": "Średni",
+      "4": "Niski",
+      "5": "Najniższy",
+      "fallback": "P{{priority}}"
+    },
+    "contentType": {
+      "listing": "Ogłoszenie",
+      "listing_photo": "Zdjęcie ogłoszenia",
+      "user_profile": "Profil użytkownika",
+      "review": "Recenzja",
+      "comment": "Komentarz",
+      "message": "Wiadomość",
+      "announcement": "Ogłoszenie",
+      "document": "Dokument",
+      "community_post": "Post społeczności"
+    },
+    "violationType": {
+      "spam": "Spam",
+      "harassment": "Nękanie",
+      "hate_speech": "Mowa nienawiści",
+      "violence": "Przemoc",
+      "illegal_content": "Nielegalne treści",
+      "misinformation": "Dezinformacja",
+      "fraud": "Oszustwo",
+      "privacy": "Prywatność",
+      "intellectual_property": "Własność intelektualna",
+      "inappropriate_content": "Nieodpowiednie treści",
+      "other": "Inne",
+      "notSpecified": "Nie określono"
+    },
+    "actionType": {
+      "remove": "Usuń",
+      "restrict": "Ogranicz",
+      "warn": "Ostrzeż",
+      "approve": "Zatwierdź",
+      "ignore": "Ignoruj",
+      "escalate": "Eskaluj"
+    },
+    "card": {
+      "contentOwner": "Właściciel treści",
+      "assignedTo": "Przypisane do",
+      "decision": "Decyzja",
+      "appealFiled": "Złożono odwołanie",
+      "appealUpheld": "Odwołanie podtrzymane",
+      "appealRejected": "Odwołanie odrzucone",
+      "ageAgo": "{{age}} temu",
+      "created": "Utworzono: {{date}}",
+      "viewContent": "Zobacz treść",
+      "assignToMe": "Przypisz do mnie",
+      "takeAction": "Podejmij działanie",
+      "decideAppeal": "Rozstrzygnij odwołanie"
+    },
+    "prompts": {
+      "actionType": "Wprowadź typ działania (remove, restrict, warn, approve):",
+      "actionRationale": "Wprowadź uzasadnienie tego działania:",
+      "decision": "Wprowadź decyzję (uphold, overturn):",
+      "decisionRationale": "Wprowadź uzasadnienie tej decyzji:",
+      "assignError": "Nie udało się przypisać sprawy. Spróbuj ponownie.",
+      "actionError": "Nie udało się podjąć działania. Spróbuj ponownie.",
+      "appealError": "Nie udało się rozstrzygnąć odwołania. Spróbuj ponownie."
+    }
+  },
   "common": {
     "search": "Szukaj",
     "login": "Zaloguj się",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1,4 +1,117 @@
 {
+  "moderation": {
+    "dashboard": {
+      "title": "Nástenka moderovania obsahu",
+      "subtitle": "Kontrolujte a moderujte používateľský obsah v súlade s DSA.",
+      "loading": "Načítavanie frontu moderovania...",
+      "loadError": "Nepodarilo sa načítať prípady moderovania: {{message}}",
+      "retry": "Skúsiť znova"
+    },
+    "queue": {
+      "heading": "Front moderovania",
+      "emptyTitle": "Nenašli sa žiadne prípady moderovania zodpovedajúce kritériám.",
+      "emptySubtitle": "Front moderovania je momentálne prázdny."
+    },
+    "filters": {
+      "status": "Stav",
+      "contentType": "Typ obsahu",
+      "violationType": "Typ porušenia",
+      "priority": "Priorita",
+      "unassignedOnly": "Iba nepriradené",
+      "allStatuses": "Všetky stavy",
+      "allTypes": "Všetky typy",
+      "allViolations": "Všetky porušenia",
+      "allPriorities": "Všetky priority"
+    },
+    "templates": {
+      "heading": "Šablóny akcií"
+    },
+    "stats": {
+      "pendingCases": "Čakajúce prípady",
+      "underReview": "Kontrolované",
+      "totalQueue": "Celý front",
+      "avgResolution": "Priem. vyriešenie",
+      "byPriority": "Podľa priority",
+      "byViolationType": "Podľa typu porušenia",
+      "overdue_one": "{{count}} prípad po termíne (SLA 24 h+)",
+      "overdue_other": "{{count}} prípadov po termíne (SLA 24 h+)"
+    },
+    "status": {
+      "pending": "Čaká",
+      "under_review": "Kontrolované",
+      "approved": "Schválené",
+      "removed": "Odstránené",
+      "restricted": "Obmedzené",
+      "warned": "Upozornené",
+      "appealed": "Odvolané",
+      "appeal_approved": "Odvolanie schválené",
+      "appeal_rejected": "Odvolanie zamietnuté"
+    },
+    "priorityLabel": {
+      "1": "Kritická",
+      "2": "Vysoká",
+      "3": "Stredná",
+      "4": "Nízka",
+      "5": "Najnižšia",
+      "fallback": "P{{priority}}"
+    },
+    "contentType": {
+      "listing": "Inzerát",
+      "listing_photo": "Foto inzerátu",
+      "user_profile": "Profil používateľa",
+      "review": "Recenzia",
+      "comment": "Komentár",
+      "message": "Správa",
+      "announcement": "Oznam",
+      "document": "Dokument",
+      "community_post": "Komunitný príspevok"
+    },
+    "violationType": {
+      "spam": "Spam",
+      "harassment": "Obťažovanie",
+      "hate_speech": "Nenávistný prejav",
+      "violence": "Násilie",
+      "illegal_content": "Nelegálny obsah",
+      "misinformation": "Dezinformácie",
+      "fraud": "Podvod",
+      "privacy": "Súkromie",
+      "intellectual_property": "Duševné vlastníctvo",
+      "inappropriate_content": "Nevhodný obsah",
+      "other": "Iné",
+      "notSpecified": "Neuvedené"
+    },
+    "actionType": {
+      "remove": "Odstrániť",
+      "restrict": "Obmedziť",
+      "warn": "Upozorniť",
+      "approve": "Schváliť",
+      "ignore": "Ignorovať",
+      "escalate": "Eskalovať"
+    },
+    "card": {
+      "contentOwner": "Vlastník obsahu",
+      "assignedTo": "Priradené",
+      "decision": "Rozhodnutie",
+      "appealFiled": "Podané odvolanie",
+      "appealUpheld": "Odvolanie potvrdené",
+      "appealRejected": "Odvolanie zamietnuté",
+      "ageAgo": "pred {{age}}",
+      "created": "Vytvorené: {{date}}",
+      "viewContent": "Zobraziť obsah",
+      "assignToMe": "Priradiť mne",
+      "takeAction": "Vykonať akciu",
+      "decideAppeal": "Rozhodnúť o odvolaní"
+    },
+    "prompts": {
+      "actionType": "Zadajte typ akcie (remove, restrict, warn, approve):",
+      "actionRationale": "Zadajte odôvodnenie tejto akcie:",
+      "decision": "Zadajte rozhodnutie (uphold, overturn):",
+      "decisionRationale": "Zadajte odôvodnenie tohto rozhodnutia:",
+      "assignError": "Nepodarilo sa priradiť prípad. Skúste to znova.",
+      "actionError": "Nepodarilo sa vykonať akciu. Skúste to znova.",
+      "appealError": "Nepodarilo sa rozhodnúť o odvolaní. Skúste to znova."
+    }
+  },
   "common": {
     "search": "Hladať",
     "login": "Prihlásiť sa",

--- a/frontend/apps/ppt-web/src/features/compliance/components/ModerationCaseCard.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/components/ModerationCaseCard.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export type ModerationStatus =
   | 'pending'
@@ -85,67 +86,12 @@ export interface ModerationCaseCardProps {
   isModerator?: boolean;
 }
 
-const getStatusLabel = (status: ModerationStatus): string => {
-  switch (status) {
-    case 'pending':
-      return 'Pending';
-    case 'under_review':
-      return 'Under Review';
-    case 'approved':
-      return 'Approved';
-    case 'removed':
-      return 'Removed';
-    case 'restricted':
-      return 'Restricted';
-    case 'warned':
-      return 'Warned';
-    case 'appealed':
-      return 'Appealed';
-    case 'appeal_approved':
-      return 'Appeal Approved';
-    case 'appeal_rejected':
-      return 'Appeal Rejected';
-    default:
-      return status;
-  }
-};
-
-const getContentTypeLabel = (type: ModeratedContentType): string => {
-  return type
+// Fallback humanizer for enum values that lack an explicit translation key.
+const humanize = (value: string): string =>
+  value
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
-};
-
-const getViolationTypeLabel = (type?: ViolationType): string => {
-  if (!type) return 'Not specified';
-  return type
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-};
-
-const getActionLabel = (action?: ModerationActionType): string => {
-  if (!action) return '';
-  return action.charAt(0).toUpperCase() + action.slice(1);
-};
-
-const getPriorityLabel = (priority: number): string => {
-  switch (priority) {
-    case 1:
-      return 'Critical';
-    case 2:
-      return 'High';
-    case 3:
-      return 'Medium';
-    case 4:
-      return 'Low';
-    case 5:
-      return 'Lowest';
-    default:
-      return `P${priority}`;
-  }
-};
 
 const formatAge = (hours: number): string => {
   if (hours < 1) {
@@ -177,6 +123,21 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
   showActions = true,
   isModerator = false,
 }) => {
+  const { t } = useTranslation();
+
+  const getStatusLabel = (status: ModerationStatus): string =>
+    t(`moderation.status.${status}`, humanize(status));
+  const getContentTypeLabel = (type: ModeratedContentType): string =>
+    t(`moderation.contentType.${type}`, humanize(type));
+  const getViolationTypeLabel = (type?: ViolationType): string =>
+    type
+      ? t(`moderation.violationType.${type}`, humanize(type))
+      : t('moderation.violationType.notSpecified');
+  const getActionLabel = (action?: ModerationActionType): string =>
+    action ? t(`moderation.actionType.${action}`, humanize(action)) : '';
+  const getPriorityLabel = (priority: number): string =>
+    t(`moderation.priorityLabel.${priority}`, t('moderation.priorityLabel.fallback', { priority }));
+
   const isOverdue = case_.age_hours >= 24 && case_.status === 'pending';
   const canTakeAction =
     isModerator && (case_.status === 'pending' || case_.status === 'under_review');
@@ -196,7 +157,7 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
             {getStatusLabel(case_.status)}
           </span>
           <span className={`moderation-case-age ${isOverdue ? 'overdue' : ''}`}>
-            {formatAge(case_.age_hours)} ago
+            {t('moderation.card.ageAgo', { age: formatAge(case_.age_hours) })}
           </span>
         </div>
       </div>
@@ -221,13 +182,13 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
 
       <div className="moderation-case-details">
         <div className="moderation-owner-info">
-          <h5>Content Owner</h5>
+          <h5>{t('moderation.card.contentOwner')}</h5>
           <span className="moderation-owner-name">{case_.content_owner.name}</span>
         </div>
 
         {case_.assigned_to_name && (
           <div className="moderation-assigned-info">
-            <h5>Assigned To</h5>
+            <h5>{t('moderation.card.assignedTo')}</h5>
             <span className="moderation-assignee">{case_.assigned_to_name}</span>
           </div>
         )}
@@ -236,7 +197,7 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
       {/* Decision Info */}
       {case_.decision && (
         <div className="moderation-decision-info">
-          <h5>Decision</h5>
+          <h5>{t('moderation.card.decision')}</h5>
           <span className={`moderation-decision ${case_.decision}`}>
             {getActionLabel(case_.decision)}
           </span>
@@ -249,13 +210,17 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
       {/* Appeal Info */}
       {case_.appeal_filed && (
         <div className="moderation-appeal-info">
-          <h5>Appeal Filed</h5>
+          <h5>{t('moderation.card.appealFiled')}</h5>
           {case_.appeal_reason && <p className="moderation-appeal-reason">{case_.appeal_reason}</p>}
           {case_.status === 'appeal_approved' && (
-            <span className="moderation-appeal-outcome approved">Appeal Upheld</span>
+            <span className="moderation-appeal-outcome approved">
+              {t('moderation.card.appealUpheld')}
+            </span>
           )}
           {case_.status === 'appeal_rejected' && (
-            <span className="moderation-appeal-outcome rejected">Appeal Rejected</span>
+            <span className="moderation-appeal-outcome rejected">
+              {t('moderation.card.appealRejected')}
+            </span>
           )}
         </div>
       )}
@@ -269,7 +234,7 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
               className="moderation-action-button secondary"
               onClick={() => onViewContent(case_.id)}
             >
-              View Content
+              {t('moderation.card.viewContent')}
             </button>
           )}
           {!case_.assigned_to_name && isModerator && onAssign && (
@@ -278,7 +243,7 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
               className="moderation-action-button secondary"
               onClick={() => onAssign(case_.id)}
             >
-              Assign to Me
+              {t('moderation.card.assignToMe')}
             </button>
           )}
           {canTakeAction && onTakeAction && (
@@ -287,7 +252,7 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
               className="moderation-action-button primary"
               onClick={() => onTakeAction(case_.id)}
             >
-              Take Action
+              {t('moderation.card.takeAction')}
             </button>
           )}
           {canDecideAppeal && onDecideAppeal && (
@@ -296,14 +261,16 @@ export const ModerationCaseCard: React.FC<ModerationCaseCardProps> = ({
               className="moderation-action-button primary"
               onClick={() => onDecideAppeal(case_.id)}
             >
-              Decide Appeal
+              {t('moderation.card.decideAppeal')}
             </button>
           )}
         </div>
       )}
 
       <div className="moderation-case-footer">
-        <span className="moderation-case-created">Created: {formatDate(case_.created_at)}</span>
+        <span className="moderation-case-created">
+          {t('moderation.card.created', { date: formatDate(case_.created_at) })}
+        </span>
       </div>
     </div>
   );

--- a/frontend/apps/ppt-web/src/features/compliance/components/ModerationQueueStats.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/components/ModerationQueueStats.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface PriorityCount {
   priority: number;
@@ -32,29 +33,12 @@ export interface ModerationQueueStatsProps {
   onShowOverdue?: () => void;
 }
 
-const getPriorityLabel = (priority: number): string => {
-  switch (priority) {
-    case 1:
-      return 'Critical';
-    case 2:
-      return 'High';
-    case 3:
-      return 'Medium';
-    case 4:
-      return 'Low';
-    case 5:
-      return 'Lowest';
-    default:
-      return `P${priority}`;
-  }
-};
-
-const formatViolationType = (type: string): string => {
-  return type
+// Fallback humanizer for enum values that lack an explicit translation key.
+const humanize = (value: string): string =>
+  value
     .split('_')
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(' ');
-};
 
 const formatHours = (hours: number): string => {
   if (hours < 1) {
@@ -74,7 +58,13 @@ export const ModerationQueueStats: React.FC<ModerationQueueStatsProps> = ({
   onFilterByViolationType,
   onShowOverdue,
 }) => {
+  const { t } = useTranslation();
   const totalPending = stats.pending_count + stats.under_review_count;
+
+  const getPriorityLabel = (priority: number): string =>
+    t(`moderation.priorityLabel.${priority}`, t('moderation.priorityLabel.fallback', { priority }));
+  const getViolationTypeLabel = (type: string): string =>
+    t(`moderation.violationType.${type}`, humanize(type));
 
   return (
     <div className="moderation-queue-stats">
@@ -82,21 +72,21 @@ export const ModerationQueueStats: React.FC<ModerationQueueStatsProps> = ({
       <div className="moderation-stats-overview">
         <div className="moderation-stat-card pending">
           <div className="moderation-stat-value">{stats.pending_count}</div>
-          <div className="moderation-stat-label">Pending Cases</div>
+          <div className="moderation-stat-label">{t('moderation.stats.pendingCases')}</div>
         </div>
         <div className="moderation-stat-card review">
           <div className="moderation-stat-value">{stats.under_review_count}</div>
-          <div className="moderation-stat-label">Under Review</div>
+          <div className="moderation-stat-label">{t('moderation.stats.underReview')}</div>
         </div>
         <div className="moderation-stat-card total">
           <div className="moderation-stat-value">{totalPending}</div>
-          <div className="moderation-stat-label">Total Queue</div>
+          <div className="moderation-stat-label">{t('moderation.stats.totalQueue')}</div>
         </div>
         <div className="moderation-stat-card time">
           <div className="moderation-stat-value">
             {formatHours(stats.avg_resolution_time_hours)}
           </div>
-          <div className="moderation-stat-label">Avg Resolution</div>
+          <div className="moderation-stat-label">{t('moderation.stats.avgResolution')}</div>
         </div>
       </div>
 
@@ -111,14 +101,14 @@ export const ModerationQueueStats: React.FC<ModerationQueueStatsProps> = ({
         >
           <span className="moderation-overdue-icon">!</span>
           <span className="moderation-overdue-text">
-            {stats.overdue_count} case{stats.overdue_count > 1 ? 's' : ''} overdue (24h+ SLA)
+            {t('moderation.stats.overdue', { count: stats.overdue_count })}
           </span>
         </div>
       )}
 
       {/* Priority Breakdown */}
       <div className="moderation-priority-breakdown">
-        <h4>By Priority</h4>
+        <h4>{t('moderation.stats.byPriority')}</h4>
         <div className="moderation-priority-bars">
           {stats.by_priority.map((item) => (
             <div
@@ -147,7 +137,7 @@ export const ModerationQueueStats: React.FC<ModerationQueueStatsProps> = ({
       {/* Violation Type Breakdown */}
       {stats.by_violation_type.length > 0 && (
         <div className="moderation-violation-breakdown">
-          <h4>By Violation Type</h4>
+          <h4>{t('moderation.stats.byViolationType')}</h4>
           <ul className="moderation-violation-list">
             {stats.by_violation_type.map((item, index) => (
               <li
@@ -159,7 +149,7 @@ export const ModerationQueueStats: React.FC<ModerationQueueStatsProps> = ({
                 }
               >
                 <span className="moderation-violation-type">
-                  {formatViolationType(item.violation_type)}
+                  {getViolationTypeLabel(item.violation_type)}
                 </span>
                 <span className="moderation-violation-count">{item.count}</span>
               </li>

--- a/frontend/apps/ppt-web/src/features/compliance/pages/ContentModerationPage.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/pages/ContentModerationPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@ppt/api-client';
 import type React from 'react';
 import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import type { ModerationCase } from '../components/ModerationCaseCard';
 import { ModerationCaseCard } from '../components/ModerationCaseCard';
 import type { ModerationQueueStatsData } from '../components/ModerationQueueStats';
@@ -30,6 +31,8 @@ interface ActionTemplate {
 }
 
 export const ContentModerationPage: React.FC = () => {
+  const { t } = useTranslation();
+
   // Filters
   const [statusFilter, setStatusFilter] = useState<string>('pending');
   const [contentTypeFilter, setContentTypeFilter] = useState<string>('');
@@ -112,24 +115,21 @@ export const ContentModerationPage: React.FC = () => {
       assignCase.mutate(caseId, {
         onError: (err) => {
           console.error('Failed to assign case:', err);
-          alert('Failed to assign case. Please try again.');
+          alert(t('moderation.prompts.assignError'));
         },
       });
     },
-    [assignCase]
+    [assignCase, t]
   );
 
   const handleTakeAction = useCallback(
     (caseId: string) => {
       // TODO(Phase-2): Replace window.prompt with modal form with action templates integration
       // Phase 1: Basic prompts for action type and rationale
-      const actionType = window.prompt(
-        'Enter action type (remove, restrict, warn, approve):',
-        'approve'
-      );
+      const actionType = window.prompt(t('moderation.prompts.actionType'), 'approve');
       if (!actionType) return;
 
-      const rationale = window.prompt('Enter rationale for this action:');
+      const rationale = window.prompt(t('moderation.prompts.actionRationale'));
       if (!rationale) return;
 
       takeAction.mutate(
@@ -144,12 +144,12 @@ export const ContentModerationPage: React.FC = () => {
         {
           onError: (err) => {
             console.error('Failed to take action:', err);
-            alert('Failed to take action. Please try again.');
+            alert(t('moderation.prompts.actionError'));
           },
         }
       );
     },
-    [takeAction]
+    [takeAction, t]
   );
 
   const handleViewContent = useCallback((caseId: string) => {
@@ -162,10 +162,10 @@ export const ContentModerationPage: React.FC = () => {
     (caseId: string) => {
       // TODO(Phase-2): Replace window.prompt with modal form with validation
       // Phase 1: Basic prompts for decision and rationale
-      const decision = window.prompt('Enter decision (uphold, overturn):', 'uphold');
+      const decision = window.prompt(t('moderation.prompts.decision'), 'uphold');
       if (!decision) return;
 
-      const rationale = window.prompt('Enter rationale for this decision:');
+      const rationale = window.prompt(t('moderation.prompts.decisionRationale'));
       if (!rationale) return;
 
       decideAppeal.mutate(
@@ -179,12 +179,12 @@ export const ContentModerationPage: React.FC = () => {
         {
           onError: (err) => {
             console.error('Failed to decide appeal:', err);
-            alert('Failed to decide appeal. Please try again.');
+            alert(t('moderation.prompts.appealError'));
           },
         }
       );
     },
-    [decideAppeal]
+    [decideAppeal, t]
   );
 
   const handleFilterByPriority = useCallback((priority: number) => {
@@ -206,10 +206,10 @@ export const ContentModerationPage: React.FC = () => {
     return (
       <div className="content-moderation-page">
         <div className="moderation-page-header">
-          <h1>Content Moderation Dashboard</h1>
-          <p>Review and moderate user-generated content for DSA compliance.</p>
+          <h1>{t('moderation.dashboard.title')}</h1>
+          <p>{t('moderation.dashboard.subtitle')}</p>
         </div>
-        <div className="moderation-loading">Loading moderation queue...</div>
+        <div className="moderation-loading">{t('moderation.dashboard.loading')}</div>
       </div>
     );
   }
@@ -219,17 +219,17 @@ export const ContentModerationPage: React.FC = () => {
     return (
       <div className="content-moderation-page">
         <div className="moderation-page-header">
-          <h1>Content Moderation Dashboard</h1>
-          <p>Review and moderate user-generated content for DSA compliance.</p>
+          <h1>{t('moderation.dashboard.title')}</h1>
+          <p>{t('moderation.dashboard.subtitle')}</p>
         </div>
         <div className="moderation-page-error" role="alert">
-          Failed to load moderation cases: {casesError.message}
+          {t('moderation.dashboard.loadError', { message: casesError.message })}
           <button
             type="button"
             onClick={() => window.location.reload()}
             className="moderation-retry-button"
           >
-            Retry
+            {t('moderation.dashboard.retry')}
           </button>
         </div>
       </div>
@@ -239,8 +239,8 @@ export const ContentModerationPage: React.FC = () => {
   return (
     <div className="content-moderation-page">
       <div className="moderation-page-header">
-        <h1>Content Moderation Dashboard</h1>
-        <p>Review and moderate user-generated content for DSA compliance.</p>
+        <h1>{t('moderation.dashboard.title')}</h1>
+        <p>{t('moderation.dashboard.subtitle')}</p>
       </div>
 
       {/* Queue Statistics */}
@@ -255,73 +255,77 @@ export const ContentModerationPage: React.FC = () => {
 
       {/* Filters */}
       <div className="moderation-filters-section">
-        <h2>Moderation Queue</h2>
+        <h2>{t('moderation.queue.heading')}</h2>
         <div className="moderation-filters">
           <div className="moderation-filter">
-            <label htmlFor="statusFilter">Status</label>
+            <label htmlFor="statusFilter">{t('moderation.filters.status')}</label>
             <select
               id="statusFilter"
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
             >
-              <option value="">All Statuses</option>
-              <option value="pending">Pending</option>
-              <option value="under_review">Under Review</option>
-              <option value="appealed">Appealed</option>
-              <option value="removed">Removed</option>
-              <option value="restricted">Restricted</option>
-              <option value="warned">Warned</option>
-              <option value="approved">Approved</option>
+              <option value="">{t('moderation.filters.allStatuses')}</option>
+              <option value="pending">{t('moderation.status.pending')}</option>
+              <option value="under_review">{t('moderation.status.under_review')}</option>
+              <option value="appealed">{t('moderation.status.appealed')}</option>
+              <option value="removed">{t('moderation.status.removed')}</option>
+              <option value="restricted">{t('moderation.status.restricted')}</option>
+              <option value="warned">{t('moderation.status.warned')}</option>
+              <option value="approved">{t('moderation.status.approved')}</option>
             </select>
           </div>
           <div className="moderation-filter">
-            <label htmlFor="contentTypeFilter">Content Type</label>
+            <label htmlFor="contentTypeFilter">{t('moderation.filters.contentType')}</label>
             <select
               id="contentTypeFilter"
               value={contentTypeFilter}
               onChange={(e) => setContentTypeFilter(e.target.value)}
             >
-              <option value="">All Types</option>
-              <option value="listing">Listing</option>
-              <option value="listing_photo">Listing Photo</option>
-              <option value="review">Review</option>
-              <option value="comment">Comment</option>
-              <option value="community_post">Community Post</option>
-              <option value="message">Message</option>
+              <option value="">{t('moderation.filters.allTypes')}</option>
+              <option value="listing">{t('moderation.contentType.listing')}</option>
+              <option value="listing_photo">{t('moderation.contentType.listing_photo')}</option>
+              <option value="review">{t('moderation.contentType.review')}</option>
+              <option value="comment">{t('moderation.contentType.comment')}</option>
+              <option value="community_post">{t('moderation.contentType.community_post')}</option>
+              <option value="message">{t('moderation.contentType.message')}</option>
             </select>
           </div>
           <div className="moderation-filter">
-            <label htmlFor="violationTypeFilter">Violation Type</label>
+            <label htmlFor="violationTypeFilter">{t('moderation.filters.violationType')}</label>
             <select
               id="violationTypeFilter"
               value={violationTypeFilter}
               onChange={(e) => setViolationTypeFilter(e.target.value)}
             >
-              <option value="">All Violations</option>
-              <option value="spam">Spam</option>
-              <option value="harassment">Harassment</option>
-              <option value="hate_speech">Hate Speech</option>
-              <option value="violence">Violence</option>
-              <option value="illegal_content">Illegal Content</option>
-              <option value="misinformation">Misinformation</option>
-              <option value="fraud">Fraud</option>
-              <option value="privacy">Privacy</option>
-              <option value="inappropriate_content">Inappropriate Content</option>
+              <option value="">{t('moderation.filters.allViolations')}</option>
+              <option value="spam">{t('moderation.violationType.spam')}</option>
+              <option value="harassment">{t('moderation.violationType.harassment')}</option>
+              <option value="hate_speech">{t('moderation.violationType.hate_speech')}</option>
+              <option value="violence">{t('moderation.violationType.violence')}</option>
+              <option value="illegal_content">
+                {t('moderation.violationType.illegal_content')}
+              </option>
+              <option value="misinformation">{t('moderation.violationType.misinformation')}</option>
+              <option value="fraud">{t('moderation.violationType.fraud')}</option>
+              <option value="privacy">{t('moderation.violationType.privacy')}</option>
+              <option value="inappropriate_content">
+                {t('moderation.violationType.inappropriate_content')}
+              </option>
             </select>
           </div>
           <div className="moderation-filter">
-            <label htmlFor="priorityFilter">Priority</label>
+            <label htmlFor="priorityFilter">{t('moderation.filters.priority')}</label>
             <select
               id="priorityFilter"
               value={priorityFilter}
               onChange={(e) => setPriorityFilter(e.target.value)}
             >
-              <option value="">All Priorities</option>
-              <option value="1">Critical (P1)</option>
-              <option value="2">High (P2)</option>
-              <option value="3">Medium (P3)</option>
-              <option value="4">Low (P4)</option>
-              <option value="5">Lowest (P5)</option>
+              <option value="">{t('moderation.filters.allPriorities')}</option>
+              <option value="1">{t('moderation.priorityLabel.1')} (P1)</option>
+              <option value="2">{t('moderation.priorityLabel.2')} (P2)</option>
+              <option value="3">{t('moderation.priorityLabel.3')} (P3)</option>
+              <option value="4">{t('moderation.priorityLabel.4')} (P4)</option>
+              <option value="5">{t('moderation.priorityLabel.5')} (P5)</option>
             </select>
           </div>
           <div className="moderation-filter checkbox">
@@ -332,7 +336,7 @@ export const ContentModerationPage: React.FC = () => {
                 checked={unassignedOnly}
                 onChange={(e) => setUnassignedOnly(e.target.checked)}
               />
-              Unassigned Only
+              {t('moderation.filters.unassignedOnly')}
             </label>
           </div>
         </div>
@@ -356,14 +360,14 @@ export const ContentModerationPage: React.FC = () => {
         </div>
       ) : (
         <div className="moderation-empty-state">
-          <p>No moderation cases found matching the criteria.</p>
-          <p>The moderation queue is currently empty.</p>
+          <p>{t('moderation.queue.emptyTitle')}</p>
+          <p>{t('moderation.queue.emptySubtitle')}</p>
         </div>
       )}
 
       {/* Action Templates */}
       <div className="moderation-templates-section">
-        <h2>Action Templates</h2>
+        <h2>{t('moderation.templates.heading')}</h2>
         <div className="moderation-templates-list">
           {templates.map((template) => (
             <div key={template.id} className="moderation-template-card">


### PR DESCRIPTION
## Task

ppt-web moderation page renders hardcoded English strings — no i18n on user-facing surface. Route the moderation page's user-facing strings through react-i18next like the rest of ppt-web. NOTE: a sibling PR (#2776, branch auto-impl/code-review-ppt-web-ui-moderation-fabric-cb7dbe99) is in review touching the same moderation page for a different concern (removing fabricated context) — keep your diff scoped strictly to i18n string extraction to minimize overlap, and rebase onto origin/dev before opening the PR.

## Owner

pm-frontend

## What changed

Routed every user-facing string on the content moderation surface through `react-i18next`, matching the rest of ppt-web:

- `features/compliance/pages/ContentModerationPage.tsx` — page header/subtitle, loading + error states, filter labels and all `<select>` options (status / content-type / violation-type / priority), empty state, "Action Templates" heading, and the `window.prompt` / `alert` messages in the assign / take-action / decide-appeal handlers.
- `features/compliance/components/ModerationCaseCard.tsx` — status / content-type / violation-type / action / priority labels (via keyed lookups with a `humanize()` fallback for unmapped enum values), section headings, appeal outcomes, action buttons, and the age / created strings.
- `features/compliance/components/ModerationQueueStats.tsx` — stat-card labels, overdue alert (pluralized), and the priority / violation-type breakdown labels.

A new top-level `moderation` namespace was added to all six ppt-web locale bundles (`en, sk, cs, de, pl, hu`) with full translations. Enum values (status/priority/contentType/violationType) are keyed so they translate rather than being English-only `split('_')` humanizations; the humanizer is kept only as a fallback for values without an explicit key.

Strictly string extraction — no behavior, data-flow, or control-flow changes. The `alert()`/`window.prompt` call sites and the Phase-2 TODOs are left intact (only their message text is now translated).

## Sibling-PR overlap

Sibling PR #2776 (fabricated-context removal) merged into `dev` before this PR opened. The rebase onto `origin/dev` therefore picked up its deletion of the fabricated "previous violations" badge and the entire "Reported By" section from `ModerationCaseCard`. Conflict was resolved by accepting `dev`'s deletion, and the now-orphaned i18n keys (`moderation.card.reportedBy`, `moderation.card.previousViolations_*`, `moderation.reportSource.*`) were pruned from all six locale bundles so no dead keys ship.

## Verification

```
VERIFY-PLAN base=a1b479c90b7a95e282ef03519ed12d8ddf6b2986 files=9
  cd frontend && pnpm exec biome check apps/ppt-web/messages/cs.json apps/ppt-web/messages/de.json apps/ppt-web/messages/en.json apps/ppt-web/messages/hu.json apps/ppt-web/messages/pl.json apps/ppt-web/messages/sk.json apps/ppt-web/src/features/compliance/components/ModerationCaseCard.tsx apps/ppt-web/src/features/compliance/components/ModerationQueueStats.tsx apps/ppt-web/src/features/compliance/pages/ContentModerationPage.tsx
  cd frontend && pnpm --filter "...[a1b479c90b7a95e282ef03519ed12d8ddf6b2986]" typecheck
  cd frontend && pnpm --filter "...[a1b479c90b7a95e282ef03519ed12d8ddf6b2986]" test
```

```
VERIFY OK 533c247140cacb0764120d44fcb0386365ba57b3
```

biome check + `ppt-web` typecheck clean; frontend test suite 118 files / 2256 tests pass.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested

skipped

## Scope drift

None — `scope-check.sh --owner pm-frontend` exit 0 (diff confined to `frontend/apps/ppt-web/`).

## Code-reuse review

None — `reuse-grep.sh --specialist react-web` produced no warnings.

## Notes

- Enum default values passed to `window.prompt` (`'approve'`, `'uphold'`) are intentionally left untranslated — they are the literal values the backend API expects, not display labels.
- The `templates.map((t) => …)` transform param locally shadows the translation `t`, but no translation call occurs inside that map body; it was left untouched to avoid editing the data-transform block that the sibling PR also modified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCa6SDg7rNYFR4srg9qGxM)_