### PR TITLE
code-review-api-handlers-voice-exchange-device-dedup: upsert voice OAuth device on (org,user,platform)

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -1887,6 +1887,44 @@ impl LlmDocumentRepository {
         .await
     }
 
+    /// Find the active voice device for an `(organization, user, platform)`
+    /// tuple.
+    ///
+    /// This is the lookup key the OAuth-exchange (account-linking) path upserts
+    /// on: a re-link must rotate the tokens on the *existing* device row for the
+    /// tuple rather than insert an independent row. Without it, each re-link
+    /// minted a fresh `device_id` and a new row, leaving the previous row active
+    /// with its own still-usable stored token (stale-token accumulation).
+    /// Scoping to `organization_id` as well as `user_id` keeps devices a user
+    /// linked under different tenants distinct.
+    pub async fn find_active_voice_device_by_org_user_and_platform<'e, E>(
+        &self,
+        executor: E,
+        organization_id: Uuid,
+        user_id: Uuid,
+        platform: &str,
+    ) -> Result<Option<VoiceAssistantDevice>, SqlxError>
+    where
+        E: Executor<'e, Database = Postgres>,
+    {
+        sqlx::query_as::<_, VoiceAssistantDevice>(
+            r#"
+            SELECT * FROM voice_assistant_devices
+            WHERE organization_id = $1
+              AND user_id = $2
+              AND platform = $3
+              AND is_active = TRUE
+            ORDER BY linked_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(organization_id)
+        .bind(user_id)
+        .bind(platform)
+        .fetch_optional(executor)
+        .await
+    }
+
     // =========================================================================
     // Statistics
     // =========================================================================

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -499,9 +499,7 @@ async fn oauth_token_exchange(
 
     // Device is bound to the authenticated PM user and their organization
     // (derived above from the verified access token — never random UUIDs).
-    let device_id = format!("{}_{}", request.platform, Uuid::new_v4());
-
-    // Create the voice device with tokens.
+    //
     // PAP-170 (PAP-150 P2): bind the verified PM user's org/user RLS context for
     // the device write instead of touching the raw `state.db` pool.
     // `voice_assistant_devices` is not RLS-bound today, but binding context is
@@ -519,25 +517,25 @@ async fn oauth_token_exchange(
                 )),
             )
         })?;
-    let device = state
+
+    // Upsert on (org, user, platform). A re-link must ROTATE the tokens on the
+    // existing device row for this tuple, not insert an independent new row:
+    // the old code minted a fresh random `device_id` and created a row every
+    // call, so re-linking accumulated multiple active devices whose previously
+    // stored tokens stayed independently usable (stale-token accumulation). By
+    // reusing the existing row we overwrite its `access_token_encrypted` /
+    // `access_token_hash`, which invalidates the superseded token.
+    let existing = state
         .llm_document_repo
-        .create_voice_device(
+        .find_active_voice_device_by_org_user_and_platform(
             &mut **guard.conn(),
             org_id,
             user_id,
-            None,
             &request.platform,
-            &device_id,
-            Some("Voice Assistant"),
-            Some(&access_encrypted),
-            refresh_encrypted.as_deref(),
-            expires_at,
-            serde_json::json!(["check_balance", "report_fault", "check_announcements"]),
-            access_hash.as_deref(),
         )
         .await
         .map_err(|e| {
-            tracing::error!("Failed to create voice device: {}", e);
+            tracing::error!("Failed to look up existing voice device: {}", e);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse::new(
@@ -546,6 +544,83 @@ async fn oauth_token_exchange(
                 )),
             )
         })?;
+
+    let device = if let Some(existing) = existing {
+        // Re-link: rotate the tokens on the existing row in place.
+        tracing::info!(
+            device_id = %existing.id,
+            platform = %request.platform,
+            "Re-linking voice device: rotating tokens on existing (org,user,platform) row"
+        );
+        state
+            .llm_document_repo
+            .update_voice_device_tokens(
+                &mut **guard.conn(),
+                existing.id,
+                &access_encrypted,
+                refresh_encrypted.as_deref(),
+                expires_at,
+                access_hash.as_deref(),
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to rotate voice device tokens: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DEVICE_CREATION_FAILED",
+                        "Failed to link voice device",
+                    )),
+                )
+            })?
+            // The row was active when we selected it on this same connection, so
+            // the conditional UPDATE (WHERE is_active = TRUE) matches it; a None
+            // here means it was concurrently deactivated — fail closed rather
+            // than silently fall through to a duplicate INSERT.
+            .ok_or_else(|| {
+                tracing::error!(
+                    device_id = %existing.id,
+                    "Voice device disappeared during re-link token rotation"
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DEVICE_CREATION_FAILED",
+                        "Failed to link voice device",
+                    )),
+                )
+            })?
+    } else {
+        // First link for this (org, user, platform): create the device row.
+        let device_id = format!("{}_{}", request.platform, Uuid::new_v4());
+        state
+            .llm_document_repo
+            .create_voice_device(
+                &mut **guard.conn(),
+                org_id,
+                user_id,
+                None,
+                &request.platform,
+                &device_id,
+                Some("Voice Assistant"),
+                Some(&access_encrypted),
+                refresh_encrypted.as_deref(),
+                expires_at,
+                serde_json::json!(["check_balance", "report_fault", "check_announcements"]),
+                access_hash.as_deref(),
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to create voice device: {}", e);
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new(
+                        "DEVICE_CREATION_FAILED",
+                        "Failed to link voice device",
+                    )),
+                )
+            })?
+    };
 
     tracing::info!(
         "Voice device linked successfully: {} (platform: {})",

--- a/backend/servers/api-server/tests/suites/voice_oauth_exchange_auth_tests.rs
+++ b/backend/servers/api-server/tests/suites/voice_oauth_exchange_auth_tests.rs
@@ -15,11 +15,12 @@
 //! claims (no `host_tenant_middleware` needed), so we mint tokens carrying a
 //! custom `tenant_id` claim to exercise the authenticated paths.
 //!
-//! Success-path note: there is no `voice_assistant_devices` migration in the
-//! PPT schema, so a fully-authenticated request gets *past* the auth gate and
-//! then fails at the DB insert. The security contract is what we assert: a
-//! valid token is NOT rejected at the auth layer (status is never 401/403),
-//! while an unauthenticated or org-less request IS rejected before any work.
+//! Success-path note: the `voice_assistant_devices` table exists as of
+//! migration 00226, so a fully-authenticated request runs end to end. Test 4
+//! asserts the security contract (a valid token is never rejected at the auth
+//! layer, while an unauthenticated or org-less request IS rejected before any
+//! work); Test 5 asserts the device-dedup contract (re-linking rotates one row
+//! rather than accumulating independent rows).
 
 #![allow(dead_code)]
 
@@ -167,9 +168,10 @@ async fn oauth_exchange_without_org_context_is_forbidden(pool: PgPool) {
 // Test 4: valid token with an org context passes the auth gate.
 //
 // Proves the extractor admits a real authenticated principal: the response
-// status is NOT 401/403. (It does not reach a 200 because the PPT schema has
-// no `voice_assistant_devices` table, so the downstream DB insert fails — but
-// that is well past the security boundary this fix establishes.)
+// status is NOT 401/403. (This test sets no `INTEGRATION_ENCRYPTION_KEY`, so it
+// stops at the mandatory-encryption gate rather than reaching a 200 — but that
+// is well past the security boundary this fix establishes. Test 5 exercises the
+// full 200 success path with the key set.)
 // ---------------------------------------------------------------------------
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn oauth_exchange_with_valid_auth_passes_auth_gate(pool: PgPool) {
@@ -200,5 +202,95 @@ async fn oauth_exchange_with_valid_auth_passes_auth_gate(pool: PgPool) {
         StatusCode::FORBIDDEN,
         "valid token with org context must clear the org gate, got 403: {}",
         resp.text()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: re-linking the same (org, user, platform) reuses ONE device row
+// instead of accumulating independent rows with independently-usable tokens.
+//
+// Regression for the device-dedup fix: `oauth_token_exchange` used to mint a
+// fresh random `device_id` and INSERT a new `voice_assistant_devices` row on
+// every call, so re-linking left the previous row active with its own still
+// usable stored token (stale-token accumulation). The handler now upserts on
+// `(organization_id, user_id, platform)`: the second link rotates the tokens
+// on the existing row in place, so exactly one active row exists and the
+// returned `device_id` is stable across re-links.
+//
+// No upstream OAuth is configured in tests, so the handler takes its
+// simulated-tokens branch (debug build) which still runs the mandatory
+// `encrypt_required` — hence `INTEGRATION_ENCRYPTION_KEY` is set below.
+// ---------------------------------------------------------------------------
+
+/// A valid 32-byte (64 hex char) AES-256 key so the simulated-tokens branch's
+/// mandatory `encrypt_required` succeeds.
+const TEST_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn oauth_exchange_relink_reuses_single_device_row(pool: PgPool) {
+    std::env::set_var("INTEGRATION_ENCRYPTION_KEY", TEST_KEY);
+
+    let config = TestConfig::default();
+    let secret = config.jwt_secret.clone();
+    let app = TestApp::with_config(pool.clone(), config).await;
+
+    let user_id = Uuid::new_v4();
+    let org_id = Uuid::new_v4();
+    let token = mint_access_token(&secret, user_id, Some(org_id));
+
+    let build_req = || {
+        Request::builder()
+            .method(Method::POST)
+            .uri(EXCHANGE_URI)
+            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::from(exchange_body().to_string()))
+            .unwrap()
+    };
+
+    // First link.
+    let resp1 = app.execute(build_req()).await;
+    assert_eq!(
+        resp1.status,
+        StatusCode::OK,
+        "first link must succeed, got {}: {}",
+        resp1.status,
+        resp1.text()
+    );
+    let body1: serde_json::Value = serde_json::from_str(&resp1.text()).unwrap();
+    let device_id_1 = body1["device_id"].as_str().unwrap().to_string();
+
+    // Re-link (same user + org + platform).
+    let resp2 = app.execute(build_req()).await;
+    assert_eq!(
+        resp2.status,
+        StatusCode::OK,
+        "re-link must succeed, got {}: {}",
+        resp2.status,
+        resp2.text()
+    );
+    let body2: serde_json::Value = serde_json::from_str(&resp2.text()).unwrap();
+    let device_id_2 = body2["device_id"].as_str().unwrap().to_string();
+
+    assert_eq!(
+        device_id_1, device_id_2,
+        "re-link must reuse the same device row, not mint a new device_id"
+    );
+
+    // Exactly one active device row exists for the tuple.
+    let active_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM voice_assistant_devices \
+         WHERE organization_id = $1 AND user_id = $2 AND platform = $3 AND is_active = TRUE",
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .bind("alexa")
+    .fetch_one(&pool)
+    .await
+    .expect("count active voice devices");
+
+    assert_eq!(
+        active_count, 1,
+        "re-link must not accumulate active device rows (found {active_count})"
     );
 }


### PR DESCRIPTION
## Task
voice `/oauth/exchange` generates a fresh random device_id every call with no upsert on (org,user,platform) — re-linking accumulates active device rows whose old stored tokens stay independently usable. Fix: upsert the voice device on (org,user,platform) so a re-link reuses/rotates the existing device row instead of accumulating independent rows with independently-usable stale tokens.

## Owner
pm-backend

## Change
- `backend/servers/api-server/src/routes/voice_webhooks.rs` — `oauth_token_exchange` now upserts on `(organization_id, user_id, platform)`: it looks up the existing active device for the tuple on the RLS-bound connection and, if present, **rotates the tokens on that row in place** (`update_voice_device_tokens`) instead of minting a fresh random `device_id` and `INSERT`ing a new row. The rotation overwrites `access_token_encrypted` + `access_token_hash`, which invalidates the previously stored token — closing the stale-token-accumulation vector. First link for a tuple still creates the row. A `None` from the conditional token UPDATE fails closed (500) rather than falling through to a duplicate insert.
- `backend/crates/db/src/repositories/llm_document.rs` — new `find_active_voice_device_by_org_user_and_platform` finder (org-scoped, `is_active = TRUE`, most-recent). Scoping to `organization_id` keeps devices a user linked under different tenants distinct.
- `backend/servers/api-server/tests/suites/voice_oauth_exchange_auth_tests.rs` — regression test `oauth_exchange_relink_reuses_single_device_row`: links twice with the same `(org, user, platform)` and asserts the returned `device_id` is stable and exactly **one** active row exists. Refreshed two stale header comments that claimed the `voice_assistant_devices` table has no migration (it exists as of 00226).

Scope note: a DB-level `ON CONFLICT` upsert would require a unique constraint on `(organization_id, user_id, platform)`, i.e. a migration (separate `db-migration` specialist) — deliberately out of scope. This application-level upsert is contained to the exchange handler + its device-token storage. Pre-existing duplicate rows from the old behavior are not retro-deduped (that would need a data migration); the fix prevents new accumulation.

## Verification
```
VERIFY-PLAN base=b65bd46dbe9b8b6b0c9cc2856cba37ab332722ec files=3
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo clippy -p db --all-targets -- -D warnings
  (+ reverse-dependent crates: accounting-*, admin-core, api-core, reality-server, tenant-ops)
  cd backend && cargo test  -p api-server / -p db / (+ reverse dependents)
```
Sandbox limitation: `just verify` cannot run to completion here because the `utoipa-swagger-ui` build dependency downloads Swagger UI from `github.com`, which this session's egress policy returns **HTTP 403** for (org-policy denial — not routed around). This blocks compiling any backend crate in the swagger chain, unrelated to this change. To get real signal I supplied a local stub zip via `SWAGGER_UI_DOWNLOAD_URL=file:…` (type-check only; CI builds the real asset) and ran the gate on the two changed crates:

- `cargo fmt --all -- --check` — **exit 0**
- `cargo clippy -p db --all-targets -- -D warnings` — **exit 0**
- `cargo clippy -p api-server --all-targets -- -D warnings` (includes the new test target) — **exit 0**

The added `#[sqlx::test]` regression needs a live Postgres (unavailable in this sandbox) and runs under CI. The full fanned-out gate (fmt/clippy/tests across reverse-dependents) runs in CI, which has proper egress.

## CI parity (Band C — hot-path only)
skipped: touched code is auth-adjacent, but the change is a device-dedup correctness fix (no new auth/crypto primitive); full backend gate runs in CI.

## Remote-tested
skipped

## Notes
- scope-check (owner pm-backend): clean, no drift (both files under `backend/**`).
- reuse-grep (rust-backend): no warnings.
- Reused the existing `update_voice_device_tokens` for the rotation path; no new crypto/token helper introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014yeD4euQbUWNnQZybrWpjB

---
_Generated by [Claude Code](https://claude.ai/code/session_014yeD4euQbUWNnQZybrWpjB)_