### PR TITLE
code-review-reality-web-comparison-view-i18n: i18n ComparisonView across all locales

### DIFF
--- a/frontend/apps/reality-web/messages/cs.json
+++ b/frontend/apps/reality-web/messages/cs.json
@@ -118,7 +118,41 @@
   },
   "comparison": {
     "loadError": "Nepodařilo se načíst sdílené porovnání. Některé nemovitosti už nemusí být dostupné.",
-    "loading": "Načítá se sdílené porovnání..."
+    "loading": "Načítá se sdílené porovnání...",
+    "empty": {
+      "title": "Žádné nemovitosti k porovnání",
+      "description": "Přidejte nemovitosti do porovnání ze stránky s nabídkami.",
+      "browse": "Procházet nabídky"
+    },
+    "actions": {
+      "share": "Sdílet",
+      "exportPdf": "Exportovat PDF",
+      "clearAll": "Vymazat vše"
+    },
+    "toast": {
+      "linkCopied": "Odkaz na porovnání zkopírován do schránky!",
+      "shareUrl": "Sdílejte tuto adresu URL: {url}",
+      "pdfComingSoon": "Export do PDF již brzy!"
+    },
+    "currencyWarning": "Poznámka: Nemovitosti používají různé měny. Zvýrazňování porovnání cen je vypnuto.",
+    "propertyHeader": "Nemovitost",
+    "remove": "Odebrat",
+    "removeAria": "Odebrat {title} z porovnání",
+    "rows": {
+      "price": "Cena",
+      "type": "Typ",
+      "propertyType": "Typ nemovitosti",
+      "area": "Plocha",
+      "rooms": "Pokoje",
+      "floor": "Patro",
+      "city": "Město",
+      "district": "Okres",
+      "pricePerSqm": "Cena za m²"
+    },
+    "transactionType": {
+      "sale": "K prodeji",
+      "rent": "K pronájmu"
+    }
   },
   "contact": {
     "askQuestion": "Položit otázku",

--- a/frontend/apps/reality-web/messages/de.json
+++ b/frontend/apps/reality-web/messages/de.json
@@ -118,7 +118,41 @@
   },
   "comparison": {
     "loadError": "Der geteilte Vergleich konnte nicht geladen werden. Einige Immobilien sind möglicherweise nicht mehr verfügbar.",
-    "loading": "Geteilter Vergleich wird geladen..."
+    "loading": "Geteilter Vergleich wird geladen...",
+    "empty": {
+      "title": "Keine Immobilien zum Vergleichen",
+      "description": "Fügen Sie Immobilien von der Angebotsseite zu Ihrem Vergleich hinzu.",
+      "browse": "Angebote durchsuchen"
+    },
+    "actions": {
+      "share": "Teilen",
+      "exportPdf": "PDF exportieren",
+      "clearAll": "Alle löschen"
+    },
+    "toast": {
+      "linkCopied": "Vergleichslink in die Zwischenablage kopiert!",
+      "shareUrl": "Teilen Sie diese URL: {url}",
+      "pdfComingSoon": "PDF-Export kommt bald!"
+    },
+    "currencyWarning": "Hinweis: Die Immobilien verwenden unterschiedliche Währungen. Die Hervorhebung des Preisvergleichs ist deaktiviert.",
+    "propertyHeader": "Immobilie",
+    "remove": "Entfernen",
+    "removeAria": "{title} aus dem Vergleich entfernen",
+    "rows": {
+      "price": "Preis",
+      "type": "Art",
+      "propertyType": "Immobilientyp",
+      "area": "Fläche",
+      "rooms": "Zimmer",
+      "floor": "Etage",
+      "city": "Stadt",
+      "district": "Bezirk",
+      "pricePerSqm": "Preis pro m²"
+    },
+    "transactionType": {
+      "sale": "Zum Verkauf",
+      "rent": "Zur Miete"
+    }
   },
   "contact": {
     "askQuestion": "Eine Frage stellen",

--- a/frontend/apps/reality-web/messages/en.json
+++ b/frontend/apps/reality-web/messages/en.json
@@ -118,7 +118,41 @@
   },
   "comparison": {
     "loadError": "Failed to load shared comparison. Some properties may no longer be available.",
-    "loading": "Loading shared comparison..."
+    "loading": "Loading shared comparison...",
+    "empty": {
+      "title": "No properties to compare",
+      "description": "Add properties to your comparison from the listings page.",
+      "browse": "Browse Listings"
+    },
+    "actions": {
+      "share": "Share",
+      "exportPdf": "Export PDF",
+      "clearAll": "Clear All"
+    },
+    "toast": {
+      "linkCopied": "Comparison link copied to clipboard!",
+      "shareUrl": "Share this URL: {url}",
+      "pdfComingSoon": "PDF export coming soon!"
+    },
+    "currencyWarning": "Note: Properties use different currencies. Price comparison highlighting is disabled.",
+    "propertyHeader": "Property",
+    "remove": "Remove",
+    "removeAria": "Remove {title} from comparison",
+    "rows": {
+      "price": "Price",
+      "type": "Type",
+      "propertyType": "Property Type",
+      "area": "Area",
+      "rooms": "Rooms",
+      "floor": "Floor",
+      "city": "City",
+      "district": "District",
+      "pricePerSqm": "Price per m²"
+    },
+    "transactionType": {
+      "sale": "For Sale",
+      "rent": "For Rent"
+    }
   },
   "contact": {
     "askQuestion": "Ask a question",

--- a/frontend/apps/reality-web/messages/hu.json
+++ b/frontend/apps/reality-web/messages/hu.json
@@ -118,7 +118,41 @@
   },
   "comparison": {
     "loadError": "A megosztott összehasonlítás betöltése sikertelen. Egyes ingatlanok már nem érhetők el.",
-    "loading": "Megosztott összehasonlítás betöltése..."
+    "loading": "Megosztott összehasonlítás betöltése...",
+    "empty": {
+      "title": "Nincs összehasonlítható ingatlan",
+      "description": "Adjon hozzá ingatlanokat az összehasonlításhoz a hirdetések oldaláról.",
+      "browse": "Hirdetések böngészése"
+    },
+    "actions": {
+      "share": "Megosztás",
+      "exportPdf": "PDF exportálása",
+      "clearAll": "Összes törlése"
+    },
+    "toast": {
+      "linkCopied": "Összehasonlítási link a vágólapra másolva!",
+      "shareUrl": "Ossza meg ezt az URL-t: {url}",
+      "pdfComingSoon": "A PDF exportálás hamarosan!"
+    },
+    "currencyWarning": "Megjegyzés: Az ingatlanok különböző pénznemeket használnak. Az árösszehasonlítás kiemelése le van tiltva.",
+    "propertyHeader": "Ingatlan",
+    "remove": "Eltávolítás",
+    "removeAria": "{title} eltávolítása az összehasonlításból",
+    "rows": {
+      "price": "Ár",
+      "type": "Típus",
+      "propertyType": "Ingatlan típusa",
+      "area": "Terület",
+      "rooms": "Szobák",
+      "floor": "Emelet",
+      "city": "Város",
+      "district": "Kerület",
+      "pricePerSqm": "Ár per m²"
+    },
+    "transactionType": {
+      "sale": "Eladó",
+      "rent": "Kiadó"
+    }
   },
   "contact": {
     "askQuestion": "Kérdést feltenni",

--- a/frontend/apps/reality-web/messages/pl.json
+++ b/frontend/apps/reality-web/messages/pl.json
@@ -118,7 +118,41 @@
   },
   "comparison": {
     "loadError": "Nie udało się wczytać udostępnionego porównania. Niektóre nieruchomości mogą być już niedostępne.",
-    "loading": "Wczytywanie udostępnionego porównania..."
+    "loading": "Wczytywanie udostępnionego porównania...",
+    "empty": {
+      "title": "Brak nieruchomości do porównania",
+      "description": "Dodaj nieruchomości do porównania ze strony z ofertami.",
+      "browse": "Przeglądaj oferty"
+    },
+    "actions": {
+      "share": "Udostępnij",
+      "exportPdf": "Eksportuj PDF",
+      "clearAll": "Wyczyść wszystko"
+    },
+    "toast": {
+      "linkCopied": "Link do porównania skopiowany do schowka!",
+      "shareUrl": "Udostępnij ten adres URL: {url}",
+      "pdfComingSoon": "Eksport do PDF już wkrótce!"
+    },
+    "currencyWarning": "Uwaga: Nieruchomości używają różnych walut. Wyróżnianie porównania cen jest wyłączone.",
+    "propertyHeader": "Nieruchomość",
+    "remove": "Usuń",
+    "removeAria": "Usuń {title} z porównania",
+    "rows": {
+      "price": "Cena",
+      "type": "Typ",
+      "propertyType": "Typ nieruchomości",
+      "area": "Powierzchnia",
+      "rooms": "Pokoje",
+      "floor": "Piętro",
+      "city": "Miasto",
+      "district": "Dzielnica",
+      "pricePerSqm": "Cena za m²"
+    },
+    "transactionType": {
+      "sale": "Na sprzedaż",
+      "rent": "Do wynajęcia"
+    }
   },
   "contact": {
     "askQuestion": "Zadać pytanie",

--- a/frontend/apps/reality-web/messages/sk.json
+++ b/frontend/apps/reality-web/messages/sk.json
@@ -118,7 +118,41 @@
   },
   "comparison": {
     "loadError": "Nepodarilo sa načítať zdieľané porovnanie. Niektoré nehnuteľnosti už nemusia byť dostupné.",
-    "loading": "Načítava sa zdieľané porovnanie..."
+    "loading": "Načítava sa zdieľané porovnanie...",
+    "empty": {
+      "title": "Žiadne nehnuteľnosti na porovnanie",
+      "description": "Pridajte nehnuteľnosti do porovnania zo stránky s ponukami.",
+      "browse": "Prehľadávať ponuky"
+    },
+    "actions": {
+      "share": "Zdieľať",
+      "exportPdf": "Exportovať PDF",
+      "clearAll": "Vymazať všetko"
+    },
+    "toast": {
+      "linkCopied": "Odkaz na porovnanie skopírovaný do schránky!",
+      "shareUrl": "Zdieľajte túto adresu URL: {url}",
+      "pdfComingSoon": "Export do PDF čoskoro!"
+    },
+    "currencyWarning": "Poznámka: Nehnuteľnosti používajú rôzne meny. Zvýrazňovanie porovnania cien je vypnuté.",
+    "propertyHeader": "Nehnuteľnosť",
+    "remove": "Odstrániť",
+    "removeAria": "Odstrániť {title} z porovnania",
+    "rows": {
+      "price": "Cena",
+      "type": "Typ",
+      "propertyType": "Typ nehnuteľnosti",
+      "area": "Plocha",
+      "rooms": "Izby",
+      "floor": "Poschodie",
+      "city": "Mesto",
+      "district": "Okres",
+      "pricePerSqm": "Cena za m²"
+    },
+    "transactionType": {
+      "sale": "Na predaj",
+      "rent": "Na prenájom"
+    }
   },
   "contact": {
     "askQuestion": "Položiť otázku",

--- a/frontend/apps/reality-web/src/components/comparison/ComparisonView.tsx
+++ b/frontend/apps/reality-web/src/components/comparison/ComparisonView.tsx
@@ -8,89 +8,109 @@
 
 import type { ListingSummary } from '@ppt/reality-api-client';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+import { useMemo, useState } from 'react';
 
 import { useComparison } from '../../lib/comparison-context';
 
 interface ComparisonRow {
+  /** Stable, translation-independent identifier (used for keys + highlight logic). */
+  id: string;
   label: string;
   getValue: (listing: ListingSummary) => string | number | undefined;
   format?: (value: string | number | undefined, listing?: ListingSummary) => string;
   highlight?: 'lowest' | 'highest' | 'none';
 }
 
-// Format price with the listing's actual currency
-const formatPrice = (value: string | number | undefined, listing?: ListingSummary) => {
-  if (value === undefined) return '-';
-  const currency = listing?.currency ?? 'EUR';
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-    maximumFractionDigits: 0,
-  }).format(Number(value));
-};
-
-const comparisonRows: ComparisonRow[] = [
-  {
-    label: 'Price',
-    getValue: (l) => l.price,
-    format: formatPrice,
-    highlight: 'lowest',
-  },
-  {
-    label: 'Type',
-    getValue: (l) => l.transactionType,
-    format: (v) => {
-      if (!v) return '-';
-      if (v === 'sale') return 'For Sale';
-      if (v === 'rent') return 'For Rent';
-      return String(v);
-    },
-  },
-  {
-    label: 'Property Type',
-    getValue: (l) => l.propertyType,
-    format: (v) => (v ? String(v).charAt(0).toUpperCase() + String(v).slice(1) : '-'),
-  },
-  {
-    label: 'Area',
-    getValue: (l) => l.area,
-    format: (v) => (v !== undefined ? `${v} m²` : '-'),
-    highlight: 'highest',
-  },
-  {
-    label: 'Rooms',
-    getValue: (l) => l.rooms,
-    format: (v) => (v !== undefined ? String(v) : '-'),
-    highlight: 'highest',
-  },
-  {
-    label: 'Floor',
-    getValue: (l) => l.floor,
-    format: (v) => (v !== undefined ? String(v) : '-'),
-  },
-  {
-    label: 'City',
-    getValue: (l) => l.address?.city,
-    format: (v) => (v ? String(v) : '-'),
-  },
-  {
-    label: 'District',
-    getValue: (l) => l.address?.district,
-    format: (v) => (v ? String(v) : '-'),
-  },
-  {
-    label: 'Price per m²',
-    getValue: (l) => (l.area > 0 ? Math.round(l.price / l.area) : undefined),
-    format: formatPrice,
-    highlight: 'lowest',
-  },
-];
-
 export function ComparisonView() {
   const { listings, removeFromComparison, clearComparison, generateShareUrl, shareUrl } =
     useComparison();
+  const t = useTranslations('comparison');
+  const locale = useLocale();
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'info' } | null>(null);
+
+  // Format price with the listing's actual currency, in the active locale.
+  const formatPrice = useMemo(
+    () => (value: string | number | undefined, listing?: ListingSummary) => {
+      if (value === undefined) return '-';
+      const currency = listing?.currency ?? 'EUR';
+      return new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency,
+        maximumFractionDigits: 0,
+      }).format(Number(value));
+    },
+    [locale]
+  );
+
+  const comparisonRows: ComparisonRow[] = useMemo(
+    () => [
+      {
+        id: 'price',
+        label: t('rows.price'),
+        getValue: (l) => l.price,
+        format: formatPrice,
+        highlight: 'lowest',
+      },
+      {
+        id: 'type',
+        label: t('rows.type'),
+        getValue: (l) => l.transactionType,
+        format: (v) => {
+          if (!v) return '-';
+          if (v === 'sale') return t('transactionType.sale');
+          if (v === 'rent') return t('transactionType.rent');
+          return String(v);
+        },
+      },
+      {
+        id: 'propertyType',
+        label: t('rows.propertyType'),
+        getValue: (l) => l.propertyType,
+        format: (v) => (v ? String(v).charAt(0).toUpperCase() + String(v).slice(1) : '-'),
+      },
+      {
+        id: 'area',
+        label: t('rows.area'),
+        getValue: (l) => l.area,
+        format: (v) => (v !== undefined ? `${v} m²` : '-'),
+        highlight: 'highest',
+      },
+      {
+        id: 'rooms',
+        label: t('rows.rooms'),
+        getValue: (l) => l.rooms,
+        format: (v) => (v !== undefined ? String(v) : '-'),
+        highlight: 'highest',
+      },
+      {
+        id: 'floor',
+        label: t('rows.floor'),
+        getValue: (l) => l.floor,
+        format: (v) => (v !== undefined ? String(v) : '-'),
+      },
+      {
+        id: 'city',
+        label: t('rows.city'),
+        getValue: (l) => l.address?.city,
+        format: (v) => (v ? String(v) : '-'),
+      },
+      {
+        id: 'district',
+        label: t('rows.district'),
+        getValue: (l) => l.address?.district,
+        format: (v) => (v ? String(v) : '-'),
+      },
+      {
+        id: 'pricePerSqm',
+        label: t('rows.pricePerSqm'),
+        getValue: (l) => (l.area > 0 ? Math.round(l.price / l.area) : undefined),
+        format: formatPrice,
+        highlight: 'lowest',
+      },
+    ],
+    [t, formatPrice]
+  );
 
   const showToast = (message: string, type: 'success' | 'info' = 'success') => {
     setToast({ message, type });
@@ -101,10 +121,10 @@ export function ComparisonView() {
     return (
       <div className="empty-state">
         <div className="empty-icon">📊</div>
-        <h2>No properties to compare</h2>
-        <p>Add properties to your comparison from the listings page.</p>
+        <h2>{t('empty.title')}</h2>
+        <p>{t('empty.description')}</p>
         <Link href="/listings" className="browse-btn">
-          Browse Listings
+          {t('empty.browse')}
         </Link>
         <style jsx>{`
           .empty-state {
@@ -142,15 +162,15 @@ export function ComparisonView() {
     const url = generateShareUrl();
     try {
       await navigator.clipboard.writeText(url);
-      showToast('Comparison link copied to clipboard!', 'success');
+      showToast(t('toast.linkCopied'), 'success');
     } catch {
-      showToast(`Share this URL: ${url}`, 'info');
+      showToast(t('toast.shareUrl', { url }), 'info');
     }
   };
 
   const handleExportPDF = () => {
     // In a real implementation, this would generate a PDF
-    showToast('PDF export coming soon!', 'info');
+    showToast(t('toast.pdfComingSoon'), 'info');
   };
 
   // Check if all listings use the same currency
@@ -164,7 +184,7 @@ export function ComparisonView() {
     if (row.highlight === 'none' || !row.highlight) return '';
 
     // Disable price highlighting when currencies differ
-    if ((row.label === 'Price' || row.label === 'Price per m²') && !currenciesMatch()) {
+    if ((row.id === 'price' || row.id === 'pricePerSqm') && !currenciesMatch()) {
       return '';
     }
 
@@ -207,7 +227,7 @@ export function ComparisonView() {
             <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
             <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
           </svg>
-          Share
+          {t('actions.share')}
         </button>
         <button type="button" className="action-btn" onClick={handleExportPDF}>
           <svg
@@ -224,10 +244,10 @@ export function ComparisonView() {
             <line x1="12" y1="18" x2="12" y2="12" />
             <line x1="9" y1="15" x2="15" y2="15" />
           </svg>
-          Export PDF
+          {t('actions.exportPdf')}
         </button>
         <button type="button" className="action-btn danger" onClick={clearComparison}>
-          Clear All
+          {t('actions.clearAll')}
         </button>
       </div>
 
@@ -239,9 +259,7 @@ export function ComparisonView() {
 
       {!currenciesMatch() && (
         <div className="currency-warning" role="alert">
-          <p>
-            Note: Properties use different currencies. Price comparison highlighting is disabled.
-          </p>
+          <p>{t('currencyWarning')}</p>
         </div>
       )}
 
@@ -249,7 +267,7 @@ export function ComparisonView() {
         <table>
           <thead>
             <tr>
-              <th className="label-column">Property</th>
+              <th className="label-column">{t('propertyHeader')}</th>
               {listings.map((listing: ListingSummary) => (
                 <th key={listing.id} className="property-column">
                   <div className="property-header">
@@ -267,9 +285,9 @@ export function ComparisonView() {
                       type="button"
                       className="remove-btn"
                       onClick={() => removeFromComparison(listing.id)}
-                      aria-label={`Remove ${listing.title} from comparison`}
+                      aria-label={t('removeAria', { title: listing.title })}
                     >
-                      Remove
+                      {t('remove')}
                     </button>
                   </div>
                 </th>
@@ -278,7 +296,7 @@ export function ComparisonView() {
           </thead>
           <tbody>
             {comparisonRows.map((row) => (
-              <tr key={row.label}>
+              <tr key={row.id}>
                 <td className="label-cell">{row.label}</td>
                 {listings.map((listing: ListingSummary) => {
                   const value = row.getValue(listing);


### PR DESCRIPTION
## Task
reality-web ComparisonView.tsx has no i18n — every string renders English on 4-locale portal

## Owner
pm-backend (hint — see Scope drift; this is a reality-web / next-intl frontend change)

## What changed
`frontend/apps/reality-web/src/components/comparison/ComparisonView.tsx` rendered **every** user-visible string in hardcoded English. All of them now go through next-intl:

- Row labels (Price, Type, Property Type, Area, Rooms, Floor, City, District, Price per m²)
- Transaction type values (For Sale / For Rent)
- Action buttons (Share, Export PDF, Clear All), table header (Property), Remove button + its `aria-label`
- Empty state (title, description, Browse Listings link)
- Toasts (link copied, share URL, PDF-coming-soon) and the mixed-currency warning

Implementation notes:
- Strings resolve via `useTranslations('comparison')`; prices now format in the active locale via `useLocale()` instead of a hardcoded `'en-US'`.
- `comparisonRows` moved inside the component (memoized on `t`/locale) so labels are translatable; each row carries a stable `id` and the highlight logic keys off `id` rather than the English label text (previously `row.label === 'Price'`).
- Added the `comparison.*` keys to **all six** message catalogs — `en, sk, cs, de, pl, hu` — with real native copy in each (row labels/transaction types reuse the existing wording from the `listing`/`filters` namespaces for consistency).

Note: the codebase actually ships 6 locale catalogs, not the 4 named in the finding.

## Scope drift
`scope-check.sh --owner pm-backend` exits 2 — the diff is entirely under `frontend/apps/reality-web/`, outside the `pm-backend` owner area. The `owner_role` hint is mislabeled: this is a pure reality-web (next-intl) frontend task. Drifting paths:
- `frontend/apps/reality-web/src/components/comparison/ComparisonView.tsx`
- `frontend/apps/reality-web/messages/{en,sk,cs,de,pl,hu}.json`

No backend/other-area files touched. Reviewer to adjudicate.

## Code-reuse review
`reuse-grep.sh --specialist nextjs-web` — no warnings.

## Verification
```
VERIFY-PLAN base=fb98c37b6a5cb75764b2e74b044dbb6203d5837e files=7
  cd frontend && pnpm exec biome check apps/reality-web/messages/cs.json apps/reality-web/messages/de.json apps/reality-web/messages/en.json apps/reality-web/messages/hu.json apps/reality-web/messages/pl.json apps/reality-web/messages/sk.json apps/reality-web/src/components/comparison/ComparisonView.tsx
  cd frontend && pnpm --filter "...[fb98c37b6a5cb75764b2e74b044dbb6203d5837e]" typecheck
  cd frontend && pnpm --filter "...[fb98c37b6a5cb75764b2e74b044dbb6203d5837e]" test
```
```
VERIFY OK 030d89d2f75092adec42479c00d4bdc69e8175fb
```
biome clean · reality-web typecheck clean · vitest 243 passed (25 files). All 6 catalogs carry the full `comparison` key set (11 keys each).

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Notes
- Property type values still render via capitalization of the backend enum (data-driven), not a per-value translation — out of scope for this UI-string fix and would need the full enum set to avoid loud dev fallbacks.
- Goal-check IG1/IG2/IG8 are N/A for this dispatcher code-review task (no `.research/plans/<slug>.md`, dispatcher-chosen `auto-impl/*` branch, no plan-archive move). Substantive gate IG7 (`just verify`) is green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XyKRuUBiyBqxtwCJ3qzrNH)_