### PR TITLE
code-review-reality-server-inquiry-detail-empty-messages: return persisted inquiry messages

### DIFF
--- a/backend/crates/db/src/repositories/reality_portal/inquiries.rs
+++ b/backend/crates/db/src/repositories/reality_portal/inquiries.rs
@@ -153,6 +153,24 @@ impl RealityPortalRepository {
         .await
     }
 
+    /// List the persisted conversation messages for an inquiry, oldest first.
+    ///
+    /// Ownership is expected to be verified by the caller (the detail handler
+    /// resolves the inquiry via [`Self::get_inquiry_for_realtor`] first), so
+    /// this query is scoped only by `inquiry_id`. Ordered by `created_at` so
+    /// the realtor sees the thread in chronological order.
+    pub async fn list_inquiry_messages(
+        &self,
+        inquiry_id: Uuid,
+    ) -> Result<Vec<InquiryMessage>, SqlxError> {
+        sqlx::query_as::<_, InquiryMessage>(
+            "SELECT * FROM inquiry_messages WHERE inquiry_id = $1 ORDER BY created_at ASC",
+        )
+        .bind(inquiry_id)
+        .fetch_all(&self.pool)
+        .await
+    }
+
     /// Mark inquiry as read.
     pub async fn mark_inquiry_read(&self, id: Uuid) -> Result<(), SqlxError> {
         sqlx::query("UPDATE listing_inquiries SET status = 'read', read_at = NOW() WHERE id = $1 AND read_at IS NULL")

--- a/backend/crates/db/src/repositories/reality_portal/tests.rs
+++ b/backend/crates/db/src/repositories/reality_portal/tests.rs
@@ -183,3 +183,47 @@ async fn realtor_b_cannot_respond_to_realtor_a_inquiry() {
 
     cleanup(&pool, &emails).await;
 }
+
+/// Regression: the inquiry-detail path must surface persisted conversation
+/// messages instead of the previously hardcoded empty array.
+///
+/// Reproduces the bug where `get_inquiry` returned `messages: vec![]`
+/// unconditionally: a realtor responded to an inquiry (persisting a row in
+/// `inquiry_messages`), yet the detail response showed an empty thread.
+/// `list_inquiry_messages` — the method the detail handler now calls — must
+/// return the persisted message.
+#[tokio::test]
+#[ignore = "requires Postgres test database (test_pool); run with --ignored"]
+async fn list_inquiry_messages_returns_persisted_message() {
+    let pool = test_pool().await;
+    let emails = ["realtor_a_msgs@test.sk"];
+    cleanup(&pool, &emails).await;
+
+    let realtor_a = seed_portal_user(&pool, emails[0]).await;
+    let listing = seed_listing(&pool, realtor_a).await;
+    let inquiry_id = seed_inquiry(&pool, listing, realtor_a).await;
+
+    let repo = RealityPortalRepository::new(pool.clone());
+
+    // Persist a message on the conversation thread.
+    repo.respond_to_inquiry(inquiry_id, realtor_a, "Thanks, viewing on Friday?")
+        .await
+        .expect("repo call failed")
+        .expect("realtor A must be able to respond to own inquiry");
+
+    // The detail handler now loads the thread via this method.
+    let messages = repo
+        .list_inquiry_messages(inquiry_id)
+        .await
+        .expect("list_inquiry_messages failed");
+
+    assert_eq!(
+        messages.len(),
+        1,
+        "The persisted message must appear in the inquiry detail thread"
+    );
+    assert_eq!(messages[0].message, "Thanks, viewing on Friday?");
+    assert_eq!(messages[0].sender_type, "realtor");
+
+    cleanup(&pool, &emails).await;
+}

--- a/backend/servers/reality-server/src/routes/inquiries.rs
+++ b/backend/servers/reality-server/src/routes/inquiries.rs
@@ -703,10 +703,24 @@ pub async fn get_inquiry(
         .mark_inquiry_read_for_realtor(id, principal.user_id)
         .await;
 
-    Ok(Json(InquiryDetailResponse {
-        inquiry,
-        messages: vec![], // Would fetch conversation messages
-    }))
+    // Load the persisted conversation thread. Ownership is already verified by
+    // the `get_inquiry_for_realtor` lookup above, so scoping by inquiry id is
+    // safe here.
+    let messages = state
+        .reality_portal_repo
+        .list_inquiry_messages(id)
+        .await
+        .map_err(|e| crate::util::errors::db_error("list inquiry messages", e))?
+        .into_iter()
+        .map(|m| InquiryMessageResponse {
+            id: m.id,
+            sender_type: m.sender_type,
+            message: m.message,
+            created_at: m.created_at.to_rfc3339(),
+        })
+        .collect();
+
+    Ok(Json(InquiryDetailResponse { inquiry, messages }))
 }
 
 /// Mark inquiry as read.


### PR DESCRIPTION
## Task

reality-server inquiry-detail endpoint hardcodes `messages: []` — realtors never see a persisted inquiry conversation thread. Load the persisted messages for the inquiry from the database and return them in the inquiry-detail response instead of the hardcoded empty array. Add a regression test that a persisted message appears in the detail response.

## Owner

pm-backend

## Changes

- `backend/crates/db/src/repositories/reality_portal/inquiries.rs` — new `list_inquiry_messages(inquiry_id)` repo method (`SELECT * FROM inquiry_messages WHERE inquiry_id = $1 ORDER BY created_at ASC`). Ownership is already verified by the handler's `get_inquiry_for_realtor` lookup, so the query is scoped by inquiry id.
- `backend/servers/reality-server/src/routes/inquiries.rs` — `get_inquiry` now calls `list_inquiry_messages` and maps rows into `InquiryMessageResponse` (id / sender_type / message / created_at as RFC3339), replacing the hardcoded `messages: vec[]`.
- `backend/crates/db/src/repositories/reality_portal/tests.rs` — regression test `list_inquiry_messages_returns_persisted_message`: seeds an inquiry, persists a realtor response, asserts the persisted message is returned by the method the detail handler now calls. Live-DB test, `#[ignore]` like the sibling IDOR-guard tests (run with `cargo test -p db -- --ignored --test-threads=1`).

No schema change — the `inquiry_messages` table and `InquiryMessage` model already exist (written by `respond_to_inquiry`). No sqlx offline-data change (runtime `query_as`, not macros).

## Verification

VERIFY-PLAN base=fbe0fb7f008d9ef18da10036cf1b244f1a4b774d files=3

The full `scripts/verify-impact.sh` gate could NOT complete in this sandbox for two environment reasons unrelated to the diff (CI is the authoritative gate):

1. Every server crate (accounting-server / api-server / reality-server) fails to build because `utoipa-swagger-ui`'s build script downloads Swagger UI from `github.com/swagger-api/swagger-ui`, which the session egress policy returns `403` for ("GitHub access to this repository is not enabled for this session"). Policy denial — not retried.
2. The `#[sqlx::test]` suites in the `db` crate require a live Postgres (none available here); they panic in `sqlx-postgres .../testing/mod.rs`.

What DID run clean against the actual change (the `db` crate does not pull swagger):

- `cd backend && cargo clippy -p db --all-targets -- -D warnings` → clean (exit 0)
- `cd backend && cargo test -p db` → the new test compiles and is registered; it is `#[ignore]` (needs DB) so it does not run without `--ignored`. The only failures are the 10 pre-existing `#[sqlx::test]` suites that need a live Postgres — all unrelated to this diff.

## CI parity (Band C — hot-path only)

skipped: not a hot-path PR (no security/auth/billing/data-integrity change)

## Remote-tested

skipped

## Notes

- `get_inquiry` already resolves + ownership-checks the inquiry via `get_inquiry_for_realtor` before loading messages, so no IDOR is introduced by scoping the message query on `inquiry_id` alone.
- The response DTO `InquiryMessageResponse` (id, sender_type, message, created_at) was already defined and wired into the OpenAPI schema; only the population changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZnGpmXXYsDhKCNivTmZXN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZnGpmXXYsDhKCNivTmZXN)_