### PR TITLE
gh-issue-2804: scope RUSTSEC-2026-0258 h2 DoS ignore to the h2 0.3.x line

### DIFF
--- a/backend/deny.toml
+++ b/backend/deny.toml
@@ -85,12 +85,40 @@ ignore = [
     # advisory describes. Transitive-only, low-severity, no reachable exposure.
     # Follow-up: remove once the AWS SDK drops its hyper 0.14 / h2 0.3
     # dependency (smithy on hyper 1.x).
+    #
+    # SCOPING (GH #2804, follow-up to #2798): this advisory-id ignore is
+    # global by ID — cargo-deny (0.19.x) has NO way to scope a *vulnerability*
+    # ignore to a crate version: the `{ id, reason }` form rejects a `crate`
+    # key, and a bare package-spec entry in this list only suppresses *yanked*
+    # status, not advisories. So we cannot write "ignore RUSTSEC-2026-0258 for
+    # h2 0.3.x only" here directly. To keep the suppression effectively scoped
+    # to the un-upgradable 0.3.x line — and make a real, unpatched h2 on the
+    # 0.4.x line trip the build instead of being silently swept up — the 0.4.x
+    # patched-floor is enforced by the `[bans]` half-range guard on h2 below
+    # (same mechanism as the quick-xml pin). A genuinely new vuln on 0.4.x
+    # would in any case carry a different RUSTSEC id and is NOT covered by this
+    # ignore.
     "RUSTSEC-2026-0258",
 ]
 
 [bans]
 multiple-versions = "warn"
 deny = [
+    # h2 0.4.x PATCHED-FLOOR GUARD for RUSTSEC-2026-0258 (GH #2804, follow-up
+    # to #2798). RUSTSEC-2026-0258 (empty-DATA-frame DoS) is patched in
+    # h2 0.4.16; the residual h2 0.3.27 line is transitively pinned by the AWS
+    # SDK / hyper 0.14, has no patched upstream release, and is advisory-ignored
+    # above. cargo-deny cannot scope a vulnerability ignore to a crate version,
+    # so this ban does the scoping instead: it denies any h2 on the 0.4.x line
+    # BELOW the 0.4.16 patch floor. Effect — the advisory ignore stays confined
+    # to the un-upgradable 0.3.x line, while an unpatched h2 0.4.0–0.4.15 slipping
+    # into Cargo.lock (a downgrade or an in-range Dependabot bump) trips
+    # `cargo deny check bans` instead of being silently swept up by the ignore.
+    # It intentionally does NOT touch h2 0.3.x (< 0.4.0, allowed) or the patched
+    # h2 >= 0.4.16 (outside the range, allowed). Lift once the AWS SDK drops its
+    # hyper 0.14 / h2 0.3 dependency and the ignore above can be removed.
+    { name = "h2", version = ">=0.4.0, <0.4.16", reason = "RUSTSEC-2026-0258 patched-floor guard — h2 on the 0.4.x line must be >= 0.4.16; the advisory ignore is scoped to the un-upgradable 0.3.x line, so an unpatched 0.4.0–0.4.15 must trip cargo-deny rather than be swept up by it (GH #2804/#2798)" },
+
     # quick-xml XXE / billion-laughs SECURITY PIN (GH #2084, supersedes the
     # advisory pinned-dependency-guard.yml workflow). The inbound OTA parsers
     # in backend/crates/integrations/src/booking/ota_xml.rs rely on quick-xml


### PR DESCRIPTION
## Task
Follow-up: scope the RUSTSEC-2026-0258 (h2 DoS) advisory ignore to h2 0.3.x only (PR #2798). Closes #2804.

The advisory ignore for RUSTSEC-2026-0258 was added broadly; scope it so it only suppresses the h2 0.3.x line (the transitive-dep that can't yet be upgraded), leaving 0.4.x+ unignored so a real vuln there still trips cargo-deny. The relevant config is the cargo-deny advisories ignore list (`backend/deny.toml`). Verify with `cargo deny check advisories` in `backend/`.

## Owner
pm-tech-lead

## What changed & why (cargo-deny limitation)
`cargo-deny` (validated against 0.19.1 **and** the latest 0.19.2 — the version `cargo-deny-action@v2` runs) **cannot scope a vulnerability advisory ignore to a crate version**:
- The `{ id = "…", reason = "…" }` form rejects a `crate` key (`error[unexpected-keys]: expected: ["id", "reason"]`).
- A bare package-spec entry (`{ crate = "h2@0.3" }`) in `advisories.ignore` only suppresses **yanked** status, not vulnerabilities — the RUSTSEC-2026-0258 finding still fires (emits a spurious `yanked-not-detected` warning).

So "ignore RUSTSEC-2026-0258 for h2 0.3.x only" is not directly expressible in the advisories list. Instead, the 0.3.x scoping is **enforced with a `[bans]` half-range guard on h2** — the same mechanism this file already uses for the quick-xml XXE pin:

```toml
{ name = "h2", version = ">=0.4.0, <0.4.16", reason = "RUSTSEC-2026-0258 patched-floor guard …" }
```

Effect:
- **h2 0.3.x** (`< 0.4.0`) — allowed; stays covered by the (unavoidable, global-by-id) advisory ignore. Transitively pinned by AWS SDK / hyper 0.14, no patched upstream release.
- **h2 0.4.0–0.4.15** (unpatched 0.4.x) — **denied**; an accidental downgrade or in-range Dependabot bump into this window trips `cargo deny check bans` instead of being silently swept up by the ignore.
- **h2 ≥ 0.4.16** (patched, current 0.4.16) — allowed; outside the ban range.

A genuinely new vuln on h2 0.4.x would carry a **different** RUSTSEC id and is not covered by the RUSTSEC-2026-0258 ignore at all, so it already trips the build.

The RUSTSEC-2026-0258 comment block in `deny.toml` was expanded to document this limitation and point at the guard.

### Ban-semantics evidence
- Guard `>=0.4.0, <0.4.99` (deliberately covering the real 0.4.16) → `error[banned]: crate 'h2 = 0.4.16' is explicitly banned` / `bans FAILED` — proves the matcher fires on an in-range 0.4.x.
- Real guard `>=0.4.0, <0.4.16` → `bans ok` (0.4.16 and 0.3.27 both untouched).

## Verification
`verify-impact.sh` escalates a `deny.toml` edit to the full backend band:
```
VERIFY-PLAN base=3763fcdd142415638014d46b1ed50514f00ed6dc files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```
This change touches only `backend/deny.toml` (cargo-deny metadata) — no Rust source, zero compilation impact — so the full-workspace fmt/clippy/test band adds no signal (coordinator waived it). The authoritative gate is `cargo deny check`, which the `cargo-deny` CI job (`backend.yml`) re-runs on this PR.

cargo-deny (0.19.2, the version `cargo-deny-action@v2` resolves):
```
$ cd backend && cargo deny check advisories   # issue's stated verify command
advisories ok
$ cargo deny check bans
bans ok
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
```

Repo `deny-toml-ban-gate.yml` quick-xml assertion still satisfied (both half-range pin lines present).

## CI parity (Band C — hot-path only)
skipped: config-only change to `backend/deny.toml`; no security/auth/billing/data-integrity code path touched. The `cargo-deny` CI job (`backend.yml`) is the authoritative check and is exercised above.

## Scope drift
`scope-check.sh --owner pm-tech-lead` flags `backend/deny.toml` as outside the pm-tech-lead owner globs (exit 2). The change is a cargo-deny config edit and is the exact file named by the issue — advisory only; reviewer to confirm.

## Remote-tested
skipped

## Notes
- No Rust code changed; the change cannot affect compilation. The authoritative signal is `cargo deny check` (all four sections green above) plus the CI `cargo-deny` job.
- Follow-up (unchanged): lift both the ignore and this ban once the AWS SDK drops its hyper 0.14 / h2 0.3 dependency (smithy on hyper 1.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BUUHeturW82Kepv19UFyWo)_