### PR TITLE
code-review-api-handlers-voice-webhook-default-secret-retry2: voice webhook HMAC fails closed on empty secret

### DIFF
--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -2420,6 +2420,14 @@ fwIDAQAB
         // (Err) rather than silently verifying against a hardcoded default.
         std::env::remove_var("VOICE_WEBHOOK_SECRET");
         assert!(verify_hmac_signature(&good, body).is_err());
+
+        // ...and a *blank* secret is treated the same as unset — never key the
+        // HMAC with an empty value (mirrors the sibling PORTAL/AIRBNB/STRIPE
+        // receivers). Both a correct-looking and a bogus signature must Err.
+        std::env::set_var("VOICE_WEBHOOK_SECRET", "");
+        assert!(verify_hmac_signature(&good, body).is_err());
+        assert!(verify_hmac_signature("anything", body).is_err());
+        std::env::remove_var("VOICE_WEBHOOK_SECRET");
     }
 
     // --- ct_eq_str / voice_device_token_matches (issue #2658) -----------

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -1486,14 +1486,19 @@ fn ct_eq_str(a: &str, b: &str) -> bool {
 
 /// Verify HMAC-SHA256 signature.
 ///
-/// Issue #2658 (#2): fails **closed** when `VOICE_WEBHOOK_SECRET` is unset.
-/// The previous `unwrap_or("default_secret")` verified against a literal
-/// present in source, letting anyone forge signatures; the sibling receivers
-/// (`PORTAL_WEBHOOK_SECRET`, `AIRBNB_WEBHOOK_SECRET`, `STRIPE_WEBHOOK_SECRET`)
-/// all fail closed, and so do we now.
+/// Issue #2658 (#2): fails **closed** when `VOICE_WEBHOOK_SECRET` is unset
+/// **or empty**. The previous `unwrap_or("default_secret")` verified against a
+/// literal present in source, letting anyone forge signatures; the sibling
+/// receivers (`PORTAL_WEBHOOK_SECRET`, `AIRBNB_WEBHOOK_SECRET`,
+/// `STRIPE_WEBHOOK_SECRET`) read the secret with `unwrap_or_default()` and then
+/// reject a blank value as "not configured" (see `routes/integrations/webhook.rs`),
+/// so an empty env var can never key the HMAC. We mirror that here: unset and
+/// empty both fail closed.
 fn verify_hmac_signature(signature: &str, body: &str) -> Result<bool, String> {
-    let secret = std::env::var("VOICE_WEBHOOK_SECRET")
-        .map_err(|_| "VOICE_WEBHOOK_SECRET is not configured".to_string())?;
+    let secret = std::env::var("VOICE_WEBHOOK_SECRET").unwrap_or_default();
+    if secret.is_empty() {
+        return Err("VOICE_WEBHOOK_SECRET is not configured".to_string());
+    }
 
     let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
         .map_err(|e| format!("Invalid HMAC key: {}", e))?;


### PR DESCRIPTION
## Summary

Closes a signature-verification bypass in the voice-assistant webhook receiver. `verify_hmac_signature()` in `backend/servers/api-server/src/routes/voice_webhooks.rs` already rejected an **unset** `VOICE_WEBHOOK_SECRET`, but an **empty** value (`VOICE_WEBHOOK_SECRET=""`) still slipped through `std::env::var(...)?` (which returns `Ok("")`) and keyed the HMAC with an empty key — a guessable/known key an attacker could forge signatures against. The function now fails closed on unset **and** empty, matching the sibling webhook receivers.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Task (verbatim)
> `backend/servers/api-server/src/routes/voice_webhooks.rs` (~line 950) — `verify_hmac_signature()` reads `VOICE_WEBHOOK_SECRET` via `std::env::var(...).unwrap_or_else(|_| "default_secret".to_string())`, so when the env var is unset the HMAC key silently falls back to a hardcoded default secret — a signature-verification bypass. Fix: fail closed when the secret is unset/empty (reject the webhook / return an auth error) instead of using a default; align with how other required secrets are handled in this codebase. Add a regression test.

Note: the hardcoded-`"default_secret"` fallback and the unset case were already remediated on `dev` (issue #2658 #2). The residual gap this retry closes is the **empty-string** case, which the "unset/empty" wording of the task calls out and which the sibling receivers already guard against.

## Owner
pm-backend — specialist: `rust-backend`

## Related Issues
Issue #2658 (voice webhook hardening).

## Changes Made
- `verify_hmac_signature()` now reads the secret with `std::env::var("VOICE_WEBHOOK_SECRET").unwrap_or_default()` and returns `Err("VOICE_WEBHOOK_SECRET is not configured")` when the result `is_empty()`. This mirrors the canonical pattern used by `PORTAL_WEBHOOK_SECRET` / `AIRBNB_WEBHOOK_SECRET` / `STRIPE_WEBHOOK_SECRET` in `routes/integrations/webhook.rs` (`unwrap_or_default()` + `is_empty()` → fail closed). No new helper introduced.
- Regression test: extended `routes::voice_webhooks::tests::hmac_and_verify_endpoint_google_branch` to assert that with `VOICE_WEBHOOK_SECRET=""`, both a correct-looking and a bogus signature return `Err` (never `Ok`). Split into a `test:` commit (fails on the pre-fix code) followed by the `fix:` commit (turns it green) for TDD evidence.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed

## Test Plan
1. `cd backend && cargo test -p api-server --lib -- routes::voice_webhooks::tests::hmac_and_verify_endpoint_google_branch` → passes with the fix; the empty-secret assertions fail on the pre-fix function body.

## Verification

```
VERIFY-PLAN base=31b45139c2836607a9713306a4dfff2e6b2be7a7 files=1
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy -p api-server --all-targets -- -D warnings
  cd backend && cargo test -p api-server
```

Results (this diff touches exactly one file, `voice_webhooks.rs`):
- `cargo fmt --all -- --check` → **PASS**
- `cargo clippy -p api-server --all-targets -- -D warnings` → **PASS**
- `cargo test -p api-server` → **621/621 lib tests PASS** (including the new regression assertions). Every integration test passes **except one pre-existing, unrelated failure** — see below. No clean `VERIFY OK` line is pasted because the gate's `cargo test` step exits non-zero solely on that pre-existing failure.

### Pre-existing, unrelated gate failure (not introduced by this PR)
`suite_1::airbnb_oauth_routes_tests::token_exchange_returns_503_when_not_configured` fails under a full-suite run (expects 503, gets 400). Root cause is a test-isolation bug in files this PR does not touch: `tests/suites/airbnb_install_routes_tests.rs:81` calls `std::env::set_var("AIRBNB_CLIENT_ID", …)` with **no** matching `remove_var`, so the process-global var leaks into the later `token_exchange_returns_503_when_not_configured` test (which documents that it "relies on the fact that no `AIRBNB_CLIENT_ID` env var is set"). The test **passes in isolation** (`cargo test -p api-server --test suite_1 -- token_exchange_returns_503_when_not_configured --exact`). This PR's diff is a single non-test-touching function change, so the failure reproduces on `dev` independently. Suggest a separate follow-up to add the missing `remove_var` teardown in the Airbnb test suite.

### Environment adaptations needed to run the gate here (informational)
The sandbox lacks pieces CI provides; none affect the change:
- `utoipa-swagger-ui` build downloads Swagger UI from github.com, which the egress proxy blocks (403). Supplied the exact `v5.17.14` dist (from the allowed npm mirror `swagger-ui-dist@5.17.14`) into the build's cache path so the workspace compiles.
- No Postgres in-sandbox → started a local PG 16 for the `#[sqlx::test]` DB-backed tests.
- The agent's `HTTPS_PROXY` diverts reqwest's connector, so `api_call::tests::execute_rejects_dns_rebinding_to_private_ip_at_connect` (an SSRF test) only re-resolves once; passes with the proxy env cleared. Unrelated to this change.

## CI parity (Band C — hot-path)
This is a security (auth/signature-verification) change. `backend.yml` runs `cargo fmt`, `clippy`, and `cargo test` on a clean runner with a real Postgres and no egress proxy — the environment where all three commands above pass without the local adaptations. Deferred to CI on this PR rather than replicated locally (the local `act`/proxy-free run is not reproducible in-sandbox).

## Remote-tested
skipped (ppt-bridge MCP not connected)

## Security Considerations
Eliminates a signature-verification bypass: a deployment with `VOICE_WEBHOOK_SECRET` set to an empty string would previously verify webhook signatures against an empty HMAC key, letting anyone forge a valid signature. The receiver now fails closed (returns an auth error) for both unset and empty secrets, consistent with the other webhook receivers in the codebase.

## Notes for the reviewer
- `scope_drift=false` (single file inside `backend/servers/api-server/`, pm-backend area), `code_reuse_warn=none`.
- Deliberately did **not** fix the unrelated Airbnb test-isolation bug here (different concern; would be scope drift). Flagged above for a follow-up task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYrAaj3gr9iGsS53Hm8Rto

---
_Generated by [Claude Code](https://claude.ai/code/session_01RYrAaj3gr9iGsS53Hm8Rto)_