### PR TITLE
gh-issue-2824: i18n VerificationBadge expiry copy + de-duplicate expiry logic

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -2031,5 +2031,37 @@
       "cancelDone": "Hlasování zrušeno",
       "cancelFailed": "Nepodařilo se zrušit hlasování"
     }
+  },
+  "marketplace": {
+    "verificationBadge": {
+      "expired": "Vypršelo",
+      "expiringSoon": "Brzy vyprší",
+      "soon": "Brzy",
+      "expires": "Platnost do",
+      "noVerifications": "Zatím nebyla odeslána žádná ověření",
+      "moreCount": "+{{count}} dalších",
+      "badge": {
+        "verified_business": "Ověřená firma",
+        "insured": "Pojištěno",
+        "certified": "Certifikováno",
+        "top_rated": "Nejlépe hodnocené",
+        "fast_responder": "Rychlá odezva",
+        "preferred": "Preferováno"
+      },
+      "status": {
+        "pending": "Čeká na vyřízení",
+        "under_review": "Probíhá kontrola",
+        "verified": "Ověřeno",
+        "rejected": "Zamítnuto",
+        "expired": "Vypršelo"
+      },
+      "type": {
+        "business_registration": "Registrace podniku",
+        "insurance": "Pojištění",
+        "certification": "Certifikace",
+        "license": "Licence",
+        "identity": "Totožnost"
+      }
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1924,5 +1924,37 @@
       "cancelDone": "Abstimmung abgebrochen",
       "cancelFailed": "Abstimmung konnte nicht abgebrochen werden"
     }
+  },
+  "marketplace": {
+    "verificationBadge": {
+      "expired": "Abgelaufen",
+      "expiringSoon": "Läuft bald ab",
+      "soon": "Bald",
+      "expires": "Läuft ab",
+      "noVerifications": "Noch keine Verifizierungen eingereicht",
+      "moreCount": "+{{count}} weitere",
+      "badge": {
+        "verified_business": "Verifiziertes Unternehmen",
+        "insured": "Versichert",
+        "certified": "Zertifiziert",
+        "top_rated": "Top bewertet",
+        "fast_responder": "Schnelle Reaktion",
+        "preferred": "Bevorzugt"
+      },
+      "status": {
+        "pending": "Ausstehend",
+        "under_review": "In Prüfung",
+        "verified": "Verifiziert",
+        "rejected": "Abgelehnt",
+        "expired": "Abgelaufen"
+      },
+      "type": {
+        "business_registration": "Gewerbeanmeldung",
+        "insurance": "Versicherung",
+        "certification": "Zertifizierung",
+        "license": "Lizenz",
+        "identity": "Identität"
+      }
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -4214,5 +4214,37 @@
       "cancelDone": "Vote cancelled",
       "cancelFailed": "Failed to cancel vote"
     }
+  },
+  "marketplace": {
+    "verificationBadge": {
+      "expired": "Expired",
+      "expiringSoon": "Expiring soon",
+      "soon": "Soon",
+      "expires": "Expires",
+      "noVerifications": "No verifications submitted yet",
+      "moreCount": "+{{count}} more",
+      "badge": {
+        "verified_business": "Verified Business",
+        "insured": "Insured",
+        "certified": "Certified",
+        "top_rated": "Top Rated",
+        "fast_responder": "Fast Responder",
+        "preferred": "Preferred"
+      },
+      "status": {
+        "pending": "Pending",
+        "under_review": "Under Review",
+        "verified": "Verified",
+        "rejected": "Rejected",
+        "expired": "Expired"
+      },
+      "type": {
+        "business_registration": "Business Registration",
+        "insurance": "Insurance",
+        "certification": "Certification",
+        "license": "License",
+        "identity": "Identity"
+      }
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1897,5 +1897,37 @@
       "cancelDone": "Szavazás visszavonva",
       "cancelFailed": "A szavazás visszavonása sikertelen"
     }
+  },
+  "marketplace": {
+    "verificationBadge": {
+      "expired": "Lejárt",
+      "expiringSoon": "Hamarosan lejár",
+      "soon": "Hamarosan",
+      "expires": "Lejár",
+      "noVerifications": "Még nincsenek beküldött ellenőrzések",
+      "moreCount": "+{{count}} további",
+      "badge": {
+        "verified_business": "Ellenőrzött vállalkozás",
+        "insured": "Biztosított",
+        "certified": "Tanúsított",
+        "top_rated": "Kiemelt értékelésű",
+        "fast_responder": "Gyors válaszadó",
+        "preferred": "Előnyben részesített"
+      },
+      "status": {
+        "pending": "Függőben",
+        "under_review": "Felülvizsgálat alatt",
+        "verified": "Ellenőrzött",
+        "rejected": "Elutasítva",
+        "expired": "Lejárt"
+      },
+      "type": {
+        "business_registration": "Cégbejegyzés",
+        "insurance": "Biztosítás",
+        "certification": "Tanúsítás",
+        "license": "Engedély",
+        "identity": "Személyazonosság"
+      }
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1903,5 +1903,37 @@
       "cancelDone": "Głosowanie anulowane",
       "cancelFailed": "Nie udało się anulować głosowania"
     }
+  },
+  "marketplace": {
+    "verificationBadge": {
+      "expired": "Wygasłe",
+      "expiringSoon": "Wkrótce wygasa",
+      "soon": "Wkrótce",
+      "expires": "Wygasa",
+      "noVerifications": "Nie przesłano jeszcze żadnych weryfikacji",
+      "moreCount": "+{{count}} więcej",
+      "badge": {
+        "verified_business": "Zweryfikowana firma",
+        "insured": "Ubezpieczony",
+        "certified": "Certyfikowany",
+        "top_rated": "Najwyżej oceniane",
+        "fast_responder": "Szybka reakcja",
+        "preferred": "Preferowany"
+      },
+      "status": {
+        "pending": "Oczekujące",
+        "under_review": "W trakcie weryfikacji",
+        "verified": "Zweryfikowano",
+        "rejected": "Odrzucone",
+        "expired": "Wygasłe"
+      },
+      "type": {
+        "business_registration": "Rejestracja działalności",
+        "insurance": "Ubezpieczenie",
+        "certification": "Certyfikacja",
+        "license": "Licencja",
+        "identity": "Tożsamość"
+      }
+    }
   }
 }

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -2033,5 +2033,37 @@
       "cancelDone": "Hlasovanie zrušené",
       "cancelFailed": "Nepodarilo sa zrušiť hlasovanie"
     }
+  },
+  "marketplace": {
+    "verificationBadge": {
+      "expired": "Vypršané",
+      "expiringSoon": "Čoskoro vyprší",
+      "soon": "Čoskoro",
+      "expires": "Platnosť do",
+      "noVerifications": "Zatiaľ neboli odoslané žiadne overenia",
+      "moreCount": "+{{count}} ďalších",
+      "badge": {
+        "verified_business": "Overený podnik",
+        "insured": "Poistené",
+        "certified": "Certifikované",
+        "top_rated": "Najlepšie hodnotené",
+        "fast_responder": "Rýchla odozva",
+        "preferred": "Preferované"
+      },
+      "status": {
+        "pending": "Čaká sa",
+        "under_review": "Prebieha kontrola",
+        "verified": "Overené",
+        "rejected": "Zamietnuté",
+        "expired": "Vypršané"
+      },
+      "type": {
+        "business_registration": "Registrácia podniku",
+        "insurance": "Poistenie",
+        "certification": "Certifikácia",
+        "license": "Licencia",
+        "identity": "Totožnosť"
+      }
+    }
   }
 }

--- a/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx
+++ b/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx
@@ -12,7 +12,12 @@
 
 import { render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { type Badge, VerificationBadge, VerificationStatusBadge } from './VerificationBadge';
+import {
+  type Badge,
+  getExpiryState,
+  VerificationBadge,
+  VerificationStatusBadge,
+} from './VerificationBadge';
 
 const DAY = 24 * 60 * 60 * 1000;
 const NOW = new Date('2026-08-21T12:00:00.000Z');
@@ -35,6 +40,35 @@ afterEach(() => {
 function badgeTitle(container: HTMLElement): string | null {
   return container.querySelector('span[title]')?.getAttribute('title') ?? null;
 }
+
+describe('getExpiryState', () => {
+  const NOW_MS = NOW.getTime();
+
+  it('returns "valid" when no expiry date is given', () => {
+    expect(getExpiryState(undefined, NOW_MS)).toBe('valid');
+  });
+
+  it('returns "expired" for a date that already passed', () => {
+    expect(getExpiryState(iso(-5 * DAY), NOW_MS)).toBe('expired');
+  });
+
+  it('returns "expired" exactly at the expiry instant (boundary)', () => {
+    expect(getExpiryState(iso(0), NOW_MS)).toBe('expired');
+  });
+
+  it('returns "expiring" inside the 30-day window', () => {
+    expect(getExpiryState(iso(10 * DAY), NOW_MS)).toBe('expiring');
+  });
+
+  it('returns "valid" just outside the 30-day window', () => {
+    expect(getExpiryState(iso(31 * DAY), NOW_MS)).toBe('valid');
+  });
+
+  it('defaults `now` to the current time', () => {
+    // 5 days ago is expired regardless of the exact wall clock.
+    expect(getExpiryState(new Date(Date.now() - 5 * DAY).toISOString())).toBe('expired');
+  });
+});
 
 describe('VerificationBadge expiry state', () => {
   it('marks an already-expired badge as (Expired), not (Expiring soon)', () => {

--- a/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx
+++ b/frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx
@@ -3,6 +3,8 @@
  * Epic 68: Service Provider Marketplace (Story 68.4)
  */
 
+import { useTranslation } from 'react-i18next';
+
 export type VerificationType =
   | 'business_registration'
   | 'insurance'
@@ -46,66 +48,76 @@ interface VerificationStatusBadgeProps {
   size?: 'sm' | 'md' | 'lg';
 }
 
-const badgeConfig: Record<
-  BadgeType,
-  { label: string; icon: string; bgColor: string; textColor: string }
-> = {
+/**
+ * A trust signal is "expiring soon" only inside this window before its expiry
+ * instant. Shared by {@link VerificationBadge} and {@link VerificationStatusBadge}
+ * via {@link getExpiryState} so the threshold lives in exactly one place.
+ */
+const EXPIRING_SOON_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type ExpiryState = 'valid' | 'expiring' | 'expired';
+
+/**
+ * Pure classifier for a verification/badge expiry timestamp.
+ *
+ * - no `expiresAt`         → `'valid'` (nothing to expire)
+ * - already past the instant → `'expired'` (must NOT read as "expiring soon")
+ * - inside the 30-day window → `'expiring'`
+ * - otherwise               → `'valid'`
+ *
+ * Extracted so both badge components share one source of truth for the
+ * expired/expiring boundaries (issue #2824 — the logic was duplicated inline
+ * and could drift).
+ */
+export function getExpiryState(expiresAt?: string, now: number = Date.now()): ExpiryState {
+  if (!expiresAt) return 'valid';
+  const msUntilExpiry = new Date(expiresAt).getTime() - now;
+  if (msUntilExpiry <= 0) return 'expired';
+  if (msUntilExpiry < EXPIRING_SOON_WINDOW_MS) return 'expiring';
+  return 'valid';
+}
+
+const badgeConfig: Record<BadgeType, { icon: string; bgColor: string; textColor: string }> = {
   verified_business: {
-    label: 'Verified Business',
     icon: 'M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z',
     bgColor: 'bg-green-100',
     textColor: 'text-green-800',
   },
   insured: {
-    label: 'Insured',
     icon: 'M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z',
     bgColor: 'bg-blue-100',
     textColor: 'text-blue-800',
   },
   certified: {
-    label: 'Certified',
     icon: 'M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z',
     bgColor: 'bg-purple-100',
     textColor: 'text-purple-800',
   },
   top_rated: {
-    label: 'Top Rated',
     icon: 'M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z',
     bgColor: 'bg-yellow-100',
     textColor: 'text-yellow-800',
   },
   fast_responder: {
-    label: 'Fast Responder',
     icon: 'M13 10V3L4 14h7v7l9-11h-7z',
     bgColor: 'bg-cyan-100',
     textColor: 'text-cyan-800',
   },
   preferred: {
-    label: 'Preferred',
     icon: 'M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z',
     bgColor: 'bg-orange-100',
     textColor: 'text-orange-800',
   },
 };
 
-const verificationStatusConfig: Record<
-  VerificationStatus,
-  { label: string; bgColor: string; textColor: string }
-> = {
-  pending: { label: 'Pending', bgColor: 'bg-gray-100', textColor: 'text-gray-800' },
-  under_review: { label: 'Under Review', bgColor: 'bg-yellow-100', textColor: 'text-yellow-800' },
-  verified: { label: 'Verified', bgColor: 'bg-green-100', textColor: 'text-green-800' },
-  rejected: { label: 'Rejected', bgColor: 'bg-red-100', textColor: 'text-red-800' },
-  expired: { label: 'Expired', bgColor: 'bg-orange-100', textColor: 'text-orange-800' },
-};
-
-const verificationTypeLabels: Record<VerificationType, string> = {
-  business_registration: 'Business Registration',
-  insurance: 'Insurance',
-  certification: 'Certification',
-  license: 'License',
-  identity: 'Identity',
-};
+const verificationStatusColors: Record<VerificationStatus, { bgColor: string; textColor: string }> =
+  {
+    pending: { bgColor: 'bg-gray-100', textColor: 'text-gray-800' },
+    under_review: { bgColor: 'bg-yellow-100', textColor: 'text-yellow-800' },
+    verified: { bgColor: 'bg-green-100', textColor: 'text-green-800' },
+    rejected: { bgColor: 'bg-red-100', textColor: 'text-red-800' },
+    expired: { bgColor: 'bg-orange-100', textColor: 'text-orange-800' },
+  };
 
 const sizeClasses = {
   sm: { badge: 'px-2 py-0.5 text-xs', icon: 'w-3 h-3' },
@@ -118,25 +130,29 @@ export function VerificationBadge({
   size = 'md',
   showTooltip = true,
 }: VerificationBadgeProps) {
+  const { t } = useTranslation();
   const config = badgeConfig[badge.type];
   const classes = sizeClasses[size];
+  const label = t(`marketplace.verificationBadge.badge.${badge.type}`);
 
-  const msUntilExpiry = badge.expiresAt
-    ? new Date(badge.expiresAt).getTime() - new Date().getTime()
-    : undefined;
-  // Already past the expiry instant → expired, not "expiring soon".
-  const isExpired = msUntilExpiry !== undefined && msUntilExpiry <= 0;
-  // Only a not-yet-expired badge inside the 30-day window is "expiring soon".
-  const isExpiring =
-    msUntilExpiry !== undefined && msUntilExpiry > 0 && msUntilExpiry < 30 * 24 * 60 * 60 * 1000;
-
-  const statusSuffix = isExpired ? ' (Expired)' : isExpiring ? ' (Expiring soon)' : '';
-  const ringClass = isExpired ? 'ring-2 ring-red-400' : isExpiring ? 'ring-2 ring-orange-300' : '';
+  const expiryState = getExpiryState(badge.expiresAt);
+  const statusSuffix =
+    expiryState === 'expired'
+      ? ` (${t('marketplace.verificationBadge.expired')})`
+      : expiryState === 'expiring'
+        ? ` (${t('marketplace.verificationBadge.expiringSoon')})`
+        : '';
+  const ringClass =
+    expiryState === 'expired'
+      ? 'ring-2 ring-red-400'
+      : expiryState === 'expiring'
+        ? 'ring-2 ring-orange-300'
+        : '';
 
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-full font-medium ${config.bgColor} ${config.textColor} ${classes.badge} ${ringClass}`}
-      title={showTooltip ? `${config.label}${statusSuffix}` : undefined}
+      title={showTooltip ? `${label}${statusSuffix}` : undefined}
     >
       <svg
         className={classes.icon}
@@ -145,10 +161,10 @@ export function VerificationBadge({
         viewBox="0 0 24 24"
         strokeWidth={2}
       >
-        <title>{config.label}</title>
+        <title>{label}</title>
         <path strokeLinecap="round" strokeLinejoin="round" d={config.icon} />
       </svg>
-      {config.label}
+      {label}
     </span>
   );
 }
@@ -157,20 +173,16 @@ export function VerificationStatusBadge({
   verification,
   size = 'md',
 }: VerificationStatusBadgeProps) {
-  const config = verificationStatusConfig[verification.status];
+  const { t } = useTranslation();
+  const config = verificationStatusColors[verification.status];
   const classes = sizeClasses[size];
-  const typeLabel = verificationTypeLabels[verification.type];
+  const typeLabel = t(`marketplace.verificationBadge.type.${verification.type}`);
+  const statusLabel = t(`marketplace.verificationBadge.status.${verification.status}`);
 
-  const msUntilExpiry = verification.expiryDate
-    ? new Date(verification.expiryDate).getTime() - new Date().getTime()
-    : undefined;
-  // "Soon" only for a still-valid verification inside the 30-day window —
-  // an already-expired date (msUntilExpiry <= 0) must not read as expiring soon.
+  // "Soon" only for a still-valid verification inside the 30-day window — an
+  // already-expired date must not read as expiring soon (see getExpiryState).
   const isExpiring =
-    verification.status === 'verified' &&
-    msUntilExpiry !== undefined &&
-    msUntilExpiry > 0 &&
-    msUntilExpiry < 30 * 24 * 60 * 60 * 1000;
+    verification.status === 'verified' && getExpiryState(verification.expiryDate) === 'expiring';
 
   return (
     <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
@@ -179,15 +191,16 @@ export function VerificationStatusBadge({
         <p className="text-sm text-gray-500">{verification.documentName}</p>
         {verification.expiryDate && (
           <p className={`text-xs ${isExpiring ? 'text-orange-600' : 'text-gray-400'}`}>
-            Expires: {new Date(verification.expiryDate).toLocaleDateString()}
-            {isExpiring && ' (Soon)'}
+            {t('marketplace.verificationBadge.expires')}:{' '}
+            {new Date(verification.expiryDate).toLocaleDateString()}
+            {isExpiring && ` (${t('marketplace.verificationBadge.soon')})`}
           </p>
         )}
       </div>
       <span
         className={`inline-flex items-center rounded-full font-medium ${config.bgColor} ${config.textColor} ${classes.badge}`}
       >
-        {config.label}
+        {statusLabel}
       </span>
     </div>
   );
@@ -200,6 +213,7 @@ interface BadgeListProps {
 }
 
 export function BadgeList({ badges, size = 'md', maxDisplay = 5 }: BadgeListProps) {
+  const { t } = useTranslation();
   const displayedBadges = badges.slice(0, maxDisplay);
   const remainingCount = badges.length - maxDisplay;
 
@@ -214,7 +228,7 @@ export function BadgeList({ badges, size = 'md', maxDisplay = 5 }: BadgeListProp
       ))}
       {remainingCount > 0 && (
         <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
-          +{remainingCount} more
+          {t('marketplace.verificationBadge.moreCount', { count: remainingCount })}
         </span>
       )}
     </div>
@@ -226,6 +240,8 @@ interface VerificationListProps {
 }
 
 export function VerificationList({ verifications }: VerificationListProps) {
+  const { t } = useTranslation();
+
   if (verifications.length === 0) {
     return (
       <div className="text-center py-8 bg-gray-50 rounded-lg">
@@ -235,7 +251,7 @@ export function VerificationList({ verifications }: VerificationListProps) {
           stroke="currentColor"
           viewBox="0 0 24 24"
         >
-          <title>No verifications</title>
+          <title>{t('marketplace.verificationBadge.noVerifications')}</title>
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
@@ -243,7 +259,7 @@ export function VerificationList({ verifications }: VerificationListProps) {
             d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
           />
         </svg>
-        <p className="mt-2 text-gray-500">No verifications submitted yet</p>
+        <p className="mt-2 text-gray-500">{t('marketplace.verificationBadge.noVerifications')}</p>
       </div>
     );
   }

--- a/frontend/apps/ppt-web/src/i18n/verificationBadgeI18n.test.ts
+++ b/frontend/apps/ppt-web/src/i18n/verificationBadgeI18n.test.ts
@@ -1,0 +1,90 @@
+/// <reference types="vitest/globals" />
+/**
+ * `marketplace.verificationBadge.*` namespace i18n key-presence regression.
+ *
+ * The marketplace `VerificationBadge` / `VerificationStatusBadge` components
+ * (`src/features/marketplace/components/VerificationBadge.tsx`) shipped with
+ * hardcoded English literals for their expiry suffixes (" (Expired)",
+ * " (Expiring soon)", "(Soon)") and their badge/status/type labels instead of
+ * going through react-i18next like the rest of ppt-web (see issue #2824,
+ * follow-up to PR #2819). Non-English users saw English text in the badge
+ * tooltip and labels — invisible to typecheck + lint because the literals were
+ * valid JSX.
+ *
+ * The strings now live under the `marketplace.verificationBadge` namespace and
+ * are consumed via `t('marketplace.verificationBadge.*')`. This test locks it
+ * in: every leaf key present under `marketplace.verificationBadge` in `en.json`
+ * must exist — and be a non-empty string — in all six shipped locale bundles.
+ * It fails on `main` (the namespace does not exist in any bundle) and passes
+ * once the block is added to all six.
+ */
+
+import cs from '../../messages/cs.json';
+import de from '../../messages/de.json';
+import en from '../../messages/en.json';
+import hu from '../../messages/hu.json';
+import pl from '../../messages/pl.json';
+import sk from '../../messages/sk.json';
+
+type Json = Record<string, unknown>;
+
+const BUNDLES: Record<string, Json> = { en, sk, cs, de, pl, hu };
+
+/** Dotted leaf-key paths reachable from a nested object. */
+function leafPaths(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object') return [prefix];
+  return Object.entries(obj as Json).flatMap(([k, v]) =>
+    leafPaths(v, prefix ? `${prefix}.${k}` : k)
+  );
+}
+
+function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((acc, part) => {
+    if (acc === null || typeof acc !== 'object') return undefined;
+    return (acc as Json)[part];
+  }, obj);
+}
+
+/** The full set of marketplace.verificationBadge.* leaf-key paths, from en.json. */
+const BADGE_PATHS: string[] = leafPaths(
+  (en as Json).marketplace && ((en as Json).marketplace as Json).verificationBadge,
+  'marketplace.verificationBadge'
+);
+
+describe('marketplace.verificationBadge.* i18n keys', () => {
+  it('covers exactly the six shipped locale bundles', () => {
+    expect(Object.keys(BUNDLES).sort()).toEqual(['cs', 'de', 'en', 'hu', 'pl', 'sk']);
+  });
+
+  it('reference key set includes the expiry suffixes', () => {
+    expect(BADGE_PATHS).toEqual(
+      expect.arrayContaining([
+        'marketplace.verificationBadge.expired',
+        'marketplace.verificationBadge.expiringSoon',
+        'marketplace.verificationBadge.soon',
+      ])
+    );
+  });
+
+  for (const [locale, bundle] of Object.entries(BUNDLES)) {
+    describe(`locale: ${locale}`, () => {
+      for (const path of BADGE_PATHS) {
+        it(`defines a non-empty ${path}`, () => {
+          const value = getPath(bundle, path);
+          expect(value, `${path} missing in ${locale}.json`).toBeTypeOf('string');
+          expect((value as string).trim().length).toBeGreaterThan(0);
+        });
+      }
+    });
+  }
+
+  it('keeps every locale in lockstep — no locale has missing verificationBadge keys', () => {
+    for (const [locale, bundle] of Object.entries(BUNDLES)) {
+      const present = BADGE_PATHS.filter((p) => typeof getPath(bundle, p) === 'string');
+      expect(
+        present,
+        `${locale}.json verificationBadge-key set drifted from the reference`
+      ).toEqual(BADGE_PATHS);
+    }
+  });
+});


### PR DESCRIPTION
## Task
Follow-up: VerificationBadge expiry suffixes are hardcoded English + logic duplicated across two components (PR #2819) (Closes #2824)

Closes #2824.

Two adjacent gaps left by PR #2819 in
`frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx`:

- **i18n (low):** the expiry suffixes (`(Expired)`, `(Expiring soon)`, `(Soon)`) and the
  badge/status/type labels were hardcoded English literals — non-English users saw English
  text in the badge tooltip/labels.
- **DRY (low):** `VerificationBadge` and `VerificationStatusBadge` each recomputed the same
  `msUntilExpiry` / expired / 30-day-window logic inline, so the threshold could drift.

### Changes
- Extract a pure, exported `getExpiryState(expiresAt?, now = Date.now()) => 'valid' | 'expiring' | 'expired'`
  helper (single `EXPIRING_SOON_WINDOW_MS = 30d` constant); both components call it.
- Route **all** user-facing copy in the file through `react-i18next` under a new
  `marketplace.verificationBadge` namespace, added to all six locale bundles
  (`en/sk/cs/de/pl/hu`) — suffixes, badge labels, status labels, verification-type labels,
  the "Expires" prefix, the empty-state text and the "+N more" pill.
- Add `src/i18n/verificationBadgeI18n.test.ts` — a key-presence regression mirroring
  `offlineIndicatorI18n.test.ts` (#2736): every `marketplace.verificationBadge.*` leaf key
  must be a non-empty string in all six bundles. **Fails on `dev`** (namespace absent),
  passes here.
- Add `getExpiryState` unit tests to `VerificationBadge.test.tsx` (boundary + window cases).
  The existing state-bug regression tests from #2819 still pass unchanged.

## Owner
pm-tech-lead

## Verification
```
VERIFY-PLAN base=c8135bf220c1d89f4b50d2e3641d81989b502957 files=9
  cd frontend && pnpm exec biome check apps/ppt-web/messages/cs.json apps/ppt-web/messages/de.json apps/ppt-web/messages/en.json apps/ppt-web/messages/hu.json apps/ppt-web/messages/pl.json apps/ppt-web/messages/sk.json apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx apps/ppt-web/src/i18n/verificationBadgeI18n.test.ts
  cd frontend && pnpm --filter "...[c8135bf220c1d89f4b50d2e3641d81989b502957]" typecheck
  cd frontend && pnpm --filter "...[c8135bf220c1d89f4b50d2e3641d81989b502957]" test
VERIFY OK fb04aa929b37532e96283472d3529a833a0885d9
```
Full ppt-web suite: 122 files / 2406 tests passed.

## Scope drift
`scope_drift=true`. The owner_role hint for this follow-up is `pm-tech-lead`
(owns `docs/**`, `.research/**`, `_bmad-output/**`), but the task is a frontend
fix, so every changed path falls outside that area:

- `frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.tsx`
- `frontend/apps/ppt-web/src/features/marketplace/components/VerificationBadge.test.tsx`
- `frontend/apps/ppt-web/src/i18n/verificationBadgeI18n.test.ts`
- `frontend/apps/ppt-web/messages/{en,sk,cs,de,pl,hu}.json`

This is the expected area for the work (issue tagged `pm-frontend` as the suggested
specialist); flagging for reviewer awareness only.

## Code-reuse review
`code_reuse_warn=none` — `reuse-grep.sh` reported no overlap with existing helpers.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped.

## Notes
- No behavior change: `getExpiryState` preserves the exact `<= 0` (expired) and
  `< 30d` (expiring) boundaries from #2819; `VerificationStatusBadge` still gates the
  "soon" hint on `status === 'verified'`.
- Locale bundle edits are additive (a single `marketplace` top-level key appended);
  no existing keys were reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015AWDNw5EsEGeCjBBqwqdWC)_