### PR TITLE
code-review-ppt-web-ui-verification-badge-expired-as-soon: render expired verification badges as expired, not expiring soon

### DIFF
--- a/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx
+++ b/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * VerificationBadge expiry-logic regression tests.
+ *
+ * Bug: `isExpiring` was `expiresAt - now < 30 days`, which is ALSO true when the
+ * difference is negative (already expired). An already-expired trust signal was
+ * therefore rendered as "(Expiring soon)" — as if still valid.
+ *
+ * Fix: an already-expired badge renders as "(Expired)"; only a not-yet-expired
+ * badge inside the 30-day window renders as "(Expiring soon)".
+ */
+/// <reference types="vitest/globals" />
+
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Badge, VerificationBadge, VerificationStatusBadge } from './VerificationBadge';
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-08-21T12:00:00.000Z');
+
+function iso(offsetMs: number): string {
+  return new Date(NOW.getTime() + offsetMs).toISOString();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// The badge label appears twice in the DOM (visible text + the SVG <title>),
+// so we read the tooltip from the outer <span>'s `title` attribute directly.
+function badgeTitle(container: HTMLElement): string | null {
+  return container.querySelector('span[title]')?.getAttribute('title') ?? null;
+}
+
+describe('VerificationBadge expiry state', () => {
+  it('marks an already-expired badge as (Expired), not (Expiring soon)', () => {
+    const badge: Badge = {
+      type: 'verified_business',
+      awardedAt: iso(-400 * DAY),
+      expiresAt: iso(-5 * DAY),
+    };
+    const { container } = render(<VerificationBadge badge={badge} />);
+    expect(badgeTitle(container)).toBe('Verified Business (Expired)');
+    expect(badgeTitle(container)).not.toContain('Expiring soon');
+  });
+
+  it('marks a not-yet-expired badge inside 30 days as (Expiring soon)', () => {
+    const badge: Badge = {
+      type: 'verified_business',
+      awardedAt: iso(-300 * DAY),
+      expiresAt: iso(10 * DAY),
+    };
+    const { container } = render(<VerificationBadge badge={badge} />);
+    expect(badgeTitle(container)).toBe('Verified Business (Expiring soon)');
+  });
+
+  it('leaves a far-future badge with no expiry suffix', () => {
+    const badge: Badge = {
+      type: 'verified_business',
+      awardedAt: iso(-1 * DAY),
+      expiresAt: iso(200 * DAY),
+    };
+    const { container } = render(<VerificationBadge badge={badge} />);
+    expect(badgeTitle(container)).toBe('Verified Business');
+  });
+
+  it('leaves a badge with no expiry date unmarked', () => {
+    const badge: Badge = { type: 'insured', awardedAt: iso(-1 * DAY) };
+    const { container } = render(<VerificationBadge badge={badge} />);
+    expect(badgeTitle(container)).toBe('Insured');
+  });
+});
+
+describe('VerificationStatusBadge expiry hint', () => {
+  it('does not show "(Soon)" for a verification whose expiry date already passed', () => {
+    render(
+      <VerificationStatusBadge
+        verification={{
+          id: '1',
+          type: 'insurance',
+          documentName: 'policy.pdf',
+          status: 'verified',
+          expiryDate: iso(-3 * DAY),
+        }}
+      />
+    );
+    expect(screen.queryByText(/\(Soon\)/)).toBeNull();
+  });
+
+  it('shows "(Soon)" for a still-valid verification inside the 30-day window', () => {
+    render(
+      <VerificationStatusBadge
+        verification={{
+          id: '2',
+          type: 'insurance',
+          documentName: 'policy.pdf',
+          status: 'verified',
+          expiryDate: iso(7 * DAY),
+        }}
+      />
+    );
+    expect(screen.getByText(/\(Soon\)/)).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx
@@ -121,14 +121,22 @@ export function VerificationBadge({
   const config = badgeConfig[badge.type];
   const classes = sizeClasses[size];
 
+  const msUntilExpiry = badge.expiresAt
+    ? new Date(badge.expiresAt).getTime() - new Date().getTime()
+    : undefined;
+  // Already past the expiry instant → expired, not "expiring soon".
+  const isExpired = msUntilExpiry !== undefined && msUntilExpiry <= 0;
+  // Only a not-yet-expired badge inside the 30-day window is "expiring soon".
   const isExpiring =
-    badge.expiresAt &&
-    new Date(badge.expiresAt).getTime() - new Date().getTime() < 30 * 24 * 60 * 60 * 1000;
+    msUntilExpiry !== undefined && msUntilExpiry > 0 && msUntilExpiry < 30 * 24 * 60 * 60 * 1000;
+
+  const statusSuffix = isExpired ? ' (Expired)' : isExpiring ? ' (Expiring soon)' : '';
+  const ringClass = isExpired ? 'ring-2 ring-red-400' : isExpiring ? 'ring-2 ring-orange-300' : '';
 
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded-full font-medium ${config.bgColor} ${config.textColor} ${classes.badge} ${isExpiring ? 'ring-2 ring-orange-300' : ''}`}
-      title={showTooltip ? `${config.label}${isExpiring ? ' (Expiring soon)' : ''}` : undefined}
+      className={`inline-flex items-center gap-1 rounded-full font-medium ${config.bgColor} ${config.textColor} ${classes.badge} ${ringClass}`}
+      title={showTooltip ? `${config.label}${statusSuffix}` : undefined}
     >
       <svg
         className={classes.icon}
@@ -153,10 +161,16 @@ export function VerificationStatusBadge({
   const classes = sizeClasses[size];
   const typeLabel = verificationTypeLabels[verification.type];
 
+  const msUntilExpiry = verification.expiryDate
+    ? new Date(verification.expiryDate).getTime() - new Date().getTime()
+    : undefined;
+  // "Soon" only for a still-valid verification inside the 30-day window —
+  // an already-expired date (msUntilExpiry <= 0) must not read as expiring soon.
   const isExpiring =
     verification.status === 'verified' &&
-    verification.expiryDate &&
-    new Date(verification.expiryDate).getTime() - new Date().getTime() < 30 * 24 * 60 * 60 * 1000;
+    msUntilExpiry !== undefined &&
+    msUntilExpiry > 0 &&
+    msUntilExpiry < 30 * 24 * 60 * 60 * 1000;
 
   return (
     <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">


### PR DESCRIPTION
## Task
ppt-web VerificationBadge marks already-expired badges as '(Expiring soon)' — an already-expired trust signal is rendered as if still valid. Fix the badge so an expired verification renders as expired (not "Expiring soon"), and only genuinely near-expiry (not-yet-expired) badges show "Expiring soon".

## Owner
pm-frontend (specialist: react-web)

## Fix
`VerificationBadge` computed `isExpiring` as `new Date(expiresAt).getTime() - now < 30 days`. That comparison is also true when the difference is **negative** — i.e. the badge already expired — so an already-expired trust signal was rendered with the "(Expiring soon)" tooltip and orange ring, as if still valid.

Split the single flag into two:
- `isExpired` — `msUntilExpiry <= 0` → tooltip suffix `(Expired)`, red ring.
- `isExpiring` — `0 < msUntilExpiry < 30d` → tooltip suffix `(Expiring soon)`, orange ring (unchanged behaviour for genuinely near-expiry badges).

The identical latent flaw in `VerificationStatusBadge`'s `(Soon)` hint (a `verified` verification whose `expiryDate` had already passed would still read as "Soon") got the same `> 0` guard.

Files:
- `frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx`
- `frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx` (new)

## IG3 evidence (regression test)
Added `VerificationBadge.test.tsx` as a separate `test:` commit ahead of the `fix:` commit. On pre-fix (dev) code the two already-expired assertions FAIL:
```
× marks an already-expired badge as (Expired), not (Expiring soon)
× does not show "(Soon)" for a verification whose expiry date already passed
```
After the fix all 6 tests pass.

## Verification
```
VERIFY-PLAN base=7d496e632b8c99611d4ccbb90ac68228f2bb1587 files=2
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx
  cd frontend && pnpm --filter "...[7d496e632b8c99611d4ccbb90ac68228f2bb1587]" typecheck
  cd frontend && pnpm --filter "...[7d496e632b8c99611d4ccbb90ac68228f2bb1587]" test
```
```
VERIFY OK bc16c9f2dd8202795845d1cbd83f60872c40fd45
```
Full ppt-web suite: 119 files / 2262 tests passed. Biome clean, typecheck clean.

goal-check: PASS (IG3 ok — 1 test: commit + 1 fix: commit; IG7 ok — verify green). IG1/IG2/IG8 skipped as N/A for a dispatcher code-review task (no `.research/plans` file, dispatcher-chosen `auto-impl/` branch, no archive move).

Scope-drift: false (diff confined to pm-frontend area). Code-reuse pre-flight: no warnings.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped

## Notes
Minimal, scoped to the badge's expiry logic. The `Badge` type carries no status field, so expiry is derived purely from `expiresAt`; the fix does not change the label/icon of the underlying badge, only the expiry annotation (tooltip suffix + ring colour).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HjNvqRqf7ZcLHTtqC9zSB6)_