### PR TITLE
gh-issue-2822: neutralize CR/LF in CSV export sanitizer (Closes #2822)

### DIFF
--- a/backend/servers/api-server/src/routes/admin/audit.rs
+++ b/backend/servers/api-server/src/routes/admin/audit.rs
@@ -12,6 +12,8 @@
 //! * `severity=high` — new: when set, restricts results to capabilities in
 //!   the platform-level high-risk list.
 
+use std::borrow::Cow;
+
 use admin_core::{require_capability, Capability, RequireCapability};
 use axum::{
     extract::{Query, State},
@@ -39,37 +41,61 @@ pub fn router() -> Router<AppState> {
         )
 }
 
-/// Sanitize a string cell for CSV output to prevent spreadsheet formula
-/// injection. The `csv` crate already handles quoting/escaping of commas,
-/// quotes, and newlines — we only need to neutralize the `=`, `+`, `-`,
-/// `@` characters that some spreadsheet apps interpret as formulas.
+/// Sanitize a string cell for CSV output. Closes two cell-integrity classes
+/// in one call so every hand-rolled exporter can rely on a single guard:
 ///
-/// Two checks:
-///   1. The classic START-of-cell rule (leading `=+-@`).
-///   2. The "anywhere" rule (M5 fix): a cell whose body contains one of
-///      these chars also gets the quote prefix. This matters for the
-///      JSON `details` blob, which starts with `{` (so the leading-char
-///      check passes) but can embed `=cmd|...` that Excel still parses
-///      when the operator copy-pastes the cell contents.
+///   A. **Record-separator neutralization (CR/LF).** Every embedded `\r` and
+///      `\n` is collapsed to a single space. Not all callers run their cells
+///      through the `csv` crate's `Writer` (which would quote newlines) — the
+///      reports export ([`crate::routes::reports`]) is hand-rolled `format!`
+///      with a raw `\n` row terminator and no quoting, so a free-form cell
+///      containing `\n`/`\r\n` would otherwise terminate the row early and let
+///      attacker-controlled content be parsed as a *new record* (CSV
+///      row-injection / report tampering). Stripping the separator here means
+///      no cell can carry one regardless of how the caller frames the row. For
+///      `csv`-crate callers this is a harmless single-line normalization.
 ///
-/// We prepend a single quote (`'`) which is the standard mitigation: it
-/// forces the cell to be treated as text without being visible in most
-/// spreadsheet UIs. False positives (a legit cell containing `-`) are
-/// acceptable for an audit export — the prefix is harmless when pasted
-/// into a viewer and the operator can strip it.
+///   B. **Spreadsheet-formula neutralization (`= + - @`).** Some spreadsheet
+///      apps interpret a cell that contains one of these as a formula. Two
+///      checks:
+///        1. The classic START-of-cell rule (leading `=+-@`).
+///        2. The "anywhere" rule (M5 fix): a cell whose body contains one of
+///           these chars also gets the quote prefix. This matters for the
+///           JSON `details` blob, which starts with `{` (so the leading-char
+///           check passes) but can embed `=cmd|...` that Excel still parses
+///           when the operator copy-pastes the cell contents.
+///      We prepend a single quote (`'`), the standard mitigation: it forces
+///      the cell to be treated as text without being visible in most
+///      spreadsheet UIs. False positives (a legit cell containing `-`) are
+///      acceptable for an export — the prefix is harmless when pasted into a
+///      viewer and the operator can strip it.
+///
+/// Note this guard does NOT escape the field delimiter (`,`): callers that
+/// frame rows by hand still own that dimension (e.g. `voting_csv_row` replaces
+/// `,` with `;`), and `csv`-crate callers must keep raw commas for the writer
+/// to quote — folding comma-escaping in here would corrupt those exports.
 ///
 /// `pub(crate)` so other CSV exporters (e.g. the reports export in
 /// [`crate::routes::reports`]) reuse this single implementation instead of
-/// re-deriving their own formula-injection guard.
+/// re-deriving their own injection guards.
 pub(crate) fn sanitize_csv_cell(value: &str) -> String {
+    // A. Collapse embedded record separators so no cell can carry a raw
+    //    CR/LF (see rustdoc class A above). Only allocates when needed.
+    let value = if value.contains(['\r', '\n']) {
+        Cow::Owned(value.replace(['\r', '\n'], " "))
+    } else {
+        Cow::Borrowed(value)
+    };
+
+    // B. Neutralize spreadsheet formula triggers.
     let dangerous = value.chars().any(|c| matches!(c, '=' | '+' | '-' | '@'));
     if dangerous {
         let mut out = String::with_capacity(value.len() + 1);
         out.push('\'');
-        out.push_str(value);
+        out.push_str(&value);
         out
     } else {
-        value.to_string()
+        value.into_owned()
     }
 }
 
@@ -374,6 +400,35 @@ mod tests {
         // `@` inside the JSON should also trigger the prefix.
         let json = r#"{"actor":"@SUM(A1:A9)"}"#;
         assert!(sanitize_csv_cell(json).starts_with('\''));
+    }
+
+    #[test]
+    fn sanitize_csv_cell_collapses_embedded_crlf() {
+        // #2822: a free-form cell containing a raw record separator must not
+        // be able to terminate the row. Every CR/LF collapses to a space so
+        // hand-rolled exporters (no `csv`-crate quoting) cannot be tricked
+        // into parsing injected content as a new record.
+        let out = sanitize_csv_cell("Roof\r\nInjected row");
+        assert!(
+            !out.contains('\r') && !out.contains('\n'),
+            "no raw CR/LF may survive; got {out:?}"
+        );
+        // Each separator char maps to one space, so CRLF becomes two spaces.
+        assert_eq!(out, "Roof  Injected row");
+
+        // A lone LF and a lone CR are both neutralized.
+        assert_eq!(sanitize_csv_cell("a\nb"), "a b");
+        assert_eq!(sanitize_csv_cell("a\rb"), "a b");
+    }
+
+    #[test]
+    fn sanitize_csv_cell_crlf_and_formula_trigger_combine() {
+        // Both classes in one cell: CR/LF collapsed AND the leading `=` is
+        // prefixed with `'`.
+        let out = sanitize_csv_cell("=SUM(A1)\r\nrow2");
+        assert!(!out.contains('\r') && !out.contains('\n'));
+        // CRLF -> two spaces, then the leading `=` gets the `'` prefix.
+        assert_eq!(out, "'=SUM(A1)  row2");
     }
 
     #[test]

--- a/backend/servers/api-server/src/routes/reports/helpers.rs
+++ b/backend/servers/api-server/src/routes/reports/helpers.rs
@@ -100,10 +100,12 @@ pub(super) async fn estimate_report_row_count(
 /// is routed through the shared [`sanitize_csv_cell`] guard to neutralize
 /// spreadsheet formula injection: a title beginning with `=`, `+`, `-`, or
 /// `@` is prefixed with `'` so Excel/Sheets treat it as text rather than a
-/// formula. Commas are then replaced with `;` so the cell cannot spill into
-/// adjacent columns (this hand-rolled export does not use the `csv` crate's
-/// quoting). Extracted into its own function so the neutralization is unit
-/// testable without a database.
+/// formula. The shared guard also collapses any embedded `\r`/`\n` to a space
+/// so a crafted title cannot inject a fabricated *record* into this hand-rolled
+/// export (which terminates rows with a raw `\n` and does not use the `csv`
+/// crate's quoting — see #2822). Commas are then replaced with `;` so the cell
+/// cannot spill into adjacent columns. Extracted into its own function so the
+/// neutralization is unit testable without a database.
 fn voting_csv_row(v: &VoteParticipationDetail) -> String {
     format!(
         "{},{},{},{},{},{},{},{:.1}%,{},{}\n",
@@ -376,5 +378,30 @@ mod tests {
     fn voting_csv_row_escapes_commas_in_title() {
         let row = voting_csv_row(&sample_vote("Roof, Facade, Windows"));
         assert_eq!(title_cell(&row), "Roof; Facade; Windows");
+    }
+
+    /// Regression (#2822): a title carrying an embedded CR/LF must not inject a
+    /// fabricated record. The only newline in the rendered row is the trailing
+    /// terminator, the title cell contains no raw CR/LF, and it does not spill
+    /// into adjacent columns.
+    #[test]
+    fn voting_csv_row_neutralizes_crlf_in_title() {
+        let row = voting_csv_row(&sample_vote("Roof\r\nInjected,row"));
+
+        // Exactly one newline — the row terminator at the very end.
+        assert_eq!(
+            row.matches('\n').count(),
+            1,
+            "crafted CR/LF must not add extra records: {row:?}"
+        );
+        assert!(row.ends_with('\n'));
+        assert!(!row.trim_end_matches('\n').contains('\r'));
+
+        // The row still has exactly 10 comma-separated fields (no spill).
+        assert_eq!(row.trim_end_matches('\n').split(',').count(), 10);
+
+        // The title cell has the separators neutralized to spaces and the
+        // comma escaped to `;`.
+        assert_eq!(title_cell(&row), "Roof  Injected;row");
     }
 }


### PR DESCRIPTION
## Task
Follow-up: CSV export sanitizer does not neutralize CR/LF in free-form cells (PR #2731) (Closes #2822)

Harden the shared `sanitize_csv_cell` (`backend/servers/api-server/src/routes/admin/audit.rs`) so a single call closes the whole cell-integrity class: every embedded `\r`/`\n` is collapsed to a space before the existing formula-trigger (`= + - @`) guard. This protects the hand-rolled reports voting export (`voting_csv_row` in `backend/servers/api-server/src/routes/reports/helpers.rs`), which uses `format!` with a raw `\n` row terminator and no `csv`-crate quoting — a vote `title` containing `\n`/`\r\n` could otherwise inject a fabricated record (CSV row-injection / report tampering). For the audit export (which already runs cells through the `csv` crate's `Writer`) this is a harmless single-line normalization.

Comma delimiter-escaping is deliberately left to callers: `voting_csv_row` keeps its `.replace(',', ";")`, and folding comma-escaping into the shared guard would corrupt the `csv`-crate audit export (which needs raw commas to quote). The rustdoc on `sanitize_csv_cell` was updated to document both integrity classes and this boundary.

## Owner
pm-tech-lead (hint). NOTE: the issue itself suggests `pm-rust-backend`; this is inherently a backend-only fix, hence the scope drift below.

## Scope drift
`scope-check.sh --owner pm-tech-lead` reports drift (exit 2) because the fix touches backend code, outside pm-tech-lead's `docs/**`, `.research/**`, `_bmad-output/**` areas:
- `backend/servers/api-server/src/routes/admin/audit.rs`
- `backend/servers/api-server/src/routes/reports/helpers.rs`

Expected: the owner_role hint was pm-tech-lead but the issue's suggested specialist is pm-rust-backend, and the change is intrinsically backend. No unrelated files were touched.

## Code-reuse review
`reuse-grep.sh --specialist rust-backend` — no warnings. The fix extends the existing shared `sanitize_csv_cell` rather than adding a new helper; no duplication introduced.

## Verification
`VERIFY-PLAN base=c8135bf220c1d89f4b50d2e3641d81989b502957 files=2`
```
cd backend && cargo fmt --all -- --check                                # PASS (exit 0)
cd backend && cargo clippy -p api-server --all-targets -- -D warnings   # PASS (exit 0)
cd backend && cargo test -p api-server                                  # see below
```

- `cargo fmt --all -- --check` — **PASS**.
- `cargo clippy -p api-server --all-targets -- -D warnings` — **PASS** (only a pre-existing third-party future-incompat warning in `proc-macro-error2`, unrelated).
- `cargo test -p api-server`: this environment has **no Postgres/Redis and restricted network**, so the DB-/network-backed integration suites cannot run locally. The **targeted unit tests for this change all pass**:
  - `sanitize_csv_cell*` — 6 passed / 0 failed
  - `voting_csv_row*` — 4 passed / 0 failed
  - Full `--lib` run: 610 passed; the 14 failures are all DB/network-dependent tests in unrelated modules (`voice_webhooks`, `scheduler`, `oauth`, `services::actions::api_call` DNS-rebinding, `voice_commands`) that require a live database — none touch CSV export.

**CI is the gating authority for the full test suite** (it provisions Postgres/Redis); this draft runs `backend.yml` in CI over the complete gate.

> Build note: `utoipa-swagger-ui`'s build script downloads the Swagger UI zip from github.com, which this environment's egress proxy denies. Worked around **locally only** by pointing `SWAGGER_UI_DOWNLOAD_URL` at a `file://` zip repackaged from the `swagger-ui-dist` npm release — no repo files changed for it; CI is unaffected.

## CI parity (Band C — hot-path only)
Security-relevant fix (CSV/report injection). Full local `act` parity not run because the DB-backed test job cannot execute in this sandbox; the draft runs `backend.yml` in CI, which is the parity source.

## Remote-tested
skipped (no ppt-bridge MCP in session)

## Notes
- Added regression tests mirroring the existing `voting_csv_row_*` / `sanitize_csv_cell_*` suites, including a `"Roof\r\nInjected,row"` title asserting no raw CR/LF survives and the row does not gain a record (issue's requested vector).
- CRLF collapses to two spaces (one per char); assertions reflect that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AWDNw5EsEGeCjBBqwqdWC