### PR TITLE
code-review-api-core-voice-actions-fabricated-empty-retry1: query real announcement/meter data in voice actions

### DIFF
--- a/backend/crates/db/src/repositories/meter.rs
+++ b/backend/crates/db/src/repositories/meter.rs
@@ -14,7 +14,7 @@ use crate::models::meter::{
 use crate::DbPool;
 use chrono::{NaiveDate, Utc};
 use rust_decimal::Decimal;
-use sqlx::Error as SqlxError;
+use sqlx::{Error as SqlxError, Executor, Postgres};
 use uuid::Uuid;
 
 /// Repository for meter operations.
@@ -507,6 +507,38 @@ impl MeterRepository {
         .bind(org_id)
         .bind(building_id)
         .fetch_all(&self.pool)
+        .await
+    }
+
+    /// List pending meter readings for a single unit, honouring the caller's
+    /// RLS session context.
+    ///
+    /// Unlike [`get_pending_readings`] (org/building-wide, own-pool), this is
+    /// scoped to one resident's unit and runs on the caller-supplied,
+    /// context-set connection so tenant isolation is enforced. Used by the
+    /// voice assistant's "check meter readings" intent, which must answer with
+    /// the resident's own pending readings rather than fabricating an empty
+    /// result.
+    pub async fn get_pending_readings_for_unit_rls<'e, E>(
+        &self,
+        executor: E,
+        unit_id: Uuid,
+    ) -> Result<Vec<MeterReading>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, MeterReading>(
+            r#"
+            SELECT r.*
+            FROM meter_readings r
+            JOIN meters m ON r.meter_id = m.id
+            WHERE m.unit_id = $1
+              AND r.status = 'pending'
+            ORDER BY r.reading_date ASC
+            "#,
+        )
+        .bind(unit_id)
+        .fetch_all(executor)
         .await
     }
 

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -178,6 +178,8 @@ async fn alexa_webhook(
                 state.llm_document_repo.clone(),
                 state.fault_repo.clone(),
                 state.unit_repo.clone(),
+                state.announcement_repo.clone(),
+                state.meter_repo.clone(),
             );
             let (result, _) = processor
                 .process_command(rls.conn(), device.id, "help", &locale)
@@ -198,6 +200,8 @@ async fn alexa_webhook(
                 state.llm_document_repo.clone(),
                 state.fault_repo.clone(),
                 state.unit_repo.clone(),
+                state.announcement_repo.clone(),
+                state.meter_repo.clone(),
             );
             let (result, _) = processor
                 .process_command(rls.conn(), device.id, &command_text, &locale)
@@ -311,6 +315,8 @@ async fn google_actions_webhook(
         state.llm_document_repo.clone(),
         state.fault_repo.clone(),
         state.unit_repo.clone(),
+        state.announcement_repo.clone(),
+        state.meter_repo.clone(),
     );
     let (result, _) = processor
         .process_command(rls.conn(), device.id, command_text, locale)

--- a/backend/servers/api-server/src/services/voice_commands.rs
+++ b/backend/servers/api-server/src/services/voice_commands.rs
@@ -9,7 +9,9 @@ use db::models::{
     fault_category, voice_intent, CreateFault, ParsedVoiceCommand, VoiceActionResult,
     VoiceAssistantDevice, VoiceCard, VoiceCommandHistory,
 };
-use db::repositories::{FaultRepository, LlmDocumentRepository, UnitRepository};
+use db::repositories::{
+    AnnouncementRepository, FaultRepository, LlmDocumentRepository, MeterRepository, UnitRepository,
+};
 use serde_json::json;
 use sqlx::PgConnection;
 use std::time::Instant;
@@ -47,6 +49,8 @@ pub struct VoiceCommandProcessor {
     llm_document_repo: LlmDocumentRepository,
     fault_repo: FaultRepository,
     unit_repo: UnitRepository,
+    announcement_repo: AnnouncementRepository,
+    meter_repo: MeterRepository,
 }
 
 impl VoiceCommandProcessor {
@@ -55,11 +59,15 @@ impl VoiceCommandProcessor {
         llm_document_repo: LlmDocumentRepository,
         fault_repo: FaultRepository,
         unit_repo: UnitRepository,
+        announcement_repo: AnnouncementRepository,
+        meter_repo: MeterRepository,
     ) -> Self {
         Self {
             llm_document_repo,
             fault_repo,
             unit_repo,
+            announcement_repo,
+            meter_repo,
         }
     }
 
@@ -157,10 +165,10 @@ impl VoiceCommandProcessor {
             voice_intent::CHECK_BALANCE => self.action_check_balance(device, parsed).await,
             voice_intent::REPORT_FAULT => self.action_report_fault(conn, device, parsed).await,
             voice_intent::CHECK_ANNOUNCEMENTS => {
-                self.action_check_announcements(device, parsed).await
+                self.action_check_announcements(conn, device, parsed).await
             }
             voice_intent::BOOK_FACILITY => self.action_book_facility(device, parsed).await,
-            voice_intent::CHECK_METER => self.action_check_meter(device, parsed).await,
+            voice_intent::CHECK_METER => self.action_check_meter(conn, device, parsed).await,
             voice_intent::CONTACT_MANAGER => self.action_contact_manager(device, parsed).await,
             voice_intent::GET_HELP => self.action_get_help(device, parsed).await,
             _ => Err(VoiceCommandError::InvalidIntent(parsed.intent.clone())),
@@ -384,30 +392,55 @@ impl VoiceCommandProcessor {
 
     async fn action_check_announcements(
         &self,
-        _device: &VoiceAssistantDevice,
+        conn: &mut PgConnection,
+        device: &VoiceAssistantDevice,
         parsed: &ParsedVoiceCommand,
     ) -> Result<VoiceActionResult, VoiceCommandError> {
-        // No announcement repository is wired into the voice processor yet, so
-        // there is nothing to query. This used to fabricate a "you have no new
-        // announcements" success response with an empty `data` payload on this
-        // live webhook path (code review: fabricated success) — a resident
-        // could be told there is nothing new when announcements were never
-        // actually queried. Fail honestly instead: tell the caller the feature
-        // isn't available via voice yet rather than asserting an empty inbox.
-        let response = match parsed.language.as_str() {
-            "sk" => "Kontrola oznamov hlasom momentalne nie je dostupna. Prosim, pouzite mobilnu aplikaciu alebo webovy portal.",
-            "cs" => "Kontrola oznameni hlasem momentalne neni dostupna. Prosim, pouzijte mobilni aplikaci nebo webovy portal.",
-            _ => "Checking announcements is not yet available via voice assistant. Please use the mobile app or web portal.",
+        // Actually query the resident's unread published announcements before
+        // answering. This handler used to fabricate a "you have no new
+        // announcements" success response with an empty `data` payload without
+        // ever consulting a repository (code review: fabricated empty success)
+        // — a resident could be told there is nothing new when announcements
+        // were never queried. Now we count genuinely-unread announcements on
+        // the caller's RLS-scoped connection and only report an empty inbox
+        // when the query truly returned zero.
+        let unread = self
+            .announcement_repo
+            .count_unread_rls(&mut *conn, device.organization_id, device.user_id)
+            .await?;
+
+        let response = if unread == 0 {
+            match parsed.language.as_str() {
+                "sk" => "Nemate ziadne nove oznamy.".to_string(),
+                "cs" => "Nemate zadna nova oznameni.".to_string(),
+                _ => "You have no new announcements.".to_string(),
+            }
+        } else {
+            match parsed.language.as_str() {
+                "sk" => format!(
+                    "Mate {unread} novych oznamov. Podrobnosti najdete v mobilnej aplikacii alebo na webovom portali."
+                ),
+                "cs" => format!(
+                    "Mate {unread} novych oznameni. Podrobnosti najdete v mobilni aplikaci nebo na webovem portalu."
+                ),
+                _ => format!(
+                    "You have {unread} new announcement(s). Open the mobile app or web portal to read them."
+                ),
+            }
         };
 
         Ok(VoiceActionResult {
-            success: false,
+            success: true,
             action_type: voice_intent::CHECK_ANNOUNCEMENTS.to_string(),
-            response_text: response.to_string(),
+            response_text: response.clone(),
             ssml: Some(format!("<speak>{}</speak>", response)),
-            card: None,
+            card: Some(VoiceCard {
+                title: self.localize("Announcements", &parsed.language),
+                content: response.clone(),
+                image_url: None,
+            }),
             should_end_session: true,
-            data: None,
+            data: Some(json!({ "unread_count": unread })),
         })
     }
 
@@ -435,31 +468,63 @@ impl VoiceCommandProcessor {
 
     async fn action_check_meter(
         &self,
-        _device: &VoiceAssistantDevice,
+        conn: &mut PgConnection,
+        device: &VoiceAssistantDevice,
         parsed: &ParsedVoiceCommand,
     ) -> Result<VoiceActionResult, VoiceCommandError> {
-        // No meter repository is wired into the voice processor yet, so there
-        // is nothing to query. This used to fabricate a "there are no pending
-        // readings" success response with an empty `data` payload on this live
-        // webhook path (code review: fabricated success) — a resident could be
-        // told their readings are up to date when the meter state was never
-        // actually queried. Fail honestly instead: tell the caller the feature
-        // isn't available via voice yet rather than asserting there is nothing
-        // pending.
-        let response = match parsed.language.as_str() {
-            "sk" => "Kontrola odcitania meracov hlasom momentalne nie je dostupna. Prosim, pouzite mobilnu aplikaciu alebo webovy portal.",
-            "cs" => "Kontrola odectu meracu hlasem momentalne neni dostupna. Prosim, pouzijte mobilni aplikaci nebo webovy portal.",
-            _ => "Checking meter readings is not yet available via voice assistant. Please use the mobile app or web portal.",
+        // Actually query the resident's pending meter readings before
+        // answering. This handler used to fabricate a "there are no pending
+        // readings" success response with an empty `data` payload without ever
+        // consulting a repository (code review: fabricated empty success) — a
+        // resident could be told their readings are up to date when the meter
+        // state was never queried. The device is linked to a unit; resolve it
+        // and count genuinely-pending readings on the caller's RLS-scoped
+        // connection, only reporting "nothing pending" when the query truly
+        // returned zero.
+        let unit_id = device.unit_id.ok_or_else(|| {
+            VoiceCommandError::ActionFailed(
+                "voice device is not linked to a unit; cannot check meter readings".to_string(),
+            )
+        })?;
+
+        let pending = self
+            .meter_repo
+            .get_pending_readings_for_unit_rls(&mut *conn, unit_id)
+            .await?;
+        let pending_count = pending.len();
+
+        let response = if pending_count == 0 {
+            match parsed.language.as_str() {
+                "sk" => "Nemate ziadne cakajuce odcitania meracov.".to_string(),
+                "cs" => "Nemate zadne cekajici odecty meracu.".to_string(),
+                _ => "You have no pending meter readings.".to_string(),
+            }
+        } else {
+            match parsed.language.as_str() {
+                "sk" => format!(
+                    "Mate {pending_count} cakajucich odcitani meracov. Podrobnosti najdete v mobilnej aplikacii alebo na webovom portali."
+                ),
+                "cs" => format!(
+                    "Mate {pending_count} cekajicich odectu meracu. Podrobnosti najdete v mobilni aplikaci nebo na webovem portalu."
+                ),
+                _ => format!(
+                    "You have {pending_count} pending meter reading(s). Open the mobile app or web portal for details."
+                ),
+            }
         };
 
         Ok(VoiceActionResult {
-            success: false,
+            success: true,
             action_type: voice_intent::CHECK_METER.to_string(),
-            response_text: response.to_string(),
+            response_text: response.clone(),
             ssml: Some(format!("<speak>{}</speak>", response)),
-            card: None,
+            card: Some(VoiceCard {
+                title: self.localize("Meter Readings", &parsed.language),
+                content: response.clone(),
+                image_url: None,
+            }),
             should_end_session: true,
-            data: None,
+            data: Some(json!({ "pending_count": pending_count })),
         })
     }
 
@@ -621,7 +686,9 @@ mod tests {
         VoiceCommandProcessor::new(
             LlmDocumentRepository::new(pool.clone()),
             FaultRepository::new(pool.clone()),
-            UnitRepository::new(pool),
+            UnitRepository::new(pool.clone()),
+            AnnouncementRepository::new(pool.clone()),
+            MeterRepository::new(pool),
         )
     }
 
@@ -629,7 +696,9 @@ mod tests {
         VoiceCommandProcessor::new(
             LlmDocumentRepository::new(pool.clone()),
             FaultRepository::new(pool.clone()),
-            UnitRepository::new(pool),
+            UnitRepository::new(pool.clone()),
+            AnnouncementRepository::new(pool.clone()),
+            MeterRepository::new(pool),
         )
     }
 
@@ -785,81 +854,163 @@ mod tests {
     }
 
     /// Regression (code-review: voice check-announcements fabricated empty
-    /// success): the handler used to unconditionally report `success: true`
-    /// with a hardcoded "you have no new announcements" response and an empty
-    /// `data` payload on this live webhook path, without ever consulting an
-    /// announcement repository. No announcement service is wired in yet, so it
-    /// must now fail honestly — `success: false`, no fabricated `data`, and a
-    /// response that tells the caller the feature isn't available rather than
-    /// asserting an empty inbox.
-    #[tokio::test]
-    async fn test_check_announcements_fails_honestly_instead_of_fabricating_empty() {
-        let processor = create_test_processor();
-        let device = make_device(Uuid::new_v4(), Uuid::new_v4(), Some(Uuid::new_v4()));
+    /// success): the handler used to unconditionally report "you have no new
+    /// announcements" with an empty `data` payload without ever consulting an
+    /// announcement repository — a resident could be told there is nothing new
+    /// when announcements were never queried. It must now actually query the
+    /// resident's unread announcements and only report an empty inbox when the
+    /// query genuinely returned zero. Skipped by the offline verify gate (no
+    /// DATABASE_URL); runs under backend.yml CI.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_check_announcements_reports_empty_only_when_query_is_empty(pool: sqlx::PgPool) {
+        let org = seed_org(&pool, "ann").await;
+        let user = seed_user(&pool, "ann@voice.test").await;
+
+        let processor = processor_with_pool(pool.clone());
+        let device = make_device(org, user, Some(Uuid::new_v4()));
         let parsed = processor.parse_command("Any new announcements?", "en-US");
         assert_eq!(parsed.intent, voice_intent::CHECK_ANNOUNCEMENTS);
 
-        // action_check_announcements doesn't touch the database, so it can be
-        // called directly without acquiring a real connection.
-        let result = processor
-            .action_check_announcements(&device, &parsed)
+        // With no announcements in the org, the genuine query returns zero and
+        // the handler reports a real empty inbox.
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        let empty = processor
+            .action_check_announcements(&mut conn, &device, &parsed)
             .await
-            .expect("check-announcements must not error, it must fail honestly in-band");
+            .expect("check-announcements should succeed");
+        assert!(empty.success);
+        assert_eq!(
+            empty.data.as_ref().and_then(|d| d.get("unread_count")),
+            Some(&json!(0)),
+            "empty-inbox count must reflect the real query result"
+        );
+        assert!(empty
+            .response_text
+            .to_lowercase()
+            .contains("no new announcements"));
 
-        assert!(
-            !result.success,
-            "check-announcements must not report fabricated success"
+        // Publish an announcement the user has not read; the query must now see
+        // it and the handler must report a non-empty inbox.
+        sqlx::query(
+            r#"
+            INSERT INTO announcements
+                (organization_id, author_id, title, content, target_type, target_ids, status, published_at)
+            VALUES ($1, $2, 'Roof works', 'Scheduled maintenance', 'all', '[]'::jsonb, 'published', NOW())
+            "#,
+        )
+        .bind(org)
+        .bind(user)
+        .execute(&pool)
+        .await
+        .expect("insert published announcement");
+
+        let non_empty = processor
+            .action_check_announcements(&mut conn, &device, &parsed)
+            .await
+            .expect("check-announcements should succeed");
+        assert!(non_empty.success);
+        assert_eq!(
+            non_empty.data.as_ref().and_then(|d| d.get("unread_count")),
+            Some(&json!(1)),
+            "the handler must report the real unread count, not a fabricated empty inbox"
         );
-        assert!(
-            result.data.is_none(),
-            "no announcement data must be fabricated when no repository was queried"
-        );
-        assert!(
-            !result
-                .response_text
-                .to_lowercase()
-                .contains("no new announcements"),
-            "response must not claim a fabricated empty inbox"
-        );
+        assert!(!non_empty
+            .response_text
+            .to_lowercase()
+            .contains("no new announcements"));
     }
 
     /// Regression (code-review: voice check-meter fabricated empty success):
-    /// the handler used to unconditionally report `success: true` with a
-    /// hardcoded "there are no pending readings" response and an empty `data`
-    /// payload on this live webhook path, without ever consulting a meter
-    /// repository. No meter service is wired in yet, so it must now fail
-    /// honestly — `success: false`, no fabricated `data`, and a response that
-    /// tells the caller the feature isn't available rather than asserting
-    /// nothing is pending.
-    #[tokio::test]
-    async fn test_check_meter_fails_honestly_instead_of_fabricating_empty() {
-        let processor = create_test_processor();
-        let device = make_device(Uuid::new_v4(), Uuid::new_v4(), Some(Uuid::new_v4()));
+    /// the handler used to unconditionally report "there are no pending
+    /// readings" with an empty `data` payload without ever consulting a meter
+    /// repository — a resident could be told their readings are up to date when
+    /// the meter state was never queried. It must now actually query the
+    /// resident's pending readings and only report nothing pending when the
+    /// query genuinely returned zero. Skipped by the offline verify gate (no
+    /// DATABASE_URL); runs under backend.yml CI.
+    #[sqlx::test(migrator = "db::MIGRATOR")]
+    async fn test_check_meter_reports_empty_only_when_query_is_empty(pool: sqlx::PgPool) {
+        use db::models::meter::{RegisterMeter, SubmitReading};
+
+        let org = seed_org(&pool, "mtr").await;
+        let user = seed_user(&pool, "mtr@voice.test").await;
+        let building = seed_building(&pool, org, "MTR").await;
+        let unit = seed_unit(&pool, building, "MTR-1").await;
+
+        let processor = processor_with_pool(pool.clone());
+        let device = make_device(org, user, Some(unit));
         let parsed = processor.parse_command("Do I have any pending meter readings?", "en-US");
         assert_eq!(parsed.intent, voice_intent::CHECK_METER);
 
-        // action_check_meter doesn't touch the database, so it can be called
-        // directly without acquiring a real connection.
-        let result = processor
-            .action_check_meter(&device, &parsed)
+        // With no readings on the unit's meters, the genuine query returns zero
+        // and the handler reports a real "nothing pending".
+        let mut conn = pool.acquire().await.expect("acquire connection");
+        let empty = processor
+            .action_check_meter(&mut conn, &device, &parsed)
             .await
-            .expect("check-meter must not error, it must fail honestly in-band");
+            .expect("check-meter should succeed");
+        assert!(empty.success);
+        assert_eq!(
+            empty.data.as_ref().and_then(|d| d.get("pending_count")),
+            Some(&json!(0)),
+            "empty count must reflect the real query result"
+        );
+        assert!(empty
+            .response_text
+            .to_lowercase()
+            .contains("no pending meter readings"));
 
-        assert!(
-            !result.success,
-            "check-meter must not report fabricated success"
+        // Register a meter on the unit and submit a manual reading (which lands
+        // in `pending` status). The query must now see it.
+        let meter = processor
+            .meter_repo
+            .register_meter(
+                org,
+                RegisterMeter {
+                    building_id: building,
+                    unit_id: Some(unit),
+                    meter_number: "MTR-0001".to_string(),
+                    meter_type: db::models::meter::MeterType::Water,
+                    location: None,
+                    description: None,
+                    initial_reading: rust_decimal::Decimal::from(0),
+                    unit_of_measure: "m3".to_string(),
+                    is_shared: false,
+                    installed_at: None,
+                },
+            )
+            .await
+            .expect("register meter");
+        processor
+            .meter_repo
+            .submit_reading(
+                user,
+                SubmitReading {
+                    meter_id: meter.id,
+                    reading: rust_decimal::Decimal::from(42),
+                    reading_date: None,
+                    reading_time: None,
+                    source: db::models::meter::ReadingSource::Manual,
+                    photo_url: None,
+                },
+            )
+            .await
+            .expect("submit pending reading");
+
+        let non_empty = processor
+            .action_check_meter(&mut conn, &device, &parsed)
+            .await
+            .expect("check-meter should succeed");
+        assert!(non_empty.success);
+        assert_eq!(
+            non_empty.data.as_ref().and_then(|d| d.get("pending_count")),
+            Some(&json!(1)),
+            "the handler must report the real pending count, not a fabricated empty result"
         );
-        assert!(
-            result.data.is_none(),
-            "no meter data must be fabricated when no repository was queried"
-        );
-        assert!(
-            !result
-                .response_text
-                .to_lowercase()
-                .contains("no pending readings"),
-            "response must not claim fabricated absence of pending readings"
-        );
+        assert!(!non_empty
+            .response_text
+            .to_lowercase()
+            .contains("no pending meter readings"));
     }
 
     #[test]


### PR DESCRIPTION
## Task
Voice check-announcements & check-meter fabricate success with empty data — residents told "no new announcements" / "no pending readings" without any query being run. Make the voice action handlers actually query the announcements / meter-reading data before responding, and surface a genuine "nothing to report" only when the query truly returned empty (retry 1/2 of a previously-failed task).

## Owner
pm-backend

## What changed
`VoiceCommandProcessor` (`backend/servers/api-server/src/services/voice_commands.rs`) now holds `AnnouncementRepository` + `MeterRepository` and the two handlers query genuinely on the caller's RLS-scoped connection (`&mut PgConnection`, threaded through `execute_action` the same way `report_fault` already is):

- **check-announcements** — counts the resident's unread published announcements via the existing `AnnouncementRepository::count_unread_rls(conn, org_id, user_id)`. Reports "no new announcements" only when the count is genuinely `0`; otherwise reports the real count. `data` now carries the true `unread_count`.
- **check-meter** — resolves the device's `unit_id` and counts pending meter readings via a new unit-scoped `MeterRepository::get_pending_readings_for_unit_rls(conn, unit_id)`. Reports "no pending meter readings" only on a genuine empty result; `data` carries the true `pending_count`. A unit-less device errors (mirrors `report_fault`) instead of fabricating success.

The prior stopgap (both handlers returning a hardcoded "feature not available via voice") is replaced by real queries. `check-balance` is intentionally left untouched (out of scope — this task is announcements & meter only).

The two in-memory "fails-honestly" regression tests are replaced by `#[sqlx::test]`s that assert the empty-vs-non-empty response is driven by the real query result (empty org → genuine empty; after inserting a published announcement / submitting a pending reading → genuine non-empty).

New repo method added in `backend/crates/db/src/repositories/meter.rs` (own owner area — no migration/schema change; uses runtime `query_as`, no sqlx offline data needed).

## Verification
- `cd backend && SQLX_OFFLINE=true cargo clippy -p db --all-targets -- -D warnings` → **exit 0** (clean). Covers the new `get_pending_readings_for_unit_rls` repo method + imports.
- `cargo clippy -p api-server` could **not** run to completion in this sandbox: the `utoipa-swagger-ui v9.0.2` build script downloads `https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip`, and github.com is denied by this session's egress policy (HTTP 403 — "repository not enabled for this session"). Per the proxy policy I did not route around the 403. **api-server compilation + the new `#[sqlx::test]`s are delegated to `backend.yml` CI**, which has github access and a real Postgres.

The api-server diff is mechanical and mirrors the already-proven `report_fault` pattern in the same file line-for-line (conn threading, `&mut *conn` reborrow, `.await?` into `VoiceCommandError::Database`, `self.localize(..)` cards). Reviewer: please confirm CI (backend.yml) goes green before un-drafting.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested
skipped

## Scope drift
None — the diff touches only three `backend/` files (`crates/db/src/repositories/meter.rs`, `servers/api-server/src/{services/voice_commands.rs,routes/voice_webhooks.rs}`), all within pm-backend. (`scope-check.sh` reported a false positive because the worktree's local `dev` ref is stale relative to `origin/dev`; `git diff --stat origin/dev...HEAD` shows only the three files.)

## Code-reuse review
None — reuse-grep clean. Reused the existing `count_unread_rls`; the one new method is a unit-scoped RLS sibling of the existing org/building-scoped `get_pending_readings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AHg3rskE16Prqj8Tfmka1

---
_Generated by [Claude Code](https://claude.ai/code/session_015AHg3rskE16Prqj8Tfmka1)_