### PR TITLE
code-review-ppt-web-ui-facilities-booking-silent-errors: surface booking fetch/approve/reject/cancel errors

### DIFF
--- a/frontend/apps/ppt-web/src/features/facilities/pages/MyBookingsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/facilities/pages/MyBookingsPage.tsx
@@ -8,12 +8,14 @@ import type { BookingStatus, BookingWithDetails } from '@ppt/api-client';
 import { cancelBooking, getMyBookings } from '@ppt/api-client';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useToast } from '../../../components';
 import { BookingList, CancelBookingDialog } from '../components';
 
 const PAGE_SIZE = 10;
 
 export function MyBookingsPage() {
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   const [bookings, setBookings] = useState<BookingWithDetails[]>([]);
   const [total, setTotal] = useState(0);
@@ -36,7 +38,11 @@ export function MyBookingsPage() {
       setBookings(response.items);
       setTotal(response.total);
     } catch (error) {
-      console.error('Failed to fetch bookings:', error);
+      showToast({
+        type: 'error',
+        title: 'Failed to load bookings',
+        message: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
     } finally {
       setIsLoading(false);
     }
@@ -73,7 +79,11 @@ export function MyBookingsPage() {
       await fetchBookings(page, statusFilter);
       setCancelDialogBooking(null);
     } catch (error) {
-      console.error('Failed to cancel booking:', error);
+      showToast({
+        type: 'error',
+        title: 'Failed to cancel booking',
+        message: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
     } finally {
       setIsCancelling(false);
     }

--- a/frontend/apps/ppt-web/src/features/facilities/pages/PendingBookingsPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/facilities/pages/PendingBookingsPage.test.tsx
@@ -1,0 +1,154 @@
+/// <reference types="vitest/globals" />
+/**
+ * PendingBookingsPage error-surfacing tests.
+ *
+ * Regression cover for the silent-error bug: fetch / approve / reject failures
+ * previously only hit `console.error`, so the manager saw no feedback. These
+ * tests pin that each failure now raises an error toast via useToast().
+ *
+ * Covered:
+ *  (a) list fetch failure   → error toast ("Failed to load pending bookings")
+ *  (b) approve failure      → error toast ("Failed to approve booking", Error.message)
+ *  (c) reject failure       → error toast ("Failed to reject booking")
+ *  (d) non-Error rejection  → error toast falls back to generic message
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { PendingBookingsPage } from './PendingBookingsPage';
+
+// ── api-client: list + approve + reject ──
+const mockListPendingBookings = vi.fn();
+const mockApproveBooking = vi.fn();
+const mockRejectBooking = vi.fn();
+vi.mock('@ppt/api-client', () => ({
+  listPendingBookings: (...args: unknown[]) => mockListPendingBookings(...args),
+  approveBooking: (...args: unknown[]) => mockApproveBooking(...args),
+  rejectBooking: (...args: unknown[]) => mockRejectBooking(...args),
+}));
+
+// ── toast ──
+const mockShowToast = vi.fn();
+vi.mock('../../../components', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+// ── router ──
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ buildingId: 'b-1' }),
+}));
+
+// ── stub child components so we can drive the page handlers ──
+vi.mock('../components', () => ({
+  BookingList: ({
+    onApprove,
+    onReject,
+  }: {
+    onApprove?: (id: string) => void;
+    onReject?: (id: string) => void;
+  }) => (
+    <div>
+      <button type="button" onClick={() => onApprove?.('bk-1')}>
+        approve
+      </button>
+      <button type="button" onClick={() => onReject?.('bk-1')}>
+        reject
+      </button>
+    </div>
+  ),
+  RejectBookingDialog: ({ onConfirm }: { onConfirm: (reason: string) => void }) => (
+    <button type="button" onClick={() => onConfirm('no')}>
+      confirm-reject
+    </button>
+  ),
+}));
+
+const ONE_BOOKING = {
+  items: [
+    {
+      id: 'bk-1',
+      facility_name: 'Gym',
+      start_time: '2026-09-01T10:00:00Z',
+    },
+  ],
+  total: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListPendingBookings.mockResolvedValue(ONE_BOOKING);
+  mockApproveBooking.mockResolvedValue(undefined);
+  mockRejectBooking.mockResolvedValue(undefined);
+});
+
+describe('PendingBookingsPage error surfacing', () => {
+  it('(a) list fetch failure → error toast', async () => {
+    mockListPendingBookings.mockRejectedValueOnce(new Error('list boom'));
+    render(<PendingBookingsPage />);
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Failed to load pending bookings',
+          message: 'list boom',
+        })
+      );
+    });
+  });
+
+  it('(b) approve failure → error toast with Error.message', async () => {
+    mockApproveBooking.mockRejectedValueOnce(new Error('approve boom'));
+    render(<PendingBookingsPage />);
+
+    await waitFor(() => expect(mockListPendingBookings).toHaveBeenCalled());
+    screen.getByRole('button', { name: /^approve$/i }).click();
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Failed to approve booking',
+          message: 'approve boom',
+        })
+      );
+    });
+  });
+
+  it('(c) reject failure → error toast', async () => {
+    mockRejectBooking.mockRejectedValueOnce(new Error('reject boom'));
+    render(<PendingBookingsPage />);
+
+    await waitFor(() => expect(mockListPendingBookings).toHaveBeenCalled());
+    // open the reject dialog, then confirm
+    screen.getByRole('button', { name: /^reject$/i }).click();
+    (await screen.findByRole('button', { name: /confirm-reject/i })).click();
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Failed to reject booking',
+          message: 'reject boom',
+        })
+      );
+    });
+  });
+
+  it('(d) non-Error rejection → error toast falls back to generic message', async () => {
+    mockApproveBooking.mockRejectedValueOnce('network down');
+    render(<PendingBookingsPage />);
+
+    await waitFor(() => expect(mockListPendingBookings).toHaveBeenCalled());
+    screen.getByRole('button', { name: /^approve$/i }).click();
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Failed to approve booking',
+          message: 'An unexpected error occurred.',
+        })
+      );
+    });
+  });
+});

--- a/frontend/apps/ppt-web/src/features/facilities/pages/PendingBookingsPage.tsx
+++ b/frontend/apps/ppt-web/src/features/facilities/pages/PendingBookingsPage.tsx
@@ -8,6 +8,7 @@ import type { BookingWithDetails } from '@ppt/api-client';
 import { approveBooking, listPendingBookings, rejectBooking } from '@ppt/api-client';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useToast } from '../../../components';
 import { BookingList, RejectBookingDialog } from '../components';
 
 const PAGE_SIZE = 10;
@@ -15,6 +16,7 @@ const PAGE_SIZE = 10;
 export function PendingBookingsPage() {
   const { buildingId } = useParams<{ buildingId: string }>();
   const navigate = useNavigate();
+  const { showToast } = useToast();
 
   const [bookings, setBookings] = useState<BookingWithDetails[]>([]);
   const [total, setTotal] = useState(0);
@@ -37,7 +39,11 @@ export function PendingBookingsPage() {
       setBookings(response.items);
       setTotal(response.total);
     } catch (error) {
-      console.error('Failed to fetch pending bookings:', error);
+      showToast({
+        type: 'error',
+        title: 'Failed to load pending bookings',
+        message: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
     } finally {
       setIsLoading(false);
     }
@@ -58,7 +64,11 @@ export function PendingBookingsPage() {
       await approveBooking(id);
       await refreshBookings();
     } catch (error) {
-      console.error('Failed to approve booking:', error);
+      showToast({
+        type: 'error',
+        title: 'Failed to approve booking',
+        message: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
     } finally {
       setIsProcessing(false);
     }
@@ -80,7 +90,11 @@ export function PendingBookingsPage() {
       await refreshBookings();
       setRejectDialogBooking(null);
     } catch (error) {
-      console.error('Failed to reject booking:', error);
+      showToast({
+        type: 'error',
+        title: 'Failed to reject booking',
+        message: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
     } finally {
       setIsProcessing(false);
     }


### PR DESCRIPTION
## Task
ppt-web facilities booking pages swallow fetch/approve/reject/cancel errors to console only — manager & tenant see no failure feedback. Fix: surface user-visible error feedback (toast / inline error state) on fetch AND on the approve/reject/cancel mutations, instead of only `console.error`. Follow the existing error-surfacing pattern used elsewhere in ppt-web (reuse the toast hook — do NOT invent a new pattern).

## Owner
pm-backend (hint) — actual change is `frontend/apps/ppt-web`; specialist: react-web.

## What changed
- `MyBookingsPage.tsx` — fetch (`getMyBookings`) and cancel (`cancelBooking`) failures now raise an error toast via `useToast()` instead of `console.error` only (tenant-facing).
- `PendingBookingsPage.tsx` — fetch (`listPendingBookings`), approve (`approveBooking`), and reject (`rejectBooking`) failures now raise an error toast (manager-facing).
- Reused the existing `useToast()` error-toast pattern from `components/Toast.tsx` (same shape as the disputes flow: `showToast({ type: 'error', title, message: error instanceof Error ? error.message : <fallback> })`). No new pattern introduced.
- The facilities feature is not i18n-ized (all hardcoded English strings), so toast titles/messages use plain strings to stay consistent with the feature and avoid touching the 6 locale message files.
- Added `PendingBookingsPage.test.tsx` — regression cover for fetch / approve / reject error toasts + non-Error fallback message.

## Verification
```
VERIFY-PLAN base=f30878f88c8a8abe12dcac2d251167936c6097b4 files=3
  cd frontend && pnpm exec biome check apps/ppt-web/src/features/facilities/pages/MyBookingsPage.tsx apps/ppt-web/src/features/facilities/pages/PendingBookingsPage.test.tsx apps/ppt-web/src/features/facilities/pages/PendingBookingsPage.tsx
  cd frontend && pnpm --filter "...[f30878f88c8a8abe12dcac2d251167936c6097b4]" typecheck
  cd frontend && pnpm --filter "...[f30878f88c8a8abe12dcac2d251167936c6097b4]" test
```
```
VERIFY OK 5727f93284231ccce83327170fe3d2ae7c6fc5ce
```
Biome clean, typecheck clean, all frontend tests pass (123 files / 2410 tests). New facilities test: 4/4 pass.

## Scope drift
scope-check (owner=pm-frontend): exit 0 — all 3 changed files inside `frontend/apps/ppt-web/**`. No drift.

## Code-reuse review
reuse-grep (react-web): no warnings — reuses existing `useToast` hook.

## CI parity (Band C — hot-path only)
skipped: not a hot-path PR (no security/auth/billing/data-integrity change).

## Remote-tested
skipped (no ppt-bridge MCP).

## Notes
- Draft PR: CI is the gating authority; opened as draft per the implementer contract.
- Error toasts are persistent by design (Toast.tsx sets error duration = 0), so a failed fetch/mutation stays visible until the user dismisses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SshkMYFsR2yyEG6tvdkf75

---
_Generated by [Claude Code](https://claude.ai/code/session_01SshkMYFsR2yyEG6tvdkf75)_