### PR TITLE
code-review-api-handlers-voice-oauth-exchange-no-rate-limit: rate-limit voice /oauth/exchange per user

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -98,6 +98,30 @@ fn voice_refresh_attempt_allowed(user_id: Uuid) -> bool {
     )
 }
 
+// `oauth_token_exchange` completes account linking by making a live call to
+// Amazon/Google (`exchange_code`). Like `oauth_token_refresh`, an authenticated
+// caller must not be able to loop it and amplify against the upstream OAuth
+// provider, so throttle per PM user with the same in-process sliding-window
+// limiter idiom (#2769).
+const VOICE_EXCHANGE_MAX_ATTEMPTS: u32 = 10;
+const VOICE_EXCHANGE_WINDOW: std::time::Duration = std::time::Duration::from_secs(900);
+const VOICE_EXCHANGE_SWEEP_THRESHOLD: usize = 1024;
+
+static VOICE_EXCHANGE_RATE_LIMITER: std::sync::LazyLock<InProcessRateLimiter<Uuid>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+
+/// Record an exchange attempt for `user_id`; `false` once more than
+/// `VOICE_EXCHANGE_MAX_ATTEMPTS` occur in a rolling `VOICE_EXCHANGE_WINDOW`.
+fn voice_exchange_attempt_allowed(user_id: Uuid) -> bool {
+    rate_limit_allowed(
+        &VOICE_EXCHANGE_RATE_LIMITER,
+        user_id,
+        VOICE_EXCHANGE_MAX_ATTEMPTS,
+        VOICE_EXCHANGE_WINDOW,
+        VOICE_EXCHANGE_SWEEP_THRESHOLD,
+    )
+}
+
 // ============================================================================
 // Router
 // ============================================================================
@@ -367,6 +391,7 @@ async fn google_actions_webhook(
         (status = 400, description = "Invalid authorization code"),
         (status = 401, description = "Unauthorized - missing or invalid PM access token"),
         (status = 403, description = "Forbidden - no active organization context"),
+        (status = 429, description = "Too many exchange attempts"),
         (status = 500, description = "Token exchange failed"),
     ),
     security(("bearer_auth" = [])),
@@ -378,6 +403,23 @@ async fn oauth_token_exchange(
     Json(request): Json<VoiceOAuthExchangeRequest>,
 ) -> Result<Json<VoiceOAuthExchangeResponse>, (StatusCode, Json<ErrorResponse>)> {
     use integrations::{VoiceOAuthManager, VoicePlatform};
+
+    // Throttle authenticated abuse: a valid principal must not be able to loop
+    // this endpoint and amplify against the upstream OAuth provider (#2769).
+    if !voice_exchange_attempt_allowed(auth.user_id) {
+        tracing::warn!(
+            user_id = %auth.user_id,
+            platform = %request.platform,
+            "Voice OAuth exchange rate limit exceeded"
+        );
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(ErrorResponse::new(
+                "RATE_LIMITED",
+                "Too many token exchange attempts; try again later",
+            )),
+        ));
+    }
 
     // Bind the linking to the authenticated PM user + their active org.
     // Without an org context we cannot create a tenant-scoped voice device.
@@ -1842,6 +1884,38 @@ mod tests {
             voice_simulated_oauth_allowed(true),
             "debug builds may use the simulated fallback"
         );
+    }
+
+    // --- oauth exchange rate limiting (#2769) ---------------------------
+
+    #[test]
+    fn exchange_rate_limiter_throttles_after_max_attempts() {
+        // Fresh principal => isolated bucket in the process-global limiter.
+        let user_id = Uuid::new_v4();
+        for i in 0..VOICE_EXCHANGE_MAX_ATTEMPTS {
+            assert!(
+                voice_exchange_attempt_allowed(user_id),
+                "attempt {i} within the window should be allowed"
+            );
+        }
+        // One past the limit within the same window is throttled, mirroring the
+        // /oauth/refresh guard.
+        assert!(
+            !voice_exchange_attempt_allowed(user_id),
+            "attempt beyond VOICE_EXCHANGE_MAX_ATTEMPTS should be throttled"
+        );
+    }
+
+    #[test]
+    fn exchange_rate_limiter_isolates_per_user() {
+        let user_a = Uuid::new_v4();
+        let user_b = Uuid::new_v4();
+        for _ in 0..VOICE_EXCHANGE_MAX_ATTEMPTS {
+            assert!(voice_exchange_attempt_allowed(user_a));
+        }
+        // user_a is now throttled, but a distinct principal is unaffected.
+        assert!(!voice_exchange_attempt_allowed(user_a));
+        assert!(voice_exchange_attempt_allowed(user_b));
     }
 
     // --- validate_alexa_cert_url ----------------------------------------


### PR DESCRIPTION
## Task
voice `/oauth/exchange` makes a live upstream OAuth call (`exchange_code`) per request with no per-user rate limit, unlike its sibling `/oauth/refresh` (#2769) — same authenticated amplification vector left unthrottled. Fix: apply the same per-user rate limit to `/oauth/exchange` that `/oauth/refresh` already uses (mirror the #2769 idiom), so an authenticated caller cannot amplify live upstream OAuth calls.

## Owner
pm-security

## What changed
- `backend/servers/api-server/src/routes/voice_webhooks.rs`:
  - Added `VOICE_EXCHANGE_MAX_ATTEMPTS`/`VOICE_EXCHANGE_WINDOW`/`VOICE_EXCHANGE_SWEEP_THRESHOLD` + a `VOICE_EXCHANGE_RATE_LIMITER` `LazyLock<InProcessRateLimiter<Uuid>>` and a `voice_exchange_attempt_allowed(user_id)` helper — an exact mirror of the existing `voice_refresh_attempt_allowed` idiom (#2769), reusing the shared `rate_limit_allowed` primitive (no new mechanism).
  - Guarded `oauth_token_exchange` at the top: returns `429 TOO_MANY_REQUESTS` (`RATE_LIMITED`) once a PM user exceeds the window budget, before any `exchange_code` upstream call.
  - Documented the `429` response in the utoipa path.
  - Added two isolated unit tests (`exchange_rate_limiter_throttles_after_max_attempts`, `exchange_rate_limiter_isolates_per_user`) keyed on fresh random UUIDs (no DB).

Scoped identically to the merged #2769 refresh guard; each endpoint keeps its own per-user bucket (mirror, not a shared counter). No unrelated refactoring.

## Verification
```
VERIFY-PLAN base=23773163fddf6897844bfe6035bbd6d0382763c9 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

- `cargo fmt --all -- --check` — **PASS** (exit 0).
- `cargo clippy -p api-server` / `cargo test -p api-server` — **could not run in this sandbox**: the `utoipa-swagger-ui` build script downloads the Swagger UI zip from github.com at build time, and this session's org egress policy returns HTTP 403 for that host (`InvalidArchive("Could not find EOCD")`). This is an environmental limitation of the sandbox — identical class to the DB-backed `#[sqlx::test]` cases that need a live Postgres — and is unrelated to this diff. **CI (`backend.yml`, which has github access) is the authoritative gate** and runs the full clippy + test suite, including the two new unit tests.

The change is a mechanical mirror of the already-merged #2769 refresh idiom (same primitive, same signature), and `cargo fmt` is clean.

## Scope drift
`scope-check.sh --owner pm-security` flags `backend/servers/api-server/src/routes/voice_webhooks.rs` as outside the pm-security owner-area glob (exit 2, advisory). This is the exact file the task scoped, and it is the same file the merged #2769 refresh guard lives in. No other files touched.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no warnings. The guard reuses the existing `crate::routes::rate_limit::rate_limit_allowed` helper and the `InProcessRateLimiter` type; no new mechanism introduced.

## CI parity (Band C — hot-path)
Not replicated locally — the local clippy/test gate is blocked by the swagger-ui github egress issue above, so `act`/workflow replication would hit the same wall. Deferred to CI `backend.yml`.

## Remote-tested
skipped

## Notes
- Rebased onto the latest `origin/dev` (which had just merged #2791 / #890 fail-closed changes touching the same file); resolved a purely-additive test-region conflict by keeping both the #890 fallback-gate tests and the new exchange rate-limit tests. Final diff is `voice_webhooks.rs` +74 lines only.
- Sibling task `code-review-api-handlers-voice-exchange-device-dedup` may also touch this file; this diff is confined to the rate-limit guard to stay mergeable.
- IG goal-check (plan-driven flow) reports IG1/IG2/IG3 fails that are flow-mismatch, not defects: no `.research/plans/` file exists for this dispatcher code-review task; the branch is the dispatcher-assigned `auto-impl/...`; and the regression tests are in the single Conventional-Commits `fix:` commit rather than a separate `test:` commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yeD4euQbUWNnQZybrWpjB

---
_Generated by [Claude Code](https://claude.ai/code/session_014yeD4euQbUWNnQZybrWpjB)_