### PR TITLE
gh-issue-2807: route ai/voice link path through single-writer voice-device upsert

### DIFF
--- a/backend/crates/db/src/repositories/llm_document.rs
+++ b/backend/crates/db/src/repositories/llm_document.rs
@@ -1942,7 +1942,12 @@ impl LlmDocumentRepository {
         platform: &str,
         device_id: &str,
         device_name: Option<&str>,
-        access_token_encrypted: &str,
+        // `None` stores a NULL token — the client-linking path (`ai/voice.rs`)
+        // hits this when the platform's OAuth is not configured (dev/testing),
+        // mirroring what `create_voice_device` has always allowed. On a re-link
+        // conflict a `Some` token overwrites the stored one (rotation); a `None`
+        // leaves the existing token in place (see the `DO UPDATE` COALESCE).
+        access_token_encrypted: Option<&str>,
         refresh_token_encrypted: Option<&str>,
         token_expires_at: Option<DateTime<Utc>>,
         capabilities: serde_json::Value,
@@ -1993,13 +1998,33 @@ impl LlmDocumentRepository {
                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())
                     ON CONFLICT (organization_id, user_id, platform) WHERE is_active = TRUE
                     DO UPDATE SET
-                        access_token_encrypted  = EXCLUDED.access_token_encrypted,
+                        -- A NULL incoming token means "no new token to store"
+                        -- (client-link path with unconfigured OAuth): keep the
+                        -- existing token rather than blanking it. The webhook
+                        -- path always supplies a token, so this is a rotation.
+                        access_token_encrypted  = COALESCE(
+                            EXCLUDED.access_token_encrypted,
+                            voice_assistant_devices.access_token_encrypted
+                        ),
                         refresh_token_encrypted = COALESCE(
                             EXCLUDED.refresh_token_encrypted,
                             voice_assistant_devices.refresh_token_encrypted
                         ),
-                        token_expires_at        = EXCLUDED.token_expires_at,
-                        access_token_hash       = EXCLUDED.access_token_hash,
+                        token_expires_at        = CASE
+                            WHEN EXCLUDED.access_token_encrypted IS NULL
+                                THEN voice_assistant_devices.token_expires_at
+                            ELSE EXCLUDED.token_expires_at
+                        END,
+                        -- Keep the HMAC hash in lock-step with the access token:
+                        -- when a new token is supplied, adopt the incoming hash
+                        -- (which may itself be NULL, e.g. the client-link path);
+                        -- when no new token is supplied, preserve the old hash so
+                        -- it never points at a superseded token.
+                        access_token_hash       = CASE
+                            WHEN EXCLUDED.access_token_encrypted IS NULL
+                                THEN voice_assistant_devices.access_token_hash
+                            ELSE EXCLUDED.access_token_hash
+                        END,
                         updated_at              = NOW()
                     RETURNING *
                     "#,

--- a/backend/servers/api-server/src/routes/ai/voice.rs
+++ b/backend/servers/api-server/src/routes/ai/voice.rs
@@ -86,10 +86,19 @@ pub(crate) async fn link_voice_device(
         }
     };
 
+    // #2807: route through the same single-writer upsert the OAuth-exchange
+    // webhook path uses. The `uniq_voice_devices_active_org_user_platform`
+    // partial UNIQUE index (migration 00231) constrains *every* insert into the
+    // table, so a plain `create_voice_device` here raised a `23505`
+    // unique-violation (surfaced as an opaque 500) whenever the caller re-linked
+    // a device that already had an active row for this (org, user, platform).
+    // The upsert makes the DB the arbiter: first link inserts, a re-link
+    // conflicts on the index and rotates the tokens on the existing row in
+    // place, keeping `device_id` stable and one active row per tuple.
     let device = state
         .llm_document_repo
-        .create_voice_device(
-            &mut **rls.conn(),
+        .upsert_active_voice_device(
+            rls.conn(),
             tenant_id,
             user_id,
             req.unit_id,

--- a/backend/servers/api-server/src/routes/voice_webhooks.rs
+++ b/backend/servers/api-server/src/routes/voice_webhooks.rs
@@ -602,7 +602,7 @@ async fn oauth_token_exchange(
             &request.platform,
             &device_id,
             Some("Voice Assistant"),
-            &access_encrypted,
+            Some(&access_encrypted),
             refresh_encrypted.as_deref(),
             expires_at,
             serde_json::json!(["check_balance", "report_fault", "check_announcements"]),

--- a/backend/servers/api-server/tests/suites/ai_llm_workflow_batch5_tests.rs
+++ b/backend/servers/api-server/tests/suites/ai_llm_workflow_batch5_tests.rs
@@ -873,6 +873,94 @@ async fn delete_voice_device_returns_no_content(pool: PgPool) {
     );
 }
 
+// POST /api/v1/ai/llm/voice/devices — re-link keeps exactly one active row.
+//
+// Regression for #2807: PR #2796 added the global partial UNIQUE index
+// `uniq_voice_devices_active_org_user_platform` (WHERE is_active = TRUE,
+// migration 00231) but only converted the OAuth-exchange *webhook* path to the
+// atomic upsert. This second link path (`ai/voice.rs::link_voice_device`, the
+// React-Native voice-linking flow) still went through a plain
+// `INSERT ... RETURNING *`, so a re-link for an (org, user, platform) that
+// already had an active row hit a Postgres `23505` unique-violation which the
+// handler mapped to an opaque 500. Routing it through `upsert_active_voice_device`
+// makes the DB the single writer: the first link inserts, the re-link conflicts
+// on the index and rotates the row in place. This test links twice for the same
+// tuple and asserts both calls are non-500 (201) and leave exactly one active
+// row — it fails on the pre-fix plain-insert path with a 500 on the second call.
+//
+// The OAuth platform is intentionally left unconfigured in the test env, so
+// `exchange_voice_oauth_tokens` returns no tokens and the device is stored with
+// a NULL access token (the dev/testing path) — exercising the link write itself
+// without a live provider.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn link_voice_device_relink_keeps_single_active_row(pool: PgPool) {
+    create_llm_tables(&pool).await;
+    let app = TestApp::new(pool.clone()).await;
+    let user = TestUser::new();
+    let (token, org_id) = create_authenticated_user_with_org(&app, &user, "llm-voice-relink").await;
+    let user_id = user_id_for(&pool, &user.email).await;
+    let session = app.session(token, org_id);
+
+    let link = |name: &str| {
+        session
+            .post("/api/v1/ai/llm/voice/devices")
+            .json(json!({
+                "platform": "alexa",
+                "auth_code": "test-auth-code",
+                "device_name": name,
+                "unit_id": null,
+            }))
+            .build()
+    };
+
+    // First link: inserts the device row.
+    let resp1 = app.execute(link("Kitchen Echo")).await;
+    assert_eq!(
+        resp1.status,
+        StatusCode::CREATED,
+        "first voice-device link must return 201; body={}",
+        resp1.text()
+    );
+
+    // Re-link for the same (org, user, platform): pre-fix this hit the new
+    // partial UNIQUE index and returned a 500; the upsert must make it idempotent.
+    let resp2 = app.execute(link("Kitchen Echo v2")).await;
+    assert_eq!(
+        resp2.status,
+        StatusCode::CREATED,
+        "re-link must upsert (not 23505 -> 500); body={}",
+        resp2.text()
+    );
+
+    // The DB is the single writer of the invariant: exactly one active row.
+    let active_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM voice_assistant_devices \
+         WHERE organization_id = $1 AND user_id = $2 AND platform = $3 AND is_active = TRUE",
+    )
+    .bind(org_id)
+    .bind(user_id)
+    .bind("alexa")
+    .fetch_one(&pool)
+    .await
+    .expect("count active voice devices");
+    assert_eq!(
+        active_count, 1,
+        "re-link must not accumulate active device rows (found {active_count})"
+    );
+
+    // The device_id (row id) is stable across the re-link: the upsert rotated the
+    // existing row rather than minting a new one.
+    let id1: Uuid = resp1.json::<serde_json::Value>()["device_id"]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .expect("first link returns a device_id");
+    let id2: Uuid = resp2.json::<serde_json::Value>()["device_id"]
+        .as_str()
+        .and_then(|s| s.parse().ok())
+        .expect("re-link returns a device_id");
+    assert_eq!(id1, id2, "re-link must preserve the existing device row id");
+}
+
 // =============================================================================
 // ai/llm.rs — statistics and requests (3 endpoints)
 // =============================================================================


### PR DESCRIPTION
## Task
Follow-up: second voice-device link path (ai/voice.rs) can now 23505-violate the new active-device unique index (PR #2796). The primary OAuth-exchange webhook path handles the conflict; the second link path in `backend/servers/api-server/src/routes/ai/voice.rs::link_voice_device` did not, so it could raise a Postgres `23505` unique_violation (surfaced as an opaque 500) instead of gracefully upserting/deactivating the prior active device. Align the second path with the primary pattern and add a regression test.

Closes #2807

## Owner
pm-tech-lead (specialist: rust-backend)

## What changed
- `routes/ai/voice.rs::link_voice_device` now routes through `LlmDocumentRepository::upsert_active_voice_device` (the same single-writer path the webhook uses) instead of the plain-`INSERT` `create_voice_device`. First link inserts; a re-link conflicts on `uniq_voice_devices_active_org_user_platform` (migration 00231) and rotates the row in place — `device_id` stays stable, one active row per tuple, no more `23505` → 500.
- Reconciled the `upsert_active_voice_device` signature: `access_token_encrypted` is now `Option<&str>` (was `&str`) so the client-link path can store a NULL token the way `create_voice_device` allowed (dev/testing path where the platform's OAuth is unconfigured). The `DO UPDATE` now preserves the existing token / expiry / HMAC-hash when no new token is supplied, keeping the hash in lock-step with the token. The webhook path always supplies a token, so its rotation behavior is unchanged (call site updated to pass `Some(&access_encrypted)`).
- Regression test `link_voice_device_relink_keeps_single_active_row` (batch5 suite): links twice for the same `(org, user, platform)` and asserts both calls are non-500 (201), exactly one active row remains, and the device id is stable across the re-link. Fails on the pre-fix plain-insert path (500 on the second call).

## Verification
Environment note: the sandbox blocks the `utoipa-swagger-ui` build-dep download (github.com is egress-denied — the archive comes back as an access-denied JSON, `InvalidArchive("Could not find EOCD")`), and no Postgres/`DATABASE_URL` is provisioned by default. Adapted (not faked): built a minimal valid Swagger-UI zip and pointed `SWAGGER_UI_DOWNLOAD_URL=file:...` at it purely to let the crate compile, and stood up a local Postgres 16 cluster with `db::MIGRATOR` (which applies migration 00231's UNIQUE index) to run the tests. CI runs the real gate.

- `cargo fmt --all -- --check` — OK
- `cargo clippy -p db --all-targets -- -D warnings` — OK
- `cargo clippy -p api-server --all-targets -- -D warnings` — OK (with the swagger stub; caught and fixed an `explicit_auto_deref` on the new call site)
- `cargo test -p api-server --test suite_1 link_voice_device_relink_keeps_single_active_row` — **ok. 1 passed**
- `cargo test -p api-server --test suite_8 voice_oauth` (webhook exchange + refresh, affected by the shared signature change) — **ok. 11 passed**
- `cargo test -p api-server --test suite_1 voice_device` (existing batch5 voice tests) — **ok. 3 passed**

## CI parity (Band C — hot-path)
Data-integrity change. Local gate green as above; leaving the CI-parity workflow replication to GitHub Actions since the swagger download only succeeds there (the real `backend.yml` job will run `clippy` + the full `api-server` test suite against a real Postgres).

## Remote-tested
skipped (ppt-bridge MCP not connected)

## Scope drift
`scope-check.sh --owner pm-tech-lead` flags all four backend files as out-of-area because `pm-tech-lead` maps only to `docs/**`, `.research/**`, `_bmad-output/**`. The drift is expected: this is a backend code fix (specialist `rust-backend`); the natural owner area is `pm-backend` (`backend/**`). No unrelated areas were touched — only:
- `backend/crates/db/src/repositories/llm_document.rs`
- `backend/servers/api-server/src/routes/ai/voice.rs`
- `backend/servers/api-server/src/routes/voice_webhooks.rs`
- `backend/servers/api-server/tests/suites/ai_llm_workflow_batch5_tests.rs`

## Notes
- `create_voice_device` is left in place (still a valid `pub` repository method; no longer called from either link path).
- RLS safety: `set_request_context` sets session-level GUCs (`set_config(..., FALSE)`), so the short transaction `upsert_active_voice_device` opens internally still sees the tenant/user context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019o3cJWAabX76MNXZSNY12a

---
_Generated by [Claude Code](https://claude.ai/code/session_019o3cJWAabX76MNXZSNY12a)_