### PR TITLE
code-review-mobile-rn-nfc-securestore-2kb-blob: chunk NFC credentials across SecureStore slots to avoid 2KB cap

### DIFF
--- a/frontend/apps/mobile/src/nfc/NFCCredentialManager.test.ts
+++ b/frontend/apps/mobile/src/nfc/NFCCredentialManager.test.ts
@@ -8,13 +8,60 @@
  * treated as an empty/unavailable log rather than throwing.
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 import { NFCCredentialManager } from './NFCCredentialManager';
+import type { NFCCredential } from './types';
 
 const getItem = AsyncStorage.getItem as jest.Mock;
 const setItem = AsyncStorage.setItem as jest.Mock;
 
+const secureGet = SecureStore.getItemAsync as jest.Mock;
+const secureSet = SecureStore.setItemAsync as jest.Mock;
+const secureDelete = SecureStore.deleteItemAsync as jest.Mock;
+
 const ACCESS_LOG_KEY = '@ppt/access_log';
+const CREDENTIALS_KEY = 'ppt_nfc_credentials';
+// SecureStore's Android per-value cap. Every persisted slot must stay under it.
+const SECURE_STORE_MAX_BYTES = 2048;
+
+/** UTF-8 byte length of a string, without depending on Node's Buffer type. */
+function utf8ByteLength(str: string): number {
+  // encodeURIComponent percent-escapes each non-ASCII byte, so the decoded
+  // length equals the UTF-8 byte count.
+  return unescape(encodeURIComponent(str)).length;
+}
+
+/** Back the mocked SecureStore with a real in-memory map for round-trip tests. */
+function installStatefulSecureStore(): Map<string, string> {
+  const store = new Map<string, string>();
+  secureGet.mockImplementation(async (key: string) => store.get(key) ?? null);
+  secureSet.mockImplementation(async (key: string, value: string) => {
+    store.set(key, value);
+  });
+  secureDelete.mockImplementation(async (key: string) => {
+    store.delete(key);
+  });
+  return store;
+}
+
+/** Build a credential whose serialized size is dominated by `encryptedData`. */
+function makeCredential(id: string, payloadBytes: number): NFCCredential {
+  return {
+    id,
+    buildingId: `building-${id}`,
+    buildingName: `Building ${id}`,
+    userId: 'user-1',
+    accessLevel: 'resident',
+    accessPoints: [{ id: `ap-${id}`, name: 'Main Entrance', type: 'main_entrance' }],
+    validFrom: '2026-01-01T00:00:00.000Z',
+    validUntil: '2027-01-01T00:00:00.000Z',
+    status: 'active',
+    usageCount: 0,
+    // 'x'.repeat stands in for the base64 encrypted credential payload.
+    encryptedData: 'x'.repeat(payloadBytes),
+  };
+}
 
 describe('NFCCredentialManager.getAccessLog', () => {
   let manager: NFCCredentialManager;
@@ -71,5 +118,125 @@ describe('NFCCredentialManager.getAccessLog', () => {
       accessPointName: 'Front Door',
       result: 'granted',
     });
+  });
+});
+
+/**
+ * Regression guard: credentials must be chunked across SecureStore slots so a
+ * large fetched set is never silently dropped by SecureStore's ~2 KB per-value
+ * Android cap. The pre-fix implementation stringified the whole array into one
+ * slot; a set larger than 2 KB would exceed the cap and fail to persist.
+ */
+describe('NFCCredentialManager credential storage (SecureStore chunking)', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installStatefulSecureStore();
+    // No legacy AsyncStorage credentials in these suites.
+    getItem.mockResolvedValue(null);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  /** Drive fetchCredentials() to persist a given credential set. */
+  async function persist(manager: NFCCredentialManager, creds: NFCCredential[]): Promise<void> {
+    const fetchSpy = jest
+      .spyOn(
+        manager as unknown as { apiRequest: (...a: unknown[]) => Promise<unknown> },
+        'apiRequest'
+      )
+      .mockResolvedValueOnce({ credentials: creds });
+    await manager.fetchCredentials();
+    fetchSpy.mockRestore();
+  }
+
+  it('keeps every SecureStore value under the 2 KB cap for a large credential set', async () => {
+    const manager = new NFCCredentialManager('http://localhost:8080');
+    // Five ~1 KB credentials => ~5 KB serialized, well past the single-slot cap.
+    const creds = Array.from({ length: 5 }, (_, i) => makeCredential(`c${i}`, 1000));
+
+    await persist(manager, creds);
+
+    // Multiple slots were written (manifest + chunks), and none breaches the cap.
+    expect(secureSet.mock.calls.length).toBeGreaterThan(1);
+    for (const [, value] of secureSet.mock.calls) {
+      expect(utf8ByteLength(value as string)).toBeLessThanOrEqual(SECURE_STORE_MAX_BYTES);
+    }
+  });
+
+  it('round-trips a large credential set through a fresh manager instance', async () => {
+    const writer = new NFCCredentialManager('http://localhost:8080');
+    const creds = Array.from({ length: 6 }, (_, i) => makeCredential(`c${i}`, 900));
+    await persist(writer, creds);
+
+    // A brand-new instance sharing the same (in-memory) SecureStore must load
+    // the identical credential set back.
+    const reader = new NFCCredentialManager('http://localhost:8080');
+    await reader.initialize();
+    expect(reader.getCredentialById('c0')).toEqual(creds[0]);
+    expect(reader.getCredentialById('c5')).toEqual(creds[5]);
+    expect(reader.getActiveCredentials()).toHaveLength(6);
+  });
+
+  it('reads the legacy single-slot format (raw JSON array under the key)', async () => {
+    const store = installStatefulSecureStore();
+    const legacy = [makeCredential('legacy-1', 200)];
+    store.set(CREDENTIALS_KEY, JSON.stringify(legacy));
+
+    const manager = new NFCCredentialManager('http://localhost:8080');
+    await manager.initialize();
+    expect(manager.getCredentialById('legacy-1')).toEqual(legacy[0]);
+  });
+
+  it('cleans up stale chunks when the credential set shrinks', async () => {
+    const store = installStatefulSecureStore();
+    const manager = new NFCCredentialManager('http://localhost:8080');
+
+    await persist(
+      manager,
+      Array.from({ length: 6 }, (_, i) => makeCredential(`c${i}`, 900))
+    );
+    const chunkKeysAfterLarge = [...store.keys()].filter((k) =>
+      k.startsWith(`${CREDENTIALS_KEY}_c`)
+    );
+    expect(chunkKeysAfterLarge.length).toBeGreaterThan(1);
+
+    // Shrink to a single small credential.
+    await persist(manager, [makeCredential('c0', 100)]);
+    const chunkKeysAfterSmall = [...store.keys()].filter((k) =>
+      k.startsWith(`${CREDENTIALS_KEY}_c`)
+    );
+    expect(chunkKeysAfterSmall).toEqual([`${CREDENTIALS_KEY}_c0`]);
+
+    // The shrunken set still reloads correctly (no stranded-chunk corruption).
+    const reader = new NFCCredentialManager('http://localhost:8080');
+    await reader.initialize();
+    expect(reader.getActiveCredentials()).toHaveLength(1);
+    expect(reader.getCredentialById('c0')).toBeDefined();
+  });
+
+  it('treats a missing chunk as corruption and falls back to an empty list', async () => {
+    const store = installStatefulSecureStore();
+    const manager = new NFCCredentialManager('http://localhost:8080');
+    await persist(
+      manager,
+      Array.from({ length: 5 }, (_, i) => makeCredential(`c${i}`, 900))
+    );
+
+    // Simulate a torn write: drop one chunk slot.
+    const chunkKey = [...store.keys()].find((k) => k.startsWith(`${CREDENTIALS_KEY}_c`));
+    store.delete(chunkKey as string);
+
+    const reader = new NFCCredentialManager('http://localhost:8080');
+    await expect(reader.initialize()).resolves.toBeUndefined();
+    expect(reader.getActiveCredentials()).toEqual([]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('credentials corrupted'),
+      expect.anything()
+    );
   });
 });

--- a/frontend/apps/mobile/src/nfc/NFCCredentialManager.ts
+++ b/frontend/apps/mobile/src/nfc/NFCCredentialManager.ts
@@ -18,15 +18,68 @@ import type {
 // they're encrypted at rest. Access logs are not sensitive and remain in
 // AsyncStorage for simpler querying of the last N entries.
 //
-// SecureStore has a per-value size cap of ~2 KB, which is plenty for the
-// credential list we expect (tens of entries). We stringify the whole array
-// into one slot to keep the single-slot API simple.
+// SecureStore has a per-value size cap of ~2 KB on Android: writing a larger
+// value logs a warning and the write can silently fail, which would drop
+// credentials we just fetched from the server. A single NFCCredential carries
+// an `encryptedData` blob plus an `accessPoints` array, so even a handful of
+// buildings can push the serialized list past 2 KB. We therefore split the
+// serialized array across as many chunk slots as needed (each kept under the
+// cap) and record the chunk count in a small manifest stored at
+// CREDENTIALS_KEY. Reads reassemble the chunks; the legacy single-slot format
+// (a raw JSON array under CREDENTIALS_KEY) is still read transparently.
 const CREDENTIALS_KEY = 'ppt_nfc_credentials';
+// Prefix for the per-chunk slots, e.g. `ppt_nfc_credentials_c0`.
+const CREDENTIALS_CHUNK_PREFIX = 'ppt_nfc_credentials_c';
+// Byte budget per chunk. SecureStore's Android cap is ~2048 bytes; leave
+// headroom for encryption/framing overhead.
+const MAX_CHUNK_BYTES = 1800;
+// Upper bound on chunk slots we ever scan when cleaning up a corrupted/stale
+// write. 64 * 1800 B ≈ 115 KB, far beyond the "tens of entries" we expect.
+const MAX_CREDENTIAL_CHUNKS = 64;
 // Legacy key used by earlier versions that stored credentials in AsyncStorage;
 // read-through once at startup so upgraded users don't lose their credentials.
 const LEGACY_CREDENTIALS_KEY = '@ppt/nfc_credentials';
 const ACCESS_LOG_KEY = '@ppt/access_log';
 const MAX_LOG_ENTRIES = 100;
+
+/** Manifest written at CREDENTIALS_KEY describing the chunked credential blob. */
+interface CredentialManifest {
+  v: 1;
+  chunks: number;
+}
+
+/** UTF-8 byte length of a single Unicode code point. */
+function codePointUtf8Bytes(codePoint: number): number {
+  if (codePoint < 0x80) return 1;
+  if (codePoint < 0x800) return 2;
+  if (codePoint < 0x10000) return 3;
+  return 4;
+}
+
+/**
+ * Split a string into chunks whose UTF-8 encodings each stay within `maxBytes`.
+ * Iterates by code point (surrogate-safe), so `chunks.join('')` reproduces the
+ * original string exactly. Always returns at least one chunk (possibly empty).
+ */
+function chunkByUtf8Bytes(str: string, maxBytes: number): string[] {
+  const chunks: string[] = [];
+  let current = '';
+  let currentBytes = 0;
+  for (const ch of str) {
+    const chBytes = codePointUtf8Bytes(ch.codePointAt(0) ?? 0);
+    if (currentBytes + chBytes > maxBytes && current.length > 0) {
+      chunks.push(current);
+      current = '';
+      currentBytes = 0;
+    }
+    current += ch;
+    currentBytes += chBytes;
+  }
+  if (current.length > 0 || chunks.length === 0) {
+    chunks.push(current);
+  }
+  return chunks;
+}
 
 /**
  * Manages NFC credentials for building access.
@@ -274,17 +327,18 @@ export class NFCCredentialManager {
 
   private async loadStoredCredentials(): Promise<void> {
     // Stored credentials may be corrupted (partial writes, manual app-data
-    // restore, OS wipe of secure store). Never let a parse failure crash
-    // app startup: fall back to an empty list and drop the bad blob.
+    // restore, OS wipe of secure store) or split across chunk slots (large
+    // credential sets, see storeCredentials). Never let a read/parse failure
+    // crash app startup: fall back to an empty list and drop the bad blob.
     const stored = await SecureStore.getItemAsync(CREDENTIALS_KEY);
     if (stored) {
       try {
-        this.credentials = JSON.parse(stored);
+        this.credentials = await this.deserializeStoredCredentials(stored);
         return;
       } catch (err) {
         console.warn('[nfc] Stored credentials corrupted; discarding.', err);
         this.credentials = [];
-        await SecureStore.deleteItemAsync(CREDENTIALS_KEY);
+        await this.clearStoredCredentials();
         return;
       }
     }
@@ -302,8 +356,93 @@ export class NFCCredentialManager {
     }
   }
 
+  /**
+   * Reconstruct the credential array from what's stored at CREDENTIALS_KEY.
+   * Handles both the chunked manifest format and the legacy single-slot format
+   * (a raw JSON array). Throws if the data is malformed or a chunk is missing,
+   * which the caller treats as corruption.
+   */
+  private async deserializeStoredCredentials(stored: string): Promise<NFCCredential[]> {
+    const parsed: unknown = JSON.parse(stored);
+
+    // Chunked format: a manifest pointing at N chunk slots.
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      typeof (parsed as CredentialManifest).chunks === 'number'
+    ) {
+      const { chunks } = parsed as CredentialManifest;
+      const parts: string[] = [];
+      for (let i = 0; i < chunks; i++) {
+        const part = await SecureStore.getItemAsync(`${CREDENTIALS_CHUNK_PREFIX}${i}`);
+        if (part === null) {
+          throw new Error(`missing credential chunk ${i} of ${chunks}`);
+        }
+        parts.push(part);
+      }
+      return JSON.parse(parts.join('')) as NFCCredential[];
+    }
+
+    // Legacy single-slot format: the whole array stringified under the key.
+    if (Array.isArray(parsed)) {
+      return parsed as NFCCredential[];
+    }
+
+    throw new Error('unrecognized stored credential format');
+  }
+
+  /** Delete the manifest and every chunk slot it could have written. */
+  private async clearStoredCredentials(): Promise<void> {
+    await SecureStore.deleteItemAsync(CREDENTIALS_KEY);
+    // Deleting a non-existent SecureStore key is a no-op, so a bounded sweep is
+    // safe even when we don't know the exact prior chunk count.
+    for (let i = 0; i < MAX_CREDENTIAL_CHUNKS; i++) {
+      await SecureStore.deleteItemAsync(`${CREDENTIALS_CHUNK_PREFIX}${i}`);
+    }
+  }
+
   private async storeCredentials(): Promise<void> {
-    await SecureStore.setItemAsync(CREDENTIALS_KEY, JSON.stringify(this.credentials));
+    const serialized = JSON.stringify(this.credentials);
+    const parts = chunkByUtf8Bytes(serialized, MAX_CHUNK_BYTES);
+
+    // How many chunk slots did the previous write leave behind? Needed so a
+    // shrinking credential set doesn't strand stale chunks that a later read
+    // might reassemble into a corrupt blob.
+    const previousChunks = await this.readManifestChunkCount();
+
+    // Write the chunks first, then the manifest that points at them: a crash
+    // between the two leaves the (still-consistent) previous manifest in place.
+    for (let i = 0; i < parts.length; i++) {
+      await SecureStore.setItemAsync(`${CREDENTIALS_CHUNK_PREFIX}${i}`, parts[i]);
+    }
+    const manifest: CredentialManifest = { v: 1, chunks: parts.length };
+    await SecureStore.setItemAsync(CREDENTIALS_KEY, JSON.stringify(manifest));
+
+    // Remove chunk slots left over from a previously larger credential set.
+    for (let i = parts.length; i < previousChunks; i++) {
+      await SecureStore.deleteItemAsync(`${CREDENTIALS_CHUNK_PREFIX}${i}`);
+    }
+  }
+
+  /** Chunk count recorded by the last chunked write, or 0 if none/legacy. */
+  private async readManifestChunkCount(): Promise<number> {
+    const raw = await SecureStore.getItemAsync(CREDENTIALS_KEY);
+    if (!raw) return 0;
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        !Array.isArray(parsed) &&
+        typeof (parsed as CredentialManifest).chunks === 'number'
+      ) {
+        return (parsed as CredentialManifest).chunks;
+      }
+    } catch {
+      // Not a manifest (legacy raw array or corrupt) — nothing to clean up.
+    }
+    return 0;
   }
 
   private async apiRequest<T>(


### PR DESCRIPTION
## Task
NFC credentials stored as one SecureStore value can exceed the ~2KB cap, silently dropping fetched credentials.

`NFCCredentialManager.storeCredentials()` stringified the entire credential array into a single `expo-secure-store` value. On Android SecureStore has a ~2KB per-value cap: a larger write logs a warning and can silently fail, so credentials just fetched from the server are never persisted. A single `NFCCredential` carries an `encryptedData` blob plus an `accessPoints` array, so even a handful of buildings can push the serialized list past 2KB — the "tens of entries is plenty" assumption in the old comment was the defect.

### Fix
- Split the serialized array across as many chunk slots as needed (`ppt_nfc_credentials_c0…cN`), each kept under a 1800-byte budget (headroom below the ~2048-byte cap), with a small manifest `{ v, chunks }` at the existing `ppt_nfc_credentials` key.
- Chunking is UTF-8-byte aware and surrogate-safe (`chunkByUtf8Bytes` iterates by code point), so `chunks.join('')` reproduces the exact string even with multibyte building names.
- Reads reassemble the chunks. The **legacy single-slot format** (raw JSON array under the key) and the **legacy AsyncStorage migration** path are still read transparently, so upgrades don't lose credentials.
- Shrinking credential sets clean up now-stale chunk slots; a missing chunk is treated as corruption and falls back to an empty list (consistent with the existing corrupt-blob handling).

## Owner
pm-backend (hint) — see Scope drift below.

## Scope drift
`scope-check.sh --owner pm-backend` reports **exit 2 (drift)** for:
- `frontend/apps/mobile/src/nfc/NFCCredentialManager.ts`
- `frontend/apps/mobile/src/nfc/NFCCredentialManager.test.ts`

This is expected and justified: the task is explicitly a **mobile-rn** (React Native / Expo SecureStore) finding, but the dispatcher tagged `owner_role=pm-backend`. The change lives entirely in the correct place — the RN mobile app's NFC module. No backend code touched.

## Verification
```
VERIFY-PLAN base=1215ec9dbeca750180c2ea2f28e9ba7146e8bc5d files=2
  cd frontend && pnpm exec biome check apps/mobile/src/nfc/NFCCredentialManager.test.ts apps/mobile/src/nfc/NFCCredentialManager.ts
  cd frontend && pnpm --filter "...[1215ec9dbeca750180c2ea2f28e9ba7146e8bc5d]" typecheck
  cd frontend && pnpm --filter "...[1215ec9dbeca750180c2ea2f28e9ba7146e8bc5d]" test
```
```
VERIFY OK 4c6bcf0ea10dac48bf16e62a9c8c2770c00fcff1
```
Frontend impact-scoped gate green: Biome clean, `mobile` typecheck clean, 657 tests pass (53 suites).

### TDD evidence (IG3)
- `test:` commit adds a regression guard that **fails on the pre-fix single-slot impl** — verified: `expect(secureSet.mock.calls.length).toBeGreaterThan(1)` fails because the old code writes exactly one slot, and the 2KB-cap byte assertion also fails.
- `fix:` commit makes it green. New tests cover: every slot ≤ 2KB for a large set, round-trip through a fresh manager, legacy single-slot read, stale-chunk cleanup on shrink, and missing-chunk → empty fallback.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (local credential cache; no security/auth/billing/data-integrity server change).

## Remote-tested
skipped (ppt-bridge MCP not used).

## Notes
- Chunk-then-manifest write order means a crash mid-write leaves the previous (consistent) manifest in place rather than a half-updated pointer.
- Cleanup sweep is bounded by `MAX_CREDENTIAL_CHUNKS = 64` (~115KB ceiling), far beyond the expected tens of entries.
- Priority: low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyKRuUBiyBqxtwCJ3qzrNH

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyKRuUBiyBqxtwCJ3qzrNH)_