### PR TITLE
gh-issue-2816: remove orphaned saved_searches int4 path

### DIFF
--- a/backend/crates/db/migrations/00233_drop_orphan_saved_searches.sql
+++ b/backend/crates/db/migrations/00233_drop_orphan_saved_searches.sql
@@ -1,0 +1,29 @@
+-- Drop the orphaned `saved_searches` (int4) table introduced by migration
+-- 00046 (`create_smart_search.sql`). Follow-up to #2816 / PR #2815.
+--
+-- Background
+-- ----------
+-- Two parallel saved-search implementations existed:
+--
+--   1. LIVE: `portal_saved_searches` (migration 00063), served by
+--      `RealityPortalRepository`, wired into reality-server's
+--      `/api/v1/saved-searches` routes and the `SavedSearchAlertWorker`.
+--      Its `match_count` was hardened to bigint in migration 00232 (#2814).
+--
+--   2. ORPHAN (this migration removes it): `saved_searches` (migration 00046),
+--      targeted by the `PortalRepository` saved-search cluster
+--      (`create_saved_search`, `get_saved_search(es)`, `update_saved_search`,
+--      `delete_saved_search`, `count_saved_searches`, `update_match_count`).
+--      None of those methods had any caller anywhere in the tree, and the
+--      table's actual columns (query/filters/alert_enabled) never even matched
+--      the `SavedSearch` model (criteria/alerts_enabled/match_count) the
+--      repository bound against — the path was dead on arrival.
+--
+-- Removing the model + repository methods leaves this table with no reader or
+-- writer, so it is dropped here together with the RLS policy and updated-at
+-- trigger created for it in 00046. `DROP TABLE` also removes the dependent
+-- `idx_saved_searches_user` index.
+
+DROP TRIGGER IF EXISTS update_saved_searches_updated_at ON saved_searches;
+DROP POLICY IF EXISTS saved_searches_user_isolation ON saved_searches;
+DROP TABLE IF EXISTS saved_searches;

--- a/backend/crates/db/src/models/mod.rs
+++ b/backend/crates/db/src/models/mod.rs
@@ -324,11 +324,10 @@ pub use listing::{
 
 // Epic 16: Portal Search & Discovery
 pub use portal::{
-    alert_frequency, AddFavorite, CreatePortalUser, CreateSavedSearch, Favorite,
-    FavoriteWithListing, FavoriteWithListingRow, FavoritesResponse, MatchedListing, PortalSession,
-    PortalUser, PublicListingDetail, PublicListingQuery, PublicListingSearchResponse,
-    PublicListingSummary, SavedSearch, SavedSearchesResponse, SearchAlert, SearchCriteria,
-    SearchSuggestions, UpdatePortalUser, UpdateSavedSearch,
+    AddFavorite, CreatePortalUser, Favorite, FavoriteWithListing, FavoriteWithListingRow,
+    FavoritesResponse, MatchedListing, PortalSession, PortalUser, PublicListingDetail,
+    PublicListingQuery, PublicListingSearchResponse, PublicListingSummary, SearchAlert,
+    SearchCriteria, SearchSuggestions, UpdatePortalUser,
 };
 
 // Epic 17: Agency & Realtor Management

--- a/backend/crates/db/src/models/portal.rs
+++ b/backend/crates/db/src/models/portal.rs
@@ -124,55 +124,6 @@ pub struct FavoritesResponse {
 // Saved Searches (Story 16.3)
 // ============================================
 
-/// Saved search entity.
-#[derive(Debug, Clone, FromRow, Serialize, Deserialize, ToSchema)]
-pub struct SavedSearch {
-    pub id: Uuid,
-    pub user_id: Uuid,
-    pub name: String,
-    pub criteria: serde_json::Value,
-    pub alerts_enabled: bool,
-    pub alert_frequency: String, // instant, daily, weekly
-    pub last_matched_at: Option<DateTime<Utc>>,
-    pub match_count: i32,
-    pub created_at: DateTime<Utc>,
-    pub updated_at: DateTime<Utc>,
-}
-
-/// Alert frequency enum.
-pub mod alert_frequency {
-    pub const INSTANT: &str = "instant";
-    pub const DAILY: &str = "daily";
-    pub const WEEKLY: &str = "weekly";
-}
-
-/// Create saved search request.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct CreateSavedSearch {
-    pub name: String,
-    pub criteria: SearchCriteria,
-    #[serde(default = "default_true")]
-    pub alerts_enabled: bool,
-    #[serde(default = "default_daily")]
-    pub alert_frequency: String,
-}
-
-fn default_true() -> bool {
-    true
-}
-
-fn default_daily() -> String {
-    alert_frequency::DAILY.to_string()
-}
-
-/// Update saved search request.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
-pub struct UpdateSavedSearch {
-    pub name: Option<String>,
-    pub alerts_enabled: Option<bool>,
-    pub alert_frequency: Option<String>,
-}
-
 /// Search criteria (stored as JSON).
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct SearchCriteria {
@@ -187,13 +138,6 @@ pub struct SearchCriteria {
     pub rooms_max: Option<i32>,
     pub city: Option<String>,
     pub country: Option<String>,
-}
-
-/// Saved searches list response.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct SavedSearchesResponse {
-    pub searches: Vec<SavedSearch>,
-    pub total: i64,
 }
 
 /// Search alert notification.

--- a/backend/crates/db/src/repositories/portal.rs
+++ b/backend/crates/db/src/repositories/portal.rs
@@ -1,9 +1,8 @@
 //! Portal repository (Epic 16: Portal Search & Discovery).
 
 use crate::models::portal::{
-    CreatePortalUser, CreateSavedSearch, Favorite, FavoriteWithListing, FavoriteWithListingRow,
-    PortalUser, PublicListingQuery, PublicListingSummary, SavedSearch, SearchCriteria,
-    UpdatePortalUser, UpdateSavedSearch,
+    CreatePortalUser, Favorite, FavoriteWithListing, FavoriteWithListingRow, PortalUser,
+    PublicListingQuery, PublicListingSummary, SearchCriteria, UpdatePortalUser,
 };
 use crate::DbPool;
 use chrono::Utc;
@@ -588,112 +587,6 @@ impl PortalRepository {
     // Saved Searches (Story 16.3)
     // ========================================================================
 
-    /// Create a saved search.
-    pub async fn create_saved_search(
-        &self,
-        user_id: Uuid,
-        data: CreateSavedSearch,
-    ) -> Result<SavedSearch, SqlxError> {
-        let criteria_json = serde_json::to_value(&data.criteria).unwrap_or(serde_json::json!({}));
-
-        let search = sqlx::query_as::<_, SavedSearch>(
-            r#"
-            INSERT INTO saved_searches (user_id, name, criteria, alerts_enabled, alert_frequency)
-            VALUES ($1, $2, $3, $4, $5)
-            RETURNING *
-            "#,
-        )
-        .bind(user_id)
-        .bind(&data.name)
-        .bind(&criteria_json)
-        .bind(data.alerts_enabled)
-        .bind(&data.alert_frequency)
-        .fetch_one(&self.pool)
-        .await?;
-
-        Ok(search)
-    }
-
-    /// Get saved search by ID.
-    pub async fn get_saved_search(
-        &self,
-        id: Uuid,
-        user_id: Uuid,
-    ) -> Result<Option<SavedSearch>, SqlxError> {
-        let search = sqlx::query_as::<_, SavedSearch>(
-            r#"SELECT * FROM saved_searches WHERE id = $1 AND user_id = $2"#,
-        )
-        .bind(id)
-        .bind(user_id)
-        .fetch_optional(&self.pool)
-        .await?;
-
-        Ok(search)
-    }
-
-    /// Get user's saved searches.
-    pub async fn get_saved_searches(&self, user_id: Uuid) -> Result<Vec<SavedSearch>, SqlxError> {
-        let searches = sqlx::query_as::<_, SavedSearch>(
-            r#"SELECT * FROM saved_searches WHERE user_id = $1 ORDER BY created_at DESC"#,
-        )
-        .bind(user_id)
-        .fetch_all(&self.pool)
-        .await?;
-
-        Ok(searches)
-    }
-
-    /// Update a saved search.
-    pub async fn update_saved_search(
-        &self,
-        id: Uuid,
-        user_id: Uuid,
-        data: UpdateSavedSearch,
-    ) -> Result<SavedSearch, SqlxError> {
-        let search = sqlx::query_as::<_, SavedSearch>(
-            r#"
-            UPDATE saved_searches SET
-                name = COALESCE($3, name),
-                alerts_enabled = COALESCE($4, alerts_enabled),
-                alert_frequency = COALESCE($5, alert_frequency),
-                updated_at = NOW()
-            WHERE id = $1 AND user_id = $2
-            RETURNING *
-            "#,
-        )
-        .bind(id)
-        .bind(user_id)
-        .bind(&data.name)
-        .bind(data.alerts_enabled)
-        .bind(&data.alert_frequency)
-        .fetch_one(&self.pool)
-        .await?;
-
-        Ok(search)
-    }
-
-    /// Delete a saved search.
-    pub async fn delete_saved_search(&self, id: Uuid, user_id: Uuid) -> Result<bool, SqlxError> {
-        let result = sqlx::query(r#"DELETE FROM saved_searches WHERE id = $1 AND user_id = $2"#)
-            .bind(id)
-            .bind(user_id)
-            .execute(&self.pool)
-            .await?;
-
-        Ok(result.rows_affected() > 0)
-    }
-
-    /// Count user's saved searches.
-    pub async fn count_saved_searches(&self, user_id: Uuid) -> Result<i64, SqlxError> {
-        let row: (i64,) =
-            sqlx::query_as(r#"SELECT COUNT(*) FROM saved_searches WHERE user_id = $1"#)
-                .bind(user_id)
-                .fetch_one(&self.pool)
-                .await?;
-
-        Ok(row.0)
-    }
-
     /// Find matching listings for a saved search (for alerts).
     pub async fn find_matching_listings(
         &self,
@@ -777,19 +670,6 @@ impl PortalRepository {
             .collect();
 
         Ok(listings)
-    }
-
-    /// Update saved search match count.
-    pub async fn update_match_count(&self, id: Uuid, count: i32) -> Result<(), SqlxError> {
-        sqlx::query(
-            r#"UPDATE saved_searches SET match_count = $2, last_matched_at = NOW() WHERE id = $1"#,
-        )
-        .bind(id)
-        .bind(count)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Follow-up to PR #2815. Removes the second, orphaned saved-search implementation that lived on the int4 `saved_searches` table (migration 00046) as dead code.

The **live** saved-search alert feature is served by `RealityPortalRepository` against the `portal_saved_searches` table (already hardened to bigint in PR #2815, migration 00232). This PR deletes the parallel, unreachable `PortalRepository` implementation.

## Why removal is safe (verified)

- **No callers.** grep confirmed reality-server's routes (`routes/saved_searches.rs`) drive all saved-search CRUD through `state.reality_portal_repo` (the `RealityPortalRepository` / `portal_saved_searches` path). The `PortalRepository` saved-search methods — `create_saved_search`, `get_saved_search`, `get_saved_searches`, `update_saved_search`, `delete_saved_search`, `count_saved_searches`, `update_match_count` — had **zero** call sites anywhere in the tree.
- **Non-functional anyway.** The bound `SavedSearch` model expected `criteria` / `alerts_enabled` / `match_count`, but the actual `saved_searches` table (00046) has `query` / `filters` / `alert_enabled` and no `match_count` — the queries would never have run. The path was dead on arrival.

## Changes

- `crates/db/src/repositories/portal.rs` — remove the 7 orphaned `PortalRepository` saved-search methods and the now-unused model imports. `find_matching_listings` is retained (still uses `SearchCriteria`).
- `crates/db/src/models/portal.rs` — remove `SavedSearch`, `CreateSavedSearch`, `UpdateSavedSearch`, `SavedSearchesResponse`, plus the now-unused `alert_frequency` module and `default_true`/`default_daily` helpers. `SearchCriteria`, `SearchAlert`, `MatchedListing` retained.
- `crates/db/src/models/mod.rs` — drop the removed types from the `portal` re-export.
- `crates/db/migrations/00233_drop_orphan_saved_searches.sql` — **new** migration dropping the `saved_searches` table, its RLS policy `saved_searches_user_isolation`, and its `update_saved_searches_updated_at` trigger (all from 00046). `DROP TABLE` also removes `idx_saved_searches_user`.

No `.sqlx` regeneration needed: the removed code used runtime `query_as` (string SQL), not the compile-checked `query!` macros, so there were no offline cache entries for it.

## Verification

Run in `backend/` on this branch:

- `cargo fmt --all` — clean
- `cargo clippy -p db --all-targets -- -D warnings` — clean (only an unrelated future-incompat note from the `proc-macro-error2` dependency)
- `cargo test -p db --no-run` — test binaries build clean

Live DB test execution (`cargo test -p db`) requires a Postgres instance not available on this runner; the change carries no runtime logic (pure deletion + a `DROP` migration) and touches no code exercised by any test.

Closes #2816.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7iXWWCqStgzNo9EkDosyT)_