### PR TITLE
repeated-churn voice_webhooks.rs: don't panic building Google JWKS HTTP client

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -1249,7 +1249,11 @@ fn google_jwks_http() -> &'static reqwest::Client {
         reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(5))
             .build()
-            .expect("build Google JWKS HTTP client")
+            // Mirror `alexa_cert_http_client`: a builder failure means the TLS
+            // backend could not initialise, and a default client would fail the
+            // same way — fall back to it rather than panicking inside the
+            // request-serving `verify_google_request` path.
+            .unwrap_or_else(|_| reqwest::Client::new())
     })
 }
 


### PR DESCRIPTION
Auto: address repeated-churn hot-path in `backend/servers/api-server/src/routes/` — harmonise `google_jwks_http()` with its non-panicking sibling `alexa_cert_http_client()` so neither can panic inside a request-serving handler.

Branch was pushed by a reclaimed implementer that did not open a PR (recovered by the dispatcher Phase 2 branch-exists/no-PR path). Commit: `8bb7353 refactor(api-server): don't panic building Google JWKS HTTP client`.

---
_Generated by [Claude Code](https://claude.ai/code/session_015AHg3rskE16Prqj8Tfmka1)_