### PR TITLE
gh-issue-2814: widen saved-search match_count to bigint

### DIFF
--- a/backend/crates/db/migrations/00232_widen_portal_saved_searches_match_count.sql
+++ b/backend/crates/db/migrations/00232_widen_portal_saved_searches_match_count.sql
@@ -1,0 +1,37 @@
+-- Widen `portal_saved_searches.match_count` from int4 to bigint so a long-lived,
+-- high-traffic saved search can never wedge itself on integer overflow (#2814,
+-- follow-up to PR #2812).
+--
+-- Background
+-- ----------
+-- `RealityPortalRepository::mark_saved_search_matched` advances the alert
+-- watermark with `match_count = match_count + N`. Since PR #2812 made the
+-- enqueue + watermark advance atomic (correct, all-or-nothing), a failed
+-- advance now rolls the whole run back — which is the intended contract for
+-- ordinary failures but exposes a nasty latent edge for arithmetic overflow:
+-- once a saved search accumulates `match_count` near `i32::MAX`, every
+-- subsequent advance overflows `integer`, aborts the transaction, and the
+-- watermark never moves again. The search then stops delivering alerts
+-- **permanently**, with no self-recovery and no alerting once it trips.
+--
+-- The failure mode is exactly what the regression test
+-- `failed_watermark_advance_rolls_back_enqueue` induces deliberately (it
+-- primes `match_count = i32::MAX` to force the overflow to validate the
+-- rollback contract). In production the overflow is implausible for a single
+-- search in the near term, but `match_count` is unbounded and monotonic, so
+-- it is a real "wedges forever, silently" edge — pick a durable ceiling.
+--
+-- Fix
+-- ---
+-- Widen the column to `bigint` (i64). `bigint` shares int4's storage class in
+-- Postgres for ALTER TYPE — the rewrite is O(N) but touches at most a few
+-- rows per portal user, so the migration is fast even on populated
+-- environments. Repo/model types move from `i32` -> `i64` in the same PR;
+-- utoipa's `ToSchema` still surfaces a JSON number, so the on-the-wire shape
+-- is unchanged for consumers (JSON numbers cover both).
+--
+-- Column default and NOT NULL are preserved by ALTER COLUMN TYPE; the
+-- existing rows keep their current values (bigint is a strict superset of
+-- int4).
+ALTER TABLE portal_saved_searches
+    ALTER COLUMN match_count TYPE bigint;

--- a/backend/crates/db/src/models/reality_portal.rs
+++ b/backend/crates/db/src/models/reality_portal.rs
@@ -114,7 +114,11 @@ pub struct PortalSavedSearch {
     pub alerts_enabled: bool,
     pub alert_frequency: String,
     pub last_matched_at: Option<DateTime<Utc>>,
-    pub match_count: i32,
+    /// Running total of listings matched by this saved search across every
+    /// alert run. Widened to `bigint` (i64) in migration 00232 so a long-lived,
+    /// high-traffic search can never wedge itself on integer overflow — see
+    /// #2814 and the `saved_search_watermark_advance_tests` suite.
+    pub match_count: i64,
     pub last_alert_sent_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,

--- a/backend/crates/db/src/repositories/reality_portal/searches.rs
+++ b/backend/crates/db/src/repositories/reality_portal/searches.rs
@@ -133,6 +133,12 @@ impl RealityPortalRepository {
 
     /// Advance a saved search's match watermark (`last_matched_at = now()`) and
     /// add `new_matches` to its running `match_count`.
+    ///
+    /// `match_count` is stored as `bigint` (i64) — see migration 00232 and
+    /// #2814. The pre-widening `int4` column could overflow near `i32::MAX`
+    /// and wedge the search forever once PR #2812 made the advance atomic
+    /// (a failed advance rolls the enqueue back). `bigint` pushes the ceiling
+    /// far past any realistic per-search match volume.
     pub async fn mark_saved_search_matched<'e, E>(
         &self,
         executor: E,
@@ -152,7 +158,7 @@ impl RealityPortalRepository {
             "#,
         )
         .bind(id)
-        .bind(new_matches as i32)
+        .bind(new_matches)
         .execute(executor)
         .await?;
         Ok(())

--- a/backend/crates/db/tests/suites/saved_search_watermark_advance_tests.rs
+++ b/backend/crates/db/tests/suites/saved_search_watermark_advance_tests.rs
@@ -58,8 +58,11 @@ async fn seed_saved_search(repo: &RealityPortalRepository, user_id: Uuid) -> Uui
     .id
 }
 
-async fn match_count(pool: &PgPool, search_id: Uuid) -> i32 {
-    sqlx::query_scalar::<_, i32>("SELECT match_count FROM portal_saved_searches WHERE id = $1")
+async fn match_count(pool: &PgPool, search_id: Uuid) -> i64 {
+    // `match_count` is `bigint` (i64) since migration 00232 (#2814) — was
+    // `int4` before, which overflowed and permanently wedged high-traffic
+    // saved searches once the alert-advance became atomic.
+    sqlx::query_scalar::<_, i64>("SELECT match_count FROM portal_saved_searches WHERE id = $1")
         .bind(search_id)
         .fetch_one(pool)
         .await
@@ -98,7 +101,7 @@ async fn enqueue_and_advance_commits_both_writes(pool: PgPool) {
     );
     assert_eq!(
         match_count(&pool, search).await,
-        2,
+        2_i64,
         "match_count must advance by the number of matched listings",
     );
     assert!(
@@ -132,10 +135,16 @@ async fn enqueue_and_advance_with_no_matches_only_advances_watermark(pool: PgPoo
 
 /// Regression (#983): if the watermark advance fails, the enqueue must roll back
 /// so no orphaned `pending` alert is left behind. We force the advance to fail
-/// by pushing `match_count` to `i32::MAX`, so the `match_count + N` update
-/// overflows `integer` and aborts the transaction. The pre-enqueued alert row
+/// by pushing `match_count` to `i64::MAX`, so the `match_count + N` update
+/// overflows `bigint` and aborts the transaction. The pre-enqueued alert row
 /// must NOT survive, and a subsequent successful run must then queue exactly one
 /// alert — not two — proving a failed advance never causes a duplicate send.
+///
+/// Note: pre-#2814 the column was `int4` and this test primed to `i32::MAX`.
+/// Since migration 00232 widened it to `bigint`, `i32::MAX + N` fits fine —
+/// we still exercise the same rollback contract by climbing to `i64::MAX`.
+/// The realism of the prime doesn't matter; what matters is that a DB-side
+/// arithmetic failure inside the tx rolls both writes back.
 #[sqlx::test(migrator = "db::MIGRATOR")]
 async fn failed_watermark_advance_rolls_back_enqueue(pool: PgPool) {
     let repo = RealityPortalRepository::new(pool.clone());
@@ -143,13 +152,13 @@ async fn failed_watermark_advance_rolls_back_enqueue(pool: PgPool) {
     let search = seed_saved_search(&repo, user).await;
 
     // Force the watermark advance (`match_count = match_count + N`) to overflow
-    // int4 and abort the transaction.
+    // bigint and abort the transaction.
     sqlx::query("UPDATE portal_saved_searches SET match_count = $2 WHERE id = $1")
         .bind(search)
-        .bind(i32::MAX)
+        .bind(i64::MAX)
         .execute(&pool)
         .await
-        .expect("prime match_count to i32::MAX");
+        .expect("prime match_count to i64::MAX");
 
     let listing = Uuid::new_v4();
     let err = repo
@@ -166,7 +175,7 @@ async fn failed_watermark_advance_rolls_back_enqueue(pool: PgPool) {
     );
     assert_eq!(
         match_count(&pool, search).await,
-        i32::MAX,
+        i64::MAX,
         "the watermark must be unchanged after the aborted transaction",
     );
 
@@ -187,5 +196,54 @@ async fn failed_watermark_advance_rolls_back_enqueue(pool: PgPool) {
         repo.count_pending_search_alerts(user).await.unwrap(),
         1,
         "the retry must queue exactly one alert — a failed advance must not duplicate",
+    );
+}
+
+/// Regression (#2814): a saved search whose accumulated `match_count` is
+/// already past the old `int4` ceiling MUST continue to advance its watermark
+/// and deliver alerts. Before migration 00232 widened the column to `bigint`,
+/// `match_count + N` overflowed `integer` and the atomic-run contract
+/// (introduced by PR #2812) rolled the whole run back — so the search stopped
+/// delivering alerts forever with no self-recovery. This test locks the fix
+/// in: prime `match_count` just past `i32::MAX`, run one more advance, and
+/// prove the run commits (watermark timestamp stamped, count grows, one alert
+/// queued) rather than being rolled back.
+#[sqlx::test(migrator = "db::MIGRATOR")]
+async fn watermark_advances_past_i32_max_boundary(pool: PgPool) {
+    let repo = RealityPortalRepository::new(pool.clone());
+    let user = seed_portal_user(&pool, "watermark-past-i32-max@test.sk").await;
+    let search = seed_saved_search(&repo, user).await;
+
+    // Prime to a value that would have overflowed the pre-#2814 `int4` column
+    // on any non-trivial advance. `bigint` swallows this comfortably.
+    let primed: i64 = i32::MAX as i64;
+    sqlx::query("UPDATE portal_saved_searches SET match_count = $2 WHERE id = $1")
+        .bind(search)
+        .bind(primed)
+        .execute(&pool)
+        .await
+        .expect("prime match_count past i32::MAX");
+
+    let listing = Uuid::new_v4();
+    repo.enqueue_and_advance_saved_search(search, user, &[listing])
+        .await
+        .expect(
+            "advance past i32::MAX must commit — the pre-widening column overflowed here and \
+             permanently wedged the search",
+        );
+
+    assert_eq!(
+        repo.count_pending_search_alerts(user).await.unwrap(),
+        1,
+        "the run must queue exactly one alert once the ceiling is gone",
+    );
+    assert_eq!(
+        match_count(&pool, search).await,
+        primed + 1,
+        "match_count must grow past i32::MAX now that the column is bigint",
+    );
+    assert!(
+        last_matched_at_is_set(&pool, search).await,
+        "the watermark timestamp must be stamped so the cadence window restarts",
     );
 }


### PR DESCRIPTION
## Summary
Follow-up to PR #2812 (issue #2814). `RealityPortalRepository::mark_saved_search_matched` advances the alert watermark with `match_count = match_count + N`, and `portal_saved_searches.match_count` was `int4` (i32). Since PR #2812 made the enqueue + watermark-advance atomic, a failed advance now rolls the whole run back — which is the intended contract for ordinary failures but exposes a nasty latent overflow edge: once a long-lived, high-traffic saved search accumulates `match_count` near `i32::MAX`, every subsequent advance overflows `integer`, aborts the transaction, and rolls back — the search then stops delivering alerts **permanently**, with no self-recovery and no alerting once it trips.

This PR picks the issue author's preferred fix — **Option 1 (widen the column to bigint / i64)**. It is the cleanest durable fix, and the reference count is trivially small (one repo method + one struct field + a scalar in tests), so widening does not cascade.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)

## Related Issues
Closes #2814. Follow-up to PR #2812.

## Changes Made
- **Migration 00232** (`backend/crates/db/migrations/00232_widen_portal_saved_searches_match_count.sql`) — `ALTER TABLE portal_saved_searches ALTER COLUMN match_count TYPE bigint;`. Column default and NOT NULL are preserved by `ALTER COLUMN TYPE`; existing rows keep their current values (bigint is a strict superset of int4). Live-DB validated: pre-existing `i32::MAX` values round-trip and `match_count + N` advances past the old ceiling without overflow.
- **Model** (`backend/crates/db/src/models/reality_portal.rs`) — `PortalSavedSearch.match_count: i32 -> i64`, with a docstring pointing at #2814 and migration 00232. utoipa's `ToSchema` still surfaces a JSON number, so the on-the-wire shape is unchanged for consumers (JSON numbers cover both).
- **Repository** (`backend/crates/db/src/repositories/reality_portal/searches.rs`) — `mark_saved_search_matched` drops the `as i32` cast on `.bind(new_matches)`. Docstring explains the bigint rationale in-place.
- **Regression tests** (`backend/crates/db/tests/suites/saved_search_watermark_advance_tests.rs`):
    - `watermark_advances_past_i32_max_boundary` — **new**. Primes `match_count = i32::MAX`, runs one advance, and asserts the run commits (watermark stamped, count grows past `i32::MAX + 1`, one alert queued) — locks the fix in against regression.
    - `failed_watermark_advance_rolls_back_enqueue` — preserved. Since bigint no longer overflows at `i32::MAX + N`, the rollback contract is now exercised by climbing to `i64::MAX` (same all-or-nothing behavior, new ceiling).
    - `enqueue_and_advance_commits_both_writes` — typed helper now returns `i64`.

## Verification

```
VERIFY-PLAN base=e7e75e2ac3b5cbf08a2292b7bb5763ba874c3fcb files=4
  # WARN: migrations touched — SQL truth needs a live DB (localhost:5433); runtime sqlx compiles without one, so run DB-backed tests before merge
  cd backend && cargo fmt --all -- --check
  cd backend && cargo clippy --workspace --all-targets -- -D warnings
  cd backend && cargo test --workspace
```

- `cd backend && cargo fmt --all -- --check` — exit 0.
- `cd backend && cargo clippy --workspace --all-targets -- -D warnings` — exit 0.
- **Target regression suite** `suite_4::saved_search_watermark_advance_tests` — **4 passed / 0 failed / 0 ignored** against a live Postgres 16 (`DATABASE_URL=postgres://ppt_dev:ppt_dev@localhost:5432/ppt`, migrator applied fresh per test, so migration 00232 is exercised there), including the new `watermark_advances_past_i32_max_boundary`.
- `cd backend && cargo test --workspace` — every crate + integration binary passed **except two pre-existing, diff-unrelated tests that are mutually-exclusively sensitive to this sandbox's egress proxy** (both are api-server tests, neither shares any code path with the db-crate `match_count` change):
    1. `services::actions::api_call::tests::execute_rejects_dns_rebinding_to_private_ip_at_connect` — a DNS-rebinding SSRF test that requires the outbound proxy to be **off** (it asserts reqwest re-consults the local resolver at connect time). Passes with `HTTPS_PROXY` unset.
    2. `airbnb_oauth_routes_tests::token_exchange_returns_503_when_not_configured` — its own docstring notes it "relies on the fact that no `AIRBNB_CLIENT_ID` env var is set in test runs" and must **not** reach the network. With `HTTPS_PROXY` unset (needed to pass test 1), the handler's outbound token-exchange attempt reaches out and returns `400 TOKEN_EXCHANGE_FAILED` instead of `503`. It passes when the proxy is on / the exchange is blocked. `AIRBNB_CLIENT_ID` is not set in the env, `.env`, or CI config.
  These two have contradictory proxy requirements in this sandbox, so no single local run turns both green — but each passes under its required proxy state, and **neither can be affected by this PR's 4-file db-crate diff**. CI (`backend.yml`) runs hermetically with the proper egress/config and is the authoritative gate; both tests are expected green there.

Environment note (sandbox-only, not code-visible): `SWAGGER_UI_DOWNLOAD_URL=file:///…/v5.17.14.zip` used because the agent proxy blocks direct GitHub downloads for `swagger-api/swagger-ui`. The zip contents are the standard `swagger-ui-dist@5.17.14` from the npm registry, re-layered as `swagger-ui-5.17.14/dist/` per utoipa's expectations. `SWAGGER_UI_DOWNLOAD_URL` only steers the build script's fetch source, so CI (which downloads directly) is unaffected.

## Scope drift
`owner_role=pm-tech-lead` (dispatcher-suggested `pm-rust-backend`) — this PR touches `backend/crates/db/**` (migration, model, repository, tests), not `pm-tech-lead`'s docs-owned areas. The drift is justified: the issue explicitly calls for a `pm-rust-backend` change (reality-server / DB repositories + a SQLx migration), so the correct specialist was routed regardless of the owner_role hint. `scope-check.sh` exit 2 reports the four backend paths; there is no doc-area work that was omitted.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no findings. Zero new helper introductions; this PR only widens an existing type and its accessor semantics.

## Testing
- [x] Unit tests added/updated (new regression test `watermark_advances_past_i32_max_boundary`; existing overflow-rollback test rehomed to `i64::MAX`).
- [x] Integration tests added/updated (the whole suite is `#[sqlx::test]`-driven — validated against a live Postgres 16).
- [x] Manual testing performed (migration semantics validated on a scratch table: `int4` -> `bigint`, existing `i32::MAX` value preserved, `match_count + N` advances past the old ceiling).

## Test Plan
1. `cd backend && SQLX_OFFLINE=true cargo test -p db --test suite_4 saved_search_watermark_advance -- --test-threads=1` against a live Postgres — expect 4 passed.
2. Existing prod DBs: `\d portal_saved_searches` after applying migration 00232 shows `match_count` as `bigint NOT NULL DEFAULT 0`; existing values preserved.
3. Optional smoke: prime a saved search to `match_count = 2147483650` (past `i32::MAX`) and run one alert scan — the watermark advances instead of aborting.

## Performance Impact
`ALTER COLUMN TYPE bigint` is an O(N) table rewrite in Postgres. `portal_saved_searches` is a per-user, low-cardinality table (a saved search per portal user, capped at a handful per user), so the rewrite is fast even on populated environments. No index rebuild required (no index references `match_count`). Steady-state cost is unchanged — `bigint` and `int4` have the same fixed-width payload behavior on modern amd64 rows.

## Security Considerations
This closes a "silent forever" denial-of-service edge for saved-search alert delivery. No auth/RLS/tenant boundary changes. `portal_saved_searches` was already not RLS-gated (documented at the module level), and this PR does not touch that.
