### PR TITLE
gh-issue-2797: resolve RUSTSEC-2026-0258 (h2 empty-DATA-frame DoS) blocking backend cargo-deny

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.4.2",
  "http-body 0.4.6",
@@ -3000,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3285,7 +3285,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
@@ -5495,7 +5495,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",

--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -67,6 +67,25 @@ ignore = [
     # Follow-up: BIT-279 — drop when genpdf ships a release on lopdf >= 0.42.0,
     # or migrate off genpdf to a maintained PDF generator.
     "RUSTSEC-2026-0187",
+
+    # RUSTSEC-2026-0258 (added 2026-08-19) — h2 empty-DATA-frame DoS. The
+    # directly-fixable path (h2 0.4.x via hyper 1.x / reqwest / axum / AWS SDK)
+    # is already resolved to h2 0.4.16 in Cargo.lock (>= 0.4.16 is patched).
+    # This ignore covers ONLY the residual h2 0.3.27 (0.3.x major line), which
+    # has no patched upstream release: it is pulled in transitively via
+    # `aws-smithy-http-client` -> `aws-config` / `aws-sdk-{s3,sso,ssooidc,sts}`
+    # and `hyper 0.14`. An in-range `aws-smithy-http-client` bump (1.1.13 ->
+    # 1.2.0) does NOT drop the hyper 0.14 / h2 0.3 path; only a major AWS SDK /
+    # smithy upgrade onto hyper 1.x would, which is out of scope here — matching
+    # how the other AWS-SDK-pinned advisories were handled (GH #2445/#2141/#2009).
+    #
+    # Reachability: the h2 0.3.27 codepath is only the AWS SDK's outbound HTTP/2
+    # client talking to well-behaved AWS endpoints (S3, STS, SSO); we never run
+    # an h2 0.3 server that would accept the malicious empty-DATA frames the
+    # advisory describes. Transitive-only, low-severity, no reachable exposure.
+    # Follow-up: remove once the AWS SDK drops its hyper 0.14 / h2 0.3
+    # dependency (smithy on hyper 1.x).
+    "RUSTSEC-2026-0258",
 ]
 
 [bans]


### PR DESCRIPTION
## Task
cargo-deny advisories FAILED on dev: RUSTSEC-2026-0258 (h2 empty-DATA-frame DoS) blocks every backend PR (Closes #2797)

Closes #2797

## Owner
pm-security

## What changed
1. `cargo update -p h2@0.4.14` advanced **h2 0.4.14 -> 0.4.16** in `backend/Cargo.lock` — the patched release (>= 0.4.16) for the directly-fixable path (hyper 1.x / reqwest / axum / AWS SDK smithy hyper-1 client). Lock diff is limited to h2.
2. A **second** h2 remains on the 0.3.x major line (`h2 v0.3.27`), pulled in transitively only via `aws-smithy-http-client` -> `aws-config` / `aws-sdk-{s3,sso,ssooidc,sts}` and `hyper 0.14`. It has no patched upstream 0.3.x release. I verified an in-range `aws-smithy-http-client` bump (1.1.13 -> 1.2.0) does **not** drop the hyper 0.14 / h2 0.3 path — only a major AWS SDK/smithy migration onto hyper 1.x would, which is out of scope here. Added a **scoped, dated `[advisories] ignore`** entry for `RUSTSEC-2026-0258` in `backend/deny.toml` with a reachability note and a remove-when follow-up, matching how the prior AWS-SDK-pinned advisories (#2445/#2141/#2009) were handled.

Reachability: the residual h2 0.3.27 codepath is only the AWS SDK's outbound HTTP/2 client to well-behaved AWS endpoints (S3/STS/SSO); we run no h2 0.3 server that would accept the malicious empty-DATA frames. Transitive-only, low-severity, no reachable exposure.

## Verification
Impact-scoped gate for a Cargo.lock + deny.toml change (cargo-deny is authoritative; a full `cargo test --workspace` was deliberately NOT run per the task's light-verify scope):

```
$ cargo deny check advisories
advisories ok            # exit 0

$ cargo deny check       # full: advisories/bans/licenses/sources
advisories ok, bans ok, licenses ok, sources ok   # exit 0
(2 pre-existing license-not-encountered warnings for OpenSSL / Unicode-DFS-2016 — unrelated)

$ cargo tree --locked -p api-server   # lockfile consistency
LOCK-CONSISTENT          # exit 0

$ cargo fmt --all --check
                         # exit 0 (no Rust source changed)
```

cargo-deny version: 0.20.2.

## CI parity (Band C — hot-path only)
This is a security-advisory change; the authoritative CI gate is the `cargo-deny` job in `backend.yml`, which runs `cargo deny check advisories` — replicated locally above (exit 0). No app/auth/billing code path changed, so no further workflow-job replication is needed.

## Scope drift
`scripts/scope-check.sh --owner pm-security` flags `backend/Cargo.lock` and `backend/deny.toml` as outside pm-security's mapped file areas (exit 2). This is expected and justified: a cargo-deny advisory remediation task inherently edits only the dependency lockfile and the deny policy. No source, route, or handler code was touched.

## Code-reuse review
`scripts/reuse-grep.sh --specialist rust-backend` — no warnings (no new helpers added; dependency/config-only change).

## Remote-tested
skipped (ppt-bridge MCP not required for a cargo-deny lockfile change)

## Notes
- Follow-up to remove the `deny.toml` ignore is captured in the entry's comment: drop `RUSTSEC-2026-0258` once the AWS SDK drops its hyper 0.14 / h2 0.3 dependency (smithy on hyper 1.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKZGtyh7zx1heZ1F9UxfwV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKZGtyh7zx1heZ1F9UxfwV)_