### PR TITLE
code-review-ppt-web-ui-aml-dashboard-prompt-alert-flow: replace AML dashboard prompt/alert decision flow with in-app dialogs + i18n

### DIFF
--- a/frontend/apps/ppt-web/messages/cs.json
+++ b/frontend/apps/ppt-web/messages/cs.json
@@ -1,4 +1,103 @@
 {
+  "aml": {
+    "dashboard": {
+      "title": "Dashboard souladu AML",
+      "subtitle": "Sledujte hodnocení rizika praní špinavých peněz a stav souladu.",
+      "loading": "Načítají se data AML...",
+      "loadError": "Nepodařilo se načíst data AML: {{message}}",
+      "retry": "Zkusit znovu"
+    },
+    "thresholds": {
+      "title": "Prahové hodnoty AML",
+      "transaction": "Prahová hodnota transakce",
+      "cumulative": "Kumulativní prahová hodnota",
+      "reviewScore": "Prahové skóre pro přezkum"
+    },
+    "countryRisks": {
+      "title": "Databáze rizik zemí",
+      "country": "Země",
+      "riskRating": "Hodnocení rizika",
+      "sanctioned": "Sankcionovaná",
+      "fatfStatus": "Stav FATF"
+    },
+    "filters": {
+      "title": "Hodnocení rizika",
+      "status": "Stav",
+      "allStatuses": "Všechny stavy",
+      "riskLevel": "Úroveň rizika",
+      "allLevels": "Všechny úrovně",
+      "flaggedOnly": "Pouze označené k přezkumu"
+    },
+    "status": {
+      "pending": "Čeká se",
+      "in_progress": "Probíhá",
+      "completed": "Dokončeno",
+      "requires_review": "Vyžaduje přezkum",
+      "approved": "Schváleno",
+      "rejected": "Zamítnuto"
+    },
+    "riskLevel": {
+      "low": "Nízká",
+      "medium": "Střední",
+      "high": "Vysoká",
+      "critical": "Kritická"
+    },
+    "emptyState": {
+      "none": "Nebyla nalezena žádná hodnocení rizika AML odpovídající kritériím.",
+      "hint": "Hodnocení se vytvářejí automaticky, když transakce překročí prahovou hodnotu."
+    },
+    "card": {
+      "title": "Hodnocení rizika AML",
+      "party": "Strana: {{type}}",
+      "country": "Země: {{code}}",
+      "transactionAmount": "Částka transakce:",
+      "verificationStatus": "Stav ověření",
+      "idVerified": "Ověřená totožnost",
+      "sourceOfFunds": "Původ finančních prostředků",
+      "pepCheck": "Kontrola PEP",
+      "sanctionsCheck": "Kontrola sankcí",
+      "yes": "A",
+      "no": "N",
+      "riskFactors": "Rizikové faktory",
+      "weight": "Váha: {{weight}}",
+      "recommendations": "Doporučení",
+      "flaggedForReview": "Označeno k přezkumu",
+      "initiateEdd": "Spustit EDD",
+      "reviewAssessment": "Přezkoumat hodnocení"
+    },
+    "edd": {
+      "title": "Spustit rozšířenou hloubkovou kontrolu (EDD)",
+      "description": "Uveďte důvod spuštění rozšířené hloubkové kontroly pro toto hodnocení.",
+      "reasonLabel": "Důvod",
+      "reasonPlaceholder": "Zadejte důvod spuštění rozšířené hloubkové kontroly",
+      "reasonRequired": "Důvod je povinný.",
+      "submit": "Spustit EDD",
+      "submitting": "Spouští se...",
+      "successTitle": "Rozšířená hloubková kontrola spuštěna",
+      "successMessage": "Rozšířená hloubková kontrola byla úspěšně spuštěna.",
+      "errorTitle": "Nepodařilo se spustit EDD",
+      "errorMessage": "Nepodařilo se spustit EDD. Zkuste to znovu."
+    },
+    "review": {
+      "title": "Přezkoumat hodnocení",
+      "description": "Zaznamenejte rozhodnutí o souladu pro toto hodnocení rizika.",
+      "decisionLabel": "Rozhodnutí",
+      "decision": {
+        "approve": "Schválit",
+        "reject": "Zamítnout",
+        "escalate": "Eskalovat"
+      },
+      "notesLabel": "Poznámky k přezkumu",
+      "notesPlaceholder": "Zadejte poznámky k přezkumu",
+      "notesRequired": "Poznámky k přezkumu jsou povinné.",
+      "submit": "Odeslat rozhodnutí",
+      "submitting": "Odesílá se...",
+      "successTitle": "Hodnocení přezkoumáno",
+      "successMessage": "Hodnocení bylo úspěšně přezkoumáno.",
+      "errorTitle": "Nepodařilo se přezkoumat hodnocení",
+      "errorMessage": "Nepodařilo se přezkoumat hodnocení. Zkuste to znovu."
+    }
+  },
   "moderation": {
     "dashboard": {
       "title": "Nástěnka moderování obsahu",

--- a/frontend/apps/ppt-web/messages/de.json
+++ b/frontend/apps/ppt-web/messages/de.json
@@ -1,4 +1,103 @@
 {
+  "aml": {
+    "dashboard": {
+      "title": "AML-Compliance-Dashboard",
+      "subtitle": "Überwachen Sie Risikobewertungen zur Geldwäschebekämpfung und den Compliance-Status.",
+      "loading": "AML-Daten werden geladen...",
+      "loadError": "AML-Daten konnten nicht geladen werden: {{message}}",
+      "retry": "Erneut versuchen"
+    },
+    "thresholds": {
+      "title": "AML-Schwellenwerte",
+      "transaction": "Transaktionsschwellenwert",
+      "cumulative": "Kumulativer Schwellenwert",
+      "reviewScore": "Prüfungsschwellenwert"
+    },
+    "countryRisks": {
+      "title": "Länderrisiko-Datenbank",
+      "country": "Land",
+      "riskRating": "Risikobewertung",
+      "sanctioned": "Sanktioniert",
+      "fatfStatus": "FATF-Status"
+    },
+    "filters": {
+      "title": "Risikobewertungen",
+      "status": "Status",
+      "allStatuses": "Alle Status",
+      "riskLevel": "Risikostufe",
+      "allLevels": "Alle Stufen",
+      "flaggedOnly": "Nur zur Prüfung markierte"
+    },
+    "status": {
+      "pending": "Ausstehend",
+      "in_progress": "In Bearbeitung",
+      "completed": "Abgeschlossen",
+      "requires_review": "Prüfung erforderlich",
+      "approved": "Genehmigt",
+      "rejected": "Abgelehnt"
+    },
+    "riskLevel": {
+      "low": "Niedrig",
+      "medium": "Mittel",
+      "high": "Hoch",
+      "critical": "Kritisch"
+    },
+    "emptyState": {
+      "none": "Keine AML-Risikobewertungen gefunden, die den Kriterien entsprechen.",
+      "hint": "Bewertungen werden automatisch erstellt, wenn Transaktionen den Schwellenwert überschreiten."
+    },
+    "card": {
+      "title": "AML-Risikobewertung",
+      "party": "Partei: {{type}}",
+      "country": "Land: {{code}}",
+      "transactionAmount": "Transaktionsbetrag:",
+      "verificationStatus": "Verifizierungsstatus",
+      "idVerified": "Identität verifiziert",
+      "sourceOfFunds": "Herkunft der Mittel",
+      "pepCheck": "PEP-Prüfung",
+      "sanctionsCheck": "Sanktionsprüfung",
+      "yes": "J",
+      "no": "N",
+      "riskFactors": "Risikofaktoren",
+      "weight": "Gewichtung: {{weight}}",
+      "recommendations": "Empfehlungen",
+      "flaggedForReview": "Zur Prüfung markiert",
+      "initiateEdd": "EDD einleiten",
+      "reviewAssessment": "Bewertung prüfen"
+    },
+    "edd": {
+      "title": "Erweiterte Sorgfaltsprüfung (EDD) einleiten",
+      "description": "Geben Sie einen Grund für die Einleitung der erweiterten Sorgfaltsprüfung für diese Bewertung an.",
+      "reasonLabel": "Grund",
+      "reasonPlaceholder": "Grund für die Einleitung der erweiterten Sorgfaltsprüfung eingeben",
+      "reasonRequired": "Ein Grund ist erforderlich.",
+      "submit": "EDD einleiten",
+      "submitting": "Wird eingeleitet...",
+      "successTitle": "Erweiterte Sorgfaltsprüfung eingeleitet",
+      "successMessage": "Erweiterte Sorgfaltsprüfung wurde erfolgreich eingeleitet.",
+      "errorTitle": "EDD konnte nicht eingeleitet werden",
+      "errorMessage": "EDD konnte nicht eingeleitet werden. Bitte versuchen Sie es erneut."
+    },
+    "review": {
+      "title": "Bewertung prüfen",
+      "description": "Erfassen Sie eine Compliance-Entscheidung für diese Risikobewertung.",
+      "decisionLabel": "Entscheidung",
+      "decision": {
+        "approve": "Genehmigen",
+        "reject": "Ablehnen",
+        "escalate": "Eskalieren"
+      },
+      "notesLabel": "Prüfungsnotizen",
+      "notesPlaceholder": "Prüfungsnotizen eingeben",
+      "notesRequired": "Prüfungsnotizen sind erforderlich.",
+      "submit": "Entscheidung senden",
+      "submitting": "Wird gesendet...",
+      "successTitle": "Bewertung geprüft",
+      "successMessage": "Bewertung wurde erfolgreich geprüft.",
+      "errorTitle": "Bewertung konnte nicht geprüft werden",
+      "errorMessage": "Bewertung konnte nicht geprüft werden. Bitte versuchen Sie es erneut."
+    }
+  },
   "moderation": {
     "dashboard": {
       "title": "Dashboard zur Inhaltsmoderation",

--- a/frontend/apps/ppt-web/messages/en.json
+++ b/frontend/apps/ppt-web/messages/en.json
@@ -1,4 +1,103 @@
 {
+  "aml": {
+    "dashboard": {
+      "title": "AML Compliance Dashboard",
+      "subtitle": "Monitor anti-money laundering risk assessments and compliance status.",
+      "loading": "Loading AML data...",
+      "loadError": "Failed to load AML data: {{message}}",
+      "retry": "Retry"
+    },
+    "thresholds": {
+      "title": "AML Thresholds",
+      "transaction": "Transaction Threshold",
+      "cumulative": "Cumulative Threshold",
+      "reviewScore": "Review Score Threshold"
+    },
+    "countryRisks": {
+      "title": "Country Risk Database",
+      "country": "Country",
+      "riskRating": "Risk Rating",
+      "sanctioned": "Sanctioned",
+      "fatfStatus": "FATF Status"
+    },
+    "filters": {
+      "title": "Risk Assessments",
+      "status": "Status",
+      "allStatuses": "All Statuses",
+      "riskLevel": "Risk Level",
+      "allLevels": "All Levels",
+      "flaggedOnly": "Flagged for Review Only"
+    },
+    "status": {
+      "pending": "Pending",
+      "in_progress": "In Progress",
+      "completed": "Completed",
+      "requires_review": "Requires Review",
+      "approved": "Approved",
+      "rejected": "Rejected"
+    },
+    "riskLevel": {
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High",
+      "critical": "Critical"
+    },
+    "emptyState": {
+      "none": "No AML risk assessments found matching the criteria.",
+      "hint": "Assessments are automatically created when transactions exceed the threshold."
+    },
+    "card": {
+      "title": "AML Risk Assessment",
+      "party": "Party: {{type}}",
+      "country": "Country: {{code}}",
+      "transactionAmount": "Transaction Amount:",
+      "verificationStatus": "Verification Status",
+      "idVerified": "ID Verified",
+      "sourceOfFunds": "Source of Funds",
+      "pepCheck": "PEP Check",
+      "sanctionsCheck": "Sanctions Check",
+      "yes": "Y",
+      "no": "N",
+      "riskFactors": "Risk Factors",
+      "weight": "Weight: {{weight}}",
+      "recommendations": "Recommendations",
+      "flaggedForReview": "Flagged for Review",
+      "initiateEdd": "Initiate EDD",
+      "reviewAssessment": "Review Assessment"
+    },
+    "edd": {
+      "title": "Initiate Enhanced Due Diligence",
+      "description": "Provide a reason for initiating Enhanced Due Diligence on this assessment.",
+      "reasonLabel": "Reason",
+      "reasonPlaceholder": "Enter reason for initiating Enhanced Due Diligence",
+      "reasonRequired": "A reason is required.",
+      "submit": "Initiate EDD",
+      "submitting": "Initiating...",
+      "successTitle": "Enhanced Due Diligence initiated",
+      "successMessage": "Enhanced Due Diligence initiated successfully.",
+      "errorTitle": "Failed to initiate EDD",
+      "errorMessage": "Failed to initiate EDD. Please try again."
+    },
+    "review": {
+      "title": "Review Assessment",
+      "description": "Record a compliance decision for this risk assessment.",
+      "decisionLabel": "Decision",
+      "decision": {
+        "approve": "Approve",
+        "reject": "Reject",
+        "escalate": "Escalate"
+      },
+      "notesLabel": "Review notes",
+      "notesPlaceholder": "Enter review notes",
+      "notesRequired": "Review notes are required.",
+      "submit": "Submit decision",
+      "submitting": "Submitting...",
+      "successTitle": "Assessment reviewed",
+      "successMessage": "Assessment reviewed successfully.",
+      "errorTitle": "Failed to review assessment",
+      "errorMessage": "Failed to review assessment. Please try again."
+    }
+  },
   "moderation": {
     "dashboard": {
       "title": "Content Moderation Dashboard",

--- a/frontend/apps/ppt-web/messages/hu.json
+++ b/frontend/apps/ppt-web/messages/hu.json
@@ -1,4 +1,103 @@
 {
+  "aml": {
+    "dashboard": {
+      "title": "AML megfelelőségi irányítópult",
+      "subtitle": "Kövesse nyomon a pénzmosás elleni kockázatértékeléseket és a megfelelőségi állapotot.",
+      "loading": "AML-adatok betöltése...",
+      "loadError": "Az AML-adatok betöltése sikertelen: {{message}}",
+      "retry": "Újrapróbálkozás"
+    },
+    "thresholds": {
+      "title": "AML küszöbértékek",
+      "transaction": "Tranzakciós küszöbérték",
+      "cumulative": "Kumulatív küszöbérték",
+      "reviewScore": "Felülvizsgálati pontszám küszöbértéke"
+    },
+    "countryRisks": {
+      "title": "Országkockázati adatbázis",
+      "country": "Ország",
+      "riskRating": "Kockázati besorolás",
+      "sanctioned": "Szankcionált",
+      "fatfStatus": "FATF állapot"
+    },
+    "filters": {
+      "title": "Kockázatértékelések",
+      "status": "Állapot",
+      "allStatuses": "Minden állapot",
+      "riskLevel": "Kockázati szint",
+      "allLevels": "Minden szint",
+      "flaggedOnly": "Csak a felülvizsgálatra megjelöltek"
+    },
+    "status": {
+      "pending": "Függőben",
+      "in_progress": "Folyamatban",
+      "completed": "Befejezett",
+      "requires_review": "Felülvizsgálat szükséges",
+      "approved": "Jóváhagyva",
+      "rejected": "Elutasítva"
+    },
+    "riskLevel": {
+      "low": "Alacsony",
+      "medium": "Közepes",
+      "high": "Magas",
+      "critical": "Kritikus"
+    },
+    "emptyState": {
+      "none": "Nem található a feltételeknek megfelelő AML-kockázatértékelés.",
+      "hint": "Az értékelések automatikusan létrejönnek, amikor a tranzakciók meghaladják a küszöbértéket."
+    },
+    "card": {
+      "title": "AML-kockázatértékelés",
+      "party": "Fél: {{type}}",
+      "country": "Ország: {{code}}",
+      "transactionAmount": "Tranzakció összege:",
+      "verificationStatus": "Ellenőrzési állapot",
+      "idVerified": "Személyazonosság ellenőrizve",
+      "sourceOfFunds": "Pénzeszközök forrása",
+      "pepCheck": "PEP-ellenőrzés",
+      "sanctionsCheck": "Szankcióellenőrzés",
+      "yes": "I",
+      "no": "N",
+      "riskFactors": "Kockázati tényezők",
+      "weight": "Súly: {{weight}}",
+      "recommendations": "Ajánlások",
+      "flaggedForReview": "Felülvizsgálatra megjelölve",
+      "initiateEdd": "EDD indítása",
+      "reviewAssessment": "Értékelés felülvizsgálata"
+    },
+    "edd": {
+      "title": "Fokozott ügyfél-átvilágítás (EDD) indítása",
+      "description": "Adja meg a fokozott ügyfél-átvilágítás indításának okát ehhez az értékeléshez.",
+      "reasonLabel": "Indok",
+      "reasonPlaceholder": "Adja meg a fokozott ügyfél-átvilágítás indításának okát",
+      "reasonRequired": "Az indok megadása kötelező.",
+      "submit": "EDD indítása",
+      "submitting": "Indítás...",
+      "successTitle": "Fokozott ügyfél-átvilágítás elindítva",
+      "successMessage": "A fokozott ügyfél-átvilágítás sikeresen elindult.",
+      "errorTitle": "Az EDD indítása sikertelen",
+      "errorMessage": "Az EDD indítása sikertelen. Kérjük, próbálja újra."
+    },
+    "review": {
+      "title": "Értékelés felülvizsgálata",
+      "description": "Rögzítsen megfelelőségi döntést ehhez a kockázatértékeléshez.",
+      "decisionLabel": "Döntés",
+      "decision": {
+        "approve": "Jóváhagyás",
+        "reject": "Elutasítás",
+        "escalate": "Eszkaláció"
+      },
+      "notesLabel": "Felülvizsgálati megjegyzések",
+      "notesPlaceholder": "Adja meg a felülvizsgálati megjegyzéseket",
+      "notesRequired": "A felülvizsgálati megjegyzések megadása kötelező.",
+      "submit": "Döntés elküldése",
+      "submitting": "Küldés...",
+      "successTitle": "Értékelés felülvizsgálva",
+      "successMessage": "Az értékelés sikeresen felülvizsgálva.",
+      "errorTitle": "Az értékelés felülvizsgálata sikertelen",
+      "errorMessage": "Az értékelés felülvizsgálata sikertelen. Kérjük, próbálja újra."
+    }
+  },
   "moderation": {
     "dashboard": {
       "title": "Tartalommoderálási irányítópult",

--- a/frontend/apps/ppt-web/messages/pl.json
+++ b/frontend/apps/ppt-web/messages/pl.json
@@ -1,4 +1,103 @@
 {
+  "aml": {
+    "dashboard": {
+      "title": "Panel zgodności AML",
+      "subtitle": "Monitoruj oceny ryzyka prania pieniędzy i status zgodności.",
+      "loading": "Ładowanie danych AML...",
+      "loadError": "Nie udało się załadować danych AML: {{message}}",
+      "retry": "Spróbuj ponownie"
+    },
+    "thresholds": {
+      "title": "Progi AML",
+      "transaction": "Próg transakcji",
+      "cumulative": "Próg skumulowany",
+      "reviewScore": "Próg oceny do przeglądu"
+    },
+    "countryRisks": {
+      "title": "Baza ryzyka krajów",
+      "country": "Kraj",
+      "riskRating": "Ocena ryzyka",
+      "sanctioned": "Objęty sankcjami",
+      "fatfStatus": "Status FATF"
+    },
+    "filters": {
+      "title": "Oceny ryzyka",
+      "status": "Status",
+      "allStatuses": "Wszystkie statusy",
+      "riskLevel": "Poziom ryzyka",
+      "allLevels": "Wszystkie poziomy",
+      "flaggedOnly": "Tylko oznaczone do przeglądu"
+    },
+    "status": {
+      "pending": "Oczekujące",
+      "in_progress": "W toku",
+      "completed": "Zakończone",
+      "requires_review": "Wymaga przeglądu",
+      "approved": "Zatwierdzone",
+      "rejected": "Odrzucone"
+    },
+    "riskLevel": {
+      "low": "Niski",
+      "medium": "Średni",
+      "high": "Wysoki",
+      "critical": "Krytyczny"
+    },
+    "emptyState": {
+      "none": "Nie znaleziono ocen ryzyka AML spełniających kryteria.",
+      "hint": "Oceny są tworzone automatycznie, gdy transakcje przekroczą próg."
+    },
+    "card": {
+      "title": "Ocena ryzyka AML",
+      "party": "Strona: {{type}}",
+      "country": "Kraj: {{code}}",
+      "transactionAmount": "Kwota transakcji:",
+      "verificationStatus": "Status weryfikacji",
+      "idVerified": "Tożsamość zweryfikowana",
+      "sourceOfFunds": "Źródło środków",
+      "pepCheck": "Weryfikacja PEP",
+      "sanctionsCheck": "Weryfikacja sankcji",
+      "yes": "T",
+      "no": "N",
+      "riskFactors": "Czynniki ryzyka",
+      "weight": "Waga: {{weight}}",
+      "recommendations": "Zalecenia",
+      "flaggedForReview": "Oznaczone do przeglądu",
+      "initiateEdd": "Rozpocznij EDD",
+      "reviewAssessment": "Przejrzyj ocenę"
+    },
+    "edd": {
+      "title": "Rozpocznij wzmożoną należytą staranność (EDD)",
+      "description": "Podaj powód rozpoczęcia wzmożonej należytej staranności dla tej oceny.",
+      "reasonLabel": "Powód",
+      "reasonPlaceholder": "Wprowadź powód rozpoczęcia wzmożonej należytej staranności",
+      "reasonRequired": "Powód jest wymagany.",
+      "submit": "Rozpocznij EDD",
+      "submitting": "Rozpoczynanie...",
+      "successTitle": "Wzmożona należyta staranność rozpoczęta",
+      "successMessage": "Wzmożona należyta staranność została pomyślnie rozpoczęta.",
+      "errorTitle": "Nie udało się rozpocząć EDD",
+      "errorMessage": "Nie udało się rozpocząć EDD. Spróbuj ponownie."
+    },
+    "review": {
+      "title": "Przejrzyj ocenę",
+      "description": "Zarejestruj decyzję dotyczącą zgodności dla tej oceny ryzyka.",
+      "decisionLabel": "Decyzja",
+      "decision": {
+        "approve": "Zatwierdź",
+        "reject": "Odrzuć",
+        "escalate": "Eskaluj"
+      },
+      "notesLabel": "Notatki z przeglądu",
+      "notesPlaceholder": "Wprowadź notatki z przeglądu",
+      "notesRequired": "Notatki z przeglądu są wymagane.",
+      "submit": "Prześlij decyzję",
+      "submitting": "Przesyłanie...",
+      "successTitle": "Ocena przejrzana",
+      "successMessage": "Ocena została pomyślnie przejrzana.",
+      "errorTitle": "Nie udało się przejrzeć oceny",
+      "errorMessage": "Nie udało się przejrzeć oceny. Spróbuj ponownie."
+    }
+  },
   "moderation": {
     "dashboard": {
       "title": "Panel moderacji treści",

--- a/frontend/apps/ppt-web/messages/sk.json
+++ b/frontend/apps/ppt-web/messages/sk.json
@@ -1,4 +1,103 @@
 {
+  "aml": {
+    "dashboard": {
+      "title": "Dashboard súladu AML",
+      "subtitle": "Sledujte hodnotenia rizika prania špinavých peňazí a stav súladu.",
+      "loading": "Načítavajú sa údaje AML...",
+      "loadError": "Nepodarilo sa načítať údaje AML: {{message}}",
+      "retry": "Skúsiť znova"
+    },
+    "thresholds": {
+      "title": "Prahové hodnoty AML",
+      "transaction": "Prahová hodnota transakcie",
+      "cumulative": "Kumulatívna prahová hodnota",
+      "reviewScore": "Prahové skóre na preskúmanie"
+    },
+    "countryRisks": {
+      "title": "Databáza rizík krajín",
+      "country": "Krajina",
+      "riskRating": "Hodnotenie rizika",
+      "sanctioned": "Sankcionovaná",
+      "fatfStatus": "Stav FATF"
+    },
+    "filters": {
+      "title": "Hodnotenia rizika",
+      "status": "Stav",
+      "allStatuses": "Všetky stavy",
+      "riskLevel": "Úroveň rizika",
+      "allLevels": "Všetky úrovne",
+      "flaggedOnly": "Iba označené na preskúmanie"
+    },
+    "status": {
+      "pending": "Čaká sa",
+      "in_progress": "Prebieha",
+      "completed": "Dokončené",
+      "requires_review": "Vyžaduje preskúmanie",
+      "approved": "Schválené",
+      "rejected": "Zamietnuté"
+    },
+    "riskLevel": {
+      "low": "Nízka",
+      "medium": "Stredná",
+      "high": "Vysoká",
+      "critical": "Kritická"
+    },
+    "emptyState": {
+      "none": "Nenašli sa žiadne hodnotenia rizika AML zodpovedajúce kritériám.",
+      "hint": "Hodnotenia sa vytvárajú automaticky, keď transakcie prekročia prahovú hodnotu."
+    },
+    "card": {
+      "title": "Hodnotenie rizika AML",
+      "party": "Strana: {{type}}",
+      "country": "Krajina: {{code}}",
+      "transactionAmount": "Suma transakcie:",
+      "verificationStatus": "Stav overenia",
+      "idVerified": "Overená totožnosť",
+      "sourceOfFunds": "Pôvod finančných prostriedkov",
+      "pepCheck": "Kontrola PEP",
+      "sanctionsCheck": "Kontrola sankcií",
+      "yes": "Á",
+      "no": "N",
+      "riskFactors": "Rizikové faktory",
+      "weight": "Váha: {{weight}}",
+      "recommendations": "Odporúčania",
+      "flaggedForReview": "Označené na preskúmanie",
+      "initiateEdd": "Spustiť EDD",
+      "reviewAssessment": "Preskúmať hodnotenie"
+    },
+    "edd": {
+      "title": "Spustiť rozšírenú hĺbkovú kontrolu (EDD)",
+      "description": "Uveďte dôvod spustenia rozšírenej hĺbkovej kontroly pre toto hodnotenie.",
+      "reasonLabel": "Dôvod",
+      "reasonPlaceholder": "Zadajte dôvod spustenia rozšírenej hĺbkovej kontroly",
+      "reasonRequired": "Dôvod je povinný.",
+      "submit": "Spustiť EDD",
+      "submitting": "Spúšťa sa...",
+      "successTitle": "Rozšírená hĺbková kontrola spustená",
+      "successMessage": "Rozšírená hĺbková kontrola bola úspešne spustená.",
+      "errorTitle": "Nepodarilo sa spustiť EDD",
+      "errorMessage": "Nepodarilo sa spustiť EDD. Skúste to znova."
+    },
+    "review": {
+      "title": "Preskúmať hodnotenie",
+      "description": "Zaznamenajte rozhodnutie o súlade pre toto hodnotenie rizika.",
+      "decisionLabel": "Rozhodnutie",
+      "decision": {
+        "approve": "Schváliť",
+        "reject": "Zamietnuť",
+        "escalate": "Eskalovať"
+      },
+      "notesLabel": "Poznámky k preskúmaniu",
+      "notesPlaceholder": "Zadajte poznámky k preskúmaniu",
+      "notesRequired": "Poznámky k preskúmaniu sú povinné.",
+      "submit": "Odoslať rozhodnutie",
+      "submitting": "Odosiela sa...",
+      "successTitle": "Hodnotenie preskúmané",
+      "successMessage": "Hodnotenie bolo úspešne preskúmané.",
+      "errorTitle": "Nepodarilo sa preskúmať hodnotenie",
+      "errorMessage": "Nepodarilo sa preskúmať hodnotenie. Skúste to znova."
+    }
+  },
   "moderation": {
     "dashboard": {
       "title": "Nástenka moderovania obsahu",

--- a/frontend/apps/ppt-web/src/features/compliance/components/AmlRiskAssessmentCard.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/components/AmlRiskAssessmentCard.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export interface RiskFactor {
   factor_type: string;
@@ -70,25 +71,6 @@ const getRiskLevelColor = (level: AmlRiskLevel): string => {
   }
 };
 
-const getStatusLabel = (status: AmlAssessmentStatus): string => {
-  switch (status) {
-    case 'pending':
-      return 'Pending';
-    case 'in_progress':
-      return 'In Progress';
-    case 'completed':
-      return 'Completed';
-    case 'requires_review':
-      return 'Requires Review';
-    case 'approved':
-      return 'Approved';
-    case 'rejected':
-      return 'Rejected';
-    default:
-      return status;
-  }
-};
-
 const formatAmount = (cents: number, currency?: string): string => {
   const amount = cents / 100;
   return new Intl.NumberFormat('en-EU', {
@@ -103,20 +85,23 @@ export const AmlRiskAssessmentCard: React.FC<AmlRiskAssessmentCardProps> = ({
   onReview,
   showActions = true,
 }) => {
+  const { t } = useTranslation();
   const riskLevelClass = getRiskLevelColor(assessment.risk_level);
 
   return (
     <div className="aml-risk-assessment-card">
       <div className="aml-risk-assessment-header">
         <div className="aml-risk-assessment-title">
-          <h3>AML Risk Assessment</h3>
+          <h3>{t('aml.card.title')}</h3>
           <span className={`aml-status-badge ${assessment.status}`}>
-            {getStatusLabel(assessment.status)}
+            {t(`aml.status.${assessment.status}`)}
           </span>
         </div>
         <div className="aml-risk-assessment-meta">
-          <span>Party: {assessment.party_type}</span>
-          {assessment.country_code && <span>Country: {assessment.country_code}</span>}
+          <span>{t('aml.card.party', { type: assessment.party_type })}</span>
+          {assessment.country_code && (
+            <span>{t('aml.card.country', { code: assessment.country_code })}</span>
+          )}
         </div>
       </div>
 
@@ -135,7 +120,7 @@ export const AmlRiskAssessmentCard: React.FC<AmlRiskAssessmentCardProps> = ({
 
       {assessment.transaction_amount_cents && (
         <div className="aml-transaction-info">
-          <span className="aml-transaction-label">Transaction Amount:</span>
+          <span className="aml-transaction-label">{t('aml.card.transactionAmount')}</span>
           <span className="aml-transaction-value">
             {formatAmount(assessment.transaction_amount_cents, assessment.currency)}
           </span>
@@ -143,50 +128,54 @@ export const AmlRiskAssessmentCard: React.FC<AmlRiskAssessmentCardProps> = ({
       )}
 
       <div className="aml-verification-status">
-        <h4>Verification Status</h4>
+        <h4>{t('aml.card.verificationStatus')}</h4>
         <div className="aml-verification-grid">
           <div
             className={`aml-verification-item ${assessment.id_verified ? 'verified' : 'pending'}`}
           >
-            <span className="aml-verification-icon">{assessment.id_verified ? 'Y' : 'N'}</span>
-            <span className="aml-verification-label">ID Verified</span>
+            <span className="aml-verification-icon">
+              {assessment.id_verified ? t('aml.card.yes') : t('aml.card.no')}
+            </span>
+            <span className="aml-verification-label">{t('aml.card.idVerified')}</span>
           </div>
           <div
             className={`aml-verification-item ${assessment.source_of_funds_documented ? 'verified' : 'pending'}`}
           >
             <span className="aml-verification-icon">
-              {assessment.source_of_funds_documented ? 'Y' : 'N'}
+              {assessment.source_of_funds_documented ? t('aml.card.yes') : t('aml.card.no')}
             </span>
-            <span className="aml-verification-label">Source of Funds</span>
+            <span className="aml-verification-label">{t('aml.card.sourceOfFunds')}</span>
           </div>
           <div
             className={`aml-verification-item ${assessment.pep_check_completed ? 'verified' : 'pending'}`}
           >
             <span className="aml-verification-icon">
-              {assessment.pep_check_completed ? 'Y' : 'N'}
+              {assessment.pep_check_completed ? t('aml.card.yes') : t('aml.card.no')}
             </span>
-            <span className="aml-verification-label">PEP Check</span>
+            <span className="aml-verification-label">{t('aml.card.pepCheck')}</span>
           </div>
           <div
             className={`aml-verification-item ${assessment.sanctions_check_completed ? 'verified' : 'pending'}`}
           >
             <span className="aml-verification-icon">
-              {assessment.sanctions_check_completed ? 'Y' : 'N'}
+              {assessment.sanctions_check_completed ? t('aml.card.yes') : t('aml.card.no')}
             </span>
-            <span className="aml-verification-label">Sanctions Check</span>
+            <span className="aml-verification-label">{t('aml.card.sanctionsCheck')}</span>
           </div>
         </div>
       </div>
 
       {assessment.risk_factors.length > 0 && (
         <div className="aml-risk-factors">
-          <h4>Risk Factors</h4>
+          <h4>{t('aml.card.riskFactors')}</h4>
           <ul className="aml-risk-factors-list">
             {assessment.risk_factors.map((factor, index) => (
               <li key={index} className={`aml-risk-factor ${factor.mitigated ? 'mitigated' : ''}`}>
                 <span className="aml-risk-factor-type">{factor.factor_type}</span>
                 <span className="aml-risk-factor-description">{factor.description}</span>
-                <span className="aml-risk-factor-weight">Weight: {factor.weight}</span>
+                <span className="aml-risk-factor-weight">
+                  {t('aml.card.weight', { weight: factor.weight })}
+                </span>
               </li>
             ))}
           </ul>
@@ -195,7 +184,7 @@ export const AmlRiskAssessmentCard: React.FC<AmlRiskAssessmentCardProps> = ({
 
       {assessment.recommendations.length > 0 && (
         <div className="aml-recommendations">
-          <h4>Recommendations</h4>
+          <h4>{t('aml.card.recommendations')}</h4>
           <ul className="aml-recommendations-list">
             {assessment.recommendations.map((rec, index) => (
               <li key={index}>{rec}</li>
@@ -206,7 +195,7 @@ export const AmlRiskAssessmentCard: React.FC<AmlRiskAssessmentCardProps> = ({
 
       {assessment.flagged_for_review && (
         <div className="aml-review-alert">
-          <strong>Flagged for Review</strong>
+          <strong>{t('aml.card.flaggedForReview')}</strong>
           {assessment.review_reason && <p>{assessment.review_reason}</p>}
         </div>
       )}
@@ -219,7 +208,7 @@ export const AmlRiskAssessmentCard: React.FC<AmlRiskAssessmentCardProps> = ({
               className="aml-action-button primary"
               onClick={() => onInitiateEdd(assessment.id)}
             >
-              Initiate EDD
+              {t('aml.card.initiateEdd')}
             </button>
           )}
           {assessment.status === 'requires_review' && onReview && (
@@ -228,7 +217,7 @@ export const AmlRiskAssessmentCard: React.FC<AmlRiskAssessmentCardProps> = ({
               className="aml-action-button secondary"
               onClick={() => onReview(assessment.id)}
             >
-              Review Assessment
+              {t('aml.card.reviewAssessment')}
             </button>
           )}
         </div>

--- a/frontend/apps/ppt-web/src/features/compliance/components/InitiateEddDialog.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/components/InitiateEddDialog.tsx
@@ -1,0 +1,125 @@
+/**
+ * InitiateEddDialog component - modal dialog for initiating Enhanced Due
+ * Diligence on an AML risk assessment (Epic 67 / Epic 90).
+ *
+ * Replaces the Phase-1 `window.prompt` flow with an in-app, localized form.
+ * Decision semantics are preserved: a non-empty reason is required before the
+ * mutation is triggered (an empty/blank reason is a no-op, matching the old
+ * `if (!reason) return;` guard).
+ */
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface InitiateEddDialogProps {
+  isOpen: boolean;
+  isSubmitting?: boolean;
+  onSubmit: (reason: string) => void;
+  onClose: () => void;
+}
+
+export function InitiateEddDialog({
+  isOpen,
+  isSubmitting,
+  onSubmit,
+  onClose,
+}: InitiateEddDialogProps) {
+  const { t } = useTranslation();
+  const [reason, setReason] = useState('');
+  const [showError, setShowError] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = reason.trim();
+    if (!trimmed) {
+      setShowError(true);
+      return;
+    }
+    onSubmit(trimmed);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <button
+        type="button"
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity cursor-default"
+        onClick={onClose}
+        onKeyDown={(e) => e.key === 'Escape' && onClose()}
+        aria-label={t('aria.closeDialog')}
+      />
+
+      {/* Dialog */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div
+          className="relative w-full max-w-md bg-white rounded-lg shadow-xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="edd-dialog-title"
+        >
+          {/* Header */}
+          <div className="px-6 py-4 border-b">
+            <h2 id="edd-dialog-title" className="text-lg font-semibold text-gray-900">
+              {t('aml.edd.title')}
+            </h2>
+            <p className="text-sm text-gray-500 mt-1">{t('aml.edd.description')}</p>
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+            <div>
+              <label htmlFor="edd-reason" className="block text-sm font-medium text-gray-700">
+                {t('aml.edd.reasonLabel')} *
+              </label>
+              <textarea
+                id="edd-reason"
+                value={reason}
+                onChange={(e) => {
+                  setReason(e.target.value);
+                  if (showError) setShowError(false);
+                }}
+                rows={4}
+                placeholder={t('aml.edd.reasonPlaceholder')}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-invalid={showError}
+                aria-describedby={showError ? 'edd-reason-error' : undefined}
+              />
+              {showError && (
+                <p id="edd-reason-error" className="mt-1 text-sm text-red-600" role="alert">
+                  {t('aml.edd.reasonRequired')}
+                </p>
+              )}
+            </div>
+          </form>
+
+          {/* Actions */}
+          <div className="px-6 py-4 border-t flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+            >
+              {isSubmitting && (
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+              )}
+              {isSubmitting ? t('aml.edd.submitting') : t('aml.edd.submit')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+InitiateEddDialog.displayName = 'InitiateEddDialog';

--- a/frontend/apps/ppt-web/src/features/compliance/components/ReviewAssessmentDialog.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/components/ReviewAssessmentDialog.tsx
@@ -1,0 +1,153 @@
+/**
+ * ReviewAssessmentDialog component - modal dialog for recording a compliance
+ * decision on an AML risk assessment (Epic 67 / Epic 90).
+ *
+ * Replaces the Phase-1 `window.prompt` flow with an in-app, localized form.
+ * Decision semantics are preserved:
+ *  - the decision is constrained to the `approve | reject | escalate` union via a
+ *    `<select>` (a free-text typo can no longer reach the API), and
+ *  - non-empty review notes are required before the mutation is triggered
+ *    (matching the old `if (!notes) return;` guard).
+ */
+
+import type { ReviewAmlAssessmentRequest } from '@ppt/api-client';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+type AmlReviewDecision = ReviewAmlAssessmentRequest['decision'];
+
+const AML_REVIEW_DECISIONS: readonly AmlReviewDecision[] = ['approve', 'reject', 'escalate'];
+
+interface ReviewAssessmentDialogProps {
+  isOpen: boolean;
+  isSubmitting?: boolean;
+  onSubmit: (decision: AmlReviewDecision, notes: string) => void;
+  onClose: () => void;
+}
+
+export function ReviewAssessmentDialog({
+  isOpen,
+  isSubmitting,
+  onSubmit,
+  onClose,
+}: ReviewAssessmentDialogProps) {
+  const { t } = useTranslation();
+  const [decision, setDecision] = useState<AmlReviewDecision>('approve');
+  const [notes, setNotes] = useState('');
+  const [showError, setShowError] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = notes.trim();
+    if (!trimmed) {
+      setShowError(true);
+      return;
+    }
+    onSubmit(decision, trimmed);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* Backdrop */}
+      <button
+        type="button"
+        className="fixed inset-0 bg-black bg-opacity-50 transition-opacity cursor-default"
+        onClick={onClose}
+        onKeyDown={(e) => e.key === 'Escape' && onClose()}
+        aria-label={t('aria.closeDialog')}
+      />
+
+      {/* Dialog */}
+      <div className="flex min-h-full items-center justify-center p-4">
+        <div
+          className="relative w-full max-w-md bg-white rounded-lg shadow-xl"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="review-dialog-title"
+        >
+          {/* Header */}
+          <div className="px-6 py-4 border-b">
+            <h2 id="review-dialog-title" className="text-lg font-semibold text-gray-900">
+              {t('aml.review.title')}
+            </h2>
+            <p className="text-sm text-gray-500 mt-1">{t('aml.review.description')}</p>
+          </div>
+
+          {/* Form */}
+          <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+            {/* Decision */}
+            <div>
+              <label htmlFor="review-decision" className="block text-sm font-medium text-gray-700">
+                {t('aml.review.decisionLabel')} *
+              </label>
+              <select
+                id="review-decision"
+                value={decision}
+                onChange={(e) => setDecision(e.target.value as AmlReviewDecision)}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                {AML_REVIEW_DECISIONS.map((value) => (
+                  <option key={value} value={value}>
+                    {t(`aml.review.decision.${value}`)}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Notes */}
+            <div>
+              <label htmlFor="review-notes" className="block text-sm font-medium text-gray-700">
+                {t('aml.review.notesLabel')} *
+              </label>
+              <textarea
+                id="review-notes"
+                value={notes}
+                onChange={(e) => {
+                  setNotes(e.target.value);
+                  if (showError) setShowError(false);
+                }}
+                rows={4}
+                placeholder={t('aml.review.notesPlaceholder')}
+                className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                aria-invalid={showError}
+                aria-describedby={showError ? 'review-notes-error' : undefined}
+              />
+              {showError && (
+                <p id="review-notes-error" className="mt-1 text-sm text-red-600" role="alert">
+                  {t('aml.review.notesRequired')}
+                </p>
+              )}
+            </div>
+          </form>
+
+          {/* Actions */}
+          <div className="px-6 py-4 border-t flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+            >
+              {isSubmitting && (
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+              )}
+              {isSubmitting ? t('aml.review.submitting') : t('aml.review.submit')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ReviewAssessmentDialog.displayName = 'ReviewAssessmentDialog';

--- a/frontend/apps/ppt-web/src/features/compliance/components/index.ts
+++ b/frontend/apps/ppt-web/src/features/compliance/components/index.ts
@@ -31,6 +31,8 @@ export type {
 } from './EddRecordCard';
 // Story 67.2: Enhanced Due Diligence
 export { EddRecordCard } from './EddRecordCard';
+// Epic 90: AML EDD / review decision dialogs (replace window.prompt/alert flow)
+export { InitiateEddDialog } from './InitiateEddDialog';
 export type {
   ContentOwnerInfo,
   ModeratedContentType,
@@ -48,3 +50,4 @@ export type {
   PriorityCount,
 } from './ModerationQueueStats';
 export { ModerationQueueStats } from './ModerationQueueStats';
+export { ReviewAssessmentDialog } from './ReviewAssessmentDialog';

--- a/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.test.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.test.tsx
@@ -1,18 +1,27 @@
 /// <reference types="vitest/globals" />
 /**
- * AmlDashboardPage review-decision validation tests.
+ * AmlDashboardPage EDD / review decision-flow tests.
  *
- * Regression: the Phase-1 review flow reads the decision from window.prompt and
- * previously cast the raw string straight into the `approve | reject | escalate`
- * union (`decision as ...`). A typo ("aprove") therefore reached the API as an
- * invalid AML decision. The page now validates the free-text input against the
- * allowed union before calling the mutation.
+ * History: the Phase-1 EDD + review flow drove regulated decisions through
+ * `window.prompt` / `window.alert` with hardcoded English copy, and cast the raw
+ * prompt string straight into the `approve | reject | escalate` union (a typo
+ * such as "aprove" could reach the API). Epic 90 replaced that flow with in-app
+ * modal dialogs (localized, using the shared Toast for feedback):
+ *   - the decision is now constrained to the union via a <select>, so an invalid
+ *     free-text decision is structurally impossible, and
+ *   - the mutation still fires only with a non-empty reason (EDD) / non-empty
+ *     notes (review), matching the old `if (!x) return;` guards.
+ *
+ * These tests lock in: no window.prompt/window.alert is used, required fields
+ * gate the mutation, and a valid submission sends the typed union value.
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToastProvider } from '../../../components';
 import { AmlDashboardPage } from './AmlDashboardPage';
 
 const reviewMutate = vi.fn();
+const eddMutate = vi.fn();
 
 const assessment = {
   id: 'assess-1',
@@ -35,22 +44,34 @@ vi.mock('@ppt/api-client', () => ({
   })),
   useAmlThresholds: vi.fn(() => ({ data: undefined })),
   useCountryRisks: vi.fn(() => ({ data: undefined })),
-  useInitiateEdd: vi.fn(() => ({ mutate: vi.fn() })),
-  useReviewAmlAssessment: vi.fn(() => ({ mutate: reviewMutate })),
+  useInitiateEdd: vi.fn(() => ({ mutate: eddMutate, isPending: false })),
+  useReviewAmlAssessment: vi.fn(() => ({ mutate: reviewMutate, isPending: false })),
 }));
 
-function clickReview() {
-  const button = screen.getByRole('button', { name: /review assessment/i });
-  button.click();
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <AmlDashboardPage />
+    </ToastProvider>
+  );
 }
 
-describe('AmlDashboardPage review-decision validation', () => {
+function openReviewDialog() {
+  fireEvent.click(screen.getByRole('button', { name: /review assessment/i }));
+}
+
+function openEddDialog() {
+  fireEvent.click(screen.getByRole('button', { name: /initiate edd/i }));
+}
+
+describe('AmlDashboardPage decision flow', () => {
   const promptSpy = vi.spyOn(window, 'prompt');
   const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
   beforeEach(() => {
     reviewMutate.mockClear();
-    promptSpy.mockReset();
+    eddMutate.mockClear();
+    promptSpy.mockClear();
     alertSpy.mockClear();
   });
 
@@ -58,30 +79,74 @@ describe('AmlDashboardPage review-decision validation', () => {
     vi.clearAllMocks();
   });
 
-  it('does not submit when the decision prompt contains an invalid value', () => {
-    // First prompt = decision (typo). Notes are also supplied so that the old
-    // `decision as ...` cast path would have reached the mutation — the guard is
-    // what keeps it from being called.
-    promptSpy.mockReturnValueOnce('aprove').mockReturnValueOnce('some notes');
-    render(<AmlDashboardPage />);
-    clickReview();
+  it('never uses window.prompt or window.alert for the review flow', () => {
+    renderPage();
+    openReviewDialog();
 
-    expect(reviewMutate).not.toHaveBeenCalled();
-    expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid decision'));
+    // The decision dialog is rendered in-app.
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(promptSpy).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
   });
 
-  it('submits a valid decision (case/whitespace tolerant) as the typed union value', () => {
-    promptSpy
-      .mockReturnValueOnce('  Escalate ') // decision — normalised to 'escalate'
-      .mockReturnValueOnce('needs more docs'); // notes
-    render(<AmlDashboardPage />);
-    clickReview();
+  it('does not submit the review when notes are empty', () => {
+    renderPage();
+    openReviewDialog();
+
+    // Submit with the default decision but no notes.
+    fireEvent.click(screen.getByRole('button', { name: /submit decision/i }));
+
+    expect(reviewMutate).not.toHaveBeenCalled();
+    // A localized inline validation message is shown instead of an alert.
+    expect(screen.getByText(/review notes are required/i)).toBeInTheDocument();
+  });
+
+  it('submits the selected decision as the typed union value with notes', () => {
+    renderPage();
+    openReviewDialog();
+
+    const select = screen.getByLabelText(/decision/i);
+    fireEvent.change(select, { target: { value: 'escalate' } });
+
+    const notes = screen.getByLabelText(/review notes/i);
+    fireEvent.change(notes, { target: { value: 'needs more docs' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /submit decision/i }));
 
     expect(reviewMutate).toHaveBeenCalledTimes(1);
     const [payload] = reviewMutate.mock.calls[0];
     expect(payload).toMatchObject({
       assessmentId: 'assess-1',
       request: { decision: 'escalate', notes: 'needs more docs' },
+    });
+  });
+
+  it('does not submit EDD when the reason is empty, and submits it when provided', () => {
+    renderPage();
+    openEddDialog();
+
+    // Two buttons match /initiate edd/i once the dialog is open (the card action
+    // + the dialog submit); the dialog submit is the last one in the DOM.
+    const submitButtons = screen.getAllByRole('button', { name: /initiate edd/i });
+    const dialogSubmit = submitButtons[submitButtons.length - 1];
+
+    // Empty reason: no mutation, inline validation shown.
+    fireEvent.click(dialogSubmit);
+    expect(eddMutate).not.toHaveBeenCalled();
+    expect(screen.getByText(/a reason is required/i)).toBeInTheDocument();
+
+    // Provide a reason and submit.
+    fireEvent.change(screen.getByLabelText(/reason/i), {
+      target: { value: 'high risk score' },
+    });
+    fireEvent.click(dialogSubmit);
+
+    expect(eddMutate).toHaveBeenCalledTimes(1);
+    const [payload] = eddMutate.mock.calls[0];
+    expect(payload).toMatchObject({
+      assessment_id: 'assess-1',
+      reason: 'high risk score',
+      documents_requested: [],
     });
   });
 });

--- a/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.tsx
+++ b/frontend/apps/ppt-web/src/features/compliance/pages/AmlDashboardPage.tsx
@@ -1,11 +1,14 @@
 /**
  * AML Dashboard Page (Epic 67, Story 67.1).
  * Epic 90, Story 90.5: Wire up AML dashboard handlers to API.
+ * Epic 90: replace the Phase-1 window.prompt/window.alert EDD + review decision
+ * flow with in-app modal dialogs + toast feedback, and localize all copy.
  *
  * Dashboard for AML risk assessments and compliance monitoring.
  */
 
 import {
+  type ReviewAmlAssessmentRequest,
   useAmlAssessments,
   useAmlThresholds,
   useCountryRisks,
@@ -14,8 +17,12 @@ import {
 } from '@ppt/api-client';
 import type React from 'react';
 import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useToast } from '../../../components';
 import type { AmlRiskAssessment } from '../components/AmlRiskAssessmentCard';
 import { AmlRiskAssessmentCard } from '../components/AmlRiskAssessmentCard';
+import { InitiateEddDialog } from '../components/InitiateEddDialog';
+import { ReviewAssessmentDialog } from '../components/ReviewAssessmentDialog';
 
 interface AmlThresholdsDisplay {
   transaction_threshold_eur: number;
@@ -32,18 +39,20 @@ interface CountryRiskDisplay {
   fatf_status?: string;
 }
 
-type AmlReviewDecision = 'approve' | 'reject' | 'escalate';
-
-const AML_REVIEW_DECISIONS: readonly AmlReviewDecision[] = ['approve', 'reject', 'escalate'];
-
-const isAmlReviewDecision = (value: string): value is AmlReviewDecision =>
-  (AML_REVIEW_DECISIONS as readonly string[]).includes(value);
+type AmlReviewDecision = ReviewAmlAssessmentRequest['decision'];
 
 export const AmlDashboardPage: React.FC = () => {
+  const { t } = useTranslation();
+  const { showToast } = useToast();
+
   // Filters
   const [statusFilter, setStatusFilter] = useState<string>('');
   const [riskLevelFilter, setRiskLevelFilter] = useState<string>('');
   const [flaggedOnly, setFlaggedOnly] = useState(false);
+
+  // Decision dialogs: which assessment (if any) each dialog is acting on.
+  const [eddAssessmentId, setEddAssessmentId] = useState<string | null>(null);
+  const [reviewAssessmentId, setReviewAssessmentId] = useState<string | null>(null);
 
   // Fetch assessments from API
   const {
@@ -109,73 +118,75 @@ export const AmlDashboardPage: React.FC = () => {
     fatf_status: c.fatf_status,
   }));
 
-  const handleInitiateEdd = useCallback(
-    (assessmentId: string) => {
-      // TODO(Phase-2): Replace window.prompt with proper modal form with document selection
-      // Phase 1: Basic prompt for collecting reason
-      const reason = window.prompt('Enter reason for initiating Enhanced Due Diligence:');
-      if (!reason) return;
+  const handleInitiateEdd = useCallback((assessmentId: string) => {
+    setEddAssessmentId(assessmentId);
+  }, []);
 
+  const handleReview = useCallback((assessmentId: string) => {
+    setReviewAssessmentId(assessmentId);
+  }, []);
+
+  const submitEdd = useCallback(
+    (reason: string) => {
+      if (!eddAssessmentId) return;
       initiateEdd.mutate(
         {
-          assessment_id: assessmentId,
+          assessment_id: eddAssessmentId,
           reason,
           documents_requested: [],
         },
         {
           onSuccess: () => {
-            alert('Enhanced Due Diligence initiated successfully.');
+            setEddAssessmentId(null);
+            showToast({
+              type: 'success',
+              title: t('aml.edd.successTitle'),
+              message: t('aml.edd.successMessage'),
+            });
           },
           onError: (err) => {
             console.error('Failed to initiate EDD:', err);
-            alert('Failed to initiate EDD. Please try again.');
+            showToast({
+              type: 'error',
+              title: t('aml.edd.errorTitle'),
+              message: t('aml.edd.errorMessage'),
+            });
           },
         }
       );
     },
-    [initiateEdd]
+    [eddAssessmentId, initiateEdd, showToast, t]
   );
 
-  const handleReview = useCallback(
-    (assessmentId: string) => {
-      // TODO(Phase-2): Replace window.prompt with proper modal form with validation
-      // Phase 1: Basic prompts for collecting decision and notes
-      const decisionInput = window.prompt('Enter decision (approve, reject, escalate):', 'approve');
-      if (!decisionInput) return;
-
-      // Validate the free-text prompt against the allowed decision union before
-      // submitting — a typo (e.g. "aprove") must not reach the API as a decision.
-      const decision = decisionInput.trim().toLowerCase();
-      if (!isAmlReviewDecision(decision)) {
-        alert(
-          `Invalid decision "${decisionInput}". Please enter one of: approve, reject, escalate.`
-        );
-        return;
-      }
-
-      const notes = window.prompt('Enter review notes:');
-      if (!notes) return;
-
+  const submitReview = useCallback(
+    (decision: AmlReviewDecision, notes: string) => {
+      if (!reviewAssessmentId) return;
       reviewAssessment.mutate(
         {
-          assessmentId,
-          request: {
-            decision,
-            notes,
-          },
+          assessmentId: reviewAssessmentId,
+          request: { decision, notes },
         },
         {
           onSuccess: () => {
-            alert('Assessment reviewed successfully.');
+            setReviewAssessmentId(null);
+            showToast({
+              type: 'success',
+              title: t('aml.review.successTitle'),
+              message: t('aml.review.successMessage'),
+            });
           },
           onError: (err) => {
             console.error('Failed to review assessment:', err);
-            alert('Failed to review assessment. Please try again.');
+            showToast({
+              type: 'error',
+              title: t('aml.review.errorTitle'),
+              message: t('aml.review.errorMessage'),
+            });
           },
         }
       );
     },
-    [reviewAssessment]
+    [reviewAssessmentId, reviewAssessment, showToast, t]
   );
 
   // Loading state
@@ -183,10 +194,10 @@ export const AmlDashboardPage: React.FC = () => {
     return (
       <div className="aml-dashboard-page">
         <div className="aml-dashboard-header">
-          <h1>AML Compliance Dashboard</h1>
-          <p>Monitor anti-money laundering risk assessments and compliance status.</p>
+          <h1>{t('aml.dashboard.title')}</h1>
+          <p>{t('aml.dashboard.subtitle')}</p>
         </div>
-        <div className="aml-loading">Loading AML data...</div>
+        <div className="aml-loading">{t('aml.dashboard.loading')}</div>
       </div>
     );
   }
@@ -196,17 +207,17 @@ export const AmlDashboardPage: React.FC = () => {
     return (
       <div className="aml-dashboard-page">
         <div className="aml-dashboard-header">
-          <h1>AML Compliance Dashboard</h1>
-          <p>Monitor anti-money laundering risk assessments and compliance status.</p>
+          <h1>{t('aml.dashboard.title')}</h1>
+          <p>{t('aml.dashboard.subtitle')}</p>
         </div>
         <div className="aml-dashboard-error" role="alert">
-          Failed to load AML data: {assessmentsError.message}
+          {t('aml.dashboard.loadError', { message: assessmentsError.message })}
           <button
             type="button"
             onClick={() => window.location.reload()}
             className="aml-retry-button"
           >
-            Retry
+            {t('aml.dashboard.retry')}
           </button>
         </div>
       </div>
@@ -216,30 +227,30 @@ export const AmlDashboardPage: React.FC = () => {
   return (
     <div className="aml-dashboard-page">
       <div className="aml-dashboard-header">
-        <h1>AML Compliance Dashboard</h1>
-        <p>Monitor anti-money laundering risk assessments and compliance status.</p>
+        <h1>{t('aml.dashboard.title')}</h1>
+        <p>{t('aml.dashboard.subtitle')}</p>
       </div>
 
       {/* Thresholds Info */}
       {thresholds && (
         <div className="aml-thresholds-section">
-          <h2>AML Thresholds</h2>
+          <h2>{t('aml.thresholds.title')}</h2>
           <div className="aml-thresholds-grid">
             <div className="aml-threshold-card">
               <div className="aml-threshold-value">
                 {thresholds.transaction_threshold_eur.toLocaleString()} EUR
               </div>
-              <div className="aml-threshold-label">Transaction Threshold</div>
+              <div className="aml-threshold-label">{t('aml.thresholds.transaction')}</div>
             </div>
             <div className="aml-threshold-card">
               <div className="aml-threshold-value">
                 {thresholds.cumulative_threshold_eur.toLocaleString()} EUR
               </div>
-              <div className="aml-threshold-label">Cumulative Threshold</div>
+              <div className="aml-threshold-label">{t('aml.thresholds.cumulative')}</div>
             </div>
             <div className="aml-threshold-card">
               <div className="aml-threshold-value">{thresholds.review_threshold_score}</div>
-              <div className="aml-threshold-label">Review Score Threshold</div>
+              <div className="aml-threshold-label">{t('aml.thresholds.reviewScore')}</div>
             </div>
           </div>
         </div>
@@ -247,14 +258,14 @@ export const AmlDashboardPage: React.FC = () => {
 
       {/* Country Risks */}
       <div className="aml-country-risks-section">
-        <h2>Country Risk Database</h2>
+        <h2>{t('aml.countryRisks.title')}</h2>
         <table className="aml-country-risks-table">
           <thead>
             <tr>
-              <th>Country</th>
-              <th>Risk Rating</th>
-              <th>Sanctioned</th>
-              <th>FATF Status</th>
+              <th>{t('aml.countryRisks.country')}</th>
+              <th>{t('aml.countryRisks.riskRating')}</th>
+              <th>{t('aml.countryRisks.sanctioned')}</th>
+              <th>{t('aml.countryRisks.fatfStatus')}</th>
             </tr>
           </thead>
           <tbody>
@@ -268,7 +279,7 @@ export const AmlDashboardPage: React.FC = () => {
                     {country.risk_rating.toUpperCase()}
                   </span>
                 </td>
-                <td>{country.is_sanctioned ? 'Yes' : 'No'}</td>
+                <td>{country.is_sanctioned ? t('common.yes') : t('common.no')}</td>
                 <td>{country.fatf_status || '-'}</td>
               </tr>
             ))}
@@ -278,36 +289,36 @@ export const AmlDashboardPage: React.FC = () => {
 
       {/* Filters */}
       <div className="aml-filters-section">
-        <h2>Risk Assessments</h2>
+        <h2>{t('aml.filters.title')}</h2>
         <div className="aml-filters">
           <div className="aml-filter">
-            <label htmlFor="statusFilter">Status</label>
+            <label htmlFor="statusFilter">{t('aml.filters.status')}</label>
             <select
               id="statusFilter"
               value={statusFilter}
               onChange={(e) => setStatusFilter(e.target.value)}
             >
-              <option value="">All Statuses</option>
-              <option value="pending">Pending</option>
-              <option value="in_progress">In Progress</option>
-              <option value="completed">Completed</option>
-              <option value="requires_review">Requires Review</option>
-              <option value="approved">Approved</option>
-              <option value="rejected">Rejected</option>
+              <option value="">{t('aml.filters.allStatuses')}</option>
+              <option value="pending">{t('aml.status.pending')}</option>
+              <option value="in_progress">{t('aml.status.in_progress')}</option>
+              <option value="completed">{t('aml.status.completed')}</option>
+              <option value="requires_review">{t('aml.status.requires_review')}</option>
+              <option value="approved">{t('aml.status.approved')}</option>
+              <option value="rejected">{t('aml.status.rejected')}</option>
             </select>
           </div>
           <div className="aml-filter">
-            <label htmlFor="riskLevelFilter">Risk Level</label>
+            <label htmlFor="riskLevelFilter">{t('aml.filters.riskLevel')}</label>
             <select
               id="riskLevelFilter"
               value={riskLevelFilter}
               onChange={(e) => setRiskLevelFilter(e.target.value)}
             >
-              <option value="">All Levels</option>
-              <option value="low">Low</option>
-              <option value="medium">Medium</option>
-              <option value="high">High</option>
-              <option value="critical">Critical</option>
+              <option value="">{t('aml.filters.allLevels')}</option>
+              <option value="low">{t('aml.riskLevel.low')}</option>
+              <option value="medium">{t('aml.riskLevel.medium')}</option>
+              <option value="high">{t('aml.riskLevel.high')}</option>
+              <option value="critical">{t('aml.riskLevel.critical')}</option>
             </select>
           </div>
           <div className="aml-filter checkbox">
@@ -318,7 +329,7 @@ export const AmlDashboardPage: React.FC = () => {
                 checked={flaggedOnly}
                 onChange={(e) => setFlaggedOnly(e.target.checked)}
               />
-              Flagged for Review Only
+              {t('aml.filters.flaggedOnly')}
             </label>
           </div>
         </div>
@@ -339,10 +350,24 @@ export const AmlDashboardPage: React.FC = () => {
         </div>
       ) : (
         <div className="aml-empty-state">
-          <p>No AML risk assessments found matching the criteria.</p>
-          <p>Assessments are automatically created when transactions exceed the threshold.</p>
+          <p>{t('aml.emptyState.none')}</p>
+          <p>{t('aml.emptyState.hint')}</p>
         </div>
       )}
+
+      {/* Decision dialogs (replace the Phase-1 window.prompt/alert flow) */}
+      <InitiateEddDialog
+        isOpen={eddAssessmentId !== null}
+        isSubmitting={initiateEdd.isPending}
+        onSubmit={submitEdd}
+        onClose={() => setEddAssessmentId(null)}
+      />
+      <ReviewAssessmentDialog
+        isOpen={reviewAssessmentId !== null}
+        isSubmitting={reviewAssessment.isPending}
+        onSubmit={submitReview}
+        onClose={() => setReviewAssessmentId(null)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Task
ppt-web AML dashboard drives regulated EDD/review decisions through `window.prompt`/`window.alert` with hardcoded English strings (an unshipped "TODO Phase-2"). Fix: replace the `window.prompt`/`window.alert` calls in the AML dashboard EDD/review decision flow with proper in-app UI (a modal/dialog + form using the existing ppt-web component library and mutation/error patterns), and localize all user-facing strings via `useTranslation` (react-i18next) — no hardcoded English. Reuse existing dialog/toast components and i18n keys/patterns already in ppt-web; do NOT invent new primitives. Keep the decision semantics identical.

## Owner
pm-backend (hint only — this is a `frontend/apps/ppt-web` change; the real specialist is `react-web`)

## What changed
- **`InitiateEddDialog.tsx`** / **`ReviewAssessmentDialog.tsx`** — new modal dialogs built on the existing ppt-web dialog/form pattern (same Tailwind structure as `TriageFaultDialog`: `isOpen`/`isSubmitting`/`onSubmit`/`onClose`, backdrop, `role="dialog"`, inline required-field validation). No new UI primitives introduced.
- **`AmlDashboardPage.tsx`** — the `window.prompt`/`window.alert` handlers are replaced by dialog open-state + the two dialogs; success/error feedback now uses the shared `useToast()` (`type: 'success' | 'error'`) instead of `alert()`; mutation `isPending` drives the submit spinner. All user-facing copy localized via `useTranslation`.
- **`AmlRiskAssessmentCard.tsx`** — localized (it renders the dashboard's action buttons and status/verification labels; only used by this page).
- **`messages/{en,sk,cs,de,pl,hu}.json`** — new `aml` namespace added to all six locales (dashboard, thresholds, country risks, filters, status, risk levels, card, EDD dialog, review dialog).
- **`AmlDashboardPage.test.tsx`** — rewritten to drive the new in-app flow (asserts no `window.prompt`/`window.alert`, required-field gating, and that a valid review submits the typed union decision).

### Decision semantics (unchanged)
- EDD still requires a non-empty reason and sends `documents_requested: []`.
- Review decision is constrained to the `approve | reject | escalate` union via a `<select>` (a free-text typo can no longer reach the API — the prior regression class is now structurally impossible) and still requires non-empty notes.

## Verification
```
VERIFY-PLAN base=f30878f88c8a8abe12dcac2d251167936c6097b4 files=12
```
- `pnpm -F @ppt/web typecheck` → exit 0
- `biome check` (all changed files) → exit 0, no fixes needed
- `scripts/verify-impact.sh` (impact-scoped: full ppt-web suite) → **122 files, 2408 tests passed**
```
VERIFY OK 968702321bc916316a4b02627985577caaeef47b
```
The new `AmlDashboardPage.test.tsx` (4 tests) passes.

## CI parity (Band C — hot-path only)
skipped: not flagged hot-path (compliance UI change; no auth/billing/data-integrity backend logic touched — decision semantics preserved, no API/route change).

## Remote-tested
skipped (no ppt-bridge MCP).

## Scope drift
None functionally: the entire 12-file diff stays within `frontend/apps/ppt-web/**` (compliance feature + i18n message files), exactly the intended scope. The `owner_role` hint was `pm-backend`, which does not map to the frontend area, so the deterministic `scope-check.sh` against that owner would flag the frontend files — this is an owner-hint mismatch, not out-of-scope work.

## Code-reuse review
none — reused `useToast`/Toast, `useTranslation`, and the existing dialog/form pattern; no new helpers or primitives added.

## Notes
- The `TODO(Phase-2)` comments about `window.prompt` are removed; the remaining `TODO(Phase-2)` on the assessment transform (API not yet returning verification fields) is unrelated and left as-is.
- Non-English translations were authored for sk/cs/de/pl/hu; `en` remains the i18n `fallbackLng`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SshkMYFsR2yyEG6tvdkf75

---
_Generated by [Claude Code](https://claude.ai/code/session_01SshkMYFsR2yyEG6tvdkf75)_